### PR TITLE
Reorder landing page sections

### DIFF
--- a/website/SEO_TOP_PAGES.md
+++ b/website/SEO_TOP_PAGES.md
@@ -5,7 +5,7 @@ As of 2026-02-15, the website repo exposes 12 indexable pages. This list documen
 1. https://dowhiz.com/
 H1 count: 1
 H1: Empower Everyone with A Digital Employee Team
-H2: The Digital Employee Stack, Meet Your Digital Employee Team
+H2: Meet Your Digital Employee Team, The Digital Employee Stack
 
 2. https://dowhiz.com/privacy/
 H1 count: 1

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -457,25 +457,6 @@ function App() {
           </div>
         </section>
 
-        {/* Features */}
-        <section id="features" className="section features-section">
-          <div className="container">
-            <h2 className="section-title">The Digital Employee Stack</h2>
-            <p className="section-intro">
-              Built for real teams that live in their inbox. Pick an employee, send a request, and receive finished work with clear next steps.
-            </p>
-            <div className="features-grid">
-              {features.map((feature) => (
-                <div key={feature.tag} className="feature-card">
-                  <span className="feature-tag">{feature.tag}</span>
-                  <h3>{feature.title}</h3>
-                  <p>{feature.desc}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
         {/* Roles & Scenarios */}
         <section id="roles" className="section roles-section">
           <div className="container">
@@ -539,6 +520,25 @@ function App() {
                   </div>
                 );
               })}
+            </div>
+          </div>
+        </section>
+
+        {/* Features */}
+        <section id="features" className="section features-section">
+          <div className="container">
+            <h2 className="section-title">The Digital Employee Stack</h2>
+            <p className="section-intro">
+              Built for real teams that live in their inbox. Pick an employee, send a request, and receive finished work with clear next steps.
+            </p>
+            <div className="features-grid">
+              {features.map((feature) => (
+                <div key={feature.tag} className="feature-card">
+                  <span className="feature-tag">{feature.tag}</span>
+                  <h3>{feature.title}</h3>
+                  <p>{feature.desc}</p>
+                </div>
+              ))}
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary\n- move the roles section before the features section on the landing page\n- update the SEO top pages doc to reflect the new H2 order\n\n## Testing\n- not run (content/order-only change)