### PR TITLE
Add per-user secrets sync

### DIFF
--- a/DoWhiz_service/scheduler_module/src/secrets_store.rs
+++ b/DoWhiz_service/scheduler_module/src/secrets_store.rs
@@ -1,0 +1,101 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::RunTaskTask;
+
+const USER_SECRETS_DIR: &str = "secrets";
+const USER_ENV_FILENAME: &str = ".env";
+
+pub(crate) fn resolve_user_secrets_path(task: &RunTaskTask) -> Option<PathBuf> {
+    if let Some(archive_root) = task.archive_root.as_ref() {
+        if let Some(user_root) = archive_root.parent() {
+            return Some(user_root.join(USER_SECRETS_DIR).join(USER_ENV_FILENAME));
+        }
+    }
+    let user_root = task.workspace_dir.parent()?.parent()?;
+    Some(user_root.join(USER_SECRETS_DIR).join(USER_ENV_FILENAME))
+}
+
+pub(crate) fn sync_user_secrets_to_workspace(
+    user_env_path: &Path,
+    workspace_dir: &Path,
+) -> Result<(), io::Error> {
+    if !user_env_path.exists() {
+        return Ok(());
+    }
+    let workspace_env = workspace_env_path(workspace_dir);
+    fs::copy(user_env_path, workspace_env)?;
+    Ok(())
+}
+
+pub(crate) fn sync_workspace_secrets_to_user(
+    workspace_dir: &Path,
+    user_env_path: &Path,
+) -> Result<(), io::Error> {
+    let workspace_env = workspace_env_path(workspace_dir);
+    if !workspace_env.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = user_env_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(workspace_env, user_env_path)?;
+    Ok(())
+}
+
+fn workspace_env_path(workspace_dir: &Path) -> PathBuf {
+    workspace_dir.join(USER_ENV_FILENAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn base_task(workspace_dir: PathBuf, archive_root: Option<PathBuf>) -> RunTaskTask {
+        RunTaskTask {
+            workspace_dir,
+            input_email_dir: PathBuf::from("incoming_email"),
+            input_attachments_dir: PathBuf::from("incoming_attachments"),
+            memory_dir: PathBuf::from("memory"),
+            reference_dir: PathBuf::from("references"),
+            model_name: "test-model".to_string(),
+            codex_disabled: true,
+            reply_to: Vec::new(),
+            archive_root,
+            thread_id: None,
+            thread_epoch: None,
+            thread_state_path: None,
+        }
+    }
+
+    #[test]
+    fn resolve_user_secrets_path_prefers_archive_root() {
+        let temp = TempDir::new().expect("tempdir");
+        let user_root = temp.path().join("users").join("user_1");
+        let archive_root = user_root.join("mail");
+        let workspace_dir = user_root.join("workspaces").join("thread_1");
+        let task = base_task(workspace_dir, Some(archive_root));
+        let expected = user_root.join("secrets").join(".env");
+        let resolved = resolve_user_secrets_path(&task).expect("secrets path");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn sync_user_secrets_to_workspace_copies_env() {
+        let temp = TempDir::new().expect("tempdir");
+        let workspace_dir = temp.path().join("workspace");
+        fs::create_dir_all(&workspace_dir).expect("workspace");
+        let user_env = temp.path().join("secrets").join(".env");
+        fs::create_dir_all(user_env.parent().unwrap()).expect("secrets dir");
+        fs::write(&user_env, "TOKEN=origin").expect("user env");
+
+        sync_user_secrets_to_workspace(&user_env, &workspace_dir).expect("sync");
+
+        let workspace_env = workspace_dir.join(".env");
+        let contents = fs::read_to_string(workspace_env).expect("workspace env");
+        assert_eq!(contents, "TOKEN=origin");
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/service.rs
+++ b/DoWhiz_service/scheduler_module/src/service.rs
@@ -1531,6 +1531,7 @@ mod tests {
             state_dir: user_root.join("state"),
             tasks_db_path: user_root.join("state/tasks.db"),
             memory_dir: user_root.join("memory"),
+            secrets_dir: user_root.join("secrets"),
             mail_root: user_root.join("mail"),
             workspaces_root: user_root.join("workspaces"),
         };

--- a/DoWhiz_service/scheduler_module/src/user_store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/user_store/mod.rs
@@ -24,6 +24,7 @@ pub struct UserPaths {
     pub state_dir: PathBuf,
     pub tasks_db_path: PathBuf,
     pub memory_dir: PathBuf,
+    pub secrets_dir: PathBuf,
     pub mail_root: PathBuf,
     pub workspaces_root: PathBuf,
 }
@@ -118,6 +119,7 @@ impl UserStore {
         let state_dir = root.join("state");
         let tasks_db_path = state_dir.join("tasks.db");
         let memory_dir = root.join("memory");
+        let secrets_dir = root.join("secrets");
         let mail_root = root.join("mail");
         let workspaces_root = root.join("workspaces");
         UserPaths {
@@ -125,6 +127,7 @@ impl UserStore {
             state_dir,
             tasks_db_path,
             memory_dir,
+            secrets_dir,
             mail_root,
             workspaces_root,
         }
@@ -133,6 +136,7 @@ impl UserStore {
     pub fn ensure_user_dirs(&self, paths: &UserPaths) -> Result<(), UserStoreError> {
         fs::create_dir_all(&paths.state_dir)?;
         fs::create_dir_all(&paths.memory_dir)?;
+        fs::create_dir_all(&paths.secrets_dir)?;
         fs::create_dir_all(&paths.mail_root)?;
         fs::create_dir_all(&paths.workspaces_root)?;
         ensure_default_user_memo(&paths.memory_dir)?;

--- a/DoWhiz_service/scheduler_module/tests/secrets_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/secrets_e2e.rs
@@ -1,0 +1,115 @@
+use scheduler_module::{ModuleExecutor, RunTaskTask, TaskExecutor, TaskKind};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+struct EnvGuard {
+    saved: Vec<(String, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn set(vars: &[(&str, &str)]) -> Self {
+        let mut saved = Vec::with_capacity(vars.len());
+        for (key, value) in vars {
+            saved.push((key.to_string(), env::var(key).ok()));
+            env::set_var(key, value);
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..) {
+            match value {
+                Some(value) => env::set_var(&key, value),
+                None => env::remove_var(&key),
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn write_fake_codex(dir: &Path) -> std::io::Result<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script_path = dir.join("codex");
+    let script = r#"#!/bin/sh
+set -e
+if [ "$USER_SECRET_TOKEN" != "origin" ]; then
+  echo "missing user secret" >&2
+  exit 3
+fi
+cat > .env <<EOF
+USER_SECRET_TOKEN=updated
+EOF
+echo "<html><body>Test reply</body></html>" > reply_email_draft.html
+mkdir -p reply_email_attachments
+"#;
+
+    fs::write(&script_path, script)?;
+    let mut perms = fs::metadata(&script_path)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script_path, perms)?;
+    Ok(script_path)
+}
+
+#[test]
+#[cfg(unix)]
+fn secrets_sync_roundtrip_via_run_task() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let home_dir = temp.path().join("home");
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&home_dir)?;
+    fs::create_dir_all(&bin_dir)?;
+    write_fake_codex(&bin_dir)?;
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.com"),
+        ("CODEX_MODEL", "test-model"),
+    ]);
+
+    let user_root = temp.path().join("users").join("user_1");
+    let user_secrets = user_root.join("secrets");
+    let user_mail = user_root.join("mail");
+    let workspace = user_root.join("workspaces").join("thread_1");
+
+    fs::create_dir_all(&user_secrets)?;
+    fs::create_dir_all(&user_mail)?;
+    fs::create_dir_all(workspace.join("incoming_email"))?;
+    fs::create_dir_all(workspace.join("incoming_attachments"))?;
+    fs::create_dir_all(workspace.join("memory"))?;
+    fs::create_dir_all(workspace.join("references"))?;
+
+    fs::write(user_secrets.join(".env"), "USER_SECRET_TOKEN=origin")?;
+    fs::write(workspace.join(".env"), "USER_SECRET_TOKEN=stale")?;
+
+    let run_task = RunTaskTask {
+        workspace_dir: workspace.clone(),
+        input_email_dir: PathBuf::from("incoming_email"),
+        input_attachments_dir: PathBuf::from("incoming_attachments"),
+        memory_dir: PathBuf::from("memory"),
+        reference_dir: PathBuf::from("references"),
+        model_name: "test-model".to_string(),
+        codex_disabled: false,
+        reply_to: Vec::new(),
+        archive_root: Some(user_mail),
+        thread_id: None,
+        thread_epoch: None,
+        thread_state_path: None,
+    };
+
+    let executor = ModuleExecutor::default();
+    executor.execute(&TaskKind::RunTask(run_task))?;
+
+    let updated = fs::read_to_string(user_secrets.join(".env"))?;
+    assert!(updated.contains("USER_SECRET_TOKEN=updated"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add per-user secrets store backed by user_root/secrets/.env
- sync secrets into workspaces before run_task and back afterward
- cover sync with an end-to-end test

## Testing
- cargo test -p scheduler_module --test secrets_e2e