### PR TITLE
Match demo-videos font with landing page

### DIFF
--- a/website/public/demo-videos.css
+++ b/website/public/demo-videos.css
@@ -6,6 +6,9 @@
   --text-subtle: #aac2ee;
   --accent: #8ac4ff;
   --accent-strong: #c2e7ff;
+  --font-sans: 'Calibri', 'Gill Sans', 'Gill Sans MT', 'Myriad Pro', 'Myriad',
+    'DejaVu Sans Condensed', 'Liberation Sans', 'Nimbus Sans L', Tahoma, Geneva,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 * {
@@ -20,7 +23,7 @@ body {
 
 body {
   min-height: 100vh;
-  font-family: "Manrope", "Segoe UI", "Helvetica Neue", sans-serif;
+  font-family: var(--font-sans);
   background: radial-gradient(circle at 12% 8%, rgba(58, 104, 198, 0.5), transparent 38%),
     radial-gradient(circle at 88% 92%, rgba(8, 141, 168, 0.35), transparent 42%), var(--bg);
   color: var(--text-main);

--- a/website/public/demo-videos/index.html
+++ b/website/public/demo-videos/index.html
@@ -10,12 +10,6 @@
     <link rel="icon" type="image/svg+xml" href="/do-whiz-mark.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@500;600;700;800&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="/demo-videos.css" />
     <link rel="canonical" href="https://dowhiz.com/demo-videos/" />
     <title>Demo Videos | DoWhiz</title>


### PR DESCRIPTION
## Summary
- align `website/public/demo-videos.css` font stack with the main landing page font stack
- remove the `Manrope` Google Fonts include from `website/public/demo-videos/index.html` since it is no longer used

## Testing
- `cd website && npm run lint`
- `cd website && npm run build`

## Notes
- no layout or content changes; this is a typography consistency fix only
