### PR TITLE
Clean inbound email HTML

### DIFF
--- a/DoWhiz_service/Cargo.lock
+++ b/DoWhiz_service/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
- "itoa",
+ "itoa 1.0.17",
  "matchit",
  "memchr",
  "mime",
@@ -166,6 +166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +260,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754b69d351cdc2d8ee09ae203db831e005560fc6030da058f86ad60c92a9cb0a"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa 0.4.8",
+ "matches",
+ "phf",
+ "proc-macro2",
+ "quote",
+ "smallvec",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,7 +307,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -263,6 +315,21 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
 
 [[package]]
 name = "email-encoding"
@@ -360,6 +427,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +482,26 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -483,6 +580,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,7 +601,7 @@ checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.17",
 ]
 
 [[package]]
@@ -500,7 +611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "itoa",
+ "itoa 1.0.17",
 ]
 
 [[package]]
@@ -564,7 +675,7 @@ dependencies = [
  "http-body 0.4.6",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.17",
  "pin-project-lite",
  "socket2 0.5.10",
  "tokio",
@@ -588,7 +699,7 @@ dependencies = [
  "http-body 1.0.1",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.17",
  "pin-project-lite",
  "pin-utils",
  "smallvec",
@@ -767,6 +878,12 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
@@ -779,6 +896,18 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kuchiki"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea8e9c6e031377cff82ee3001dc8026cdf431ed4e2e6b51f98ab8c73484a358"
+dependencies = [
+ "cssparser",
+ "html5ever",
+ "matches",
+ "selectors",
 ]
 
 [[package]]
@@ -853,6 +982,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,7 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -920,7 +1075,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand",
+ "rand 0.9.2",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -944,6 +1099,18 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -1020,7 +1187,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1071,6 +1238,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.8.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared 0.8.0",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher 0.3.11",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1345,18 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -1148,12 +1400,45 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1163,8 +1448,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1172,7 +1472,25 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1277,6 +1595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1655,7 @@ dependencies = [
  "chrono",
  "cron",
  "dotenvy",
+ "kuchiki",
  "lettre",
  "md5",
  "reqwest",
@@ -1374,6 +1702,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "selectors"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
+dependencies = [
+ "bitflags 1.3.2",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "matches",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+ "thin-slice",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "send_emails_module"
 version = "0.1.0"
 dependencies = [
@@ -1415,7 +1769,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1424,7 +1778,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "itoa",
+ "itoa 1.0.17",
  "memchr",
  "serde",
  "serde_core",
@@ -1437,7 +1791,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
- "itoa",
+ "itoa 1.0.17",
  "serde",
  "serde_core",
 ]
@@ -1449,9 +1803,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.17",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
+dependencies = [
+ "nodrop",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1484,6 +1848,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -1537,6 +1913,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,7 +1979,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1598,11 +2010,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "thin-slice"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
@@ -1621,7 +2050,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1668,7 +2097,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1742,7 +2171,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1811,6 +2240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,7 +2257,7 @@ version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -1854,6 +2289,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1916,7 +2357,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1960,7 +2401,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1971,7 +2412,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2270,7 +2711,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2291,7 +2732,7 @@ checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2311,7 +2752,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2345,7 +2786,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/DoWhiz_service/scheduler_module/Cargo.toml
+++ b/DoWhiz_service/scheduler_module/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 uuid = { version = "1", features = ["serde", "v4"] }
+kuchiki = "0.8"
 
 send_emails_module = { path = "../send_emails_module" }
 run_task_module = { path = "../run_task_module" }

--- a/DoWhiz_service/scheduler_module/src/service.rs
+++ b/DoWhiz_service/scheduler_module/src/service.rs
@@ -7,6 +7,8 @@ use axum::{Json, Router};
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 use chrono::{DateTime, Utc};
+use kuchiki::traits::*;
+use kuchiki::NodeRef;
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
@@ -87,12 +89,10 @@ impl ServiceConfig {
                     .to_string_lossy()
                     .into_owned()
             }))?;
-        let users_root = resolve_path(env::var("USERS_ROOT").unwrap_or_else(|_| {
-            runtime_root
-                .join("users")
-                .to_string_lossy()
-                .into_owned()
-        }))?;
+        let users_root = resolve_path(
+            env::var("USERS_ROOT")
+                .unwrap_or_else(|_| runtime_root.join("users").to_string_lossy().into_owned()),
+        )?;
         let users_db_path = resolve_path(env::var("USERS_DB_PATH").unwrap_or_else(|_| {
             runtime_root
                 .join("state")
@@ -1090,7 +1090,10 @@ fn truncate_ascii(value: &str, max_len: usize) -> String {
     }
 }
 
-fn write_thread_history(incoming_email: &Path, incoming_attachments: &Path) -> Result<(), BoxError> {
+fn write_thread_history(
+    incoming_email: &Path,
+    incoming_attachments: &Path,
+) -> Result<(), BoxError> {
     let entries_email = incoming_email.join("entries");
     if !entries_email.exists() {
         return Ok(());
@@ -1111,9 +1114,7 @@ fn write_thread_history(incoming_email: &Path, incoming_attachments: &Path) -> R
 
     let mut output = String::new();
     output.push_str("# Thread history (inbound)\n");
-    output.push_str(
-        "Auto-generated from incoming_email/entries. Latest entry is last.\n\n",
-    );
+    output.push_str("Auto-generated from incoming_email/entries. Latest entry is last.\n\n");
 
     for entry_dir in entry_dirs {
         let entry_name = entry_dir
@@ -1300,13 +1301,371 @@ fn create_unique_dir(root: &Path, base: &str) -> Result<PathBuf, io::Error> {
     ))
 }
 
+fn clean_inbound_html(html: &str) -> String {
+    let document = kuchiki::parse_html().one(html);
+    remove_html_comments(&document);
+    remove_elements_by_selector(
+        &document,
+        "head, script, style, meta, link, title, noscript",
+    );
+    remove_hidden_elements(&document);
+    remove_tracking_pixels(&document);
+    remove_footer_blocks(&document);
+    sanitize_allowed_elements(&document);
+    extract_body_html(&document)
+}
+
+fn remove_html_comments(document: &NodeRef) {
+    let nodes: Vec<NodeRef> = document.descendants().collect();
+    for node in nodes {
+        if node.as_comment().is_some() {
+            node.detach();
+        }
+    }
+}
+
+fn remove_elements_by_selector(document: &NodeRef, selector: &str) {
+    if let Ok(nodes) = document.select(selector) {
+        for node in nodes {
+            node.as_node().detach();
+        }
+    }
+}
+
+fn remove_hidden_elements(document: &NodeRef) {
+    let nodes: Vec<NodeRef> = document.descendants().collect();
+    for node in nodes {
+        let element = match node.as_element() {
+            Some(value) => value,
+            None => continue,
+        };
+        if is_hidden_element(element) {
+            node.detach();
+        }
+    }
+}
+
+fn remove_tracking_pixels(document: &NodeRef) {
+    let nodes: Vec<NodeRef> = document.descendants().collect();
+    for node in nodes {
+        let element = match node.as_element() {
+            Some(value) => value,
+            None => continue,
+        };
+        if element.name.local.as_ref() == "img" && is_tracking_pixel(element) {
+            node.detach();
+        }
+    }
+}
+
+fn remove_footer_blocks(document: &NodeRef) {
+    let nodes: Vec<NodeRef> = document.descendants().collect();
+    for node in nodes {
+        let element = match node.as_element() {
+            Some(value) => value,
+            None => continue,
+        };
+        let tag = element.name.local.as_ref();
+        if !is_footer_candidate(tag) {
+            continue;
+        }
+        if element_has_footer_marker(element) {
+            node.detach();
+            continue;
+        }
+        let text = node.text_contents();
+        if text_contains_footer_hint(&text) {
+            node.detach();
+        }
+    }
+}
+
+fn sanitize_allowed_elements(document: &NodeRef) {
+    let nodes: Vec<NodeRef> = document.descendants().collect();
+    for node in nodes {
+        let element = match node.as_element() {
+            Some(value) => value,
+            None => continue,
+        };
+        let tag = element.name.local.as_ref();
+        if is_drop_tag(tag) {
+            node.detach();
+            continue;
+        }
+        if !is_allowed_tag(tag) {
+            unwrap_node(&node);
+            continue;
+        }
+        prune_attributes(tag, element);
+    }
+}
+
+fn extract_body_html(document: &NodeRef) -> String {
+    if let Ok(mut bodies) = document.select("body") {
+        if let Some(body) = bodies.next() {
+            let mut out = String::new();
+            for child in body.as_node().children() {
+                out.push_str(&child.to_string());
+            }
+            return out;
+        }
+    }
+    document.to_string()
+}
+
+fn unwrap_node(node: &NodeRef) {
+    if node.parent().is_none() {
+        return;
+    }
+    let children: Vec<NodeRef> = node.children().collect();
+    for child in children {
+        node.insert_before(child);
+    }
+    node.detach();
+}
+
+fn is_allowed_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "html"
+            | "body"
+            | "p"
+            | "br"
+            | "div"
+            | "span"
+            | "a"
+            | "img"
+            | "ul"
+            | "ol"
+            | "li"
+            | "strong"
+            | "em"
+            | "b"
+            | "i"
+            | "u"
+            | "blockquote"
+            | "pre"
+            | "code"
+            | "h1"
+            | "h2"
+            | "h3"
+            | "h4"
+            | "h5"
+            | "h6"
+            | "table"
+            | "thead"
+            | "tbody"
+            | "tr"
+            | "td"
+            | "th"
+    )
+}
+
+fn is_drop_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "script" | "style" | "head" | "meta" | "link" | "title" | "noscript"
+    )
+}
+
+fn is_footer_candidate(tag: &str) -> bool {
+    matches!(
+        tag,
+        "div" | "p" | "span" | "td" | "li" | "section" | "footer"
+    )
+}
+
+fn element_has_footer_marker(element: &kuchiki::ElementData) -> bool {
+    let attrs = element.attributes.borrow();
+    for key in ["class", "id"] {
+        if let Some(value) = attrs.get(key) {
+            let lower = value.to_ascii_lowercase();
+            if lower.contains("footer")
+                || lower.contains("unsubscribe")
+                || lower.contains("notification")
+                || lower.contains("preferences")
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn text_contains_footer_hint(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    let hints = [
+        "unsubscribe",
+        "notification settings",
+        "manage notifications",
+        "email preferences",
+        "manage your email",
+        "view this email in your browser",
+        "view in browser",
+        "you are receiving this",
+        "to stop receiving",
+        "opt out",
+        "reply to this email directly",
+    ];
+    hints.iter().any(|hint| lower.contains(hint))
+}
+
+fn is_hidden_element(element: &kuchiki::ElementData) -> bool {
+    let attrs = element.attributes.borrow();
+    if attrs.contains("hidden") {
+        return true;
+    }
+    if let Some(value) = attrs.get("aria-hidden") {
+        if value.trim().eq_ignore_ascii_case("true") {
+            return true;
+        }
+    }
+    if let Some(style) = attrs.get("style") {
+        if style_contains_hidden(style) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_tracking_pixel(element: &kuchiki::ElementData) -> bool {
+    let attrs = element.attributes.borrow();
+    if let Some(style) = attrs.get("style") {
+        if style_contains_hidden(style) {
+            return true;
+        }
+    }
+    let src = attrs.get("src").unwrap_or("");
+    let src_lower = src.to_ascii_lowercase();
+    if src_lower.contains("tracking")
+        || src_lower.contains("pixel")
+        || src_lower.contains("beacon")
+        || src_lower.contains("open.gif")
+    {
+        return true;
+    }
+    let width = attrs.get("width").and_then(parse_dimension).or_else(|| {
+        attrs
+            .get("style")
+            .and_then(|style| style_dimension(style, "width"))
+    });
+    let height = attrs.get("height").and_then(parse_dimension).or_else(|| {
+        attrs
+            .get("style")
+            .and_then(|style| style_dimension(style, "height"))
+    });
+    matches_1x1(width, height)
+}
+
+fn matches_1x1(width: Option<u32>, height: Option<u32>) -> bool {
+    match (width, height) {
+        (Some(w), Some(h)) => w <= 1 && h <= 1,
+        (Some(w), None) => w <= 1,
+        (None, Some(h)) => h <= 1,
+        (None, None) => false,
+    }
+}
+
+fn style_contains_hidden(style: &str) -> bool {
+    let normalized: String = style
+        .to_ascii_lowercase()
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect();
+    normalized.contains("display:none")
+        || normalized.contains("visibility:hidden")
+        || normalized.contains("opacity:0")
+        || normalized.contains("max-height:0")
+}
+
+fn style_dimension(style: &str, key: &str) -> Option<u32> {
+    for part in style.split(';') {
+        let mut iter = part.splitn(2, ':');
+        let name = iter.next().unwrap_or("").trim().to_ascii_lowercase();
+        if name == key {
+            let value = iter.next().unwrap_or("").trim();
+            return parse_dimension(value);
+        }
+    }
+    None
+}
+
+fn parse_dimension(raw: &str) -> Option<u32> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let digits: String = trimmed
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+fn prune_attributes(tag: &str, element: &kuchiki::ElementData) {
+    let mut attrs = element.attributes.borrow_mut();
+    let mut to_remove = Vec::new();
+    for (name, _) in attrs.map.iter() {
+        let local = name.local.as_ref();
+        let keep = match tag {
+            "a" => matches!(local, "href"),
+            "img" => matches!(local, "src" | "alt" | "width" | "height"),
+            _ => false,
+        };
+        if !keep {
+            to_remove.push(name.clone());
+        }
+    }
+    for name in to_remove {
+        attrs.map.remove(&name);
+    }
+    if tag == "a" {
+        if let Some(href) = attrs.get("href").map(|value| value.to_string()) {
+            if !is_safe_link(&href) {
+                attrs.remove("href");
+            }
+        }
+    }
+    if tag == "img" {
+        if let Some(src) = attrs.get("src").map(|value| value.to_string()) {
+            if !is_safe_image_src(&src) {
+                attrs.remove("src");
+            }
+        }
+    }
+}
+
+fn is_safe_link(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    !(lower.starts_with("javascript:") || lower.starts_with("vbscript:"))
+}
+
+fn is_safe_image_src(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    !(lower.starts_with("javascript:") || lower.starts_with("vbscript:"))
+}
+
 fn render_email_html(payload: &PostmarkInbound) -> String {
     if let Some(html) = payload
         .html_body
         .as_deref()
         .filter(|value| !value.trim().is_empty())
     {
-        return html.to_string();
+        let cleaned = clean_inbound_html(html);
+        if !cleaned.trim().is_empty() {
+            return cleaned;
+        }
     }
 
     let text_body = payload
@@ -1422,9 +1781,7 @@ fn is_no_reply_address(address: &str) -> bool {
     if local.is_empty() {
         return false;
     }
-    NO_REPLY_LOCAL_PARTS
-        .iter()
-        .any(|marker| local == *marker)
+    NO_REPLY_LOCAL_PARTS.iter().any(|marker| local == *marker)
 }
 
 fn env_flag(key: &str, default: bool) -> bool {
@@ -1644,8 +2001,7 @@ mod tests {
         let incoming_attachments = archive_dir.join("incoming_attachments");
         fs::create_dir_all(&incoming_email).expect("incoming_email");
         fs::create_dir_all(&incoming_attachments).expect("incoming_attachments");
-        fs::write(incoming_email.join("email.html"), "<pre>Hello</pre>")
-            .expect("email.html");
+        fs::write(incoming_email.join("email.html"), "<pre>Hello</pre>").expect("email.html");
         let archived_payload = r#"{
   "From": "Alice <alice@example.com>",
   "To": "Bob <bob@example.com>",
@@ -1679,7 +2035,7 @@ mod tests {
             mailbox::WorkspacePersona::LittleBear,
             None,
         )
-            .expect("create workspace");
+        .expect("create workspace");
 
         let past_root = workspace.join("references").join("past_emails");
         let index_path = past_root.join("index.json");

--- a/DoWhiz_service/scheduler_module/tests/email_html_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/email_html_e2e.rs
@@ -1,0 +1,122 @@
+use scheduler_module::index_store::IndexStore;
+use scheduler_module::service::{
+    process_inbound_payload, PostmarkInbound, ServiceConfig, DEFAULT_INBOUND_BODY_MAX_BYTES,
+};
+use scheduler_module::user_store::UserStore;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tempfile::TempDir;
+
+fn first_dir(root: &Path) -> PathBuf {
+    let mut entries = fs::read_dir(root).expect("read dir");
+    while let Some(entry) = entries.next() {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            return path;
+        }
+    }
+    panic!("no directory found");
+}
+
+fn assert_clean_html(html: &str) {
+    let lower = html.to_ascii_lowercase();
+    assert!(html.contains("Hi @bingran-you"), "missing mention");
+    assert!(html.contains("New comment on"), "missing comment text");
+    assert!(
+        html.contains("https://github.com/KnoWhiz/DoWhiz/issues/102"),
+        "missing issue link"
+    );
+    assert!(html.contains("avatar.png"), "missing image");
+    assert!(!lower.contains("unsubscribe"), "footer still present");
+    assert!(
+        !lower.contains("display:none"),
+        "hidden block still present"
+    );
+    assert!(!lower.contains("<script"), "script tag still present");
+    assert!(!lower.contains("beacon"), "tracking pixel still present");
+    assert!(!html.contains("style="), "style attribute still present");
+    assert!(!html.contains("class="), "class attribute still present");
+    assert!(!html.contains("Hidden text"), "hidden text still present");
+}
+
+#[test]
+fn inbound_email_html_is_sanitized() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let temp = TempDir::new()?;
+    let root = temp.path();
+    let users_root = root.join("users");
+    let state_root = root.join("state");
+    fs::create_dir_all(&users_root)?;
+    fs::create_dir_all(&state_root)?;
+
+    let config = ServiceConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        workspace_root: root.join("workspaces"),
+        scheduler_state_path: state_root.join("tasks.db"),
+        processed_ids_path: state_root.join("processed_ids.txt"),
+        users_root: users_root.clone(),
+        users_db_path: state_root.join("users.db"),
+        task_index_path: state_root.join("task_index.db"),
+        codex_model: "gpt-5.2-codex".to_string(),
+        codex_disabled: true,
+        scheduler_poll_interval: Duration::from_millis(50),
+        scheduler_max_concurrency: 1,
+        scheduler_user_max_concurrency: 1,
+        inbound_body_max_bytes: DEFAULT_INBOUND_BODY_MAX_BYTES,
+        skills_source_dir: None,
+    };
+
+    let user_store = UserStore::new(&config.users_db_path)?;
+    let index_store = IndexStore::new(&config.task_index_path)?;
+
+    let html_body = r#"
+<html>
+  <head>
+    <style>.footer{color:#999}</style>
+    <script>alert('x')</script>
+  </head>
+  <body>
+    <div>
+      <p>Hi @bingran-you,</p>
+      <p>New comment on <a href="https://github.com/KnoWhiz/DoWhiz/issues/102">issue #102</a>.</p>
+      <img src="https://github.com/images/avatar.png" alt="avatar" width="24" height="24" style="border-radius:12px" />
+    </div>
+    <div style="display:none">Hidden text</div>
+    <img src="https://github.com/notifications/beacon/abc?pixel=true" width="1" height="1" />
+    <p class="footer">Reply to this email directly, view it on GitHub, or <a href="https://github.com/notifications/unsubscribe">unsubscribe</a>.</p>
+  </body>
+</html>
+"#;
+
+    let payload_value = serde_json::json!({
+        "From": "Alice <alice@example.com>",
+        "To": "Service <service@example.com>",
+        "Subject": "Issue update",
+        "TextBody": "Plain text fallback",
+        "HtmlBody": html_body,
+        "Headers": [{"Name": "Message-ID", "Value": "<msg-1@example.com>"}]
+    });
+    let inbound_raw = serde_json::to_string(&payload_value)?;
+    let payload: PostmarkInbound = serde_json::from_str(&inbound_raw)?;
+    process_inbound_payload(
+        &config,
+        &user_store,
+        &index_store,
+        &payload,
+        inbound_raw.as_bytes(),
+    )?;
+
+    let user = user_store.get_or_create_user("alice@example.com")?;
+    let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
+    let workspace = first_dir(&user_paths.workspaces_root);
+
+    let email_html = fs::read_to_string(workspace.join("incoming_email").join("email.html"))?;
+    assert_clean_html(&email_html);
+
+    let entry_dir = first_dir(&workspace.join("incoming_email").join("entries"));
+    let entry_html = fs::read_to_string(entry_dir.join("email.html"))?;
+    assert_clean_html(&entry_html);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- sanitize inbound email HTML to keep readable text, images, and links
- strip hidden/tracking/footer blocks and unsafe attributes
- add an end-to-end test covering incoming email.html and entries

## Testing
- cargo test -p scheduler_module --test email_html_e2e