### PR TITLE
SEO: add Help Center page with top 20 user FAQ

### DIFF
--- a/website/SEO_TOP_PAGES.md
+++ b/website/SEO_TOP_PAGES.md
@@ -1,6 +1,6 @@
 # SEO Top Pages (H1 Audit)
 
-As of 2026-02-25, the website repo exposes 15 indexable pages.
+As of 2026-02-26, the website repo exposes 16 indexable pages.
 
 1. https://dowhiz.com/
 H1 count: 1
@@ -77,11 +77,17 @@ H1 count: 1
 H1: Rachel - GTM Specialist
 H2: Best for, How it works, Trigger examples, Output preview
 
+16. https://dowhiz.com/help-center/
+H1 count: 1
+H1: Top 20 user questions about DoWhiz
+H2: Numbered help questions (1–20)
+
 ## Duplicate / Parameterized URL Inventory (Canonical Mapping)
 
 - `https://dowhiz.com/?utm_*`, `https://dowhiz.com/?ref=*`, and other tracking/query variants canonicalize to `https://dowhiz.com/`.
 - `https://dowhiz.com/blog/?*` canonicalizes to `https://dowhiz.com/blog/`.
 - `https://dowhiz.com/user-guide/?*` canonicalizes to `https://dowhiz.com/user-guide/`.
+- `https://dowhiz.com/help-center/?*` canonicalizes to `https://dowhiz.com/help-center/`.
 - `https://dowhiz.com/integrations/?*` canonicalizes to `https://dowhiz.com/integrations/`.
 - `https://dowhiz.com/trust-safety/?*` canonicalizes to `https://dowhiz.com/trust-safety/`.
 - `https://dowhiz.com/privacy/?*` canonicalizes to `https://dowhiz.com/privacy/`.

--- a/website/public/blog/index.html
+++ b/website/public/blog/index.html
@@ -22,6 +22,7 @@
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
           <a href="/#roles">Team</a>
+          <a href="/help-center/">Help Center</a>
           <a href="/integrations/">Integrations</a>
           <a href="/user-guide/">User Guide</a>
         </nav>

--- a/website/public/help-center/index.html
+++ b/website/public/help-center/index.html
@@ -1,0 +1,400 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="DoWhiz Help Center: top 20 common user questions across setup, integrations, permissions, outputs, and support."
+    />
+    <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="canonical" href="https://dowhiz.com/help-center/" />
+    <link rel="stylesheet" href="/legal.css" />
+    <script src="/theme.js"></script>
+    <title>DoWhiz Help Center | Top 20 User Questions</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is DoWhiz?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "DoWhiz is a multi-channel, tool-native digital employee team with shared memory. You can trigger work from the tools you already use and receive finished outputs in context."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I get started?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Pick the employee that fits your request, then send a clear task with context, deliverable format, and deadline from your preferred channel such as email, chat, GitHub, or shared docs."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which channels can I use to trigger tasks?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "DoWhiz supports triggers through email, Slack, Discord, GitHub issues, and shared document comments such as Google Docs and Notion."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I choose the right digital employee?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Use Oliver for general execution tasks, Maggie for TPM coordination, Devin for coding tasks, Rachel for GTM workflows, and the other role pages for specialized scopes."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What information should I include in my request?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Include objective, context, files/links, constraints, due date, and what a successful output looks like. Clear acceptance criteria helps agents deliver faster."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What kinds of work can DoWhiz handle?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Common tasks include writing, summaries, planning docs, status updates, technical implementations, testing support, and tool-native deliverables such as docs, sheets, slides, and code."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can DoWhiz work inside existing threads or issues?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. You can trigger from existing email threads, chat channels, GitHub issues, and document comments so context stays in one place."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can multiple employees collaborate on one request?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Employees can hand off between roles when needed while preserving shared context and returning a unified result."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Do employees remember context across channels?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Shared memory keeps durable preferences and project context so follow-up requests are more consistent."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I update or reset what is remembered?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Ask in-thread to update, add, or remove memory details and the team will adjust the stored context."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Do I need to share my personal passwords?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. DoWhiz uses agent-owned identities and does not require your personal credentials for day-to-day task execution."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How are permissions managed?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Access is permission-bound. Employees only operate in workspaces and integrations that you explicitly authorize, and access can be revoked through platform controls."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How is my data used?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Data is used to route requests, execute tasks, and return outputs. See Privacy and Trust & Safety pages for details on handling, retention, and controls."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Are requests and outputs auditable?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Work is tied to the trigger surface (for example, issue, thread, or comment) and returned with a clear task summary."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can an employee access everything in my workspace?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Access is scoped to what has been granted for that workflow and channel."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can DoWhiz ship code changes and PRs?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes, for authorized repositories. Agents can implement scoped changes, run checks, and summarize outcomes."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can DoWhiz edit docs, sheets, and slides?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Tool-native workflows support document and spreadsheet updates in supported workspaces."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What if I need revisions?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Reply in the same thread with specific edits. DoWhiz iterates quickly and keeps previous context."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How quickly do tasks complete?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Simple requests can finish quickly, while complex work takes longer. You receive progress-oriented updates and final deliverables in the same channel."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I get support or request a new integration?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Email admin@dowhiz.com with your use case, current workflow, and desired integration. The team can advise setup and next steps."
+            }
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <div class="page">
+      <header class="page-header">
+        <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
+        <nav class="header-links">
+          <a href="/user-guide/">User Guide</a>
+          <a href="/integrations/">Integrations</a>
+          <a href="/trust-safety/">Trust &amp; Safety</a>
+          <a href="/privacy/">Privacy</a>
+          <a href="/terms/">Terms</a>
+          <a href="mailto:admin@dowhiz.com">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="legal-hero">
+          <div class="eyebrow">Help Center</div>
+          <h1>Top 20 user questions about DoWhiz</h1>
+          <p class="lead">
+            This Help Center answers the most common setup, workflow, security, and support questions
+            from teams using DoWhiz across channels.
+          </p>
+          <div class="updated">Last updated: February 26, 2026</div>
+        </section>
+
+        <section class="legal-card">
+          <h2>1. What is DoWhiz?</h2>
+          <p>
+            DoWhiz is a multi-channel, tool-native digital employee team with shared memory. You can
+            trigger work from the tools you already use and receive finished outputs in context.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>2. How do I get started?</h2>
+          <p>
+            Pick the employee that fits your request, then send a clear task with context,
+            deliverable format, and deadline from your preferred channel such as email, chat, GitHub,
+            or shared docs.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>3. Which channels can I use to trigger tasks?</h2>
+          <p>
+            DoWhiz supports triggers through email, Slack, Discord, GitHub issues, and shared
+            document comments such as Google Docs and Notion.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>4. How do I choose the right digital employee?</h2>
+          <p>
+            Use Oliver for general execution tasks, Maggie for TPM coordination, Devin for coding
+            tasks, Rachel for GTM workflows, and the other role pages for specialized scopes.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>5. What information should I include in my request?</h2>
+          <p>
+            Include objective, context, files/links, constraints, due date, and what a successful
+            output looks like. Clear acceptance criteria helps agents deliver faster.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>6. What kinds of work can DoWhiz handle?</h2>
+          <p>
+            Common tasks include writing, summaries, planning docs, status updates, technical
+            implementations, testing support, and tool-native deliverables such as docs, sheets,
+            slides, and code.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>7. Can DoWhiz work inside existing threads or issues?</h2>
+          <p>
+            Yes. You can trigger from existing email threads, chat channels, GitHub issues, and
+            document comments so context stays in one place.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>8. Can multiple employees collaborate on one request?</h2>
+          <p>
+            Yes. Employees can hand off between roles when needed while preserving shared context and
+            returning a unified result.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>9. Do employees remember context across channels?</h2>
+          <p>
+            Yes. Shared memory keeps durable preferences and project context so follow-up requests are
+            more consistent.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>10. Can I update or reset what is remembered?</h2>
+          <p>
+            Yes. Ask in-thread to update, add, or remove memory details and the team will adjust the
+            stored context.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>11. Do I need to share my personal passwords?</h2>
+          <p>
+            No. DoWhiz uses agent-owned identities and does not require your personal credentials for
+            day-to-day task execution.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>12. How are permissions managed?</h2>
+          <p>
+            Access is permission-bound. Employees only operate in workspaces and integrations that you
+            explicitly authorize, and access can be revoked through platform controls.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>13. How is my data used?</h2>
+          <p>
+            Data is used to route requests, execute tasks, and return outputs. See Privacy and Trust
+            &amp; Safety pages for details on handling, retention, and controls.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>14. Are requests and outputs auditable?</h2>
+          <p>
+            Yes. Work is tied to the trigger surface (for example, issue, thread, or comment) and
+            returned with a clear task summary.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>15. Can an employee access everything in my workspace?</h2>
+          <p>No. Access is scoped to what has been granted for that workflow and channel.</p>
+        </section>
+
+        <section class="legal-card">
+          <h2>16. Can DoWhiz ship code changes and PRs?</h2>
+          <p>
+            Yes, for authorized repositories. Agents can implement scoped changes, run checks, and
+            summarize outcomes.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>17. Can DoWhiz edit docs, sheets, and slides?</h2>
+          <p>
+            Yes. Tool-native workflows support document and spreadsheet updates in supported
+            workspaces.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>18. What if I need revisions?</h2>
+          <p>
+            Reply in the same thread with specific edits. DoWhiz iterates quickly and keeps previous
+            context.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>19. How quickly do tasks complete?</h2>
+          <p>
+            Simple requests can finish quickly, while complex work takes longer. You receive
+            progress-oriented updates and final deliverables in the same channel.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>20. How do I get support or request a new integration?</h2>
+          <p>
+            Email admin@dowhiz.com with your use case, current workflow, and desired integration. The
+            team can advise setup and next steps.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Explore setup, permissions, and channel-specific guidance.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/user-guide/">
+              <span class="related-item-title">User guide</span>
+              <span class="related-item-desc">Templates for requesting work in each channel.</span>
+            </a>
+            <a class="related-item" href="/integrations/">
+              <span class="related-item-title">Integrations</span>
+              <span class="related-item-desc">Trigger surfaces and output expectations.</span>
+            </a>
+            <a class="related-item" href="/trust-safety/">
+              <span class="related-item-title">Trust &amp; Safety</span>
+              <span class="related-item-desc">Isolation and permission model details.</span>
+            </a>
+            <a class="related-item" href="/privacy/">
+              <span class="related-item-title">Privacy policy</span>
+              <span class="related-item-desc">Data handling and retention details.</span>
+            </a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="page-footer">
+        <a class="back-link" href="/">Back to DoWhiz</a>
+        <span>Need help? Contact admin@dowhiz.com.</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/website/public/integrations/index.html
+++ b/website/public/integrations/index.html
@@ -21,6 +21,7 @@
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
           <a href="/user-guide/">User Guide</a>
+          <a href="/help-center/">Help Center</a>
           <a href="/trust-safety/">Trust &amp; Safety</a>
           <a href="/privacy/">Privacy</a>
           <a href="/terms/">Terms</a>
@@ -93,6 +94,10 @@
             <a class="related-item" href="/trust-safety/">
               <span class="related-item-title">Trust &amp; Safety</span>
               <span class="related-item-desc">Isolation and permission model overview.</span>
+            </a>
+            <a class="related-item" href="/help-center/">
+              <span class="related-item-title">Help Center</span>
+              <span class="related-item-desc">Top 20 user questions and quick answers.</span>
             </a>
             <a class="related-item" href="/agents/oliver/">
               <span class="related-item-title">Meet the team</span>

--- a/website/public/privacy/index.html
+++ b/website/public/privacy/index.html
@@ -21,6 +21,7 @@
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
           <a href="/user-guide/">User Guide</a>
+          <a href="/help-center/">Help Center</a>
           <a href="/integrations/">Integrations</a>
           <a href="/trust-safety/">Trust &amp; Safety</a>
           <a href="/terms/">Terms</a>
@@ -134,6 +135,10 @@
             <a class="related-item" href="/user-guide/">
               <span class="related-item-title">User guide</span>
               <span class="related-item-desc">Trigger templates and channel-specific examples.</span>
+            </a>
+            <a class="related-item" href="/help-center/">
+              <span class="related-item-title">Help Center</span>
+              <span class="related-item-desc">Top 20 user questions with practical answers.</span>
             </a>
             <a class="related-item" href="/terms/">
               <span class="related-item-title">Terms of Service</span>

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -16,6 +16,9 @@
     <loc>https://dowhiz.com/user-guide/</loc>
   </url>
   <url>
+    <loc>https://dowhiz.com/help-center/</loc>
+  </url>
+  <url>
     <loc>https://dowhiz.com/integrations/</loc>
   </url>
   <url>

--- a/website/public/terms/index.html
+++ b/website/public/terms/index.html
@@ -21,6 +21,7 @@
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
           <a href="/user-guide/">User Guide</a>
+          <a href="/help-center/">Help Center</a>
           <a href="/integrations/">Integrations</a>
           <a href="/trust-safety/">Trust &amp; Safety</a>
           <a href="/privacy/">Privacy</a>
@@ -150,6 +151,10 @@
             <a class="related-item" href="/privacy/">
               <span class="related-item-title">Privacy policy</span>
               <span class="related-item-desc">How data is handled and retained.</span>
+            </a>
+            <a class="related-item" href="/help-center/">
+              <span class="related-item-title">Help Center</span>
+              <span class="related-item-desc">Top 20 user questions and setup answers.</span>
             </a>
             <a class="related-item" href="/user-guide/">
               <span class="related-item-title">User guide</span>

--- a/website/public/trust-safety/index.html
+++ b/website/public/trust-safety/index.html
@@ -22,6 +22,7 @@
         <nav class="header-links">
           <a href="/integrations/">Integrations</a>
           <a href="/user-guide/">User Guide</a>
+          <a href="/help-center/">Help Center</a>
           <a href="/privacy/">Privacy</a>
           <a href="/terms/">Terms</a>
           <a href="mailto:admin@dowhiz.com">Contact</a>
@@ -87,6 +88,10 @@
             <a class="related-item" href="/user-guide/">
               <span class="related-item-title">User guide</span>
               <span class="related-item-desc">Request templates for email, chat, issues, and comments.</span>
+            </a>
+            <a class="related-item" href="/help-center/">
+              <span class="related-item-title">Help Center</span>
+              <span class="related-item-desc">Top 20 user questions and support basics.</span>
             </a>
             <a class="related-item" href="/privacy/">
               <span class="related-item-title">Privacy policy</span>

--- a/website/public/user-guide/index.html
+++ b/website/public/user-guide/index.html
@@ -21,6 +21,7 @@
         <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
           <a href="/integrations/">Integrations</a>
+          <a href="/help-center/">Help Center</a>
           <a href="/trust-safety/">Trust &amp; Safety</a>
           <a href="/privacy/">Privacy</a>
           <a href="/terms/">Terms</a>
@@ -131,6 +132,10 @@
             <a class="related-item" href="/integrations/">
               <span class="related-item-title">Integrations</span>
               <span class="related-item-desc">Supported trigger surfaces and delivery outcomes.</span>
+            </a>
+            <a class="related-item" href="/help-center/">
+              <span class="related-item-title">Help Center</span>
+              <span class="related-item-desc">Top 20 user questions with practical answers.</span>
             </a>
             <a class="related-item" href="/trust-safety/">
               <span class="related-item-title">Trust &amp; Safety</span>

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1181,6 +1181,11 @@ function App() {
                 </article>
               ))}
             </div>
+            <div className="faq-help-center">
+              <a href="/help-center/" className="access-playbook-link">
+                View the full Help Center with top 20 questions
+              </a>
+            </div>
           </div>
         </section>
 
@@ -1233,6 +1238,7 @@ function App() {
                 <a href="/trust-safety/" className="footer-link">Trust &amp; Safety</a>
                 <a href="/integrations/" className="footer-link">Integrations</a>
                 <a href="/user-guide/" className="footer-link">User Guide</a>
+                <a href="/help-center/" className="footer-link">Help Center</a>
                 <a href="mailto:admin@dowhiz.com" className="footer-link">Contact</a>
               </div>
             </div>

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -870,6 +870,12 @@ ul {
   line-height: 1.7;
 }
 
+.faq-help-center {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+}
+
 /* Blog */
 .blog-section {
   padding-top: 6rem;


### PR DESCRIPTION
## Summary
- add a new indexable `/help-center/` page with 20 common user questions and answers
- include FAQPage JSON-LD on the new page for SEO-rich FAQ indexing
- add internal links to Help Center from core static pages and homepage footer/FAQ section
- add `/help-center/` to sitemap and update `SEO_TOP_PAGES.md`

## Verification
- `cd website && npm run build`
- `cd website && npm run lint`

## Issue
- Related to #190
