### PR TITLE
Improve Discord context hydration and reply threading

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -66,10 +66,16 @@ pub(super) fn build_prompt(
         }
     };
     let guidance_section = build_guidance_section(workspace_dir, runner);
+    let discord_context_section = if channel.eq_ignore_ascii_case("discord") {
+        build_discord_context_section(workspace_dir)
+    } else {
+        String::new()
+    };
 
     // Build registration prompt section if user doesn't have a unified account
     // and we haven't prompted them yet in this thread
-    let registration_section = if !has_unified_account && !has_prompted_registration(workspace_dir) {
+    let registration_section = if !has_unified_account && !has_prompted_registration(workspace_dir)
+    {
         // Mark that we've prompted so we don't repeat
         mark_registration_prompted(workspace_dir);
         r#"
@@ -99,6 +105,8 @@ Inputs (relative to workspace root):
 - Incoming attachments dir: {input_attachments}
 - Memory dir (memory about the current user): {memory}
 - Reference dir (contain all past emails with the current user): {reference}
+
+{discord_context_section}
 
 Memory about the current user:
 ```{memory_section}```
@@ -132,6 +140,7 @@ Rules:
         memory_section = memory_section,
         guidance_section = guidance_section,
         reply_instruction = reply_instruction,
+        discord_context_section = discord_context_section,
         registration_section = registration_section,
     )
 }
@@ -170,6 +179,28 @@ fn load_optional_text(path: &Path) -> Option<String> {
 
 fn format_guidance_block(label: &str, content: &str) -> String {
     format!("{label}:\n```\n{content}\n```\n")
+}
+
+fn build_discord_context_section(workspace_dir: &Path) -> String {
+    let path = workspace_dir
+        .join("incoming_email")
+        .join("discord_context_for_agent.md");
+    let Ok(content) = fs::read_to_string(path) else {
+        return String::new();
+    };
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let max_chars = 12_000usize;
+    let mut clipped: String = trimmed.chars().take(max_chars).collect();
+    if trimmed.chars().count() > max_chars {
+        clipped.push_str("\n\n(Truncated. Use incoming_email/discord_thread_context_full.json and incoming_email/discord_channel_last_24h.json for complete context.)");
+    }
+    format!(
+        "Discord context snapshot (auto-generated; full history is stored in local files):\n```markdown\n{}\n```\n",
+        clipped
+    )
 }
 
 pub(super) fn load_memory_context(
@@ -308,5 +339,34 @@ mod tests {
         );
 
         assert!(!prompt2.contains("Account Registration Notice"));
+    }
+
+    #[test]
+    fn build_prompt_includes_discord_context_snapshot_when_available() {
+        let temp = TempDir::new().expect("tempdir");
+        let workspace = temp.path();
+        let incoming_dir = workspace.join("incoming_email");
+        fs::create_dir_all(&incoming_dir).expect("incoming_email");
+        fs::write(
+            incoming_dir.join("discord_context_for_agent.md"),
+            "# Discord Context Snapshot\nQuoted + thread context",
+        )
+        .expect("context file");
+
+        let prompt = build_prompt(
+            Path::new("incoming_email"),
+            Path::new("incoming_attachments"),
+            Path::new("memory"),
+            Path::new("references"),
+            workspace,
+            "codex",
+            "",
+            true,
+            "discord",
+            true,
+        );
+
+        assert!(prompt.contains("Discord context snapshot (auto-generated"));
+        assert!(prompt.contains("Quoted + thread context"));
     }
 }

--- a/DoWhiz_service/scheduler_module/src/adapters/discord.rs
+++ b/DoWhiz_service/scheduler_module/src/adapters/discord.rs
@@ -57,13 +57,13 @@ impl DiscordInboundAdapter {
         let guild_id = message.guild_id.map(|id| id.get());
         let channel_id = message.channel_id.get();
         let author_id = message.author.id.get();
+        let referenced_message = message.referenced_message.as_ref();
+        let referenced_message_id = referenced_message.map(|m| m.id.get());
 
         // Thread ID: use referenced message ID if replying, otherwise message ID
         // Discord doesn't have explicit threads like Slack's thread_ts
-        let thread_id = message
-            .referenced_message
-            .as_ref()
-            .map(|m| m.id.get().to_string())
+        let thread_id = referenced_message_id
+            .map(|id| id.to_string())
             .unwrap_or_else(|| message.id.get().to_string());
 
         // Parse attachments
@@ -86,6 +86,10 @@ impl DiscordInboundAdapter {
             author_name: message.author.name.clone(),
             content: message.content.clone(),
             timestamp: message.timestamp.to_string(),
+            referenced_message_id,
+            referenced_message_author_id: referenced_message.map(|m| m.author.id.get()),
+            referenced_message_author_name: referenced_message.map(|m| m.author.name.clone()),
+            referenced_message_content: referenced_message.map(|m| m.content.clone()),
         })
         .unwrap_or_default();
 
@@ -106,6 +110,8 @@ impl DiscordInboundAdapter {
             metadata: ChannelMetadata {
                 discord_guild_id: guild_id,
                 discord_channel_id: Some(channel_id),
+                discord_message_id: Some(message.id.get().to_string()),
+                discord_referenced_message_id: referenced_message_id.map(|id| id.to_string()),
                 ..Default::default()
             },
         })
@@ -209,6 +215,14 @@ pub struct DiscordMessagePayload {
     pub author_name: String,
     pub content: String,
     pub timestamp: String,
+    #[serde(default)]
+    pub referenced_message_id: Option<u64>,
+    #[serde(default)]
+    pub referenced_message_author_id: Option<u64>,
+    #[serde(default)]
+    pub referenced_message_author_name: Option<String>,
+    #[serde(default)]
+    pub referenced_message_content: Option<String>,
 }
 
 /// Request body for creating a Discord message.

--- a/DoWhiz_service/scheduler_module/src/channel.rs
+++ b/DoWhiz_service/scheduler_module/src/channel.rs
@@ -137,6 +137,10 @@ pub struct ChannelMetadata {
     pub discord_guild_id: Option<u64>,
     /// Discord-specific: Channel ID
     pub discord_channel_id: Option<u64>,
+    /// Discord-specific: Current inbound message ID
+    pub discord_message_id: Option<String>,
+    /// Discord-specific: Quoted/referenced message ID (if this message is a reply)
+    pub discord_referenced_message_id: Option<String>,
     /// Telegram-specific: Chat ID
     pub telegram_chat_id: Option<i64>,
     /// WhatsApp-specific: Phone number (sender's phone)
@@ -173,7 +177,6 @@ pub struct ChannelMetadata {
     // =========================================================================
     // Multi-channel collaboration support
     // =========================================================================
-
     /// Collaboration session ID linking multiple messages across channels.
     /// When set, this message is part of a collaboration session.
     pub collaboration_session_id: Option<String>,

--- a/DoWhiz_service/scheduler_module/src/scheduler/reply.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/reply.rs
@@ -52,8 +52,24 @@ impl PostmarkInboundLite {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct DiscordMetaLite {
+    channel: Option<String>,
+    message_id: Option<String>,
+}
+
 pub(crate) fn load_reply_context(workspace_dir: &Path) -> ReplyContext {
     let incoming_dir = workspace_dir.join("incoming_email");
+
+    // Discord: always reply to the current inbound message.
+    if let Some(message_id) = latest_discord_message_id(&incoming_dir) {
+        return ReplyContext {
+            subject: "Discord reply".to_string(),
+            in_reply_to: Some(message_id),
+            references: None,
+            from: None,
+        };
+    }
 
     // Try Google Docs metadata first
     let gdocs_metadata_path = incoming_dir.join("google_docs_metadata.json");
@@ -111,6 +127,35 @@ pub(crate) fn load_reply_context(workspace_dir: &Path) -> ReplyContext {
     }
 }
 
+fn latest_discord_message_id(incoming_dir: &Path) -> Option<String> {
+    let entries = fs::read_dir(incoming_dir).ok()?;
+    let mut meta_files = entries
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.ends_with("_discord_meta.json"))
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    meta_files.sort();
+    let latest = meta_files.last()?;
+    let content = fs::read_to_string(latest).ok()?;
+    let meta = serde_json::from_str::<DiscordMetaLite>(&content).ok()?;
+    if meta
+        .channel
+        .as_deref()
+        .map(|channel| channel.eq_ignore_ascii_case("discord"))
+        .unwrap_or(false)
+    {
+        return meta
+            .message_id
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+    None
+}
+
 fn reply_subject(original: &str) -> String {
     let trimmed = original.trim();
     if trimmed.is_empty() {
@@ -156,4 +201,52 @@ fn references_contains(references: &str, message_id: &str) -> bool {
     references
         .split_whitespace()
         .any(|entry| entry == message_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_reply_context_prefers_latest_discord_message_id() {
+        let temp = TempDir::new().expect("tempdir");
+        let incoming_dir = temp.path().join("incoming_email");
+        fs::create_dir_all(&incoming_dir).expect("incoming_email");
+
+        fs::write(
+            incoming_dir.join("00001_discord_meta.json"),
+            r#"{"channel":"discord","message_id":"1001"}"#,
+        )
+        .expect("write first");
+        fs::write(
+            incoming_dir.join("00002_discord_meta.json"),
+            r#"{"channel":"discord","message_id":"1002"}"#,
+        )
+        .expect("write second");
+
+        let context = load_reply_context(temp.path());
+        assert_eq!(context.in_reply_to.as_deref(), Some("1002"));
+    }
+
+    #[test]
+    fn load_reply_context_falls_back_to_email_headers() {
+        let temp = TempDir::new().expect("tempdir");
+        let incoming_dir = temp.path().join("incoming_email");
+        fs::create_dir_all(&incoming_dir).expect("incoming_email");
+        fs::write(
+            incoming_dir.join("postmark_payload.json"),
+            r#"{
+                "Subject": "Hello",
+                "MessageID": "<msg-123>",
+                "Headers": [{"Name":"References","Value":"<msg-122>"}]
+            }"#,
+        )
+        .expect("payload");
+
+        let context = load_reply_context(temp.path());
+        assert_eq!(context.subject, "Re: Hello");
+        assert_eq!(context.in_reply_to.as_deref(), Some("<msg-123>"));
+        assert_eq!(context.references.as_deref(), Some("<msg-122> <msg-123>"));
+    }
 }

--- a/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
@@ -13,8 +13,9 @@ use super::super::bump_thread_state;
 use super::super::config::ServiceConfig;
 use super::super::default_thread_state_path;
 use super::super::scheduler::cancel_pending_thread_tasks;
-use super::super::workspace::{ensure_thread_workspace};
+use super::super::workspace::ensure_thread_workspace;
 use super::super::BoxError;
+use super::discord_context::hydrate_discord_context_files;
 
 pub(crate) fn process_discord_inbound_message(
     config: &ServiceConfig,
@@ -58,6 +59,19 @@ pub(crate) fn process_discord_inbound_message(
         raw_payload,
         thread_state.last_email_seq,
     )?;
+    if let Err(err) = hydrate_discord_context_files(
+        config,
+        &workspace,
+        message,
+        raw_payload,
+        thread_state.last_email_seq,
+    ) {
+        warn!(
+            "failed to hydrate discord context files for {}: {}",
+            workspace.display(),
+            err
+        );
+    }
 
     let model_name = match config.employee_profile.model.clone() {
         Some(model) => model,
@@ -95,7 +109,7 @@ pub(crate) fn process_discord_inbound_message(
         employee_id: Some(config.employee_id.clone()),
     };
 
-// Clone run_task before consuming it, in case we need to write to account-level storage
+    // Clone run_task before consuming it, in case we need to write to account-level storage
     let run_task_for_account = run_task.clone();
 
     let mut scheduler = Scheduler::load(&user_paths.tasks_db_path, ModuleExecutor::default())?;
@@ -125,13 +139,20 @@ pub(crate) fn process_discord_inbound_message(
     if let Ok(Some(account)) = account_store.get_account_by_identifier("discord", &message.sender) {
         let user_tasks_dir = config.users_root.join(account.id.to_string()).join("state");
         if let Err(err) = std::fs::create_dir_all(&user_tasks_dir) {
-            warn!("failed to create user tasks dir for account {}: {}", account.id, err);
+            warn!(
+                "failed to create user tasks dir for account {}: {}",
+                account.id, err
+            );
         } else {
             let user_tasks_db_path = user_tasks_dir.join("tasks.db");
             match Scheduler::load(&user_tasks_db_path, ModuleExecutor::default()) {
                 Ok(mut user_scheduler) => {
                     // Use the same task_id so we can update status at completion
-                    match user_scheduler.add_one_shot_in_with_id(task_id, Duration::from_secs(0), TaskKind::RunTask(run_task_for_account)) {
+                    match user_scheduler.add_one_shot_in_with_id(
+                        task_id,
+                        Duration::from_secs(0),
+                        TaskKind::RunTask(run_task_for_account),
+                    ) {
                         Ok(()) => {
                             info!(
                                 "also enqueued task to account-level storage account={} task_id={}",
@@ -139,12 +160,18 @@ pub(crate) fn process_discord_inbound_message(
                             );
                         }
                         Err(err) => {
-                            warn!("failed to add task to user scheduler for account {}: {}", account.id, err);
+                            warn!(
+                                "failed to add task to user scheduler for account {}: {}",
+                                account.id, err
+                            );
                         }
                     }
                 }
                 Err(err) => {
-                    warn!("failed to load user scheduler for account {}: {}", account.id, err);
+                    warn!(
+                        "failed to load user scheduler for account {}: {}",
+                        account.id, err
+                    );
                 }
             }
         }
@@ -309,7 +336,14 @@ mod tests {
             },
         };
 
-        process_discord_inbound_message(&config, &user_store, &index_store, &account_store, &message, &raw_payload)?;
+        process_discord_inbound_message(
+            &config,
+            &user_store,
+            &index_store,
+            &account_store,
+            &message,
+            &raw_payload,
+        )?;
 
         let user = user_store.get_or_create_user("discord", &sender)?;
         let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
@@ -336,8 +370,8 @@ mod tests {
         );
 
         let state_path = crate::thread_state::default_thread_state_path(&run_task.workspace_dir);
-        let thread_state = crate::thread_state::load_thread_state(&state_path)
-            .expect("thread_state.json exists");
+        let thread_state =
+            crate::thread_state::load_thread_state(&state_path).expect("thread_state.json exists");
         let seq = thread_state.last_email_seq;
         let incoming_dir = run_task.workspace_dir.join("incoming_email");
         assert!(incoming_dir

--- a/DoWhiz_service/scheduler_module/src/service/inbound/discord_context.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/discord_context.rs
@@ -1,0 +1,560 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use super::super::config::ServiceConfig;
+use super::super::BoxError;
+
+const HISTORY_WINDOW_HOURS: i64 = 24;
+const MAX_HISTORY_PAGES: usize = 20;
+const INLINE_THREAD_CHAR_LIMIT: usize = 6000;
+const INLINE_THREAD_RECENT_COUNT: usize = 8;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DiscordMessageEntry {
+    id: String,
+    timestamp: String,
+    author_id: String,
+    author_name: String,
+    content: String,
+    #[serde(default)]
+    reference_message_id: Option<String>,
+    #[serde(default)]
+    attachments: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DiscordRawPayloadLite {
+    id: u64,
+    author_id: u64,
+    author_name: String,
+    content: String,
+    timestamp: String,
+    #[serde(default)]
+    referenced_message_id: Option<u64>,
+    #[serde(default)]
+    referenced_message_author_id: Option<u64>,
+    #[serde(default)]
+    referenced_message_author_name: Option<String>,
+    #[serde(default)]
+    referenced_message_content: Option<String>,
+}
+
+pub(super) fn hydrate_discord_context_files(
+    config: &ServiceConfig,
+    workspace: &Path,
+    message: &crate::channel::InboundMessage,
+    raw_payload: &[u8],
+    seq: u64,
+) -> Result<(), BoxError> {
+    let channel_id = message
+        .metadata
+        .discord_channel_id
+        .ok_or("missing discord_channel_id")?;
+    let incoming_dir = workspace.join("incoming_email");
+    std::fs::create_dir_all(&incoming_dir)?;
+
+    let now = Utc::now();
+    let cutoff = now - Duration::hours(HISTORY_WINDOW_HOURS);
+
+    let mut channel_messages = Vec::new();
+    if let Some(bot_token) = resolve_discord_bot_token(config) {
+        match fetch_channel_messages_last_day(&bot_token, channel_id, cutoff) {
+            Ok(messages) => {
+                channel_messages = messages;
+            }
+            Err(err) => {
+                warn!(
+                    "failed to fetch discord channel history for channel {}: {}",
+                    channel_id, err
+                );
+            }
+        }
+    }
+
+    let current_message = build_current_message_entry(message, raw_payload, now);
+    upsert_by_id(&mut channel_messages, current_message.clone());
+
+    let mut quoted_message = build_quoted_message_from_raw(raw_payload);
+    let referenced_id = message
+        .metadata
+        .discord_referenced_message_id
+        .clone()
+        .or_else(|| current_message.reference_message_id.clone());
+
+    if quoted_message.is_none() {
+        if let Some(ref_id) = referenced_id.as_deref() {
+            quoted_message = channel_messages.iter().find(|m| m.id == ref_id).cloned();
+        }
+    }
+
+    if quoted_message.is_none() {
+        if let (Some(bot_token), Some(ref_id)) =
+            (resolve_discord_bot_token(config), referenced_id.as_deref())
+        {
+            match fetch_single_message(&bot_token, channel_id, ref_id) {
+                Ok(found) => {
+                    upsert_by_id(&mut channel_messages, found.clone());
+                    quoted_message = Some(found);
+                }
+                Err(err) => {
+                    warn!(
+                        "failed to fetch referenced discord message {} in channel {}: {}",
+                        ref_id, channel_id, err
+                    );
+                }
+            }
+        }
+    }
+
+    channel_messages.sort_by_key(|entry| parse_timestamp(&entry.timestamp));
+    channel_messages.dedup_by(|left, right| left.id == right.id);
+
+    let current_message_id = message
+        .message_id
+        .clone()
+        .or_else(|| message.metadata.discord_message_id.clone())
+        .unwrap_or_else(|| current_message.id.clone());
+    let thread_messages = collect_thread_messages(&channel_messages, &current_message_id);
+
+    let inline_thread_messages =
+        if render_entries(&thread_messages).len() <= INLINE_THREAD_CHAR_LIMIT {
+            thread_messages.clone()
+        } else {
+            let keep = INLINE_THREAD_RECENT_COUNT.min(thread_messages.len());
+            thread_messages[thread_messages.len().saturating_sub(keep)..].to_vec()
+        };
+    let is_thread_truncated = inline_thread_messages.len() < thread_messages.len();
+
+    let channel_history_path = incoming_dir.join("discord_channel_last_24h.json");
+    let thread_full_path = incoming_dir.join("discord_thread_context_full.json");
+    let thread_recent_path = incoming_dir.join("discord_thread_context_recent.txt");
+    let context_md_path = incoming_dir.join("discord_context_for_agent.md");
+    let seq_context_md_path = incoming_dir.join(format!("{:05}_discord_context_for_agent.md", seq));
+    let seq_recent_path =
+        incoming_dir.join(format!("{:05}_discord_thread_context_recent.txt", seq));
+
+    let channel_payload = serde_json::json!({
+        "generated_at": now.to_rfc3339(),
+        "window_hours": HISTORY_WINDOW_HOURS,
+        "guild_id": message.metadata.discord_guild_id,
+        "channel_id": channel_id,
+        "message_count": channel_messages.len(),
+        "messages": channel_messages,
+    });
+    std::fs::write(
+        &channel_history_path,
+        serde_json::to_string_pretty(&channel_payload)?,
+    )?;
+
+    let thread_payload = serde_json::json!({
+        "generated_at": now.to_rfc3339(),
+        "current_message_id": current_message_id,
+        "message_count": thread_messages.len(),
+        "messages": thread_messages,
+    });
+    std::fs::write(
+        &thread_full_path,
+        serde_json::to_string_pretty(&thread_payload)?,
+    )?;
+
+    if let Some(quoted) = &quoted_message {
+        let quoted_path = incoming_dir.join("discord_quoted_message.json");
+        let quoted_payload = serde_json::json!({
+            "generated_at": now.to_rfc3339(),
+            "message": quoted,
+        });
+        std::fs::write(quoted_path, serde_json::to_string_pretty(&quoted_payload)?)?;
+    }
+
+    let recent_text = render_entries(&inline_thread_messages);
+    std::fs::write(&thread_recent_path, &recent_text)?;
+    std::fs::write(&seq_recent_path, &recent_text)?;
+
+    let quoted_block = if let Some(quoted) = quoted_message {
+        format!(
+            "## Quoted Message (Must Include)\n{}\n\n",
+            render_single_entry(&quoted)
+        )
+    } else {
+        "## Quoted Message (Must Include)\n- (none)\n\n".to_string()
+    };
+
+    let truncation_note = if is_thread_truncated {
+        format!(
+            "Thread context is large; inline section keeps the most recent {} messages. Older thread messages are stored in `incoming_email/discord_thread_context_full.json`.\n\n",
+            INLINE_THREAD_RECENT_COUNT
+        )
+    } else {
+        String::new()
+    };
+
+    let context_markdown = format!(
+        "# Discord Context Snapshot\n\
+Generated at: {generated_at}\n\n\
+Current message ID: `{current_id}`\n\
+Channel ID: `{channel_id}`\n\
+Guild ID: `{guild_id}`\n\n\
+{quoted_block}\
+## Thread Context (Inline)\n\
+{inline_thread}\n\n\
+{truncation_note}\
+## Local Context Files\n\
+- `incoming_email/discord_channel_last_24h.json`: full channel history from the last 24 hours.\n\
+- `incoming_email/discord_thread_context_full.json`: full thread context.\n\
+- `incoming_email/discord_thread_context_recent.txt`: recent thread context used inline.\n\
+- `incoming_email/discord_quoted_message.json`: quoted message payload when available.\n",
+        generated_at = now.to_rfc3339(),
+        current_id = current_message_id,
+        channel_id = channel_id,
+        guild_id = message
+            .metadata
+            .discord_guild_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "dm".to_string()),
+        quoted_block = quoted_block,
+        inline_thread = if recent_text.trim().is_empty() {
+            "- (none)".to_string()
+        } else {
+            recent_text
+        },
+        truncation_note = truncation_note,
+    );
+    std::fs::write(&context_md_path, &context_markdown)?;
+    std::fs::write(&seq_context_md_path, &context_markdown)?;
+
+    info!(
+        "discord context files updated for channel {} at {}",
+        channel_id,
+        incoming_dir.display()
+    );
+
+    Ok(())
+}
+
+fn resolve_discord_bot_token(config: &ServiceConfig) -> Option<String> {
+    let emp_upper = config.employee_profile.id.to_uppercase().replace('-', "_");
+    let emp_token_key = format!("{}_DISCORD_BOT_TOKEN", emp_upper);
+    if let Ok(token) = std::env::var(&emp_token_key) {
+        if !token.trim().is_empty() {
+            return Some(token);
+        }
+    }
+    config.discord_bot_token.clone()
+}
+
+fn fetch_channel_messages_last_day(
+    bot_token: &str,
+    channel_id: u64,
+    cutoff: DateTime<Utc>,
+) -> Result<Vec<DiscordMessageEntry>, BoxError> {
+    let mut all_messages = Vec::new();
+    let mut before: Option<String> = None;
+    let api_base = std::env::var("DISCORD_API_BASE_URL")
+        .unwrap_or_else(|_| "https://discord.com/api/v10".to_string());
+    let client = reqwest::blocking::Client::new();
+
+    for _ in 0..MAX_HISTORY_PAGES {
+        let mut url = format!(
+            "{}/channels/{}/messages?limit=100",
+            api_base.trim_end_matches('/'),
+            channel_id
+        );
+        if let Some(cursor) = before.as_deref() {
+            url.push_str("&before=");
+            url.push_str(cursor);
+        }
+
+        let response = client
+            .get(&url)
+            .header("Authorization", format!("Bot {}", bot_token))
+            .send()?;
+        if !response.status().is_success() {
+            return Err(format!("discord history api returned {}", response.status()).into());
+        }
+
+        let payload: serde_json::Value = response.json()?;
+        let Some(list) = payload.as_array() else {
+            return Err("discord history api returned invalid payload".into());
+        };
+        if list.is_empty() {
+            break;
+        }
+
+        for item in list {
+            if let Some(entry) = parse_api_message(item) {
+                if parse_timestamp(&entry.timestamp)
+                    .map(|ts| ts >= cutoff)
+                    .unwrap_or(false)
+                {
+                    all_messages.push(entry);
+                }
+            }
+        }
+
+        before = list
+            .last()
+            .and_then(|value| value.get("id"))
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string());
+
+        let oldest_ts = list
+            .last()
+            .and_then(|value| value.get("timestamp"))
+            .and_then(|value| value.as_str())
+            .and_then(parse_timestamp);
+        if oldest_ts.map(|ts| ts < cutoff).unwrap_or(false) {
+            break;
+        }
+    }
+
+    Ok(all_messages)
+}
+
+fn fetch_single_message(
+    bot_token: &str,
+    channel_id: u64,
+    message_id: &str,
+) -> Result<DiscordMessageEntry, BoxError> {
+    let api_base = std::env::var("DISCORD_API_BASE_URL")
+        .unwrap_or_else(|_| "https://discord.com/api/v10".to_string());
+    let url = format!(
+        "{}/channels/{}/messages/{}",
+        api_base.trim_end_matches('/'),
+        channel_id,
+        message_id
+    );
+    let response = reqwest::blocking::Client::new()
+        .get(url)
+        .header("Authorization", format!("Bot {}", bot_token))
+        .send()?;
+    if !response.status().is_success() {
+        return Err(format!("discord message api returned {}", response.status()).into());
+    }
+    let payload: serde_json::Value = response.json()?;
+    parse_api_message(&payload).ok_or_else(|| "invalid discord message payload".into())
+}
+
+fn parse_api_message(value: &serde_json::Value) -> Option<DiscordMessageEntry> {
+    let id = value.get("id")?.as_str()?.to_string();
+    let timestamp = value.get("timestamp")?.as_str()?.to_string();
+    let author = value.get("author")?;
+    let author_id = author
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let author_name = author
+        .get("global_name")
+        .or_else(|| author.get("username"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let content = value
+        .get("content")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let reference_message_id = value
+        .get("message_reference")
+        .and_then(|mr| mr.get("message_id"))
+        .and_then(|v| v.as_str())
+        .map(|v| v.to_string())
+        .or_else(|| {
+            value
+                .get("referenced_message")
+                .and_then(|msg| msg.get("id"))
+                .and_then(|v| v.as_str())
+                .map(|v| v.to_string())
+        });
+    let attachments = value
+        .get("attachments")
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("filename").and_then(|v| v.as_str()))
+                .map(|name| name.to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Some(DiscordMessageEntry {
+        id,
+        timestamp,
+        author_id,
+        author_name,
+        content,
+        reference_message_id,
+        attachments,
+    })
+}
+
+fn build_current_message_entry(
+    message: &crate::channel::InboundMessage,
+    raw_payload: &[u8],
+    now: DateTime<Utc>,
+) -> DiscordMessageEntry {
+    if let Ok(payload) = serde_json::from_slice::<DiscordRawPayloadLite>(raw_payload) {
+        return DiscordMessageEntry {
+            id: payload.id.to_string(),
+            timestamp: payload.timestamp,
+            author_id: payload.author_id.to_string(),
+            author_name: payload.author_name,
+            content: payload.content,
+            reference_message_id: payload.referenced_message_id.map(|id| id.to_string()),
+            attachments: Vec::new(),
+        };
+    }
+
+    DiscordMessageEntry {
+        id: message
+            .message_id
+            .clone()
+            .or_else(|| message.metadata.discord_message_id.clone())
+            .unwrap_or_else(|| "unknown".to_string()),
+        timestamp: now.to_rfc3339(),
+        author_id: message.sender.clone(),
+        author_name: message
+            .sender_name
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string()),
+        content: message.text_body.clone().unwrap_or_default(),
+        reference_message_id: message.metadata.discord_referenced_message_id.clone(),
+        attachments: Vec::new(),
+    }
+}
+
+fn build_quoted_message_from_raw(raw_payload: &[u8]) -> Option<DiscordMessageEntry> {
+    let payload = serde_json::from_slice::<DiscordRawPayloadLite>(raw_payload).ok()?;
+    let ref_id = payload.referenced_message_id?;
+    Some(DiscordMessageEntry {
+        id: ref_id.to_string(),
+        timestamp: payload.timestamp,
+        author_id: payload
+            .referenced_message_author_id
+            .map(|id| id.to_string())
+            .unwrap_or_default(),
+        author_name: payload
+            .referenced_message_author_name
+            .unwrap_or_else(|| "unknown".to_string()),
+        content: payload.referenced_message_content.unwrap_or_default(),
+        reference_message_id: None,
+        attachments: Vec::new(),
+    })
+}
+
+fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|ts| ts.with_timezone(&Utc))
+}
+
+fn upsert_by_id(messages: &mut Vec<DiscordMessageEntry>, candidate: DiscordMessageEntry) {
+    if let Some(existing) = messages.iter_mut().find(|entry| entry.id == candidate.id) {
+        if existing.content.trim().is_empty() && !candidate.content.trim().is_empty() {
+            *existing = candidate;
+        }
+        return;
+    }
+    messages.push(candidate);
+}
+
+fn collect_thread_messages(
+    messages: &[DiscordMessageEntry],
+    current_message_id: &str,
+) -> Vec<DiscordMessageEntry> {
+    let mut map = HashMap::new();
+    for message in messages {
+        map.insert(message.id.clone(), message.clone());
+    }
+    if !map.contains_key(current_message_id) {
+        return Vec::new();
+    }
+
+    let mut root_cache = HashMap::new();
+    let thread_root = resolve_root_id(current_message_id, &map, &mut root_cache);
+    let mut thread_messages = Vec::new();
+    for message in messages {
+        let root = resolve_root_id(&message.id, &map, &mut root_cache);
+        if root == thread_root {
+            thread_messages.push(message.clone());
+        }
+    }
+
+    thread_messages.sort_by_key(|entry| parse_timestamp(&entry.timestamp));
+    thread_messages
+}
+
+fn resolve_root_id(
+    message_id: &str,
+    map: &HashMap<String, DiscordMessageEntry>,
+    cache: &mut HashMap<String, String>,
+) -> String {
+    if let Some(cached) = cache.get(message_id) {
+        return cached.clone();
+    }
+
+    let mut seen = HashSet::new();
+    let mut path = Vec::new();
+    let mut current = message_id.to_string();
+    loop {
+        if !seen.insert(current.clone()) {
+            break;
+        }
+        path.push(current.clone());
+        let parent = map
+            .get(&current)
+            .and_then(|message| message.reference_message_id.clone());
+        match parent {
+            Some(parent_id) if map.contains_key(&parent_id) => {
+                current = parent_id;
+            }
+            Some(parent_id) => {
+                current = parent_id;
+                break;
+            }
+            None => break,
+        }
+    }
+
+    for id in path {
+        cache.insert(id, current.clone());
+    }
+    current
+}
+
+fn render_entries(messages: &[DiscordMessageEntry]) -> String {
+    messages
+        .iter()
+        .map(render_single_entry)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_single_entry(message: &DiscordMessageEntry) -> String {
+    let timestamp = parse_timestamp(&message.timestamp)
+        .map(|ts| ts.to_rfc3339())
+        .unwrap_or_else(|| message.timestamp.clone());
+    let mut content = message.content.replace('\n', " ");
+    if content.trim().is_empty() && !message.attachments.is_empty() {
+        content = format!("[attachments: {}]", message.attachments.join(", "));
+    }
+    if content.chars().count() > 240 {
+        content = content.chars().take(240).collect::<String>() + "...";
+    }
+    if let Some(parent) = message.reference_message_id.as_deref() {
+        format!(
+            "- [{}] {} ({}), reply_to={}: {}",
+            timestamp, message.author_name, message.author_id, parent, content
+        )
+    } else {
+        format!(
+            "- [{}] {} ({}): {}",
+            timestamp, message.author_name, message.author_id, content
+        )
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/service/inbound/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/mod.rs
@@ -1,5 +1,6 @@
 mod bluebubbles;
 mod discord;
+mod discord_context;
 mod google_docs;
 mod google_workspace;
 mod quick_responses;


### PR DESCRIPTION
## Summary
- Add Discord ingest-time context hydration to fetch/store last 24h channel history into workspace local files.
- Build thread-aware context snapshots that inline recent thread messages while storing full thread history on disk.
- Persist quoted/referenced Discord message details and expose them in generated context snapshot files.
- Ensure Discord auto-replies always use reply-to current inbound message ID (`message_reference`).
- Inject compact Discord context snapshot into run-task prompt so the agent sees quoted + recent thread context while large history remains file-based.

## Key Files
- `DoWhiz_service/scheduler_module/src/service/inbound/discord_context.rs` (new)
- `DoWhiz_service/scheduler_module/src/service/inbound/discord.rs`
- `DoWhiz_service/scheduler_module/src/adapters/discord.rs`
- `DoWhiz_service/scheduler_module/src/channel.rs`
- `DoWhiz_service/scheduler_module/src/scheduler/reply.rs`
- `DoWhiz_service/run_task_module/src/run_task/prompt.rs`

## Validation
- `CARGO_HOME=../.cargo-home cargo test -p run_task_module build_prompt_includes_discord_context_snapshot_when_available -- --nocapture`
- `CARGO_HOME=../.cargo-home cargo test -p scheduler_module load_reply_context_prefers_latest_discord_message_id -- --nocapture`

## Notes
- I also ran `process_discord_inbound_message_creates_run_task`, but that existing test fails in this environment due Postgres config (`Postgres ConfigParse: unexpected EOF`), unrelated to these changes.