### PR TITLE
Correctly set reply_to to [user_id, channel_id] for later propogation…

### DIFF
--- a/DoWhiz_service/scheduler_module/src/adapters/discord.rs
+++ b/DoWhiz_service/scheduler_module/src/adapters/discord.rs
@@ -100,7 +100,8 @@ impl DiscordInboundAdapter {
             thread_id,
             message_id: Some(message.id.get().to_string()),
             attachments,
-            reply_to: vec![channel_id.to_string()],
+            // reply_to[0] = user_id (for account lookup), reply_to[1] = channel_id (currently unused)
+            reply_to: vec![author_id.to_string(), channel_id.to_string()],
             raw_payload,
             metadata: ChannelMetadata {
                 discord_guild_id: guild_id,

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/task_rows.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/task_rows.rs
@@ -75,8 +75,9 @@ impl SqliteSchedulerStore {
         task_id: &str,
         send: &SendReplyTask,
     ) -> Result<(), SchedulerError> {
-        // For Discord, we use to[0] as channel_id and html_path as text_path
-        let discord_channel_id = send.to.first().cloned().unwrap_or_default();
+        // For Discord, reply_to is [user_id, channel_id] - use to[1] for channel_id
+        // Fall back to to[0] for backwards compatibility with old tasks
+        let discord_channel_id = send.to.get(1).or(send.to.first()).cloned().unwrap_or_default();
         let thread_id = send.in_reply_to.clone();
         let workspace_dir = send
             .archive_root

--- a/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
@@ -79,7 +79,8 @@ pub(crate) fn process_discord_inbound_message(
         model_name,
         runner: config.employee_profile.runner.clone(),
         codex_disabled: config.codex_disabled,
-        reply_to: vec![channel_id.to_string()],
+        // reply_to[0] = user_id (for account lookup), reply_to[1] = channel_id
+        reply_to: vec![message.sender.clone(), channel_id.to_string()],
         reply_from: None,
         archive_root: None,
         thread_id: Some(thread_key.clone()),


### PR DESCRIPTION
… through the full pipeline, so codex correctly picks it up