### PR TITLE
Added blocking user write queue, first checking for diffs in user memory

### DIFF
--- a/DoWhiz_service/Cargo.lock
+++ b/DoWhiz_service/Cargo.lock
@@ -302,6 +302,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,6 +2138,7 @@ dependencies = [
  "base64 0.21.7",
  "chrono",
  "cron",
+ "crossbeam-channel",
  "dirs",
  "dotenvy",
  "hex",

--- a/DoWhiz_service/scheduler_module/Cargo.toml
+++ b/DoWhiz_service/scheduler_module/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 axum = "0.7"
 base64 = "0.21"
 chrono = { version = "0.4", features = ["serde"] }
+crossbeam-channel = "0.5"
 cron = "0.12"
 dirs = "5"
 dotenvy = "0.15"

--- a/DoWhiz_service/scheduler_module/src/lib.rs
+++ b/DoWhiz_service/scheduler_module/src/lib.rs
@@ -13,6 +13,8 @@ pub mod slack_store;
 pub(crate) mod thread_state;
 
 pub mod index_store;
+pub mod memory_diff;
+pub mod memory_queue;
 pub mod memory_store;
 pub mod past_emails;
 pub mod secrets_store;

--- a/DoWhiz_service/scheduler_module/src/memory_diff.rs
+++ b/DoWhiz_service/scheduler_module/src/memory_diff.rs
@@ -1,0 +1,378 @@
+use std::collections::{HashMap, HashSet};
+
+/// Represents changes made to a memo.md file
+#[derive(Debug, Clone, Default)]
+pub struct MemoryDiff {
+    /// Sections that were added or modified, keyed by section name
+    pub changed_sections: HashMap<String, SectionChange>,
+}
+
+/// Represents a change to a specific section
+#[derive(Debug, Clone)]
+pub enum SectionChange {
+    /// New lines added to an existing section
+    Added(Vec<String>),
+    /// Section content was replaced entirely (for major rewrites)
+    Replaced(String),
+    /// A new section that didn't exist before
+    NewSection(String),
+}
+
+impl MemoryDiff {
+    pub fn is_empty(&self) -> bool {
+        self.changed_sections.is_empty()
+    }
+}
+
+/// Compute the diff between original memo.md content and modified content
+pub fn compute_memory_diff(original: &str, modified: &str) -> MemoryDiff {
+    let original_sections = parse_sections(original);
+    let modified_sections = parse_sections(modified);
+
+    let mut changed_sections = HashMap::new();
+
+    // Handle case where neither has sections (raw content without ## headers)
+    if original_sections.is_empty() && modified_sections.is_empty() {
+        if original.trim() != modified.trim() {
+            let added = find_added_lines(original, modified);
+            if !added.is_empty() {
+                // Use a special "__raw__" key for non-sectioned content
+                changed_sections.insert("__raw__".to_string(), SectionChange::Added(added));
+            } else {
+                // Content differs but no line additions - treat as replacement
+                changed_sections.insert(
+                    "__raw__".to_string(),
+                    SectionChange::Replaced(modified.to_string()),
+                );
+            }
+        }
+        return MemoryDiff { changed_sections };
+    }
+
+    for (section_name, modified_content) in &modified_sections {
+        match original_sections.get(section_name) {
+            None => {
+                // New section that didn't exist before
+                if !modified_content.trim().is_empty() {
+                    changed_sections.insert(
+                        section_name.clone(),
+                        SectionChange::NewSection(modified_content.clone()),
+                    );
+                }
+            }
+            Some(original_content) => {
+                if original_content.trim() != modified_content.trim() {
+                    // Section was modified - find what was added
+                    let added = find_added_lines(original_content, modified_content);
+                    if !added.is_empty() {
+                        changed_sections.insert(section_name.clone(), SectionChange::Added(added));
+                    } else if original_content.trim() != modified_content.trim() {
+                        // Content changed but no clear line additions - treat as replace
+                        changed_sections.insert(
+                            section_name.clone(),
+                            SectionChange::Replaced(modified_content.clone()),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    MemoryDiff { changed_sections }
+}
+
+/// Parse memo.md content into sections: "## SectionName" -> content
+fn parse_sections(content: &str) -> HashMap<String, String> {
+    let mut sections = HashMap::new();
+    let mut current_section = String::new();
+    let mut current_content = Vec::new();
+
+    for line in content.lines() {
+        if line.starts_with("## ") {
+            // Save previous section
+            if !current_section.is_empty() {
+                sections.insert(current_section.clone(), current_content.join("\n"));
+            }
+            current_section = line[3..].trim().to_string();
+            current_content = Vec::new();
+        } else if line.starts_with("# ") {
+            // Top-level header (# Memo), skip but reset section
+            if !current_section.is_empty() {
+                sections.insert(current_section.clone(), current_content.join("\n"));
+            }
+            current_section = String::new();
+            current_content = Vec::new();
+        } else if !current_section.is_empty() {
+            current_content.push(line.to_string());
+        }
+    }
+
+    // Save last section
+    if !current_section.is_empty() {
+        sections.insert(current_section, current_content.join("\n"));
+    }
+
+    sections
+}
+
+/// Find lines in modified that aren't in original
+fn find_added_lines(original: &str, modified: &str) -> Vec<String> {
+    let original_lines: HashSet<&str> = original
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    modified
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !original_lines.contains(trimmed)
+        })
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Apply a diff to existing memo.md content, returning the merged result
+pub fn apply_memory_diff(current_content: &str, diff: &MemoryDiff) -> String {
+    if diff.is_empty() {
+        return current_content.to_string();
+    }
+
+    // Handle raw (non-sectioned) content
+    if let Some(raw_change) = diff.changed_sections.get("__raw__") {
+        return match raw_change {
+            SectionChange::Added(lines) => {
+                let mut result = current_content.to_string();
+                for line in lines {
+                    // Avoid duplicates
+                    if !result.lines().any(|l| l.trim() == line.trim()) {
+                        if !result.is_empty() && !result.ends_with('\n') {
+                            result.push('\n');
+                        }
+                        result.push_str(line);
+                    }
+                }
+                result
+            }
+            SectionChange::Replaced(new_content) => new_content.clone(),
+            SectionChange::NewSection(content) => {
+                let mut result = current_content.to_string();
+                if !result.is_empty() && !result.ends_with('\n') {
+                    result.push('\n');
+                }
+                result.push_str(content);
+                result
+            }
+        };
+    }
+
+    let mut sections = parse_sections_ordered(current_content);
+
+    for (section_name, change) in &diff.changed_sections {
+        match change {
+            SectionChange::Added(lines) => {
+                // Append new lines to existing section
+                if let Some(section) = sections.iter_mut().find(|(name, _)| name == section_name) {
+                    let mut content = section.1.clone();
+                    for line in lines {
+                        // Avoid duplicates
+                        if !content.lines().any(|l| l.trim() == line.trim()) {
+                            if !content.is_empty() && !content.ends_with('\n') {
+                                content.push('\n');
+                            }
+                            content.push_str(line);
+                        }
+                    }
+                    section.1 = content;
+                } else {
+                    // Section doesn't exist yet, create it
+                    sections.push((section_name.clone(), lines.join("\n")));
+                }
+            }
+            SectionChange::Replaced(new_content) => {
+                // Replace entire section content
+                if let Some(section) = sections.iter_mut().find(|(name, _)| name == section_name) {
+                    section.1 = new_content.clone();
+                } else {
+                    sections.push((section_name.clone(), new_content.clone()));
+                }
+            }
+            SectionChange::NewSection(content) => {
+                // Add new section if it doesn't exist
+                if !sections.iter().any(|(name, _)| name == section_name) {
+                    sections.push((section_name.clone(), content.clone()));
+                }
+            }
+        }
+    }
+
+    // Rebuild memo.md from sections
+    rebuild_memo(sections)
+}
+
+/// Parse sections while preserving order
+fn parse_sections_ordered(content: &str) -> Vec<(String, String)> {
+    let mut sections = Vec::new();
+    let mut current_section = String::new();
+    let mut current_content = Vec::new();
+
+    for line in content.lines() {
+        if line.starts_with("## ") {
+            if !current_section.is_empty() {
+                sections.push((current_section.clone(), current_content.join("\n")));
+            }
+            current_section = line[3..].trim().to_string();
+            current_content = Vec::new();
+        } else if line.starts_with("# ") {
+            if !current_section.is_empty() {
+                sections.push((current_section.clone(), current_content.join("\n")));
+            }
+            current_section = String::new();
+            current_content = Vec::new();
+        } else if !current_section.is_empty() {
+            current_content.push(line.to_string());
+        }
+    }
+
+    if !current_section.is_empty() {
+        sections.push((current_section, current_content.join("\n")));
+    }
+
+    sections
+}
+
+/// Rebuild memo.md from ordered sections
+fn rebuild_memo(sections: Vec<(String, String)>) -> String {
+    let mut result = String::from("# Memo\n\n");
+
+    for (name, content) in sections {
+        result.push_str(&format!("## {}\n", name));
+        if !content.trim().is_empty() {
+            result.push_str(&content);
+            if !content.ends_with('\n') {
+                result.push('\n');
+            }
+        }
+        result.push('\n');
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_diff_added_lines() {
+        let original = r#"# Memo
+
+## Contacts
+- Alice: 555-0000
+
+## Preferences
+"#;
+        let modified = r#"# Memo
+
+## Contacts
+- Alice: 555-0000
+- Bob: 555-1234
+
+## Preferences
+"#;
+
+        let diff = compute_memory_diff(original, modified);
+        assert!(!diff.is_empty());
+        assert!(diff.changed_sections.contains_key("Contacts"));
+
+        if let Some(SectionChange::Added(lines)) = diff.changed_sections.get("Contacts") {
+            assert!(lines.iter().any(|l| l.contains("Bob")));
+        } else {
+            panic!("Expected Added change");
+        }
+    }
+
+    #[test]
+    fn test_compute_diff_new_section() {
+        let original = r#"# Memo
+
+## Profile
+
+## Contacts
+"#;
+        let modified = r#"# Memo
+
+## Profile
+
+## Contacts
+
+## Projects
+- Project Alpha
+"#;
+
+        let diff = compute_memory_diff(original, modified);
+        assert!(diff.changed_sections.contains_key("Projects"));
+
+        if let Some(SectionChange::NewSection(content)) = diff.changed_sections.get("Projects") {
+            assert!(content.contains("Project Alpha"));
+        } else {
+            panic!("Expected NewSection change");
+        }
+    }
+
+    #[test]
+    fn test_apply_diff_adds_lines() {
+        let current = r#"# Memo
+
+## Contacts
+- Alice: 555-0000
+
+## Preferences
+"#;
+
+        let diff = MemoryDiff {
+            changed_sections: HashMap::from([(
+                "Contacts".to_string(),
+                SectionChange::Added(vec!["- Bob: 555-1234".to_string()]),
+            )]),
+        };
+
+        let result = apply_memory_diff(current, &diff);
+        assert!(result.contains("Alice"));
+        assert!(result.contains("Bob"));
+    }
+
+    #[test]
+    fn test_apply_diff_no_duplicates() {
+        let current = r#"# Memo
+
+## Contacts
+- Alice: 555-0000
+
+"#;
+
+        let diff = MemoryDiff {
+            changed_sections: HashMap::from([(
+                "Contacts".to_string(),
+                SectionChange::Added(vec!["- Alice: 555-0000".to_string()]),
+            )]),
+        };
+
+        let result = apply_memory_diff(current, &diff);
+        // Should only have one Alice entry
+        assert_eq!(result.matches("Alice").count(), 1);
+    }
+
+    #[test]
+    fn test_empty_diff() {
+        let content = r#"# Memo
+
+## Contacts
+- Alice: 555-0000
+"#;
+
+        let diff = compute_memory_diff(content, content);
+        assert!(diff.is_empty());
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/memory_queue.rs
+++ b/DoWhiz_service/scheduler_module/src/memory_queue.rs
@@ -1,0 +1,310 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use crossbeam_channel::{bounded, Sender};
+use tracing::info;
+
+use crate::memory_diff::{apply_memory_diff, MemoryDiff};
+
+/// A queued memory write operation
+#[derive(Debug, Clone)]
+pub struct MemoryWriteRequest {
+    pub user_id: String,
+    pub user_memory_dir: PathBuf,
+    pub diff: MemoryDiff,
+}
+
+/// Internal request with completion signal
+struct InternalRequest {
+    request: MemoryWriteRequest,
+    /// Channel to signal completion (with result)
+    done: Sender<Result<(), MemoryQueueError>>,
+}
+
+/// Global memory write queue that ensures sequential writes per user
+pub struct MemoryWriteQueue {
+    /// Per-user channels for submitting diffs
+    user_channels: Mutex<HashMap<String, Sender<InternalRequest>>>,
+}
+
+impl MemoryWriteQueue {
+    pub fn new() -> Self {
+        Self {
+            user_channels: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Submit a diff to be applied to a user's memo.md
+    /// Blocks until the diff is applied by the worker thread
+    pub fn submit(&self, request: MemoryWriteRequest) -> Result<(), MemoryQueueError> {
+        let user_id = request.user_id.clone();
+
+        // Create completion channel
+        let (done_tx, done_rx) = bounded::<Result<(), MemoryQueueError>>(1);
+
+        let internal_request = InternalRequest {
+            request,
+            done: done_tx,
+        };
+
+        // Get or create the user's channel
+        let sender = {
+            let mut channels = self
+                .user_channels
+                .lock()
+                .map_err(|_| MemoryQueueError::LockPoisoned)?;
+
+            if let Some(sender) = channels.get(&user_id) {
+                sender.clone()
+            } else {
+                // Create a new channel and worker for this user
+                let (sender, receiver) = bounded::<InternalRequest>(100);
+
+                // Spawn worker thread for this user
+                let worker_user_id = user_id.clone();
+                thread::spawn(move || {
+                    info!("Memory queue worker started for user {}", worker_user_id);
+                    for req in receiver {
+                        let result = apply_diff_to_file(&req.request);
+                        // Signal completion (ignore send error if receiver dropped)
+                        let _ = req.done.send(result);
+                    }
+                    info!("Memory queue worker stopped for user {}", worker_user_id);
+                });
+
+                channels.insert(user_id.clone(), sender.clone());
+                sender
+            }
+        };
+
+        // Send to queue
+        sender
+            .send(internal_request)
+            .map_err(|_| MemoryQueueError::ChannelClosed)?;
+
+        // Wait for worker to complete
+        done_rx
+            .recv()
+            .map_err(|_| MemoryQueueError::ChannelClosed)?
+    }
+}
+
+impl Default for MemoryWriteQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Apply a diff to the user's memo.md file
+fn apply_diff_to_file(request: &MemoryWriteRequest) -> Result<(), MemoryQueueError> {
+    let memo_path = request.user_memory_dir.join("memo.md");
+
+    // Read current content
+    let current_content = if memo_path.exists() {
+        fs::read_to_string(&memo_path).map_err(|e| MemoryQueueError::Io(Arc::new(e)))?
+    } else {
+        // Use default memo structure
+        crate::memory_store::DEFAULT_MEMO_CONTENT.to_string()
+    };
+
+    // Apply diff
+    let merged_content = apply_memory_diff(&current_content, &request.diff);
+
+    // Write back
+    if let Some(parent) = memo_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| MemoryQueueError::Io(Arc::new(e)))?;
+    }
+    fs::write(&memo_path, &merged_content).map_err(|e| MemoryQueueError::Io(Arc::new(e)))?;
+
+    info!(
+        "Applied memory diff for user {} ({} sections changed)",
+        request.user_id,
+        request.diff.changed_sections.len()
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum MemoryQueueError {
+    #[error("IO error: {0}")]
+    Io(#[source] Arc<std::io::Error>),
+    #[error("Queue lock poisoned")]
+    LockPoisoned,
+    #[error("Channel closed")]
+    ChannelClosed,
+}
+
+impl From<std::io::Error> for MemoryQueueError {
+    fn from(err: std::io::Error) -> Self {
+        MemoryQueueError::Io(Arc::new(err))
+    }
+}
+
+/// Global singleton for the memory write queue
+static MEMORY_QUEUE: std::sync::OnceLock<Arc<MemoryWriteQueue>> = std::sync::OnceLock::new();
+
+/// Get the global memory write queue instance
+pub fn global_memory_queue() -> Arc<MemoryWriteQueue> {
+    MEMORY_QUEUE
+        .get_or_init(|| Arc::new(MemoryWriteQueue::new()))
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_diff::SectionChange;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_apply_diff_to_file() {
+        let temp = TempDir::new().expect("tempdir");
+        let memory_dir = temp.path().join("memory");
+        fs::create_dir_all(&memory_dir).expect("create dir");
+
+        // Write initial memo
+        let initial = r#"# Memo
+
+## Contacts
+- Alice: 555-0000
+
+## Preferences
+"#;
+        fs::write(memory_dir.join("memo.md"), initial).expect("write initial");
+
+        // Create diff
+        let diff = MemoryDiff {
+            changed_sections: HashMap::from([(
+                "Contacts".to_string(),
+                SectionChange::Added(vec!["- Bob: 555-1234".to_string()]),
+            )]),
+        };
+
+        let request = MemoryWriteRequest {
+            user_id: "test-user".to_string(),
+            user_memory_dir: memory_dir.clone(),
+            diff,
+        };
+
+        apply_diff_to_file(&request).expect("apply diff");
+
+        let result = fs::read_to_string(memory_dir.join("memo.md")).expect("read result");
+        assert!(result.contains("Alice"));
+        assert!(result.contains("Bob"));
+    }
+
+    #[test]
+    fn test_queue_sequential_writes() {
+        let temp = TempDir::new().expect("tempdir");
+        let memory_dir = temp.path().join("memory");
+        fs::create_dir_all(&memory_dir).expect("create dir");
+
+        let initial = r#"# Memo
+
+## Contacts
+
+## Preferences
+"#;
+        fs::write(memory_dir.join("memo.md"), initial).expect("write initial");
+
+        let queue = MemoryWriteQueue::new();
+
+        // Submit two diffs sequentially (both go through the queue)
+        let diff1 = MemoryDiff {
+            changed_sections: HashMap::from([(
+                "Contacts".to_string(),
+                SectionChange::Added(vec!["- Alice: 555-0000".to_string()]),
+            )]),
+        };
+
+        let diff2 = MemoryDiff {
+            changed_sections: HashMap::from([(
+                "Contacts".to_string(),
+                SectionChange::Added(vec!["- Bob: 555-1234".to_string()]),
+            )]),
+        };
+
+        queue
+            .submit(MemoryWriteRequest {
+                user_id: "test-user".to_string(),
+                user_memory_dir: memory_dir.clone(),
+                diff: diff1,
+            })
+            .expect("submit 1");
+
+        queue
+            .submit(MemoryWriteRequest {
+                user_id: "test-user".to_string(),
+                user_memory_dir: memory_dir.clone(),
+                diff: diff2,
+            })
+            .expect("submit 2");
+
+        let result = fs::read_to_string(memory_dir.join("memo.md")).expect("read result");
+        assert!(result.contains("Alice"), "Should contain Alice");
+        assert!(result.contains("Bob"), "Should contain Bob");
+    }
+
+    #[test]
+    fn test_concurrent_submits_serialized() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let temp = TempDir::new().expect("tempdir");
+        let memory_dir = temp.path().join("memory");
+        fs::create_dir_all(&memory_dir).expect("create dir");
+
+        let initial = r#"# Memo
+
+## Contacts
+
+## Preferences
+"#;
+        fs::write(memory_dir.join("memo.md"), initial).expect("write initial");
+
+        let queue = Arc::new(MemoryWriteQueue::new());
+        let memory_dir = Arc::new(memory_dir);
+
+        // Spawn multiple threads submitting diffs concurrently
+        let handles: Vec<_> = (0..5)
+            .map(|i| {
+                let queue = Arc::clone(&queue);
+                let memory_dir = Arc::clone(&memory_dir);
+                thread::spawn(move || {
+                    let diff = MemoryDiff {
+                        changed_sections: HashMap::from([(
+                            "Contacts".to_string(),
+                            SectionChange::Added(vec![format!("- Contact{}: 555-{:04}", i, i)]),
+                        )]),
+                    };
+                    queue
+                        .submit(MemoryWriteRequest {
+                            user_id: "test-user".to_string(),
+                            user_memory_dir: memory_dir.as_ref().clone(),
+                            diff,
+                        })
+                        .expect("submit");
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("thread join");
+        }
+
+        let result = fs::read_to_string(memory_dir.join("memo.md")).expect("read result");
+        // All 5 contacts should be present (no lost updates)
+        for i in 0..5 {
+            assert!(
+                result.contains(&format!("Contact{}", i)),
+                "Should contain Contact{}",
+                i
+            );
+        }
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/memory_store.rs
+++ b/DoWhiz_service/scheduler_module/src/memory_store.rs
@@ -4,7 +4,27 @@ use std::path::{Path, PathBuf};
 
 use crate::RunTaskTask;
 
-const DEFAULT_MEMO_CONTENT: &str = "# Memo\n\n## Profile\n\n## Preferences\n\n## Projects\n\n## Contacts\n\n## Decisions\n\n## Processes\n";
+pub const DEFAULT_MEMO_CONTENT: &str = "# Memo\n\n## Profile\n\n## Preferences\n\n## Projects\n\n## Contacts\n\n## Decisions\n\n## Processes\n";
+
+/// Snapshot the current memo.md content for later diffing
+pub fn snapshot_memo_content(memory_dir: &Path) -> Option<String> {
+    let memo_path = memory_dir.join("memo.md");
+    if memo_path.exists() {
+        fs::read_to_string(&memo_path).ok()
+    } else {
+        Some(DEFAULT_MEMO_CONTENT.to_string())
+    }
+}
+
+/// Read the current memo.md content from a directory
+pub fn read_memo_content(memory_dir: &Path) -> Option<String> {
+    let memo_path = memory_dir.join("memo.md");
+    if memo_path.exists() {
+        fs::read_to_string(&memo_path).ok()
+    } else {
+        None
+    }
+}
 
 pub(crate) fn ensure_default_user_memo(memory_dir: &Path) -> Result<(), io::Error> {
     fs::create_dir_all(memory_dir)?;


### PR DESCRIPTION
New Write Queueing Flow:
In [execute.rs](http://execute.rs/), snapshot global user memory before creating to workspace
Call run_task_module with cloned user memory
Once output returned, compare with snapshot
Compare memory markdown file via section by section analysis, check if sections have been added/removed
If the existing memory file is empty (no sections), append __raw__ which tells the worker thread to just immediately append the changes
If a diff exists, submit to user write queue
Write queue spawns a worker thread, blocks the queue while the write happens, and applies changes asynchronously