### PR TITLE
SEO: add 5 high-intent automation landing pages

### DIFF
--- a/website/SEO_TOP_PAGES.md
+++ b/website/SEO_TOP_PAGES.md
@@ -1,6 +1,6 @@
 # SEO Top Pages (H1 Audit)
 
-As of 2026-02-26, the website repo exposes 16 indexable pages.
+As of 2026-02-26, the website repo exposes 21 indexable pages.
 
 1. https://dowhiz.com/
 H1 count: 1
@@ -82,6 +82,31 @@ H1 count: 1
 H1: Top 20 user questions about DoWhiz
 H2: Numbered help questions (1–20)
 
+17. https://dowhiz.com/solutions/ai-workflow-automation/
+H1 count: 1
+H1: AI workflow automation for teams that work across tools.
+H2: High-intent keyword cluster, What this solves, How automation works in DoWhiz, Related resources
+
+18. https://dowhiz.com/solutions/github-issue-automation/
+H1 count: 1
+H1: GitHub issue automation from assignment to pull request.
+H2: High-intent keyword cluster, What this solves, Execution model, Related resources
+
+19. https://dowhiz.com/solutions/slack-task-automation/
+H1 count: 1
+H1: Slack task automation for faster team execution.
+H2: High-intent keyword cluster, What this solves, Delivery pattern, Related resources
+
+20. https://dowhiz.com/solutions/email-task-automation/
+H1 count: 1
+H1: Email task automation that keeps work in-thread.
+H2: High-intent keyword cluster, What this solves, How it works, Related resources
+
+21. https://dowhiz.com/solutions/google-docs-automation/
+H1 count: 1
+H1: Google Docs automation for action items and follow-through.
+H2: High-intent keyword cluster, What this solves, Workflow, Related resources
+
 ## Duplicate / Parameterized URL Inventory (Canonical Mapping)
 
 - `https://dowhiz.com/?utm_*`, `https://dowhiz.com/?ref=*`, and other tracking/query variants canonicalize to `https://dowhiz.com/`.
@@ -93,6 +118,7 @@ H2: Numbered help questions (1–20)
 - `https://dowhiz.com/privacy/?*` canonicalizes to `https://dowhiz.com/privacy/`.
 - `https://dowhiz.com/terms/?*` canonicalizes to `https://dowhiz.com/terms/`.
 - `https://dowhiz.com/agents/*/?*` canonicalizes to each agent page's clean trailing-slash URL (for example: `https://dowhiz.com/agents/oliver/`).
+- `https://dowhiz.com/solutions/*/?*` canonicalizes to each solution page's clean trailing-slash URL (for example: `https://dowhiz.com/solutions/ai-workflow-automation/`).
 - `https://dowhiz.com/auth/?loggedIn=true`, `https://dowhiz.com/auth/?discord=*`, `https://dowhiz.com/auth/?slack=*`, and hash callback variants canonicalize to `https://dowhiz.com/auth/`.
 
 ## Low-Value Pages Set to Noindex

--- a/website/public/integrations/index.html
+++ b/website/public/integrations/index.html
@@ -38,7 +38,7 @@
             the same model: trigger from your workspace, execute with explicit permissions, return
             results in context.
           </p>
-          <div class="updated">Last updated: February 25, 2026</div>
+          <div class="updated">Last updated: February 26, 2026</div>
         </section>
 
         <section class="legal-card">
@@ -81,6 +81,35 @@
           <h2>Phone / SMS (TBD)</h2>
           <p><strong>Trigger:</strong> Surface is in rollout planning. Placeholder only for now.</p>
           <p><strong>Outcome:</strong> Routing and status support will be published once public identifiers are ready.</p>
+        </section>
+
+        <section class="legal-card">
+          <h2>High-intent solution landing pages</h2>
+          <p class="related-intro">
+            Explore focused pages for high-intent automation queries by channel and workflow type.
+          </p>
+          <div class="related-grid">
+            <a class="related-item" href="/solutions/ai-workflow-automation/">
+              <span class="related-item-title">AI workflow automation</span>
+              <span class="related-item-desc">Cross-tool automation model for distributed teams.</span>
+            </a>
+            <a class="related-item" href="/solutions/github-issue-automation/">
+              <span class="related-item-title">GitHub issue automation</span>
+              <span class="related-item-desc">Turn assigned issues into PR-ready implementation.</span>
+            </a>
+            <a class="related-item" href="/solutions/slack-task-automation/">
+              <span class="related-item-title">Slack task automation</span>
+              <span class="related-item-desc">Convert thread requests into owner-tracked plans.</span>
+            </a>
+            <a class="related-item" href="/solutions/email-task-automation/">
+              <span class="related-item-title">Email task automation</span>
+              <span class="related-item-desc">Route inbox requests to finished deliverables.</span>
+            </a>
+            <a class="related-item" href="/solutions/google-docs-automation/">
+              <span class="related-item-title">Google Docs automation</span>
+              <span class="related-item-desc">Transform comments into actionable outputs.</span>
+            </a>
+          </div>
         </section>
 
         <section class="legal-card">

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -22,6 +22,21 @@
     <loc>https://dowhiz.com/integrations/</loc>
   </url>
   <url>
+    <loc>https://dowhiz.com/solutions/ai-workflow-automation/</loc>
+  </url>
+  <url>
+    <loc>https://dowhiz.com/solutions/github-issue-automation/</loc>
+  </url>
+  <url>
+    <loc>https://dowhiz.com/solutions/slack-task-automation/</loc>
+  </url>
+  <url>
+    <loc>https://dowhiz.com/solutions/email-task-automation/</loc>
+  </url>
+  <url>
+    <loc>https://dowhiz.com/solutions/google-docs-automation/</loc>
+  </url>
+  <url>
     <loc>https://dowhiz.com/trust-safety/</loc>
   </url>
   <url>

--- a/website/public/solutions/ai-workflow-automation/index.html
+++ b/website/public/solutions/ai-workflow-automation/index.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Automate cross-tool workflows with AI digital employees. Trigger from email, Slack, GitHub, and docs, then receive finished outputs in-thread."
+    />
+    <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="stylesheet" href="/legal.css" />
+    <script src="/theme.js"></script>
+    <link rel="canonical" href="https://dowhiz.com/solutions/ai-workflow-automation/" />
+    <title>AI Workflow Automation for Teams | DoWhiz</title>
+  </head>
+  <body>
+    <div class="page">
+      <header class="page-header">
+        <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
+        <nav class="header-links">
+          <a href="/integrations/">Integrations</a>
+          <a href="/user-guide/">User Guide</a>
+          <a href="/help-center/">Help Center</a>
+          <a href="/trust-safety/">Trust &amp; Safety</a>
+          <a href="mailto:admin@dowhiz.com">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="legal-hero">
+          <div class="eyebrow">Solution Page</div>
+          <h1>AI workflow automation for teams that work across tools.</h1>
+          <p class="lead">
+            DoWhiz gives teams a practical AI workflow automation layer across email, Slack, GitHub,
+            and shared docs. Trigger work where context already exists and get finished results back
+            in that same surface.
+          </p>
+          <div class="updated">Last updated: February 26, 2026</div>
+        </section>
+
+        <section class="legal-card">
+          <h2>High-intent keyword cluster</h2>
+          <ul>
+            <li>AI workflow automation for teams</li>
+            <li>Cross-tool workflow automation platform</li>
+            <li>Digital employee workflow automation</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>What this solves</h2>
+          <p>
+            Teams lose time when requests move between tools manually. DoWhiz normalizes intake,
+            executes in approved workspaces, and returns complete outputs with context preserved.
+          </p>
+          <ul>
+            <li>Trigger from existing channels instead of switching tools</li>
+            <li>Route to role-specialized employees for execution</li>
+            <li>Keep memory and handoffs coherent across follow-up requests</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>How automation works in DoWhiz</h2>
+          <ul>
+            <li><strong>Trigger:</strong> Send a request from email, chat, GitHub, or doc comments.</li>
+            <li><strong>Execute:</strong> Agents run in scoped integrations with explicit permissions.</li>
+            <li><strong>Deliver:</strong> Results return in-thread with summary and next steps.</li>
+          </ul>
+          <p class="callout">
+            Need channel-specific examples? See
+            <a href="/solutions/email-task-automation/">email task automation</a>,
+            <a href="/solutions/slack-task-automation/">Slack task automation</a>, and
+            <a href="/solutions/github-issue-automation/">GitHub issue automation</a>.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Explore implementation details, safety model, and trigger templates.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/integrations/">
+              <span class="related-item-title">Integrations</span>
+              <span class="related-item-desc">Channel-specific trigger and outcome examples.</span>
+            </a>
+            <a class="related-item" href="/user-guide/">
+              <span class="related-item-title">User Guide</span>
+              <span class="related-item-desc">Kickoff templates for each trigger surface.</span>
+            </a>
+            <a class="related-item" href="/trust-safety/">
+              <span class="related-item-title">Trust &amp; Safety</span>
+              <span class="related-item-desc">Permission and isolation model for execution.</span>
+            </a>
+            <a class="related-item" href="/solutions/google-docs-automation/">
+              <span class="related-item-title">Google Docs automation</span>
+              <span class="related-item-desc">Extract decisions and action items from comments.</span>
+            </a>
+            <a class="related-item" href="/solutions/email-task-automation/">
+              <span class="related-item-title">Email automation</span>
+              <span class="related-item-desc">Turn inbox requests into completed deliverables.</span>
+            </a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="page-footer">
+        <a class="back-link" href="/">Back to DoWhiz</a>
+        <span>Questions? Contact admin@dowhiz.com.</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/website/public/solutions/email-task-automation/index.html
+++ b/website/public/solutions/email-task-automation/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Route email requests to DoWhiz digital employees and get completed deliverables, summaries, and follow-up actions back in the same thread."
+    />
+    <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="stylesheet" href="/legal.css" />
+    <script src="/theme.js"></script>
+    <link rel="canonical" href="https://dowhiz.com/solutions/email-task-automation/" />
+    <title>Email Task Automation for Operations | DoWhiz</title>
+  </head>
+  <body>
+    <div class="page">
+      <header class="page-header">
+        <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
+        <nav class="header-links">
+          <a href="/integrations/">Integrations</a>
+          <a href="/user-guide/">User Guide</a>
+          <a href="/help-center/">Help Center</a>
+          <a href="/trust-safety/">Trust &amp; Safety</a>
+          <a href="mailto:admin@dowhiz.com">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="legal-hero">
+          <div class="eyebrow">Solution Page</div>
+          <h1>Email task automation that keeps work in-thread.</h1>
+          <p class="lead">
+            Use email as a direct execution surface. Forward a task to a DoWhiz digital employee and
+            receive completed artifacts, summaries, and next actions without leaving your inbox.
+          </p>
+          <div class="updated">Last updated: February 26, 2026</div>
+        </section>
+
+        <section class="legal-card">
+          <h2>High-intent keyword cluster</h2>
+          <ul>
+            <li>Email task automation</li>
+            <li>Email workflow assistant for teams</li>
+            <li>Inbox-to-action automation platform</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>What this solves</h2>
+          <p>
+            Many operational requests begin in email but stall during handoff. DoWhiz executes directly
+            from email requests, preserving thread context and reducing coordination overhead.
+          </p>
+          <ul>
+            <li>Accept links, attachments, constraints, and due dates in one place</li>
+            <li>Deliver documents, implementation updates, or structured summaries in-thread</li>
+            <li>Maintain request context for fast follow-up revisions</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>How it works</h2>
+          <ul>
+            <li><strong>Request:</strong> Email the right DoWhiz employee with task context.</li>
+            <li><strong>Execute:</strong> Agent works in approved tools based on scope.</li>
+            <li><strong>Reply:</strong> Final output returns to the same email thread.</li>
+          </ul>
+          <p class="callout">
+            Teams often combine email intake with
+            <a href="/solutions/slack-task-automation/">Slack follow-up workflows</a> and
+            <a href="/solutions/github-issue-automation/">GitHub issue execution</a>.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Set up trigger templates, permissions, and channel handoffs.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/user-guide/">
+              <span class="related-item-title">User Guide</span>
+              <span class="related-item-desc">Email request templates and output expectations.</span>
+            </a>
+            <a class="related-item" href="/integrations/">
+              <span class="related-item-title">Integrations</span>
+              <span class="related-item-desc">Trigger + outcome examples across all channels.</span>
+            </a>
+            <a class="related-item" href="/help-center/">
+              <span class="related-item-title">Help Center</span>
+              <span class="related-item-desc">Top setup and quality-control questions.</span>
+            </a>
+            <a class="related-item" href="/solutions/ai-workflow-automation/">
+              <span class="related-item-title">AI workflow automation</span>
+              <span class="related-item-desc">Cross-tool orchestration for distributed teams.</span>
+            </a>
+            <a class="related-item" href="/solutions/google-docs-automation/">
+              <span class="related-item-title">Google Docs automation</span>
+              <span class="related-item-desc">Move planning comments into accountable tasks.</span>
+            </a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="page-footer">
+        <a class="back-link" href="/">Back to DoWhiz</a>
+        <span>Questions? Contact admin@dowhiz.com.</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/website/public/solutions/github-issue-automation/index.html
+++ b/website/public/solutions/github-issue-automation/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Turn assigned GitHub issues into scoped implementation updates, tested pull requests, and concise review summaries with DoWhiz."
+    />
+    <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="stylesheet" href="/legal.css" />
+    <script src="/theme.js"></script>
+    <link rel="canonical" href="https://dowhiz.com/solutions/github-issue-automation/" />
+    <title>GitHub Issue Automation to PR Delivery | DoWhiz</title>
+  </head>
+  <body>
+    <div class="page">
+      <header class="page-header">
+        <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
+        <nav class="header-links">
+          <a href="/integrations/">Integrations</a>
+          <a href="/agents/devin/">Devin</a>
+          <a href="/help-center/">Help Center</a>
+          <a href="/trust-safety/">Trust &amp; Safety</a>
+          <a href="mailto:admin@dowhiz.com">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="legal-hero">
+          <div class="eyebrow">Solution Page</div>
+          <h1>GitHub issue automation from assignment to pull request.</h1>
+          <p class="lead">
+            Assign an issue in GitHub and let DoWhiz handle implementation sequencing, code updates,
+            validation runs, and concise PR-ready summaries so reviewers can move faster.
+          </p>
+          <div class="updated">Last updated: February 26, 2026</div>
+        </section>
+
+        <section class="legal-card">
+          <h2>High-intent keyword cluster</h2>
+          <ul>
+            <li>GitHub issue automation</li>
+            <li>AI GitHub coding agent</li>
+            <li>Issue-to-PR automation workflow</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>What this solves</h2>
+          <p>
+            Engineering teams need fast throughput without losing review quality. DoWhiz helps convert
+            scoped GitHub issues into implementation outcomes with transparent progress and handoff.
+          </p>
+          <ul>
+            <li>Issue assignment as trigger with acceptance criteria</li>
+            <li>Code changes plus targeted test/verification runs</li>
+            <li>PR and issue comments with concise technical summaries</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>Execution model</h2>
+          <ul>
+            <li><strong>Intake:</strong> Parse the issue scope and gather repository context.</li>
+            <li><strong>Build:</strong> Implement changes in a branch and run relevant checks.</li>
+            <li><strong>Handoff:</strong> Open PR and post issue update with verification commands.</li>
+          </ul>
+          <p class="callout">
+            For cross-channel planning before coding, pair this with
+            <a href="/solutions/slack-task-automation/">Slack task automation</a> and
+            <a href="/solutions/email-task-automation/">email task automation</a>.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Use these pages to set expectations and permission boundaries.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/integrations/">
+              <span class="related-item-title">GitHub integration</span>
+              <span class="related-item-desc">How issue triggers and PR delivery flows work.</span>
+            </a>
+            <a class="related-item" href="/agents/devin/">
+              <span class="related-item-title">Meet Devin</span>
+              <span class="related-item-desc">Coding specialist profile and workflow examples.</span>
+            </a>
+            <a class="related-item" href="/trust-safety/">
+              <span class="related-item-title">Trust &amp; Safety</span>
+              <span class="related-item-desc">Execution boundaries and audit model.</span>
+            </a>
+            <a class="related-item" href="/solutions/ai-workflow-automation/">
+              <span class="related-item-title">AI workflow automation</span>
+              <span class="related-item-desc">Cross-tool delivery pattern overview.</span>
+            </a>
+            <a class="related-item" href="/solutions/google-docs-automation/">
+              <span class="related-item-title">Google Docs automation</span>
+              <span class="related-item-desc">Translate planning comments into tracked tasks.</span>
+            </a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="page-footer">
+        <a class="back-link" href="/">Back to DoWhiz</a>
+        <span>Questions? Contact admin@dowhiz.com.</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/website/public/solutions/google-docs-automation/index.html
+++ b/website/public/solutions/google-docs-automation/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Use @mentions in Google Docs comments to generate action items, rewrites, summaries, and tracked follow-ups with shared context."
+    />
+    <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="stylesheet" href="/legal.css" />
+    <script src="/theme.js"></script>
+    <link rel="canonical" href="https://dowhiz.com/solutions/google-docs-automation/" />
+    <title>Google Docs Action Item Automation | DoWhiz</title>
+  </head>
+  <body>
+    <div class="page">
+      <header class="page-header">
+        <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
+        <nav class="header-links">
+          <a href="/integrations/">Integrations</a>
+          <a href="/user-guide/">User Guide</a>
+          <a href="/help-center/">Help Center</a>
+          <a href="/agents/maggie/">Maggie</a>
+          <a href="mailto:admin@dowhiz.com">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="legal-hero">
+          <div class="eyebrow">Solution Page</div>
+          <h1>Google Docs automation for action items and follow-through.</h1>
+          <p class="lead">
+            Mention DoWhiz in Google Docs comments to transform planning notes into structured actions,
+            revised copy, and trackable next steps without manual copy-paste.
+          </p>
+          <div class="updated">Last updated: February 26, 2026</div>
+        </section>
+
+        <section class="legal-card">
+          <h2>High-intent keyword cluster</h2>
+          <ul>
+            <li>Google Docs action item automation</li>
+            <li>Automate Google Docs comments and follow-ups</li>
+            <li>AI assistant for document collaboration workflows</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>What this solves</h2>
+          <p>
+            Planning docs often capture decisions but miss clear follow-through. DoWhiz converts comment
+            threads into owner-tagged tasks, polished drafts, and delivery-ready summaries.
+          </p>
+          <ul>
+            <li>Extract decisions, open questions, and dependencies from comments</li>
+            <li>Create owner + due date action lists for execution tracking</li>
+            <li>Prepare clean rewrites and status-ready updates for stakeholders</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>Workflow</h2>
+          <ul>
+            <li><strong>Mention:</strong> @mention the right agent in a Google Docs comment.</li>
+            <li><strong>Transform:</strong> Convert context into actionable outputs.</li>
+            <li><strong>Sync:</strong> Push results to email, Slack, or GitHub when needed.</li>
+          </ul>
+          <p class="callout">
+            For complete planning-to-shipping flow, combine this with
+            <a href="/solutions/slack-task-automation/">Slack task automation</a> and
+            <a href="/solutions/github-issue-automation/">GitHub issue automation</a>.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Connect documentation workflows to execution channels.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/integrations/">
+              <span class="related-item-title">Integrations</span>
+              <span class="related-item-desc">Google Docs trigger model and delivery surfaces.</span>
+            </a>
+            <a class="related-item" href="/user-guide/">
+              <span class="related-item-title">User Guide</span>
+              <span class="related-item-desc">Comment templates for summaries and action plans.</span>
+            </a>
+            <a class="related-item" href="/help-center/">
+              <span class="related-item-title">Help Center</span>
+              <span class="related-item-desc">Common questions on shared-memory collaboration.</span>
+            </a>
+            <a class="related-item" href="/solutions/email-task-automation/">
+              <span class="related-item-title">Email automation</span>
+              <span class="related-item-desc">Send finalized outputs and revisions via email.</span>
+            </a>
+            <a class="related-item" href="/solutions/ai-workflow-automation/">
+              <span class="related-item-title">AI workflow automation</span>
+              <span class="related-item-desc">Cross-tool orchestration overview.</span>
+            </a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="page-footer">
+        <a class="back-link" href="/">Back to DoWhiz</a>
+        <span>Questions? Contact admin@dowhiz.com.</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/website/public/solutions/slack-task-automation/index.html
+++ b/website/public/solutions/slack-task-automation/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Convert Slack requests and thread mentions into structured execution plans, owner-tracked action items, and delivered outputs."
+    />
+    <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="stylesheet" href="/legal.css" />
+    <script src="/theme.js"></script>
+    <link rel="canonical" href="https://dowhiz.com/solutions/slack-task-automation/" />
+    <title>Slack Task Automation for Execution Teams | DoWhiz</title>
+  </head>
+  <body>
+    <div class="page">
+      <header class="page-header">
+        <a class="brand" href="/">Do<span class="accent">Whiz</span></a>
+        <nav class="header-links">
+          <a href="/integrations/">Integrations</a>
+          <a href="/agents/maggie/">Maggie</a>
+          <a href="/user-guide/">User Guide</a>
+          <a href="/help-center/">Help Center</a>
+          <a href="mailto:admin@dowhiz.com">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="legal-hero">
+          <div class="eyebrow">Solution Page</div>
+          <h1>Slack task automation for faster team execution.</h1>
+          <p class="lead">
+            Turn Slack thread requests and @mentions into structured plans, clear owners, and shipped
+            outputs. DoWhiz keeps execution updates in-channel so teams can move without context loss.
+          </p>
+          <div class="updated">Last updated: February 26, 2026</div>
+        </section>
+
+        <section class="legal-card">
+          <h2>High-intent keyword cluster</h2>
+          <ul>
+            <li>Slack task automation</li>
+            <li>Slack AI project assistant</li>
+            <li>Automate Slack action items and follow-ups</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>What this solves</h2>
+          <p>
+            Chat-heavy teams often lose ownership and deadlines in long threads. DoWhiz converts
+            Slack discussion context into explicit work outputs and follow-through.
+          </p>
+          <ul>
+            <li>Extract owners, due dates, and dependencies from thread context</li>
+            <li>Prepare status-ready summaries for standups and async updates</li>
+            <li>Coordinate with coding and docs specialists when work spans tools</li>
+          </ul>
+        </section>
+
+        <section class="legal-card">
+          <h2>Delivery pattern</h2>
+          <ul>
+            <li><strong>Trigger:</strong> Message or @mention DoWhiz in the relevant Slack thread.</li>
+            <li><strong>Structure:</strong> Build an execution plan with owners and milestones.</li>
+            <li><strong>Deliver:</strong> Post updates and next steps back to the same channel.</li>
+          </ul>
+          <p class="callout">
+            Need full multi-channel routing? Pair Slack with
+            <a href="/solutions/github-issue-automation/">GitHub issue automation</a> and
+            <a href="/solutions/google-docs-automation/">Google Docs automation</a>.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>Related resources</h2>
+          <p class="related-intro">Map chat triggers to implementation and reporting workflows.</p>
+          <div class="related-grid">
+            <a class="related-item" href="/integrations/">
+              <span class="related-item-title">Slack integration</span>
+              <span class="related-item-desc">See how Slack triggers map to execution outcomes.</span>
+            </a>
+            <a class="related-item" href="/agents/maggie/">
+              <span class="related-item-title">Meet Maggie</span>
+              <span class="related-item-desc">TPM-style coordination and status workflows.</span>
+            </a>
+            <a class="related-item" href="/help-center/">
+              <span class="related-item-title">Help Center</span>
+              <span class="related-item-desc">Common onboarding and execution questions.</span>
+            </a>
+            <a class="related-item" href="/solutions/email-task-automation/">
+              <span class="related-item-title">Email automation</span>
+              <span class="related-item-desc">Route external requests from inbox to completion.</span>
+            </a>
+            <a class="related-item" href="/solutions/ai-workflow-automation/">
+              <span class="related-item-title">AI workflow automation</span>
+              <span class="related-item-desc">Cross-tool operating model for distributed teams.</span>
+            </a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="page-footer">
+        <a class="back-link" href="/">Back to DoWhiz</a>
+        <span>Questions? Contact admin@dowhiz.com.</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1239,6 +1239,11 @@ function App() {
                 <a href="/integrations/" className="footer-link">Integrations</a>
                 <a href="/user-guide/" className="footer-link">User Guide</a>
                 <a href="/help-center/" className="footer-link">Help Center</a>
+                <a href="/solutions/ai-workflow-automation/" className="footer-link">AI Workflow Automation</a>
+                <a href="/solutions/github-issue-automation/" className="footer-link">GitHub Issue Automation</a>
+                <a href="/solutions/slack-task-automation/" className="footer-link">Slack Task Automation</a>
+                <a href="/solutions/email-task-automation/" className="footer-link">Email Task Automation</a>
+                <a href="/solutions/google-docs-automation/" className="footer-link">Google Docs Automation</a>
                 <a href="mailto:admin@dowhiz.com" className="footer-link">Contact</a>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- create 5 high-intent solution landing pages with dedicated keyword clusters:
  - `/solutions/ai-workflow-automation/`
  - `/solutions/github-issue-automation/`
  - `/solutions/slack-task-automation/`
  - `/solutions/email-task-automation/`
  - `/solutions/google-docs-automation/`
- add on-page SEO for each page (`title`, `meta description`, canonical tag, and single H1)
- strengthen internal links from existing authority pages (integrations page + homepage footer links)
- add all 5 URLs to `website/public/sitemap.xml`
- update `website/SEO_TOP_PAGES.md` inventory and canonical mapping notes

## Verification
- `cd website && npm run build`
- `cd website && npm run lint`

## Issue
- Related to #191