### PR TITLE
Add gated Codex E2E test

### DIFF
--- a/DoWhiz_service/run_task_module/tests/README.md
+++ b/DoWhiz_service/run_task_module/tests/README.md
@@ -15,6 +15,23 @@ verify that `run_task` writes `reply_email_draft.html`, creates the
 attachments directory, and handles error cases (missing env, missing CLI,
 failed CLI, missing output, invalid paths).
 
+## Optional real Codex E2E test (RUN_CODEX_E2E)
+
+When `RUN_CODEX_E2E=1` is set, `run_task_tests` runs a live Codex CLI test.
+
+Prereqs:
+- `codex` CLI installed.
+- `AZURE_OPENAI_API_KEY_BACKUP` and `AZURE_OPENAI_ENDPOINT_BACKUP` set.
+- Optional: `CODEX_MODEL` to override the default model.
+
+Run:
+```
+RUN_CODEX_E2E=1 \
+AZURE_OPENAI_API_KEY_BACKUP=... \
+AZURE_OPENAI_ENDPOINT_BACKUP=... \
+cargo test -p run_task_module --test run_task_tests -- --nocapture
+```
+
 ## Manual smoke test (real Codex)
 
 Prereqs (Dockerfile parity):
@@ -43,7 +60,3 @@ workspace/
    - reply_email_draft.html exists in the workspace root.
    - reply_email_attachments/ exists (and contains any generated attachments).
    - Skills are copied from `DoWhiz_service/skills` automatically when preparing workspaces.
-
-## Future automated tests
-
-- Add a gated test that uses the real Codex CLI when RUN_CODEX_E2E=1 is set.

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -8,6 +8,17 @@ use support::{
     build_params, create_workspace, write_fake_codex, EnvGuard, FakeCodexMode, TempDir, ENV_MUTEX,
 };
 
+fn env_enabled(key: &str) -> bool {
+    matches!(env::var(key).as_deref(), Ok("1"))
+}
+
+fn require_env(key: &'static str) {
+    let value = env::var(key).unwrap_or_default();
+    if value.trim().is_empty() {
+        panic!("{key} must be set to run the real Codex E2E test");
+    }
+}
+
 #[test]
 #[cfg(unix)]
 fn run_task_success_with_fake_codex() {
@@ -189,4 +200,36 @@ fn run_task_codex_disabled_writes_placeholder() {
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
     assert!(html.contains("Codex disabled"));
     assert!(result.reply_attachments_dir.is_dir());
+}
+
+#[test]
+#[cfg(unix)]
+fn run_task_real_codex_e2e_when_enabled() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    if !env_enabled("RUN_CODEX_E2E") {
+        eprintln!("RUN_CODEX_E2E not set; skipping real Codex E2E test.");
+        return;
+    }
+
+    require_env("AZURE_OPENAI_API_KEY_BACKUP");
+    require_env("AZURE_OPENAI_ENDPOINT_BACKUP");
+
+    let temp = TempDir::new("codex_task_real_e2e").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+
+    let home_dir = temp.path.join("home");
+    fs::create_dir_all(&home_dir).unwrap();
+    let _env = EnvGuard::set(&[("HOME", home_dir.to_str().unwrap())]);
+
+    let mut params = build_params(&workspace);
+    params.model_name = env::var("CODEX_MODEL").unwrap_or_default();
+
+    let result = run_task(&params).unwrap_or_else(|err| {
+        panic!("Real Codex E2E test failed: {err}");
+    });
+    assert!(result.reply_html_path.exists());
+    assert!(result.reply_attachments_dir.is_dir());
+
+    let html = fs::read_to_string(&result.reply_html_path).unwrap();
+    assert!(!html.trim().is_empty());
 }


### PR DESCRIPTION
## Summary\n- add a gated real Codex E2E test for run_task_module\n- document how to run it locally\n\nCloses #56