### PR TITLE
Handle non-replyable recipients

### DIFF
--- a/DoWhiz_service/run_task_module/README.md
+++ b/DoWhiz_service/run_task_module/README.md
@@ -33,6 +33,7 @@ let params = RunTaskParams {
     input_attachments_dir: PathBuf::from("input_attachments"),
     memory_dir: PathBuf::from("memory"),
     reference_dir: PathBuf::from("references"),
+    reply_to: vec!["user@example.com".to_string()],
     model_name: "gpt-5.2-codex".to_string(),
     codex_disabled: false,
 };
@@ -50,5 +51,6 @@ println!("Reply saved at: {}", result.reply_html_path.display());
 
 - Input paths must be relative to `workspace_dir`.
 - The module creates `reply_email_draft.html` and `reply_email_attachments/` inside the workspace.
-- When `codex_disabled` is true, it writes a placeholder reply instead of calling Codex.
+- When `codex_disabled` is true, it writes a placeholder reply instead of calling Codex (unless `reply_to` is empty).
+- When `reply_to` is empty, the prompt skips email drafting and `reply_email_draft.html` is optional.
 - Skills are copied from `DoWhiz_service/skills` automatically when preparing workspaces.

--- a/DoWhiz_service/run_task_module/run_task.rs
+++ b/DoWhiz_service/run_task_module/run_task.rs
@@ -58,6 +58,7 @@ pub struct RunTaskParams {
     pub input_attachments_dir: PathBuf,
     pub memory_dir: PathBuf,
     pub reference_dir: PathBuf,
+    pub reply_to: Vec<String>,
     pub model_name: String,
     pub codex_disabled: bool,
 }
@@ -70,6 +71,7 @@ struct RunTaskRequest<'a> {
     memory_dir: &'a Path,
     reference_dir: &'a Path,
     model_name: &'a str,
+    reply_to: &'a [String],
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -242,12 +244,15 @@ pub fn run_task(params: &RunTaskParams) -> Result<RunTaskOutput, RunTaskError> {
         memory_dir: &params.memory_dir,
         reference_dir: &params.reference_dir,
         model_name: params.model_name.as_str(),
+        reply_to: &params.reply_to,
     };
 
     let (reply_html_path, reply_attachments_dir) = prepare_workspace(&request)?;
 
     if params.codex_disabled {
-        write_placeholder_reply(&reply_html_path)?;
+        if !params.reply_to.is_empty() {
+            write_placeholder_reply(&reply_html_path)?;
+        }
         return Ok(RunTaskOutput {
             reply_html_path,
             reply_attachments_dir,
@@ -305,6 +310,7 @@ fn run_codex_task(
         request.memory_dir,
         request.reference_dir,
         &memory_context,
+        !request.reply_to.is_empty(),
     );
 
     let mut cmd = Command::new("codex");
@@ -904,6 +910,7 @@ fn build_prompt(
     memory_dir: &Path,
     reference_dir: &Path,
     memory_context: &str,
+    reply_required: bool,
 ) -> String {
     let memory_section = if memory_context.trim().is_empty() {
         "Memory context (from memory/*.md):\n- (no memory files found)\n\n".to_string()
@@ -913,12 +920,17 @@ fn build_prompt(
             memory_context = memory_context.trim_end()
         )
     };
+    let reply_instruction = if reply_required {
+        "2. After finishing the task (step one), make sure you write a proper HTML email draft in reply_email_draft.html in the workspace root. If there are files to attach, put them in reply_email_attachments/ and reference them in the email draft. Do not pretend the job has been done without actually doing it, and do not write the email draft until the task is done. If you are not sure about the task, send another email to ask for clarification (and if any, attach information about why did you fail to get the task done, what is the exact error you encountered)."
+    } else {
+        "2. After finishing the task (step one), do not write any email draft. This inbound message is from a non-replyable address, so skip creating reply_email_draft.html or reply_email_attachments/."
+    };
     format!(
         r#"You are Oliver, a digital assistant at DoWhiz. You are powerful, resilient, and helpful. Your task is to read incoming emails, understand the user's intent, finish the task, and draft appropriate email replies. You can also use memory and reference materials for context (already saved under current workspace). Always be cute, patient, friendly and helpful in your replies.
 
 You main goal is
 1. Most importantly, understand the task described in the incoming email and get the task done.
-2. After finishing the task (step one), make sure you write a proper HTML email draft in reply_email_draft.html in the workspace root. If there are files to attach, put them in reply_email_attachments/ and reference them in the email draft. Do not pretend the job has been done without actually doing it, and do not write the email draft until the task is done. If you are not sure about the task, send another email to ask for clarification (and if any, attach information about why did you fail to get the task done, what is the exact error you encountered).
+{reply_instruction}
 
 Inputs (relative to workspace root):
 - Incoming email dir: {input_email} (email.html, postmark_payload.json, thread_history.md, entries/)
@@ -956,6 +968,7 @@ Rules:
         memory = memory_dir.display(),
         reference = reference_dir.display(),
         memory_section = memory_section,
+        reply_instruction = reply_instruction,
     )
 }
 
@@ -1035,6 +1048,7 @@ mod tests {
             Path::new("memory"),
             Path::new("references"),
             "--- memory/memo.md ---\nHello",
+            true,
         );
 
         assert!(prompt.contains("Memory context"));
@@ -1042,6 +1056,21 @@ mod tests {
         assert!(prompt.contains("Memory management"));
         assert!(prompt.contains("memo.md"));
         assert!(prompt.contains("500 lines"));
+    }
+
+    #[test]
+    fn build_prompt_skips_reply_instruction_for_non_replyable() {
+        let prompt = build_prompt(
+            Path::new("incoming_email"),
+            Path::new("incoming_attachments"),
+            Path::new("memory"),
+            Path::new("references"),
+            "",
+            false,
+        );
+
+        assert!(prompt.contains("non-replyable address"));
+        assert!(!prompt.contains("write a proper HTML email draft"));
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -230,6 +230,7 @@ fn run_task_rejects_absolute_input_dir() {
         input_attachments_dir: Path::new("incoming_attachments").to_path_buf(),
         memory_dir: Path::new("memory").to_path_buf(),
         reference_dir: Path::new("references").to_path_buf(),
+        reply_to: vec!["user@example.com".to_string()],
         model_name: "test-model".to_string(),
         codex_disabled: false,
     };
@@ -250,6 +251,21 @@ fn run_task_codex_disabled_writes_placeholder() {
     let result = run_task(&params).unwrap();
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
     assert!(html.contains("Codex disabled"));
+    assert!(result.reply_attachments_dir.is_dir());
+}
+
+#[test]
+fn run_task_codex_disabled_skips_placeholder_without_reply_to() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_disabled_no_reply").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+
+    let mut params = build_params(&workspace);
+    params.codex_disabled = true;
+    params.reply_to.clear();
+
+    let result = run_task(&params).unwrap();
+    assert!(!result.reply_html_path.exists());
     assert!(result.reply_attachments_dir.is_dir());
 }
 

--- a/DoWhiz_service/run_task_module/tests/support/mod.rs
+++ b/DoWhiz_service/run_task_module/tests/support/mod.rs
@@ -215,6 +215,7 @@ pub fn build_params(workspace: &Path) -> RunTaskParams {
         input_attachments_dir: PathBuf::from("incoming_attachments"),
         memory_dir: PathBuf::from("memory"),
         reference_dir: PathBuf::from("references"),
+        reply_to: vec!["user@example.com".to_string()],
         model_name: "test-model".to_string(),
         codex_disabled: false,
     }

--- a/DoWhiz_service/scheduler_module/src/lib.rs
+++ b/DoWhiz_service/scheduler_module/src/lib.rs
@@ -218,6 +218,7 @@ impl TaskExecutor for ModuleExecutor {
                     input_attachments_dir: task.input_attachments_dir.clone(),
                     memory_dir: task.memory_dir.clone(),
                     reference_dir: task.reference_dir.clone(),
+                    reply_to: task.reply_to.clone(),
                     model_name: task.model_name.clone(),
                     codex_disabled: task.codex_disabled,
                 };

--- a/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
@@ -76,6 +76,7 @@ impl TaskExecutor for RecordingExecutor {
                     input_attachments_dir: run.input_attachments_dir.clone(),
                     memory_dir: run.memory_dir.clone(),
                     reference_dir: run.reference_dir.clone(),
+                    reply_to: run.reply_to.clone(),
                     model_name: run.model_name.clone(),
                     codex_disabled: run.codex_disabled,
                 };

--- a/DoWhiz_service/scheduler_module/tests/scheduler_agent_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_agent_e2e.rs
@@ -48,6 +48,7 @@ impl TaskExecutor for RecordingExecutor {
                     input_attachments_dir: run.input_attachments_dir.clone(),
                     memory_dir: run.memory_dir.clone(),
                     reference_dir: run.reference_dir.clone(),
+                    reply_to: run.reply_to.clone(),
                     model_name: run.model_name.clone(),
                     codex_disabled: run.codex_disabled,
                 };

--- a/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
@@ -56,6 +56,7 @@ impl TaskExecutor for RecordingExecutor {
                     input_attachments_dir: run.input_attachments_dir.clone(),
                     memory_dir: run.memory_dir.clone(),
                     reference_dir: run.reference_dir.clone(),
+                    reply_to: run.reply_to.clone(),
                     model_name: run.model_name.clone(),
                     codex_disabled: run.codex_disabled,
                 };


### PR DESCRIPTION
## Summary\n- filter replyable recipients to local-part markers (noreply/no-reply/do-not-reply) and allow empty reply_to\n- pass reply_to into run_task prompts to skip drafting for non-replyable senders\n- add unit tests and update run_task docs\n\n## Testing\n- cargo test -p scheduler_module replyable_recipients\n- cargo test -p scheduler_module no_reply_detection\n- cargo test -p run_task_module build_prompt_skips_reply_instruction_for_non_replyable\n- cargo test -p run_task_module run_task_codex_disabled_skips_placeholder_without_reply_to