### PR TITLE
chore: Remove GOOGLE_ACCESS_TOKEN from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,10 +103,6 @@ GOOGLE_CLIENT_SECRET=
 GOOGLE_REFRESH_TOKEN_BOILED_EGG=
 GOOGLE_REFRESH_TOKEN_LITTLE_BEAR=
 
-# Optional: Pre-generated access token for sandbox environments
-# This is auto-generated at runtime, but can be set manually for testing
-GOOGLE_ACCESS_TOKEN=
-
 # Google Docs polling configuration
 GOOGLE_DOCS_ENABLED=true
 GOOGLE_DOCS_POLL_INTERVAL_SECS=30


### PR DESCRIPTION
This variable was causing confusion - it's only meant for sandbox testing but was being set in production with a Google API Key (AIzaSy...) instead of an OAuth access token (ya29...), causing 401 errors.

The code automatically obtains access tokens using refresh tokens, so this variable should not be set in production environments.