### PR TITLE
SEO: add canonical tags and noindex for auth page

### DIFF
--- a/website/SEO_TOP_PAGES.md
+++ b/website/SEO_TOP_PAGES.md
@@ -76,3 +76,19 @@ H2: Best for, How it works, Trigger examples, Output preview
 H1 count: 1
 H1: Rachel - GTM Specialist
 H2: Best for, How it works, Trigger examples, Output preview
+
+## Duplicate / Parameterized URL Inventory (Canonical Mapping)
+
+- `https://dowhiz.com/?utm_*`, `https://dowhiz.com/?ref=*`, and other tracking/query variants canonicalize to `https://dowhiz.com/`.
+- `https://dowhiz.com/blog/?*` canonicalizes to `https://dowhiz.com/blog/`.
+- `https://dowhiz.com/user-guide/?*` canonicalizes to `https://dowhiz.com/user-guide/`.
+- `https://dowhiz.com/integrations/?*` canonicalizes to `https://dowhiz.com/integrations/`.
+- `https://dowhiz.com/trust-safety/?*` canonicalizes to `https://dowhiz.com/trust-safety/`.
+- `https://dowhiz.com/privacy/?*` canonicalizes to `https://dowhiz.com/privacy/`.
+- `https://dowhiz.com/terms/?*` canonicalizes to `https://dowhiz.com/terms/`.
+- `https://dowhiz.com/agents/*/?*` canonicalizes to each agent page's clean trailing-slash URL (for example: `https://dowhiz.com/agents/oliver/`).
+- `https://dowhiz.com/auth/?loggedIn=true`, `https://dowhiz.com/auth/?discord=*`, `https://dowhiz.com/auth/?slack=*`, and hash callback variants canonicalize to `https://dowhiz.com/auth/`.
+
+## Low-Value Pages Set to Noindex
+
+- `https://dowhiz.com/auth/` includes `<meta name="robots" content="noindex, nofollow">` to keep sign-in / callback state pages out of search results.

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Sign in to DoWhiz to manage your digital employee integrations." />
+    <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
+    <link rel="canonical" href="https://dowhiz.com/auth/" />
     <link rel="stylesheet" href="/legal.css" />
     <title>Sign In | DoWhiz</title>
     <style>

--- a/website/public/privacy/index.html
+++ b/website/public/privacy/index.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
+    <link rel="canonical" href="https://dowhiz.com/privacy/" />
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
     <title>DoWhiz Privacy | Multi-Channel Data Handling and Access</title>

--- a/website/public/terms/index.html
+++ b/website/public/terms/index.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
+    <link rel="canonical" href="https://dowhiz.com/terms/" />
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
     <title>DoWhiz Terms | Multi-Channel Digital Employee Service Terms</title>

--- a/website/public/user-guide/index.html
+++ b/website/public/user-guide/index.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
+    <link rel="canonical" href="https://dowhiz.com/user-guide/" />
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
     <title>DoWhiz User Guide | Multi-Channel Triggers and Shared Memory</title>


### PR DESCRIPTION
## Summary\n- add missing canonical tags to user-guide, privacy, and terms pages\n- add canonical + noindex meta directives on /auth/ to keep login and callback variants out of search\n- document duplicate/parameterized URL variants and canonical mapping in SEO_TOP_PAGES.md\n\n## Validation\n- npm run build\n\nCloses #189