### PR TITLE
Rename ingestion Azure container env var

### DIFF
--- a/DoWhiz_service/CLAUDE.md
+++ b/DoWhiz_service/CLAUDE.md
@@ -128,7 +128,8 @@ After completing code changes, you must design targeted, detailed unit tests and
 - `INGESTION_QUEUE_BACKEND`: `servicebus` for gateway, `postgres` for legacy worker-only setups
 - `SERVICE_BUS_CONNECTION_STRING` / `SERVICE_BUS_QUEUE_NAME`: Service Bus ingestion queue config
 - `RAW_PAYLOAD_STORAGE_BACKEND`: `azure` for gateway, `supabase` for legacy payload storage
-- `AZURE_STORAGE_ACCOUNT` / `AZURE_STORAGE_CONTAINER` / `AZURE_STORAGE_SAS_TOKEN`: Azure Blob raw payload storage config
+- `AZURE_STORAGE_ACCOUNT` / `AZURE_STORAGE_CONTAINER_INGEST` / `AZURE_STORAGE_SAS_TOKEN`: Azure Blob raw payload storage config
+- `AZURE_STORAGE_CONNECTION_STRING` / `AZURE_STORAGE_CONTAINER`: Azure Blob memo storage config
 - `SUPABASE_DB_URL`: Postgres ingestion queue (legacy)
 - `OPENAI_API_KEY`: Enable message router quick replies
 - `TELEGRAM_BOT_TOKEN`: Telegram bot token (or per-employee `DO_WHIZ_<EMPLOYEE>_BOT`)

--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -54,7 +54,7 @@ Rust service for inbound channels (Postmark email, Slack, Discord, Twilio SMS, T
 - `RUN_TASK_USE_DOCKER=1` + `RUN_TASK_DOCKER_IMAGE` (run each task inside a disposable Docker container; use `dowhiz-service` for the repo image)
 - `RUN_TASK_DOCKER_AUTO_BUILD=1` to auto-build the image when missing (set `0` to disable)
 - `INGESTION_QUEUE_BACKEND=servicebus` + `SERVICE_BUS_CONNECTION_STRING` + `SERVICE_BUS_QUEUE_NAME` (ingestion queue)
-- `RAW_PAYLOAD_STORAGE_BACKEND=azure` + `AZURE_STORAGE_CONTAINER` + `AZURE_STORAGE_SAS_TOKEN` (raw payload storage)
+- `RAW_PAYLOAD_STORAGE_BACKEND=azure` + `AZURE_STORAGE_CONTAINER_INGEST` + `AZURE_STORAGE_SAS_TOKEN` (raw payload storage)
 - `OPENAI_API_KEY` (enables message router quick replies)
 
 ---
@@ -158,7 +158,7 @@ export INGESTION_QUEUE_BACKEND=servicebus
 export SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://..."
 export SERVICE_BUS_QUEUE_NAME="ingestion"
 export RAW_PAYLOAD_STORAGE_BACKEND=azure
-export AZURE_STORAGE_CONTAINER="ingestion-raw"
+export AZURE_STORAGE_CONTAINER_INGEST="ingestion-raw"
 export AZURE_STORAGE_SAS_TOKEN="..."
 ```
 
@@ -292,7 +292,7 @@ az functionapp config appsettings set -g <rg> -n <function-app> --settings \
   SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://..." \
   SERVICE_BUS_QUEUE_NAME="ingestion" \
   AZURE_STORAGE_ACCOUNT="<storage>" \
-  AZURE_STORAGE_CONTAINER="ingestion-raw" \
+  AZURE_STORAGE_CONTAINER_INGEST="ingestion-raw" \
   AZURE_STORAGE_SAS_TOKEN="<sas>" \
   GATEWAY_CONFIG_PATH="gateway.toml" \
   EMPLOYEE_CONFIG_PATH="employee.toml"
@@ -311,7 +311,7 @@ export INGESTION_QUEUE_BACKEND=servicebus
 export SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://..."
 export SERVICE_BUS_QUEUE_NAME="ingestion"
 export RAW_PAYLOAD_STORAGE_BACKEND=azure
-export AZURE_STORAGE_CONTAINER="ingestion-raw"
+export AZURE_STORAGE_CONTAINER_INGEST="ingestion-raw"
 export AZURE_STORAGE_SAS_TOKEN="..."
 
 ./DoWhiz_service/scripts/run_employee.sh boiled_egg 9004 --skip-hook --skip-ngrok
@@ -322,7 +322,7 @@ If you need Slack/Discord/Telegram/SMS/WhatsApp/BlueBubbles/Google Docs, run the
 ```bash
 INGESTION_QUEUE_BACKEND=servicebus \
 RAW_PAYLOAD_STORAGE_BACKEND=azure \
-AZURE_STORAGE_CONTAINER="ingestion-raw" \
+AZURE_STORAGE_CONTAINER_INGEST="ingestion-raw" \
 AZURE_STORAGE_SAS_TOKEN="..." \
   ./DoWhiz_service/scripts/run_gateway_local.sh
 ```
@@ -346,7 +346,7 @@ export INGESTION_QUEUE_BACKEND=servicebus
 export SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://..."
 export SERVICE_BUS_QUEUE_NAME="ingestion"
 export RAW_PAYLOAD_STORAGE_BACKEND=azure
-export AZURE_STORAGE_CONTAINER="ingestion-raw"
+export AZURE_STORAGE_CONTAINER_INGEST="ingestion-raw"
 export AZURE_STORAGE_SAS_TOKEN="..."
 ```
 
@@ -360,7 +360,7 @@ docker run --rm -p 9001:9001 \
   -e SERVICE_BUS_CONNECTION_STRING="$SERVICE_BUS_CONNECTION_STRING" \
   -e SERVICE_BUS_QUEUE_NAME="$SERVICE_BUS_QUEUE_NAME" \
   -e RAW_PAYLOAD_STORAGE_BACKEND="$RAW_PAYLOAD_STORAGE_BACKEND" \
-  -e AZURE_STORAGE_CONTAINER="$AZURE_STORAGE_CONTAINER" \
+  -e AZURE_STORAGE_CONTAINER_INGEST="$AZURE_STORAGE_CONTAINER_INGEST" \
   -e AZURE_STORAGE_SAS_TOKEN="$AZURE_STORAGE_SAS_TOKEN" \
   -v "$PWD/DoWhiz_service/.env:/app/.env:ro" \
   -v dowhiz-workspace-oliver:/app/.workspace \
@@ -374,7 +374,7 @@ docker run --rm -p 9002:9001 \
   -e SERVICE_BUS_CONNECTION_STRING="$SERVICE_BUS_CONNECTION_STRING" \
   -e SERVICE_BUS_QUEUE_NAME="$SERVICE_BUS_QUEUE_NAME" \
   -e RAW_PAYLOAD_STORAGE_BACKEND="$RAW_PAYLOAD_STORAGE_BACKEND" \
-  -e AZURE_STORAGE_CONTAINER="$AZURE_STORAGE_CONTAINER" \
+  -e AZURE_STORAGE_CONTAINER_INGEST="$AZURE_STORAGE_CONTAINER_INGEST" \
   -e AZURE_STORAGE_SAS_TOKEN="$AZURE_STORAGE_SAS_TOKEN" \
   -v "$PWD/DoWhiz_service/.env:/app/.env:ro" \
   -v dowhiz-workspace-maggie:/app/.workspace \
@@ -395,7 +395,7 @@ INGESTION_QUEUE_BACKEND="$INGESTION_QUEUE_BACKEND" \
 SERVICE_BUS_CONNECTION_STRING="$SERVICE_BUS_CONNECTION_STRING" \
 SERVICE_BUS_QUEUE_NAME="$SERVICE_BUS_QUEUE_NAME" \
 RAW_PAYLOAD_STORAGE_BACKEND="$RAW_PAYLOAD_STORAGE_BACKEND" \
-AZURE_STORAGE_CONTAINER="$AZURE_STORAGE_CONTAINER" \
+AZURE_STORAGE_CONTAINER_INGEST="$AZURE_STORAGE_CONTAINER_INGEST" \
 AZURE_STORAGE_SAS_TOKEN="$AZURE_STORAGE_SAS_TOKEN" \
   ./DoWhiz_service/scripts/run_gateway_local.sh
 ```
@@ -453,7 +453,7 @@ INGESTION_QUEUE_BACKEND=servicebus
 SERVICE_BUS_CONNECTION_STRING=Endpoint=sb://...
 SERVICE_BUS_QUEUE_NAME=ingestion
 RAW_PAYLOAD_STORAGE_BACKEND=azure
-AZURE_STORAGE_CONTAINER=ingestion-raw
+AZURE_STORAGE_CONTAINER_INGEST=ingestion-raw
 AZURE_STORAGE_SAS_TOKEN=...
 # For GitHub PR creation from email (recommended):
 EMPLOYEE_ID=little_bear
@@ -609,7 +609,7 @@ docker run --rm -p 9001:9001 \
   -e SERVICE_BUS_CONNECTION_STRING="$SERVICE_BUS_CONNECTION_STRING" \
   -e SERVICE_BUS_QUEUE_NAME="$SERVICE_BUS_QUEUE_NAME" \
   -e RAW_PAYLOAD_STORAGE_BACKEND="$RAW_PAYLOAD_STORAGE_BACKEND" \
-  -e AZURE_STORAGE_CONTAINER="$AZURE_STORAGE_CONTAINER" \
+  -e AZURE_STORAGE_CONTAINER_INGEST="$AZURE_STORAGE_CONTAINER_INGEST" \
   -e AZURE_STORAGE_SAS_TOKEN="$AZURE_STORAGE_SAS_TOKEN" \
   -v "$PWD/DoWhiz_service/.env:/app/.env:ro" \
   -v dowhiz-workspace:/app/.workspace \
@@ -625,7 +625,7 @@ docker run --rm -p 9100:9100 \
   -e SERVICE_BUS_CONNECTION_STRING="$SERVICE_BUS_CONNECTION_STRING" \
   -e SERVICE_BUS_QUEUE_NAME="$SERVICE_BUS_QUEUE_NAME" \
   -e RAW_PAYLOAD_STORAGE_BACKEND="$RAW_PAYLOAD_STORAGE_BACKEND" \
-  -e AZURE_STORAGE_CONTAINER="$AZURE_STORAGE_CONTAINER" \
+  -e AZURE_STORAGE_CONTAINER_INGEST="$AZURE_STORAGE_CONTAINER_INGEST" \
   -e AZURE_STORAGE_SAS_TOKEN="$AZURE_STORAGE_SAS_TOKEN" \
   -v "$PWD/DoWhiz_service/.env:/app/.env:ro" \
   -v "$PWD/DoWhiz_service/gateway.toml:/app/DoWhiz_service/gateway.toml:ro" \
@@ -716,7 +716,7 @@ export INGESTION_QUEUE_BACKEND=servicebus
 export SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://..."
 export SERVICE_BUS_QUEUE_NAME="ingestion"
 export RAW_PAYLOAD_STORAGE_BACKEND=azure
-export AZURE_STORAGE_CONTAINER="ingestion-raw"
+export AZURE_STORAGE_CONTAINER_INGEST="ingestion-raw"
 export AZURE_STORAGE_SAS_TOKEN="..."
 ```
 
@@ -730,7 +730,7 @@ docker run --rm -p 9002:9002 \
   -e SERVICE_BUS_CONNECTION_STRING="$SERVICE_BUS_CONNECTION_STRING" \
   -e SERVICE_BUS_QUEUE_NAME="$SERVICE_BUS_QUEUE_NAME" \
   -e RAW_PAYLOAD_STORAGE_BACKEND="$RAW_PAYLOAD_STORAGE_BACKEND" \
-  -e AZURE_STORAGE_CONTAINER="$AZURE_STORAGE_CONTAINER" \
+  -e AZURE_STORAGE_CONTAINER_INGEST="$AZURE_STORAGE_CONTAINER_INGEST" \
   -e AZURE_STORAGE_SAS_TOKEN="$AZURE_STORAGE_SAS_TOKEN" \
   -v "$PWD/DoWhiz_service/.env:/app/.env:ro" \
   -v dowhiz-workspace:/app/.workspace \
@@ -745,7 +745,7 @@ INGESTION_QUEUE_BACKEND="$INGESTION_QUEUE_BACKEND" \
 SERVICE_BUS_CONNECTION_STRING="$SERVICE_BUS_CONNECTION_STRING" \
 SERVICE_BUS_QUEUE_NAME="$SERVICE_BUS_QUEUE_NAME" \
 RAW_PAYLOAD_STORAGE_BACKEND="$RAW_PAYLOAD_STORAGE_BACKEND" \
-AZURE_STORAGE_CONTAINER="$AZURE_STORAGE_CONTAINER" \
+AZURE_STORAGE_CONTAINER_INGEST="$AZURE_STORAGE_CONTAINER_INGEST" \
 AZURE_STORAGE_SAS_TOKEN="$AZURE_STORAGE_SAS_TOKEN" \
   ./DoWhiz_service/scripts/run_gateway_local.sh
 ```
@@ -1144,11 +1144,17 @@ This reduces API costs and latency for simple interactions while preserving full
 | `SERVICE_BUS_PEEK_LOCK_TIMEOUT_SECS` | `30` | Peek-lock timeout for Service Bus receive |
 | `RAW_PAYLOAD_STORAGE_BACKEND` | `supabase` | `supabase` or `azure` (gateway requires `azure`) |
 | `AZURE_STORAGE_ACCOUNT` | - | Azure Storage account name |
-| `AZURE_STORAGE_CONTAINER` | - | Azure Blob container name |
+| `AZURE_STORAGE_CONTAINER_INGEST` | - | Azure Blob container for raw payloads |
 | `AZURE_STORAGE_SAS_TOKEN` | - | SAS token for container access |
 | `AZURE_STORAGE_CONTAINER_SAS_URL` | - | Full container SAS URL (optional) |
 | `AZURE_FUNCTION_POSTMARK_URL` | - | Direct Function ingress URL |
 | `AZURE_APIM_POSTMARK_URL` | - | APIM ingress URL |
+
+### Azure Memo Storage
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AZURE_STORAGE_CONNECTION_STRING` | - | Azure Blob connection string for memo storage |
+| `AZURE_STORAGE_CONTAINER` | - | Azure Blob container for memo.md (e.g., `memos`) |
 
 ### Slack
 | Variable | Default | Description |

--- a/DoWhiz_service/azure/functions/gateway_ingest/gateway_ingest/__init__.py
+++ b/DoWhiz_service/azure/functions/gateway_ingest/gateway_ingest/__init__.py
@@ -171,7 +171,7 @@ def resolve_container_sas_url() -> str:
     if sas_url:
         return sas_url.strip()
     account = os.getenv("AZURE_STORAGE_ACCOUNT") or resolve_account_from_connection_string()
-    container = os.getenv("AZURE_STORAGE_CONTAINER")
+    container = os.getenv("AZURE_STORAGE_CONTAINER_INGEST")
     sas_token = os.getenv("AZURE_STORAGE_SAS_TOKEN")
     if not account or not container or not sas_token:
         raise RuntimeError("Missing Azure storage SAS configuration")
@@ -199,9 +199,9 @@ def build_blob_url(container_sas_url: str, path: str) -> str:
 
 
 def upload_raw_payload(raw_payload: bytes, envelope_id: str, received_at: datetime.datetime) -> str:
-    container = os.getenv("AZURE_STORAGE_CONTAINER")
+    container = os.getenv("AZURE_STORAGE_CONTAINER_INGEST")
     if not container:
-        raise RuntimeError("AZURE_STORAGE_CONTAINER is required")
+        raise RuntimeError("AZURE_STORAGE_CONTAINER_INGEST is required")
     date_prefix = received_at.strftime("%Y/%m/%d")
     blob_path = f"ingestion_raw/{date_prefix}/{envelope_id}.bin"
     container_sas_url = resolve_container_sas_url()

--- a/DoWhiz_service/azure/functions/gateway_ingest/local.settings.json
+++ b/DoWhiz_service/azure/functions/gateway_ingest/local.settings.json
@@ -5,7 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "SERVICE_BUS_CONNECTION_STRING": "",
     "SERVICE_BUS_QUEUE_NAME": "ingestion",
-    "AZURE_STORAGE_CONTAINER": "ingestion-raw",
+    "AZURE_STORAGE_CONTAINER_INGEST": "ingestion-raw",
     "AZURE_STORAGE_CONTAINER_SAS_URL": "",
     "POSTMARK_INBOUND_TOKEN": "",
     "GATEWAY_CONFIG_PATH": "gateway.toml",

--- a/DoWhiz_service/scheduler_module/src/raw_payload_store.rs
+++ b/DoWhiz_service/scheduler_module/src/raw_payload_store.rs
@@ -42,7 +42,7 @@ fn resolve_raw_payload_backend() -> String {
 }
 
 fn resolve_azure_container() -> Result<String, RawPayloadStoreError> {
-    std::env::var("AZURE_STORAGE_CONTAINER")
+    std::env::var("AZURE_STORAGE_CONTAINER_INGEST")
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
@@ -61,7 +61,7 @@ fn resolve_azure_container_sas_url() -> Result<String, RawPayloadStoreError> {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .or_else(resolve_account_from_connection_string);
-    let container = std::env::var("AZURE_STORAGE_CONTAINER")
+    let container = std::env::var("AZURE_STORAGE_CONTAINER_INGEST")
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
@@ -513,13 +513,13 @@ mod tests {
     fn azure_connection_string_fallback_for_account() {
         let _guard = lock_env();
         let original_account = env::var("AZURE_STORAGE_ACCOUNT").ok();
-        let original_container = env::var("AZURE_STORAGE_CONTAINER").ok();
+        let original_container = env::var("AZURE_STORAGE_CONTAINER_INGEST").ok();
         let original_sas = env::var("AZURE_STORAGE_SAS_TOKEN").ok();
         let original_conn = env::var("AZURE_STORAGE_CONNECTION_STRING_INGEST").ok();
         let original_container_sas_url = env::var("AZURE_STORAGE_CONTAINER_SAS_URL").ok();
 
         env::remove_var("AZURE_STORAGE_ACCOUNT");
-        env::set_var("AZURE_STORAGE_CONTAINER", "ingestion-raw");
+        env::set_var("AZURE_STORAGE_CONTAINER_INGEST", "ingestion-raw");
         env::set_var("AZURE_STORAGE_SAS_TOKEN", "sig=test");
         env::remove_var("AZURE_STORAGE_CONTAINER_SAS_URL");
         env::set_var(
@@ -538,8 +538,8 @@ mod tests {
             None => env::remove_var("AZURE_STORAGE_ACCOUNT"),
         }
         match original_container {
-            Some(value) => env::set_var("AZURE_STORAGE_CONTAINER", value),
-            None => env::remove_var("AZURE_STORAGE_CONTAINER"),
+            Some(value) => env::set_var("AZURE_STORAGE_CONTAINER_INGEST", value),
+            None => env::remove_var("AZURE_STORAGE_CONTAINER_INGEST"),
         }
         match original_sas {
             Some(value) => env::set_var("AZURE_STORAGE_SAS_TOKEN", value),

--- a/DoWhiz_service/scheduler_module/tests/service_real_email.rs
+++ b/DoWhiz_service/scheduler_module/tests/service_real_email.rs
@@ -539,7 +539,7 @@ fn rust_service_real_email_end_to_end() -> Result<(), BoxError> {
             return Ok(());
         }
     };
-    let azure_container = env::var("AZURE_STORAGE_CONTAINER")
+    let azure_container = env::var("AZURE_STORAGE_CONTAINER_INGEST")
         .ok()
         .filter(|value| !value.trim().is_empty());
     let azure_sas_url = env::var("AZURE_STORAGE_CONTAINER_SAS_URL")
@@ -560,7 +560,7 @@ fn rust_service_real_email_end_to_end() -> Result<(), BoxError> {
                 && (azure_account.is_some() || azure_conn_str.is_some())));
     if !has_azure_blob {
         eprintln!(
-            "Skipping live test: Azure Blob SAS configuration is required (AZURE_STORAGE_CONTAINER_SAS_URL or AZURE_STORAGE_CONTAINER + AZURE_STORAGE_SAS_TOKEN + AZURE_STORAGE_ACCOUNT/AZURE_STORAGE_CONNECTION_STRING_INGEST)."
+            "Skipping live test: Azure Blob SAS configuration is required (AZURE_STORAGE_CONTAINER_SAS_URL or AZURE_STORAGE_CONTAINER_INGEST + AZURE_STORAGE_SAS_TOKEN + AZURE_STORAGE_ACCOUNT/AZURE_STORAGE_CONNECTION_STRING_INGEST)."
         );
         return Ok(());
     }


### PR DESCRIPTION
## Summary\n- switch raw payload ingestion config to use AZURE_STORAGE_CONTAINER_INGEST instead of AZURE_STORAGE_CONTAINER\n- update Azure Function gateway + tests to read new env var\n- refresh README/CLAUDE docs to reflect new ingestion/memo container split\n\n## Testing\n- cargo test -p scheduler_module azure_connection_string_fallback_for_account