### PR TITLE
Raise Postmark inbound body limit

### DIFF
--- a/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
@@ -1,6 +1,8 @@
 use run_task_module::RunTaskParams;
 use scheduler_module::index_store::IndexStore;
-use scheduler_module::service::{process_inbound_payload, PostmarkInbound, ServiceConfig};
+use scheduler_module::service::{
+    process_inbound_payload, PostmarkInbound, ServiceConfig, DEFAULT_INBOUND_BODY_MAX_BYTES,
+};
 use scheduler_module::user_store::UserStore;
 use scheduler_module::{Scheduler, SchedulerError, TaskExecution, TaskExecutor, TaskKind};
 use std::env;
@@ -218,6 +220,7 @@ fn email_flow_injects_github_env() {
         scheduler_poll_interval: Duration::from_millis(50),
         scheduler_max_concurrency: 1,
         scheduler_user_max_concurrency: 1,
+        inbound_body_max_bytes: DEFAULT_INBOUND_BODY_MAX_BYTES,
         skills_source_dir: None,
     };
 

--- a/DoWhiz_service/scheduler_module/tests/scheduler_concurrency.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_concurrency.rs
@@ -1,5 +1,5 @@
 use scheduler_module::index_store::IndexStore;
-use scheduler_module::service::{run_server, ServiceConfig};
+use scheduler_module::service::{run_server, ServiceConfig, DEFAULT_INBOUND_BODY_MAX_BYTES};
 use scheduler_module::user_store::UserStore;
 use scheduler_module::{ModuleExecutor, RunTaskTask, Scheduler, TaskKind};
 use std::env;
@@ -89,6 +89,7 @@ fn scheduler_parallelism_reduces_wall_clock_time() -> Result<(), Box<dyn std::er
         scheduler_poll_interval: Duration::from_millis(100),
         scheduler_max_concurrency: CONCURRENCY_LIMIT,
         scheduler_user_max_concurrency: 3,
+        inbound_body_max_bytes: DEFAULT_INBOUND_BODY_MAX_BYTES,
         skills_source_dir: None,
     };
 

--- a/DoWhiz_service/scheduler_module/tests/service_real_email.rs
+++ b/DoWhiz_service/scheduler_module/tests/service_real_email.rs
@@ -1,6 +1,6 @@
 use lettre::Transport;
 use rusqlite::OptionalExtension;
-use scheduler_module::service::{run_server, ServiceConfig};
+use scheduler_module::service::{run_server, ServiceConfig, DEFAULT_INBOUND_BODY_MAX_BYTES};
 use scheduler_module::user_store::normalize_email;
 use scheduler_module::{
     ScheduledTask, Scheduler, SchedulerError, TaskExecution, TaskExecutor, TaskKind,
@@ -326,6 +326,7 @@ fn rust_service_real_email_end_to_end() -> Result<(), Box<dyn std::error::Error>
         scheduler_poll_interval: Duration::from_secs(1),
         scheduler_max_concurrency: 10,
         scheduler_user_max_concurrency: 3,
+        inbound_body_max_bytes: DEFAULT_INBOUND_BODY_MAX_BYTES,
         skills_source_dir: None,
     };
 

--- a/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
@@ -1,6 +1,8 @@
 use run_task_module::RunTaskParams;
 use scheduler_module::index_store::IndexStore;
-use scheduler_module::service::{process_inbound_payload, PostmarkInbound, ServiceConfig};
+use scheduler_module::service::{
+    process_inbound_payload, PostmarkInbound, ServiceConfig, DEFAULT_INBOUND_BODY_MAX_BYTES,
+};
 use scheduler_module::user_store::UserStore;
 use scheduler_module::{Scheduler, SchedulerError, TaskExecution, TaskExecutor, TaskKind};
 use std::env;
@@ -161,6 +163,7 @@ fn thread_latest_epoch_end_to_end() {
         scheduler_poll_interval: Duration::from_millis(50),
         scheduler_max_concurrency: 2,
         scheduler_user_max_concurrency: 1,
+        inbound_body_max_bytes: DEFAULT_INBOUND_BODY_MAX_BYTES,
         skills_source_dir: None,
     };
 


### PR DESCRIPTION
## Summary\n- allow larger Postmark inbound payloads (default 25MB, configurable via POSTMARK_INBOUND_MAX_BYTES)\n- wire new limit into ServiceConfig and tests\n\n## Testing\n- cargo build -p scheduler_module