### PR TITLE
SEO: add contextual internal links + nav order

### DIFF
--- a/website/public/agent.css
+++ b/website/public/agent.css
@@ -196,6 +196,51 @@ h1 {
   margin-bottom: 1.5rem;
 }
 
+.related-section {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  padding: 2rem;
+}
+
+.related-intro {
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+  max-width: 720px;
+}
+
+.related-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.related-link {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.2rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  transition: all 0.2s ease;
+}
+
+.related-link:hover {
+  border-color: rgba(59, 130, 246, 0.5);
+  background: rgba(59, 130, 246, 0.08);
+  transform: translateY(-2px);
+}
+
+.related-link-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.related-link-desc {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 .info-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/website/public/agents/anna/index.html
+++ b/website/public/agents/anna/index.html
@@ -14,8 +14,8 @@
       <header class="page-header">
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
-          <a href="/#features">Features</a>
           <a href="/#roles">Team</a>
+          <a href="/#features">Features</a>
           <a href="/user-guide/">User Guide</a>
         </nav>
       </header>
@@ -117,6 +117,29 @@
               <div class="output-line">Pilot: 4 week trial with two accounts.</div>
               <div class="output-line">Success metrics: NPS uplift and churn reduction.</div>
             </div>
+          </div>
+        </section>
+
+        <section class="section related-section">
+          <h2>Explore more of the DoWhiz team</h2>
+          <p class="related-intro">Pair Anna's work with another specialist or start with the quick guide.</p>
+          <div class="related-links">
+            <a class="related-link" href="/user-guide/">
+              <span class="related-link-title">Start with the user guide</span>
+              <span class="related-link-desc">Setup tips, request templates, and workflow basics.</span>
+            </a>
+            <a class="related-link" href="/agents/rachel/">
+              <span class="related-link-title">Meet Rachel (GTM Specialist)</span>
+              <span class="related-link-desc">Plans launches and multi-channel GTM posts.</span>
+            </a>
+            <a class="related-link" href="/agents/oliver/">
+              <span class="related-link-title">Meet Oliver (Writer)</span>
+              <span class="related-link-desc">Drafts memos, summaries, and structured docs.</span>
+            </a>
+            <a class="related-link" href="/agents/maggie/">
+              <span class="related-link-title">Meet Maggie (TPM)</span>
+              <span class="related-link-desc">Turns updates into clear status, risks, and plans.</span>
+            </a>
           </div>
         </section>
       </main>

--- a/website/public/agents/claw/index.html
+++ b/website/public/agents/claw/index.html
@@ -14,8 +14,8 @@
       <header class="page-header">
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
-          <a href="/#features">Features</a>
           <a href="/#roles">Team</a>
+          <a href="/#features">Features</a>
           <a href="/user-guide/">User Guide</a>
         </nav>
       </header>
@@ -117,6 +117,29 @@
               <div class="output-line">Flow: Intake -> triage -> weekly review -> archive.</div>
               <div class="output-line">Automation: Auto label, reminders, and weekly digest.</div>
             </div>
+          </div>
+        </section>
+
+        <section class="section related-section">
+          <h2>Explore more of the DoWhiz team</h2>
+          <p class="related-intro">Pair Claw's work with another specialist or start with the quick guide.</p>
+          <div class="related-links">
+            <a class="related-link" href="/user-guide/">
+              <span class="related-link-title">Start with the user guide</span>
+              <span class="related-link-desc">Setup tips, request templates, and workflow basics.</span>
+            </a>
+            <a class="related-link" href="/agents/jeffery/">
+              <span class="related-link-title">Meet Jeffery (DeepTutor)</span>
+              <span class="related-link-desc">Explains hard topics with step-by-step guides.</span>
+            </a>
+            <a class="related-link" href="/agents/anna/">
+              <span class="related-link-title">Meet Anna (Role TBD)</span>
+              <span class="related-link-desc">Helps shape and define new specialist roles.</span>
+            </a>
+            <a class="related-link" href="/agents/rachel/">
+              <span class="related-link-title">Meet Rachel (GTM Specialist)</span>
+              <span class="related-link-desc">Plans launches and multi-channel GTM posts.</span>
+            </a>
           </div>
         </section>
       </main>

--- a/website/public/agents/devin/index.html
+++ b/website/public/agents/devin/index.html
@@ -14,8 +14,8 @@
       <header class="page-header">
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
-          <a href="/#features">Features</a>
           <a href="/#roles">Team</a>
+          <a href="/#features">Features</a>
           <a href="/user-guide/">User Guide</a>
         </nav>
       </header>
@@ -117,6 +117,29 @@
               <div class="output-line">Tests: Added 4 unit tests, all green on CI.</div>
               <div class="output-line">Notes: Requires new ENV var EXPORT_BUCKET.</div>
             </div>
+          </div>
+        </section>
+
+        <section class="section related-section">
+          <h2>Explore more of the DoWhiz team</h2>
+          <p class="related-intro">Pair Devin's work with another specialist or start with the quick guide.</p>
+          <div class="related-links">
+            <a class="related-link" href="/user-guide/">
+              <span class="related-link-title">Start with the user guide</span>
+              <span class="related-link-desc">Setup tips, request templates, and workflow basics.</span>
+            </a>
+            <a class="related-link" href="/agents/lumio/">
+              <span class="related-link-title">Meet Lumio (CEO)</span>
+              <span class="related-link-desc">Shapes strategy, decisions, and executive briefings.</span>
+            </a>
+            <a class="related-link" href="/agents/claw/">
+              <span class="related-link-title">Meet Claw (OpenClaw)</span>
+              <span class="related-link-desc">Supports OpenClaw workflows and debugging help.</span>
+            </a>
+            <a class="related-link" href="/agents/jeffery/">
+              <span class="related-link-title">Meet Jeffery (DeepTutor)</span>
+              <span class="related-link-desc">Explains hard topics with step-by-step guides.</span>
+            </a>
           </div>
         </section>
       </main>

--- a/website/public/agents/jeffery/index.html
+++ b/website/public/agents/jeffery/index.html
@@ -14,8 +14,8 @@
       <header class="page-header">
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
-          <a href="/#features">Features</a>
           <a href="/#roles">Team</a>
+          <a href="/#features">Features</a>
           <a href="/user-guide/">User Guide</a>
         </nav>
       </header>
@@ -117,6 +117,29 @@
               <div class="output-line">Key results: Gains hold across three benchmark datasets.</div>
               <div class="output-line">Open questions: Compute cost and scaling behavior.</div>
             </div>
+          </div>
+        </section>
+
+        <section class="section related-section">
+          <h2>Explore more of the DoWhiz team</h2>
+          <p class="related-intro">Pair Jeffery's work with another specialist or start with the quick guide.</p>
+          <div class="related-links">
+            <a class="related-link" href="/user-guide/">
+              <span class="related-link-title">Start with the user guide</span>
+              <span class="related-link-desc">Setup tips, request templates, and workflow basics.</span>
+            </a>
+            <a class="related-link" href="/agents/anna/">
+              <span class="related-link-title">Meet Anna (Role TBD)</span>
+              <span class="related-link-desc">Helps shape and define new specialist roles.</span>
+            </a>
+            <a class="related-link" href="/agents/rachel/">
+              <span class="related-link-title">Meet Rachel (GTM Specialist)</span>
+              <span class="related-link-desc">Plans launches and multi-channel GTM posts.</span>
+            </a>
+            <a class="related-link" href="/agents/oliver/">
+              <span class="related-link-title">Meet Oliver (Writer)</span>
+              <span class="related-link-desc">Drafts memos, summaries, and structured docs.</span>
+            </a>
           </div>
         </section>
       </main>

--- a/website/public/agents/lumio/index.html
+++ b/website/public/agents/lumio/index.html
@@ -14,8 +14,8 @@
       <header class="page-header">
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
-          <a href="/#features">Features</a>
           <a href="/#roles">Team</a>
+          <a href="/#features">Features</a>
           <a href="/user-guide/">User Guide</a>
         </nav>
       </header>
@@ -117,6 +117,29 @@
               <div class="output-line">Trade offs: Slower enterprise growth, faster adoption.</div>
               <div class="output-line">Next step: Pilot with three design partners by April.</div>
             </div>
+          </div>
+        </section>
+
+        <section class="section related-section">
+          <h2>Explore more of the DoWhiz team</h2>
+          <p class="related-intro">Pair Lumio's work with another specialist or start with the quick guide.</p>
+          <div class="related-links">
+            <a class="related-link" href="/user-guide/">
+              <span class="related-link-title">Start with the user guide</span>
+              <span class="related-link-desc">Setup tips, request templates, and workflow basics.</span>
+            </a>
+            <a class="related-link" href="/agents/claw/">
+              <span class="related-link-title">Meet Claw (OpenClaw)</span>
+              <span class="related-link-desc">Supports OpenClaw workflows and debugging help.</span>
+            </a>
+            <a class="related-link" href="/agents/jeffery/">
+              <span class="related-link-title">Meet Jeffery (DeepTutor)</span>
+              <span class="related-link-desc">Explains hard topics with step-by-step guides.</span>
+            </a>
+            <a class="related-link" href="/agents/anna/">
+              <span class="related-link-title">Meet Anna (Role TBD)</span>
+              <span class="related-link-desc">Helps shape and define new specialist roles.</span>
+            </a>
           </div>
         </section>
       </main>

--- a/website/public/agents/maggie/index.html
+++ b/website/public/agents/maggie/index.html
@@ -14,8 +14,8 @@
       <header class="page-header">
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
-          <a href="/#features">Features</a>
           <a href="/#roles">Team</a>
+          <a href="/#features">Features</a>
           <a href="/user-guide/">User Guide</a>
         </nav>
       </header>
@@ -117,6 +117,29 @@
               <div class="output-line">Risks: Vendor response pending, may slip by 2 days.</div>
               <div class="output-line">Actions: Alex to confirm budget, Priya to review rollout doc.</div>
             </div>
+          </div>
+        </section>
+
+        <section class="section related-section">
+          <h2>Explore more of the DoWhiz team</h2>
+          <p class="related-intro">Pair Maggie's work with another specialist or start with the quick guide.</p>
+          <div class="related-links">
+            <a class="related-link" href="/user-guide/">
+              <span class="related-link-title">Start with the user guide</span>
+              <span class="related-link-desc">Setup tips, request templates, and workflow basics.</span>
+            </a>
+            <a class="related-link" href="/agents/devin/">
+              <span class="related-link-title">Meet Devin (Coder)</span>
+              <span class="related-link-desc">Ships fixes, reviews code, and builds scripts.</span>
+            </a>
+            <a class="related-link" href="/agents/lumio/">
+              <span class="related-link-title">Meet Lumio (CEO)</span>
+              <span class="related-link-desc">Shapes strategy, decisions, and executive briefings.</span>
+            </a>
+            <a class="related-link" href="/agents/claw/">
+              <span class="related-link-title">Meet Claw (OpenClaw)</span>
+              <span class="related-link-desc">Supports OpenClaw workflows and debugging help.</span>
+            </a>
           </div>
         </section>
       </main>

--- a/website/public/agents/oliver/index.html
+++ b/website/public/agents/oliver/index.html
@@ -14,8 +14,8 @@
       <header class="page-header">
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
-          <a href="/#features">Features</a>
           <a href="/#roles">Team</a>
+          <a href="/#features">Features</a>
           <a href="/user-guide/">User Guide</a>
         </nav>
       </header>
@@ -117,6 +117,29 @@
               <div class="output-line">Highlights: Launch plan approved, vendor shortlist narrowed to two.</div>
               <div class="output-line">Next steps: Finalize budget, send comms draft by Thursday.</div>
             </div>
+          </div>
+        </section>
+
+        <section class="section related-section">
+          <h2>Explore more of the DoWhiz team</h2>
+          <p class="related-intro">Pair Oliver's work with another specialist or start with the quick guide.</p>
+          <div class="related-links">
+            <a class="related-link" href="/user-guide/">
+              <span class="related-link-title">Start with the user guide</span>
+              <span class="related-link-desc">Setup tips, request templates, and workflow basics.</span>
+            </a>
+            <a class="related-link" href="/agents/maggie/">
+              <span class="related-link-title">Meet Maggie (TPM)</span>
+              <span class="related-link-desc">Turns updates into clear status, risks, and plans.</span>
+            </a>
+            <a class="related-link" href="/agents/devin/">
+              <span class="related-link-title">Meet Devin (Coder)</span>
+              <span class="related-link-desc">Ships fixes, reviews code, and builds scripts.</span>
+            </a>
+            <a class="related-link" href="/agents/lumio/">
+              <span class="related-link-title">Meet Lumio (CEO)</span>
+              <span class="related-link-desc">Shapes strategy, decisions, and executive briefings.</span>
+            </a>
           </div>
         </section>
       </main>

--- a/website/public/agents/rachel/index.html
+++ b/website/public/agents/rachel/index.html
@@ -14,8 +14,8 @@
       <header class="page-header">
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
-          <a href="/#features">Features</a>
           <a href="/#roles">Team</a>
+          <a href="/#features">Features</a>
           <a href="/user-guide/">User Guide</a>
         </nav>
       </header>
@@ -117,6 +117,29 @@
               <div class="output-line">Week 2: Product Hunt launch with demo clip.</div>
               <div class="output-line">Metrics: Track signups, CTR, and retention.</div>
             </div>
+          </div>
+        </section>
+
+        <section class="section related-section">
+          <h2>Explore more of the DoWhiz team</h2>
+          <p class="related-intro">Pair Rachel's work with another specialist or start with the quick guide.</p>
+          <div class="related-links">
+            <a class="related-link" href="/user-guide/">
+              <span class="related-link-title">Start with the user guide</span>
+              <span class="related-link-desc">Setup tips, request templates, and workflow basics.</span>
+            </a>
+            <a class="related-link" href="/agents/oliver/">
+              <span class="related-link-title">Meet Oliver (Writer)</span>
+              <span class="related-link-desc">Drafts memos, summaries, and structured docs.</span>
+            </a>
+            <a class="related-link" href="/agents/maggie/">
+              <span class="related-link-title">Meet Maggie (TPM)</span>
+              <span class="related-link-desc">Turns updates into clear status, risks, and plans.</span>
+            </a>
+            <a class="related-link" href="/agents/devin/">
+              <span class="related-link-title">Meet Devin (Coder)</span>
+              <span class="related-link-desc">Ships fixes, reviews code, and builds scripts.</span>
+            </a>
           </div>
         </section>
       </main>

--- a/website/public/legal.css
+++ b/website/public/legal.css
@@ -147,6 +147,43 @@ h1 {
   margin-top: 1rem;
 }
 
+.related-intro {
+  color: var(--muted);
+  margin-bottom: 1.25rem;
+}
+
+.related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.related-item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.95rem 1.1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  transition: all 0.2s ease;
+}
+
+.related-item:hover {
+  border-color: rgba(59, 130, 246, 0.5);
+  background: rgba(59, 130, 246, 0.08);
+  transform: translateY(-2px);
+}
+
+.related-item-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.related-item-desc {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 .page-footer {
   margin-top: 3rem;
   padding-top: 2rem;

--- a/website/public/privacy/index.html
+++ b/website/public/privacy/index.html
@@ -104,6 +104,29 @@
             if changes are material.
           </p>
         </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Learn how to work with the team and review the service basics.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/user-guide/">
+              <span class="related-item-title">User guide</span>
+              <span class="related-item-desc">Setup tips and request templates.</span>
+            </a>
+            <a class="related-item" href="/terms/">
+              <span class="related-item-title">Terms of Service</span>
+              <span class="related-item-desc">Usage expectations and account responsibilities.</span>
+            </a>
+            <a class="related-item" href="/agents/oliver/">
+              <span class="related-item-title">Meet Oliver</span>
+              <span class="related-item-desc">Writer who turns notes into clean drafts.</span>
+            </a>
+            <a class="related-item" href="/agents/devin/">
+              <span class="related-item-title">Meet Devin</span>
+              <span class="related-item-desc">Coder who ships fixes and reviews code.</span>
+            </a>
+          </div>
+        </section>
       </main>
 
       <footer class="page-footer">

--- a/website/public/terms/index.html
+++ b/website/public/terms/index.html
@@ -127,6 +127,29 @@
             if changes are material.
           </p>
         </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Explore more on how to use DoWhiz and meet the team.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/user-guide/">
+              <span class="related-item-title">User guide</span>
+              <span class="related-item-desc">Setup tips and request templates.</span>
+            </a>
+            <a class="related-item" href="/privacy/">
+              <span class="related-item-title">Privacy policy</span>
+              <span class="related-item-desc">How we collect and protect your data.</span>
+            </a>
+            <a class="related-item" href="/agents/maggie/">
+              <span class="related-item-title">Meet Maggie</span>
+              <span class="related-item-desc">TPM who delivers crisp status and plans.</span>
+            </a>
+            <a class="related-item" href="/agents/lumio/">
+              <span class="related-item-title">Meet Lumio</span>
+              <span class="related-item-desc">CEO who shapes strategy and decisions.</span>
+            </a>
+          </div>
+        </section>
       </main>
 
       <footer class="page-footer">

--- a/website/public/user-guide/index.html
+++ b/website/public/user-guide/index.html
@@ -92,6 +92,29 @@
             or support, email admin@dowhiz.com.
           </p>
         </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Keep exploring to understand the service and meet key specialists.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/privacy/">
+              <span class="related-item-title">Privacy policy</span>
+              <span class="related-item-desc">How we collect and protect your data.</span>
+            </a>
+            <a class="related-item" href="/terms/">
+              <span class="related-item-title">Terms of Service</span>
+              <span class="related-item-desc">Usage expectations and account responsibilities.</span>
+            </a>
+            <a class="related-item" href="/agents/oliver/">
+              <span class="related-item-title">Meet Oliver</span>
+              <span class="related-item-desc">Writer who turns notes into clear deliverables.</span>
+            </a>
+            <a class="related-item" href="/agents/devin/">
+              <span class="related-item-title">Meet Devin</span>
+              <span class="related-item-desc">Coder who ships fixes and reviews code.</span>
+            </a>
+          </div>
+        </section>
       </main>
 
       <footer class="page-footer">

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -459,8 +459,8 @@ function App() {
           <div className="container nav-content">
             <a href="#" className="logo">Do<span className="text-gradient">Whiz</span></a>
             <div className="nav-links">
-              <a href="#features" className="nav-btn">Features</a>
               <a href="#roles" className="nav-btn">Team</a>
+              <a href="#features" className="nav-btn">Features</a>
               <a href="/user-guide/" className="nav-btn">User Guide</a>
             </div>
             <div className="nav-actions">
@@ -590,6 +590,38 @@ function App() {
                   <p>{feature.desc}</p>
                 </div>
               ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Explore */}
+        <section className="section explore-section">
+          <div className="container">
+            <h2 className="section-title">Keep exploring</h2>
+            <p className="section-intro">
+              Jump to the most helpful pages to understand the team, workflows, and how to get started fast.
+            </p>
+            <div className="explore-grid">
+              <a className="explore-card" href="/user-guide/">
+                <span className="explore-eyebrow">Get started</span>
+                <h3>User guide</h3>
+                <p>Setup tips, request templates, and workflow basics for working with DoWhiz.</p>
+              </a>
+              <a className="explore-card" href="/agents/oliver/">
+                <span className="explore-eyebrow">Writer</span>
+                <h3>Meet Oliver</h3>
+                <p>See how Oliver turns briefs into crisp drafts, summaries, and structured docs.</p>
+              </a>
+              <a className="explore-card" href="/agents/devin/">
+                <span className="explore-eyebrow">Coder</span>
+                <h3>Meet Devin</h3>
+                <p>Ship fixes, review code, and build scripts with a developer-minded teammate.</p>
+              </a>
+              <a className="explore-card" href="/agents/maggie/">
+                <span className="explore-eyebrow">TPM</span>
+                <h3>Meet Maggie</h3>
+                <p>Stay aligned with crisp status updates, risks, and action plans.</p>
+              </a>
             </div>
           </div>
         </section>

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -488,6 +488,48 @@ ul {
   line-height: 1.7;
 }
 
+/* Explore */
+.explore-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.explore-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 2.25rem;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 1.4rem;
+  backdrop-filter: blur(10px);
+  transition: all 0.3s ease;
+}
+
+.explore-card:hover {
+  border-color: var(--card-hover-border);
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateY(-4px);
+}
+
+.explore-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.explore-card h3 {
+  font-size: 1.4rem;
+}
+
+.explore-card p {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
 /* Roles */
 .roles-grid {
   display: grid;
@@ -1014,6 +1056,10 @@ ul {
     grid-template-columns: 1fr 1fr;
   }
 
+  .explore-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .roles-grid {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -1101,6 +1147,7 @@ ul {
 
   /* Card Spacing */
   .features-grid,
+  .explore-grid,
   .roles-grid,
   .security-grid {
     grid-template-columns: 1fr;
@@ -1108,6 +1155,7 @@ ul {
   }
 
   .feature-card,
+  .explore-card,
   .role-card,
   .security-card {
     padding: 1.5rem;


### PR DESCRIPTION
## Summary
- add contextual internal link sections across priority pages
- align header nav order (Team before Features) on landing + agent pages
- add related resources sections on legal/user-guide pages and styling updates

## Testing
- Not run (static HTML/CSS changes)