### PR TITLE
Update blog with weekly summary (Feb 23, 2026)

### DIFF
--- a/website/public/blog/index.html
+++ b/website/public/blog/index.html
@@ -34,10 +34,27 @@
           <p class="lead">
             Short updates on how we build digital employees, ship new workflows, and keep work moving.
           </p>
-          <div class="updated">Last updated: February 20, 2026</div>
+          <div class="updated">Last updated: February 23, 2026</div>
         </section>
 
         <section class="blog-grid">
+          <article class="blog-card" id="week-summary-2026-02-23">
+            <div class="blog-meta">
+              <span class="blog-tag">Week Summary</span>
+              <span class="blog-date">February 23, 2026</span>
+            </div>
+            <h2>Weekly summary: Google Workspace expansion + integrations</h2>
+            <p>
+              This week we expanded collaboration coverage, smoothed onboarding, and tightened the
+              integration experience across channels.
+            </p>
+            <ul>
+              <li>Added Google Sheets and Slides comment workflows, plus smarter de-dupe and mention handling.</li>
+              <li>Enabled Discord OAuth linking in the integration panel for faster setup.</li>
+              <li>Rolled out unified memo updates with support for editing shared memo content.</li>
+              <li>Extended light/dark mode styling across public pages for a consistent experience.</li>
+            </ul>
+          </article>
           <article class="blog-card" id="inbox-native">
             <div class="blog-meta">
               <span class="blog-tag">Launch Notes</span>

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -426,6 +426,13 @@ function App() {
 
   const blogPosts = [
     {
+      tag: 'Week Summary',
+      title: 'Weekly summary: Google Workspace expansion + integrations',
+      date: 'February 23, 2026',
+      excerpt: 'Sheets and Slides comments support, Discord OAuth linking, unified memo edits, and full light/dark mode coverage.',
+      link: '/blog/#week-summary-2026-02-23'
+    },
+    {
       tag: 'Launch Notes',
       title: 'Inbox-native delegation',
       date: 'February 2026',


### PR DESCRIPTION
## Summary\n- add Feb 23 weekly summary card to the blog page\n- update homepage blog preview entry\n- refresh blog last-updated date\n\n## Testing\n- Not run (content changes only)\n\nFixes #374