### PR TITLE
SEO: enforce HTTPS redirects

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -37,8 +37,16 @@ Nginx example:
 ```nginx
 server {
     listen 80;
-    server_name www.dowhiz.com;
+    server_name dowhiz.com www.dowhiz.com;
 
+    return 301 https://dowhiz.com$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name dowhiz.com www.dowhiz.com;
+
+    # SSL config omitted; use certbot or your provider's recommendations.
     root /home/azureuser/DoWhiz/website/dist;
     try_files $uri /index.html;
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,16 @@
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "header",
+          "key": "x-forwarded-proto",
+          "value": "http"
+        }
+      ],
+      "destination": "https://dowhiz.com/:path*",
+      "statusCode": 301
+    }
+  ]
+}


### PR DESCRIPTION
## Summary\n- add Vercel 301 redirect from HTTP to HTTPS\n- update Nginx example with HTTP->HTTPS redirect and HTTPS server block\n\n## Testing\n- not run (docs/config only)\n\nFixes #185