### PR TITLE
Feature/task watchdog

### DIFF
--- a/DoWhiz_service/scheduler_module/src/lib.rs
+++ b/DoWhiz_service/scheduler_module/src/lib.rs
@@ -975,6 +975,31 @@ impl<E: TaskExecutor> Scheduler<E> {
         }
         Ok(())
     }
+
+    /// Get the current retry count for a task
+    pub fn get_retry_count(&self, task_id: &str) -> Result<u32, SchedulerError> {
+        self.store.get_retry_count(task_id)
+    }
+
+    /// Increment the retry count for a task and return the new count
+    pub fn increment_retry_count(&self, task_id: &str) -> Result<u32, SchedulerError> {
+        self.store.increment_retry_count(task_id)
+    }
+
+    /// Reset the retry count for a task (after successful execution)
+    pub fn reset_retry_count(&self, task_id: &str) -> Result<(), SchedulerError> {
+        self.store.reset_retry_count(task_id)
+    }
+
+    /// Disable a task by its ID (used when max retries exceeded)
+    pub fn disable_task_by_id(&mut self, task_id: &str) -> Result<(), SchedulerError> {
+        // Update in-memory task list
+        if let Some(task) = self.tasks.iter_mut().find(|t| t.id.to_string() == task_id) {
+            task.enabled = false;
+        }
+        // Update in database
+        self.store.disable_task_by_id(task_id)
+    }
 }
 
 impl ScheduledTask {
@@ -1018,7 +1043,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     schedule_type TEXT NOT NULL,
     cron_expression TEXT,
     next_run TEXT,
-    run_at TEXT
+    run_at TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS send_email_tasks (
@@ -1143,6 +1169,13 @@ fn ensure_tasks_columns(conn: &Connection) -> Result<(), SchedulerError> {
     if !columns.contains("channel") {
         conn.execute(
             "ALTER TABLE tasks ADD COLUMN channel TEXT NOT NULL DEFAULT 'email'",
+            [],
+        )?;
+    }
+
+    if !columns.contains("retry_count") {
+        conn.execute(
+            "ALTER TABLE tasks ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0",
             [],
         )?;
     }
@@ -1910,6 +1943,52 @@ impl SqliteSchedulerStore {
         ensure_send_bluebubbles_tasks_table(&conn)?;
         ensure_run_task_task_columns(&conn)?;
         Ok(conn)
+    }
+
+    /// Get the current retry count for a task
+    pub fn get_retry_count(&self, task_id: &str) -> Result<u32, SchedulerError> {
+        let conn = self.open()?;
+        let count: i64 = conn.query_row(
+            "SELECT retry_count FROM tasks WHERE id = ?1",
+            params![task_id],
+            |row| row.get(0),
+        ).unwrap_or(0);
+        Ok(count as u32)
+    }
+
+    /// Increment the retry count for a task and return the new count
+    pub fn increment_retry_count(&self, task_id: &str) -> Result<u32, SchedulerError> {
+        let conn = self.open()?;
+        conn.execute(
+            "UPDATE tasks SET retry_count = retry_count + 1 WHERE id = ?1",
+            params![task_id],
+        )?;
+        let count: i64 = conn.query_row(
+            "SELECT retry_count FROM tasks WHERE id = ?1",
+            params![task_id],
+            |row| row.get(0),
+        )?;
+        Ok(count as u32)
+    }
+
+    /// Reset the retry count for a task (after successful execution)
+    pub fn reset_retry_count(&self, task_id: &str) -> Result<(), SchedulerError> {
+        let conn = self.open()?;
+        conn.execute(
+            "UPDATE tasks SET retry_count = 0 WHERE id = ?1",
+            params![task_id],
+        )?;
+        Ok(())
+    }
+
+    /// Disable a task by its ID (used when max retries exceeded)
+    pub fn disable_task_by_id(&self, task_id: &str) -> Result<(), SchedulerError> {
+        let conn = self.open()?;
+        conn.execute(
+            "UPDATE tasks SET enabled = 0 WHERE id = ?1",
+            params![task_id],
+        )?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- Add background watchdog thread to detect and recover from stuck/crashed tasks
- Tasks timeout after 10 minutes (configurable via TASK_TIMEOUT_SECS)
- Auto-retry up to 3 times, then disable task and notify user
- Add retry_count column to tasks database with migration

## Test plan
- [x] Build passes
- [ ] Test task timeout detection
- [ ] Verify retry count increments correctly