### PR TITLE
Improve mobile performance for top pages

### DIFF
--- a/website/public/agent.css
+++ b/website/public/agent.css
@@ -189,6 +189,8 @@ h1 {
 
 .section {
   margin-top: 3.5rem;
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 700px;
 }
 
 .section h2 {
@@ -474,6 +476,10 @@ h1 {
     grid-template-columns: 1fr;
   }
 
+  .hero-card {
+    backdrop-filter: none;
+  }
+
   .info-grid,
   .examples-grid,
   .flow-track {
@@ -499,5 +505,13 @@ h1 {
   .hero-cta {
     flex-direction: column;
     align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flow-track::before,
+  .step-dot,
+  .output-preview::after {
+    animation: none;
   }
 }

--- a/website/public/legal.css
+++ b/website/public/legal.css
@@ -119,6 +119,8 @@ h1 {
   padding: 2.25rem;
   margin-bottom: 1.75rem;
   backdrop-filter: blur(10px);
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 520px;
 }
 
 .legal-card h2 {
@@ -223,10 +225,18 @@ h1 {
 
   .legal-card {
     padding: 1.5rem;
+    backdrop-filter: none;
   }
 
   .page-footer {
     flex-direction: column;
     align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  a,
+  .related-item {
+    transition: none;
   }
 }

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1,6 +1,3 @@
-/* Google Fonts Import */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
 :root {
   /* Colors */
   --bg-color: #050505;
@@ -235,6 +232,8 @@ ul {
 .section {
   padding: var(--section-padding);
   position: relative;
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 900px;
 }
 
 .section-title {
@@ -1066,6 +1065,24 @@ ul {
 }
 
 @media (max-width: 768px) {
+  .mouse-field {
+    display: none;
+  }
+
+  .navbar {
+    backdrop-filter: none;
+  }
+
+  .feature-card {
+    backdrop-filter: none;
+  }
+
+  .halo-effect {
+    width: 540px;
+    height: 540px;
+    filter: blur(36px);
+  }
+
   .hero-title {
     font-size: 2.5rem;
     padding: 0 1rem;
@@ -1222,5 +1239,22 @@ ul {
     flex-direction: column;
     align-items: center;
     text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .hero-title,
+  .hero-subtitle,
+  .hero-cta {
+    animation: none;
+    opacity: 1;
+  }
+
+  .workflow-line {
+    animation: none;
   }
 }


### PR DESCRIPTION
## Summary\n- Defer the homepage mouse-field until idle and skip it on mobile/reduced-data connections\n- Lazy-load and de-prioritize role avatars\n- Reduce main-thread work with content-visibility and toned-down effects on mobile; respect prefers-reduced-motion\n\n## Testing\n- Not run (not available in this environment)