### PR TITLE
Stabilize gh auth login in run task

### DIFF
--- a/DoWhiz_service/scheduler_module/src/service.rs
+++ b/DoWhiz_service/scheduler_module/src/service.rs
@@ -1346,10 +1346,13 @@ pub struct PostmarkInbound {
     #[serde(rename = "From")]
     from: Option<String>,
     #[serde(rename = "To")]
+    #[allow(dead_code)]
     to: Option<String>,
     #[serde(rename = "Cc")]
+    #[allow(dead_code)]
     cc: Option<String>,
     #[serde(rename = "Bcc")]
+    #[allow(dead_code)]
     bcc: Option<String>,
     #[serde(rename = "ReplyTo")]
     reply_to: Option<String>,
@@ -1399,6 +1402,7 @@ struct PostmarkAttachment {
     #[serde(rename = "Content")]
     content: String,
     #[serde(rename = "ContentType")]
+    #[allow(dead_code)]
     content_type: String,
 }
 


### PR DESCRIPTION
## Summary\n- serialize gh auth login and skip when already authenticated\n- retry gh auth login with insecure storage on keychain errors\n- silence known dead_code warnings for Postmark/GitHub auth structs\n\n## Testing\n- Not run (service already running)