### PR TITLE
SEO: add scripted crawl report for indexability/metadata/4xx (Issue #193)

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -20,8 +20,10 @@ Open the local URL shown in the terminal (defaults to http://localhost:5173).
 - Lint: `npm run lint`
 - Production build: `npm run build`
 - Preview production build: `npm run preview`
+- SEO crawl report: `npm run seo:crawl`
 
 Build output goes to `website/dist/`.
+SEO crawl reports are written to `website/reports/` as dated `.md` + `.json` files.
 
 ## VM Deployment Workflow
 

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test:responsive": "node scripts/responsive-audit.mjs"
+    "test:responsive": "node scripts/responsive-audit.mjs",
+    "seo:crawl": "node scripts/seo-crawl-report.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.97.0",

--- a/website/reports/seo-crawl-report-2026-02-26.json
+++ b/website/reports/seo-crawl-report-2026-02-26.json
@@ -1,0 +1,435 @@
+{
+  "summary": {
+    "generated_at": "2026-02-26T05:32:44.925Z",
+    "source_sitemap": "website/public/sitemap.xml",
+    "crawl_target_count": 21,
+    "indexable_pages": 21,
+    "title_issue_pages": 0,
+    "meta_description_issue_pages": 0,
+    "duplicate_h1_groups": 0,
+    "duplicate_h1_pages": 0,
+    "status_4xx": 0,
+    "status_5xx": 0,
+    "fetch_errors": 0
+  },
+  "crawl_results": [
+    {
+      "url": "https://dowhiz.com/",
+      "finalUrl": "https://www.dowhiz.com/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 426,
+      "indexable": true,
+      "title": "DoWhiz | Multi-Channel Tool-Native Digital Employees",
+      "titleLength": 52,
+      "metaDescription": "Multi-channel, tool-native digital employee team for daily operations. Trigger work from email, chat, GitHub, and shared docs with shared memory across platforms.",
+      "metaDescriptionLength": 162,
+      "robots": "index, follow",
+      "noindex": false,
+      "h1Count": 0,
+      "h1s": [],
+      "primaryH1": "",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/blog/",
+      "finalUrl": "https://www.dowhiz.com/blog/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 148,
+      "indexable": true,
+      "title": "DoWhiz Blog | SEO and Product Workflow Guides",
+      "titleLength": 45,
+      "metaDescription": "DoWhiz blog with product updates and eight new SEO articles covering AI workflow automation, channel operations, memory, onboarding, and governance.",
+      "metaDescriptionLength": 148,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "SEO guides and workflow notes from the DoWhiz team."
+      ],
+      "primaryH1": "SEO guides and workflow notes from the DoWhiz team.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/privacy/",
+      "finalUrl": "https://www.dowhiz.com/privacy/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 199,
+      "indexable": true,
+      "title": "DoWhiz Privacy | Multi-Channel Data Handling and Access",
+      "titleLength": 55,
+      "metaDescription": "DoWhiz privacy policy covering multi-channel data handling, integration permissions, and our no-user-credentials access model.",
+      "metaDescriptionLength": 126,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Privacy for multi-channel digital work."
+      ],
+      "primaryH1": "Privacy for multi-channel digital work.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/terms/",
+      "finalUrl": "https://www.dowhiz.com/terms/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 180,
+      "indexable": true,
+      "title": "DoWhiz Terms | Multi-Channel Digital Employee Service Terms",
+      "titleLength": 59,
+      "metaDescription": "DoWhiz terms of service for multi-channel digital employee usage, integration authorization, and access responsibilities.",
+      "metaDescriptionLength": 121,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Clear terms for working with DoWhiz."
+      ],
+      "primaryH1": "Clear terms for working with DoWhiz.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/user-guide/",
+      "finalUrl": "https://www.dowhiz.com/user-guide/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 197,
+      "indexable": true,
+      "title": "DoWhiz User Guide | Multi-Channel Triggers and Shared Memory",
+      "titleLength": 60,
+      "metaDescription": "DoWhiz user guide for multi-channel triggers, tool-native execution, and shared memory across email, chat, GitHub, and shared workspaces.",
+      "metaDescriptionLength": 137,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Trigger DoWhiz from anywhere you work."
+      ],
+      "primaryH1": "Trigger DoWhiz from anywhere you work.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/help-center/",
+      "finalUrl": "https://www.dowhiz.com/help-center/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 161,
+      "indexable": true,
+      "title": "DoWhiz Help Center | Top 20 User Questions",
+      "titleLength": 42,
+      "metaDescription": "DoWhiz Help Center: top 20 common user questions across setup, integrations, permissions, outputs, and support.",
+      "metaDescriptionLength": 111,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Top 20 user questions about DoWhiz"
+      ],
+      "primaryH1": "Top 20 user questions about DoWhiz",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/integrations/",
+      "finalUrl": "https://www.dowhiz.com/integrations/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 147,
+      "indexable": true,
+      "title": "Integrations | DoWhiz",
+      "titleLength": 21,
+      "metaDescription": "DoWhiz integrations across email, Slack, Discord, GitHub, Google Docs, and Notion with trigger + outcome examples.",
+      "metaDescriptionLength": 114,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Trigger agents where work already happens."
+      ],
+      "primaryH1": "Trigger agents where work already happens.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/solutions/ai-workflow-automation/",
+      "finalUrl": "https://www.dowhiz.com/solutions/ai-workflow-automation/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 173,
+      "indexable": true,
+      "title": "AI Workflow Automation for Teams | DoWhiz",
+      "titleLength": 41,
+      "metaDescription": "Automate cross-tool workflows with AI digital employees. Trigger from email, Slack, GitHub, and docs, then receive finished outputs in-thread.",
+      "metaDescriptionLength": 142,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "AI workflow automation for teams that work across tools."
+      ],
+      "primaryH1": "AI workflow automation for teams that work across tools.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/solutions/github-issue-automation/",
+      "finalUrl": "https://www.dowhiz.com/solutions/github-issue-automation/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 162,
+      "indexable": true,
+      "title": "GitHub Issue Automation to PR Delivery | DoWhiz",
+      "titleLength": 47,
+      "metaDescription": "Turn assigned GitHub issues into scoped implementation updates, tested pull requests, and concise review summaries with DoWhiz.",
+      "metaDescriptionLength": 127,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "GitHub issue automation from assignment to pull request."
+      ],
+      "primaryH1": "GitHub issue automation from assignment to pull request.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/solutions/slack-task-automation/",
+      "finalUrl": "https://www.dowhiz.com/solutions/slack-task-automation/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 173,
+      "indexable": true,
+      "title": "Slack Task Automation for Execution Teams | DoWhiz",
+      "titleLength": 50,
+      "metaDescription": "Convert Slack requests and thread mentions into structured execution plans, owner-tracked action items, and delivered outputs.",
+      "metaDescriptionLength": 126,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Slack task automation for faster team execution."
+      ],
+      "primaryH1": "Slack task automation for faster team execution.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/solutions/email-task-automation/",
+      "finalUrl": "https://www.dowhiz.com/solutions/email-task-automation/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 153,
+      "indexable": true,
+      "title": "Email Task Automation for Operations | DoWhiz",
+      "titleLength": 45,
+      "metaDescription": "Route email requests to DoWhiz digital employees and get completed deliverables, summaries, and follow-up actions back in the same thread.",
+      "metaDescriptionLength": 138,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Email task automation that keeps work in-thread."
+      ],
+      "primaryH1": "Email task automation that keeps work in-thread.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/solutions/google-docs-automation/",
+      "finalUrl": "https://www.dowhiz.com/solutions/google-docs-automation/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 164,
+      "indexable": true,
+      "title": "Google Docs Action Item Automation | DoWhiz",
+      "titleLength": 43,
+      "metaDescription": "Use @mentions in Google Docs comments to generate action items, rewrites, summaries, and tracked follow-ups with shared context.",
+      "metaDescriptionLength": 128,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Google Docs automation for action items and follow-through."
+      ],
+      "primaryH1": "Google Docs automation for action items and follow-through.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/trust-safety/",
+      "finalUrl": "https://www.dowhiz.com/trust-safety/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 189,
+      "indexable": true,
+      "title": "Trust & Safety | DoWhiz",
+      "titleLength": 23,
+      "metaDescription": "DoWhiz Trust & Safety: isolated execution, permission-based workspace access, no personal credential handoff, and data handling basics.",
+      "metaDescriptionLength": 135,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Safety model built for real operational workflows."
+      ],
+      "primaryH1": "Safety model built for real operational workflows.",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/agents/oliver/",
+      "finalUrl": "https://www.dowhiz.com/agents/oliver/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 152,
+      "indexable": true,
+      "title": "Oliver | DoWhiz Generalist Digital Employee",
+      "titleLength": 43,
+      "metaDescription": "Meet Oliver, the DoWhiz Generalist digital employee for multi-channel requests and tool-native delivery.",
+      "metaDescriptionLength": 104,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Oliver - Generalist"
+      ],
+      "primaryH1": "Oliver - Generalist",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/agents/maggie/",
+      "finalUrl": "https://www.dowhiz.com/agents/maggie/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 146,
+      "indexable": true,
+      "title": "Maggie | DoWhiz TPM Digital Employee",
+      "titleLength": 36,
+      "metaDescription": "Meet Maggie, the DoWhiz TPM digital employee for planning, status, and cross-team follow-up workflows.",
+      "metaDescriptionLength": 102,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Maggie - TPM"
+      ],
+      "primaryH1": "Maggie - TPM",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/agents/devin/",
+      "finalUrl": "https://www.dowhiz.com/agents/devin/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 147,
+      "indexable": true,
+      "title": "Devin | DoWhiz Coder Digital Employee",
+      "titleLength": 37,
+      "metaDescription": "Meet Devin, the DoWhiz Coder digital employee for issue-to-PR execution and engineering handoffs.",
+      "metaDescriptionLength": 97,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Devin - Coder"
+      ],
+      "primaryH1": "Devin - Coder",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/agents/lumio/",
+      "finalUrl": "https://www.dowhiz.com/agents/lumio/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 243,
+      "indexable": true,
+      "title": "Lumio | DoWhiz CEO Digital Employee",
+      "titleLength": 35,
+      "metaDescription": "Meet Lumio, the DoWhiz CEO digital employee for strategic planning and executive decision support.",
+      "metaDescriptionLength": 98,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Lumio - CEO"
+      ],
+      "primaryH1": "Lumio - CEO",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/agents/claw/",
+      "finalUrl": "https://www.dowhiz.com/agents/claw/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 149,
+      "indexable": true,
+      "title": "Claw | DoWhiz Workflow Specialist",
+      "titleLength": 33,
+      "metaDescription": "Meet Claw, the DoWhiz workflow specialist focused on safe, accessible, tool-native automation across channels.",
+      "metaDescriptionLength": 110,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Claw - Workflow Specialist"
+      ],
+      "primaryH1": "Claw - Workflow Specialist",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/agents/jeffery/",
+      "finalUrl": "https://www.dowhiz.com/agents/jeffery/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 154,
+      "indexable": true,
+      "title": "Jeffery | DoWhiz DeepTutor Digital Employee",
+      "titleLength": 43,
+      "metaDescription": "Meet Jeffery, the DoWhiz DeepTutor digital employee for document comprehension and structured takeaways.",
+      "metaDescriptionLength": 104,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Jeffery - DeepTutor"
+      ],
+      "primaryH1": "Jeffery - DeepTutor",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/agents/anna/",
+      "finalUrl": "https://www.dowhiz.com/agents/anna/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 170,
+      "indexable": true,
+      "title": "Anna | DoWhiz Role Design Digital Employee",
+      "titleLength": 42,
+      "metaDescription": "Meet Anna, the DoWhiz role-design digital employee for defining new specialist scopes and pilot plans.",
+      "metaDescriptionLength": 102,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Anna - Role Design"
+      ],
+      "primaryH1": "Anna - Role Design",
+      "error": ""
+    },
+    {
+      "url": "https://dowhiz.com/agents/rachel/",
+      "finalUrl": "https://www.dowhiz.com/agents/rachel/",
+      "status": 200,
+      "statusClass": "2xx",
+      "durationMs": 179,
+      "indexable": true,
+      "title": "Rachel | DoWhiz GTM Specialist Digital Employee",
+      "titleLength": 47,
+      "metaDescription": "Meet Rachel, the DoWhiz GTM specialist digital employee for launch planning and per-channel content operations.",
+      "metaDescriptionLength": 111,
+      "robots": "",
+      "noindex": false,
+      "h1Count": 1,
+      "h1s": [
+        "Rachel - GTM Specialist"
+      ],
+      "primaryH1": "Rachel - GTM Specialist",
+      "error": ""
+    }
+  ]
+}

--- a/website/reports/seo-crawl-report-2026-02-26.md
+++ b/website/reports/seo-crawl-report-2026-02-26.md
@@ -1,0 +1,76 @@
+# SEO Crawl Report
+
+Generated at: 2026-02-26T05:32:44.925Z
+Run command: `npm run seo:crawl`
+Source sitemap: `website/public/sitemap.xml`
+
+## Summary Counts
+
+| Metric | Count |
+| --- | ---: |
+| URLs crawled | 21 |
+| Indexable pages (2xx and not noindex) | 21 |
+| Title issue pages (missing/duplicate) | 0 |
+| Meta description issue pages (missing/duplicate) | 0 |
+| Duplicate H1 groups | 0 |
+| Pages in duplicate H1 groups | 0 |
+| 4xx responses | 0 |
+| 5xx responses | 0 |
+| Fetch errors | 0 |
+
+## Title Issue Details
+
+Missing title pages: 0
+- (none)
+
+Duplicate title groups: 0
+- (none)
+
+## Meta Description Issue Details
+
+Missing meta description pages: 0
+- (none)
+
+Duplicate meta description groups: 0
+- (none)
+
+## Duplicate H1 Details
+
+- (none)
+
+## 4xx / 5xx / Fetch Error URLs
+
+4xx URLs: 0
+- (none)
+
+5xx URLs: 0
+- (none)
+
+Fetch errors: 0
+- (none)
+
+## Crawl Matrix
+
+| URL | Status | Indexable | Title chars | Meta chars | H1 count |
+| --- | ---: | :---: | ---: | ---: | ---: |
+| https://dowhiz.com/ | 200 | yes | 52 | 162 | 0 |
+| https://dowhiz.com/blog/ | 200 | yes | 45 | 148 | 1 |
+| https://dowhiz.com/privacy/ | 200 | yes | 55 | 126 | 1 |
+| https://dowhiz.com/terms/ | 200 | yes | 59 | 121 | 1 |
+| https://dowhiz.com/user-guide/ | 200 | yes | 60 | 137 | 1 |
+| https://dowhiz.com/help-center/ | 200 | yes | 42 | 111 | 1 |
+| https://dowhiz.com/integrations/ | 200 | yes | 21 | 114 | 1 |
+| https://dowhiz.com/solutions/ai-workflow-automation/ | 200 | yes | 41 | 142 | 1 |
+| https://dowhiz.com/solutions/github-issue-automation/ | 200 | yes | 47 | 127 | 1 |
+| https://dowhiz.com/solutions/slack-task-automation/ | 200 | yes | 50 | 126 | 1 |
+| https://dowhiz.com/solutions/email-task-automation/ | 200 | yes | 45 | 138 | 1 |
+| https://dowhiz.com/solutions/google-docs-automation/ | 200 | yes | 43 | 128 | 1 |
+| https://dowhiz.com/trust-safety/ | 200 | yes | 23 | 135 | 1 |
+| https://dowhiz.com/agents/oliver/ | 200 | yes | 43 | 104 | 1 |
+| https://dowhiz.com/agents/maggie/ | 200 | yes | 36 | 102 | 1 |
+| https://dowhiz.com/agents/devin/ | 200 | yes | 37 | 97 | 1 |
+| https://dowhiz.com/agents/lumio/ | 200 | yes | 35 | 98 | 1 |
+| https://dowhiz.com/agents/claw/ | 200 | yes | 33 | 110 | 1 |
+| https://dowhiz.com/agents/jeffery/ | 200 | yes | 43 | 104 | 1 |
+| https://dowhiz.com/agents/anna/ | 200 | yes | 42 | 102 | 1 |
+| https://dowhiz.com/agents/rachel/ | 200 | yes | 47 | 111 | 1 |

--- a/website/scripts/seo-crawl-report.mjs
+++ b/website/scripts/seo-crawl-report.mjs
@@ -1,0 +1,371 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const sitemapPath = path.join(root, 'public', 'sitemap.xml');
+const outputDir = path.join(root, 'reports');
+const crawlTimestamp = new Date().toISOString();
+const reportDate = crawlTimestamp.slice(0, 10);
+const markdownOutputPath = path.join(outputDir, `seo-crawl-report-${reportDate}.md`);
+const jsonOutputPath = path.join(outputDir, `seo-crawl-report-${reportDate}.json`);
+
+const ENTITY_MAP = new Map([
+  ['amp', '&'],
+  ['lt', '<'],
+  ['gt', '>'],
+  ['quot', '"'],
+  ['apos', "'"],
+  ['nbsp', ' ']
+]);
+
+function decodeHtmlEntities(input) {
+  return input.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (_, rawEntity) => {
+    const entity = rawEntity.toLowerCase();
+    if (entity.startsWith('#x')) {
+      const codePoint = Number.parseInt(entity.slice(2), 16);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : _;
+    }
+    if (entity.startsWith('#')) {
+      const codePoint = Number.parseInt(entity.slice(1), 10);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : _;
+    }
+    return ENTITY_MAP.get(entity) ?? _;
+  });
+}
+
+function cleanText(input) {
+  return decodeHtmlEntities(
+    input
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+  )
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeKey(input) {
+  return input.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function extractUrlsFromSitemap(xmlContent) {
+  const urls = [];
+  const urlPattern = /<loc>\s*([^<]+?)\s*<\/loc>/gi;
+  let match;
+  while ((match = urlPattern.exec(xmlContent)) !== null) {
+    urls.push(match[1].trim());
+  }
+  return urls;
+}
+
+function extractAttribute(tag, attributeName) {
+  const attrPattern = new RegExp(
+    `${attributeName}\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s>]+))`,
+    'i'
+  );
+  const match = tag.match(attrPattern);
+  if (!match) {
+    return '';
+  }
+  return match[2] ?? match[3] ?? match[4] ?? '';
+}
+
+function extractMetaContent(html, metaName) {
+  const metaTags = html.match(/<meta\b[^>]*>/gi) ?? [];
+  for (const tag of metaTags) {
+    const name = extractAttribute(tag, 'name').toLowerCase();
+    if (name === metaName.toLowerCase()) {
+      return cleanText(extractAttribute(tag, 'content'));
+    }
+  }
+  return '';
+}
+
+function extractTitle(html) {
+  const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  return match ? cleanText(match[1]) : '';
+}
+
+function extractH1s(html) {
+  const h1s = [];
+  const pattern = /<h1\b[^>]*>([\s\S]*?)<\/h1>/gi;
+  let match;
+  while ((match = pattern.exec(html)) !== null) {
+    const cleaned = cleanText(match[1]);
+    if (cleaned) {
+      h1s.push(cleaned);
+    }
+  }
+  return h1s;
+}
+
+function statusBucket(status) {
+  if (!Number.isFinite(status)) {
+    return 'error';
+  }
+  if (status >= 200 && status < 300) {
+    return '2xx';
+  }
+  if (status >= 300 && status < 400) {
+    return '3xx';
+  }
+  if (status >= 400 && status < 500) {
+    return '4xx';
+  }
+  if (status >= 500 && status < 600) {
+    return '5xx';
+  }
+  return 'other';
+}
+
+async function fetchWithTimeout(url, timeoutMs = 20000) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      headers: {
+        'user-agent': 'DoWhiz-SEO-Crawl/1.0 (+https://dowhiz.com)'
+      },
+      redirect: 'follow',
+      signal: controller.signal
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function crawlUrl(url) {
+  const startedAt = Date.now();
+  try {
+    const response = await fetchWithTimeout(url);
+    const status = response.status;
+    const statusClass = statusBucket(status);
+    let html = '';
+
+    if (status >= 200 && status < 400) {
+      html = await response.text();
+    }
+
+    const title = html ? extractTitle(html) : '';
+    const metaDescription = html ? extractMetaContent(html, 'description') : '';
+    const robots = html ? extractMetaContent(html, 'robots') : '';
+    const h1s = html ? extractH1s(html) : [];
+    const noindex = robots.toLowerCase().includes('noindex');
+
+    return {
+      url,
+      finalUrl: response.url || url,
+      status,
+      statusClass,
+      durationMs: Date.now() - startedAt,
+      indexable: status >= 200 && status < 300 && !noindex,
+      title,
+      titleLength: title.length,
+      metaDescription,
+      metaDescriptionLength: metaDescription.length,
+      robots,
+      noindex,
+      h1Count: h1s.length,
+      h1s,
+      primaryH1: h1s[0] ?? '',
+      error: ''
+    };
+  } catch (error) {
+    return {
+      url,
+      finalUrl: url,
+      status: NaN,
+      statusClass: 'error',
+      durationMs: Date.now() - startedAt,
+      indexable: false,
+      title: '',
+      titleLength: 0,
+      metaDescription: '',
+      metaDescriptionLength: 0,
+      robots: '',
+      noindex: false,
+      h1Count: 0,
+      h1s: [],
+      primaryH1: '',
+      error: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
+function buildDuplicateGroups(rows, pickValue) {
+  const map = new Map();
+  for (const row of rows) {
+    const value = pickValue(row);
+    if (!value) {
+      continue;
+    }
+    const key = normalizeKey(value);
+    if (!map.has(key)) {
+      map.set(key, { value, urls: [] });
+    }
+    map.get(key).urls.push(row.url);
+  }
+  return Array.from(map.values()).filter((entry) => entry.urls.length > 1);
+}
+
+function toMarkdownList(items) {
+  if (items.length === 0) {
+    return '- (none)';
+  }
+  return items.map((item) => `- ${item}`).join('\n');
+}
+
+async function main() {
+  if (!fs.existsSync(sitemapPath)) {
+    throw new Error(`Sitemap not found at ${sitemapPath}`);
+  }
+
+  const sitemapXml = fs.readFileSync(sitemapPath, 'utf8');
+  const urls = extractUrlsFromSitemap(sitemapXml);
+  if (urls.length === 0) {
+    throw new Error(`No URLs found in sitemap: ${sitemapPath}`);
+  }
+
+  const crawlResults = [];
+  for (const url of urls) {
+    crawlResults.push(await crawlUrl(url));
+  }
+
+  const indexablePages = crawlResults.filter((row) => row.indexable);
+  const status4xx = crawlResults.filter((row) => row.statusClass === '4xx');
+  const status5xx = crawlResults.filter((row) => row.statusClass === '5xx');
+  const fetchErrors = crawlResults.filter((row) => row.statusClass === 'error');
+
+  const duplicateTitleGroups = buildDuplicateGroups(indexablePages, (row) => row.title);
+  const duplicateMetaGroups = buildDuplicateGroups(indexablePages, (row) => row.metaDescription);
+  const duplicateH1Groups = buildDuplicateGroups(indexablePages, (row) => row.primaryH1);
+
+  const duplicateTitleUrls = new Set(duplicateTitleGroups.flatMap((entry) => entry.urls));
+  const duplicateMetaUrls = new Set(duplicateMetaGroups.flatMap((entry) => entry.urls));
+
+  const missingTitlePages = indexablePages.filter((row) => !row.title);
+  const missingMetaPages = indexablePages.filter((row) => !row.metaDescription);
+
+  const titleIssuePages = new Set([
+    ...missingTitlePages.map((row) => row.url),
+    ...Array.from(duplicateTitleUrls)
+  ]);
+  const metaIssuePages = new Set([
+    ...missingMetaPages.map((row) => row.url),
+    ...Array.from(duplicateMetaUrls)
+  ]);
+
+  const summary = {
+    generated_at: crawlTimestamp,
+    source_sitemap: 'website/public/sitemap.xml',
+    crawl_target_count: urls.length,
+    indexable_pages: indexablePages.length,
+    title_issue_pages: titleIssuePages.size,
+    meta_description_issue_pages: metaIssuePages.size,
+    duplicate_h1_groups: duplicateH1Groups.length,
+    duplicate_h1_pages: duplicateH1Groups.flatMap((entry) => entry.urls).length,
+    status_4xx: status4xx.length,
+    status_5xx: status5xx.length,
+    fetch_errors: fetchErrors.length
+  };
+
+  const markdown = [
+    '# SEO Crawl Report',
+    '',
+    `Generated at: ${crawlTimestamp}`,
+    `Run command: \`npm run seo:crawl\``,
+    `Source sitemap: \`website/public/sitemap.xml\``,
+    '',
+    '## Summary Counts',
+    '',
+    '| Metric | Count |',
+    '| --- | ---: |',
+    `| URLs crawled | ${summary.crawl_target_count} |`,
+    `| Indexable pages (2xx and not noindex) | ${summary.indexable_pages} |`,
+    `| Title issue pages (missing/duplicate) | ${summary.title_issue_pages} |`,
+    `| Meta description issue pages (missing/duplicate) | ${summary.meta_description_issue_pages} |`,
+    `| Duplicate H1 groups | ${summary.duplicate_h1_groups} |`,
+    `| Pages in duplicate H1 groups | ${summary.duplicate_h1_pages} |`,
+    `| 4xx responses | ${summary.status_4xx} |`,
+    `| 5xx responses | ${summary.status_5xx} |`,
+    `| Fetch errors | ${summary.fetch_errors} |`,
+    '',
+    '## Title Issue Details',
+    '',
+    `Missing title pages: ${missingTitlePages.length}`,
+    toMarkdownList(missingTitlePages.map((row) => row.url)),
+    '',
+    `Duplicate title groups: ${duplicateTitleGroups.length}`,
+    toMarkdownList(
+      duplicateTitleGroups.map(
+        (group) => `"${group.value}" (${group.urls.length} pages): ${group.urls.join(', ')}`
+      )
+    ),
+    '',
+    '## Meta Description Issue Details',
+    '',
+    `Missing meta description pages: ${missingMetaPages.length}`,
+    toMarkdownList(missingMetaPages.map((row) => row.url)),
+    '',
+    `Duplicate meta description groups: ${duplicateMetaGroups.length}`,
+    toMarkdownList(
+      duplicateMetaGroups.map(
+        (group) => `"${group.value}" (${group.urls.length} pages): ${group.urls.join(', ')}`
+      )
+    ),
+    '',
+    '## Duplicate H1 Details',
+    '',
+    toMarkdownList(
+      duplicateH1Groups.map(
+        (group) => `"${group.value}" (${group.urls.length} pages): ${group.urls.join(', ')}`
+      )
+    ),
+    '',
+    '## 4xx / 5xx / Fetch Error URLs',
+    '',
+    `4xx URLs: ${status4xx.length}`,
+    toMarkdownList(status4xx.map((row) => `${row.url} (status ${row.status})`)),
+    '',
+    `5xx URLs: ${status5xx.length}`,
+    toMarkdownList(status5xx.map((row) => `${row.url} (status ${row.status})`)),
+    '',
+    `Fetch errors: ${fetchErrors.length}`,
+    toMarkdownList(fetchErrors.map((row) => `${row.url} (${row.error})`)),
+    '',
+    '## Crawl Matrix',
+    '',
+    '| URL | Status | Indexable | Title chars | Meta chars | H1 count |',
+    '| --- | ---: | :---: | ---: | ---: | ---: |',
+    ...crawlResults.map((row) => {
+      const status = Number.isFinite(row.status) ? String(row.status) : 'ERR';
+      const indexable = row.indexable ? 'yes' : 'no';
+      return `| ${row.url} | ${status} | ${indexable} | ${row.titleLength} | ${row.metaDescriptionLength} | ${row.h1Count} |`;
+    }),
+    ''
+  ].join('\n');
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(markdownOutputPath, markdown, 'utf8');
+  fs.writeFileSync(
+    jsonOutputPath,
+    JSON.stringify(
+      {
+        summary,
+        crawl_results: crawlResults
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+
+  console.log(`SEO crawl report written: ${markdownOutputPath}`);
+  console.log(`SEO crawl JSON written: ${jsonOutputPath}`);
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary\n- add a scripted crawl task at `website/scripts/seo-crawl-report.mjs`\n- expose the task as `npm run seo:crawl` and document it in `website/README.md`\n- generate and commit dated crawl findings in `website/reports/seo-crawl-report-2026-02-26.md` and `website/reports/seo-crawl-report-2026-02-26.json`\n\n## Crawl results (2026-02-26)\n- URLs crawled: 21\n- Indexable pages: 21\n- Title issue pages: 0\n- Meta description issue pages: 0\n- Duplicate H1 groups: 0\n- 4xx: 0\n- 5xx: 0\n\n## Validation\n- `cd website && npm run seo:crawl`\n\nRefs #193