### PR TITLE
Fix Slack threaded replies and failure notices

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -12,6 +12,7 @@ use crate::channel::Channel;
 use super::actions::{apply_scheduler_actions, ingest_follow_up_tasks, schedule_auto_reply};
 use super::executor::TaskExecutor;
 use super::outbound::execute_slack_send;
+use super::reply::load_reply_context;
 use super::schedule::{next_run_after, validate_cron_expression};
 use super::snapshot::{snapshot_reply_draft, write_scheduler_snapshot};
 use super::store::SqliteSchedulerStore;
@@ -272,7 +273,13 @@ impl<E: TaskExecutor> Scheduler<E> {
                 )?;
                 // Sync failure status to user's account-level storage for Discord/Slack
                 if let TaskKind::RunTask(task) = &task_kind {
-                    sync_task_status_to_user_storage(task_id, task, executed_at, "failed", Some(&message));
+                    sync_task_status_to_user_storage(
+                        task_id,
+                        task,
+                        executed_at,
+                        "failed",
+                        Some(&message),
+                    );
                 }
                 // Disable one-shot tasks on failure, but allow a few retries for RunTask.
                 if matches!(self.tasks[index].schedule, Schedule::OneShot { .. }) {
@@ -355,7 +362,10 @@ fn sync_task_status_to_user_storage(
     error_message: Option<&str>,
 ) {
     // Only sync for channels that support unified accounts (Slack excluded - uses legacy user storage)
-    if !matches!(task.channel, Channel::Discord | Channel::GoogleDocs | Channel::GoogleSheets | Channel::GoogleSlides) {
+    if !matches!(
+        task.channel,
+        Channel::Discord | Channel::GoogleDocs | Channel::GoogleSheets | Channel::GoogleSlides
+    ) {
         return;
     }
 
@@ -363,7 +373,10 @@ fn sync_task_status_to_user_storage(
     let identifier = match task.reply_to.first() {
         Some(id) => id,
         None => {
-            warn!("no reply_to identifier for task {} to sync to user storage", task_id);
+            warn!(
+                "no reply_to identifier for task {} to sync to user storage",
+                task_id
+            );
             return;
         }
     };
@@ -381,7 +394,10 @@ fn sync_task_status_to_user_storage(
     let users_root = match std::env::var("USERS_ROOT") {
         Ok(path) => PathBuf::from(path),
         Err(_) => {
-            warn!("USERS_ROOT not set, cannot sync task {} to user storage", task_id);
+            warn!(
+                "USERS_ROOT not set, cannot sync task {} to user storage",
+                task_id
+            );
             return;
         }
     };
@@ -398,8 +414,16 @@ fn sync_task_status_to_user_storage(
             // Record execution start and finish to update status
             match store.record_execution_start(task_id, executed_at) {
                 Ok(execution_id) => {
-                    if let Err(err) = store.record_execution_finish(execution_id, executed_at, status, error_message) {
-                        warn!("failed to record execution finish for task {} in user storage: {}", task_id, err);
+                    if let Err(err) = store.record_execution_finish(
+                        execution_id,
+                        executed_at,
+                        status,
+                        error_message,
+                    ) {
+                        warn!(
+                            "failed to record execution finish for task {} in user storage: {}",
+                            task_id, err
+                        );
                     } else {
                         info!(
                             "synced task {} status '{}' to user storage account={}",
@@ -408,7 +432,10 @@ fn sync_task_status_to_user_storage(
                     }
                 }
                 Err(err) => {
-                    warn!("failed to record execution start for task {} in user storage: {}", task_id, err);
+                    warn!(
+                        "failed to record execution start for task {} in user storage: {}",
+                        task_id, err
+                    );
                 }
             }
         }
@@ -449,6 +476,9 @@ fn notify_run_task_failure(
 
     if !task.reply_to.is_empty() {
         if is_slack {
+            let slack_thread_ts = load_reply_context(&task.workspace_dir)
+                .in_reply_to
+                .or_else(|| slack_thread_ts_from_thread_key(task.thread_id.as_deref()));
             let send_task = SendReplyTask {
                 channel: Channel::Slack,
                 subject: RUN_TASK_FAILURE_NOTICE.to_string(),
@@ -458,7 +488,7 @@ fn notify_run_task_failure(
                 to: task.reply_to.clone(),
                 cc: vec![],
                 bcc: vec![],
-                in_reply_to: task.thread_id.clone(),
+                in_reply_to: slack_thread_ts,
                 references: None,
                 archive_root: None,
                 thread_epoch: None,
@@ -534,6 +564,19 @@ fn notify_run_task_failure(
     Ok(())
 }
 
+fn slack_thread_ts_from_thread_key(thread_key: Option<&str>) -> Option<String> {
+    let raw = thread_key
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let mut parts = raw.splitn(3, ':');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some("slack"), Some(_channel), Some(thread_ts)) if !thread_ts.trim().is_empty() => {
+            Some(thread_ts.trim().to_string())
+        }
+        _ => Some(raw.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -545,7 +588,6 @@ mod tests {
         // Channels that should be synced
         let syncable_channels = vec![
             Channel::Discord,
-            Channel::Slack,
             Channel::GoogleDocs,
             Channel::GoogleSheets,
             Channel::GoogleSlides,
@@ -556,7 +598,6 @@ mod tests {
                 matches!(
                     channel,
                     Channel::Discord
-                        | Channel::Slack
                         | Channel::GoogleDocs
                         | Channel::GoogleSheets
                         | Channel::GoogleSlides
@@ -580,7 +621,6 @@ mod tests {
                 !matches!(
                     channel,
                     Channel::Discord
-                        | Channel::Slack
                         | Channel::GoogleDocs
                         | Channel::GoogleSheets
                         | Channel::GoogleSlides
@@ -608,5 +648,17 @@ mod tests {
 
         assert_eq!(channel_to_identifier_type(&Channel::Discord), "discord");
         assert_eq!(channel_to_identifier_type(&Channel::Slack), "slack");
+    }
+
+    #[test]
+    fn slack_thread_ts_from_thread_key_parses_compound_key() {
+        assert_eq!(
+            super::slack_thread_ts_from_thread_key(Some("slack:C123:1700000000.001")),
+            Some("1700000000.001".to_string())
+        );
+        assert_eq!(
+            super::slack_thread_ts_from_thread_key(Some("1700000000.002")),
+            Some("1700000000.002".to_string())
+        );
     }
 }

--- a/DoWhiz_service/scheduler_module/src/scheduler/reply.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/reply.rs
@@ -58,6 +58,12 @@ struct DiscordMetaLite {
     message_id: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct SlackMetaLite {
+    channel: Option<String>,
+    thread_id: Option<String>,
+}
+
 pub(crate) fn load_reply_context(workspace_dir: &Path) -> ReplyContext {
     let incoming_dir = workspace_dir.join("incoming_email");
 
@@ -66,6 +72,16 @@ pub(crate) fn load_reply_context(workspace_dir: &Path) -> ReplyContext {
         return ReplyContext {
             subject: "Discord reply".to_string(),
             in_reply_to: Some(message_id),
+            references: None,
+            from: None,
+        };
+    }
+
+    // Slack: reply in the same thread.
+    if let Some(thread_ts) = latest_slack_thread_id(&incoming_dir) {
+        return ReplyContext {
+            subject: "Slack reply".to_string(),
+            in_reply_to: Some(thread_ts),
             references: None,
             from: None,
         };
@@ -150,6 +166,35 @@ fn latest_discord_message_id(incoming_dir: &Path) -> Option<String> {
     {
         return meta
             .message_id
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+    None
+}
+
+fn latest_slack_thread_id(incoming_dir: &Path) -> Option<String> {
+    let entries = fs::read_dir(incoming_dir).ok()?;
+    let mut meta_files = entries
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.ends_with("_slack_meta.json"))
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    meta_files.sort();
+    let latest = meta_files.last()?;
+    let content = fs::read_to_string(latest).ok()?;
+    let meta = serde_json::from_str::<SlackMetaLite>(&content).ok()?;
+    if meta
+        .channel
+        .as_deref()
+        .map(|channel| channel.eq_ignore_ascii_case("slack"))
+        .unwrap_or(false)
+    {
+        return meta
+            .thread_id
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
     }
@@ -248,5 +293,27 @@ mod tests {
         assert_eq!(context.subject, "Re: Hello");
         assert_eq!(context.in_reply_to.as_deref(), Some("<msg-123>"));
         assert_eq!(context.references.as_deref(), Some("<msg-122> <msg-123>"));
+    }
+
+    #[test]
+    fn load_reply_context_prefers_latest_slack_thread_id() {
+        let temp = TempDir::new().expect("tempdir");
+        let incoming_dir = temp.path().join("incoming_email");
+        fs::create_dir_all(&incoming_dir).expect("incoming_email");
+
+        fs::write(
+            incoming_dir.join("00001_slack_meta.json"),
+            r#"{"channel":"slack","thread_id":"1700000000.001"}"#,
+        )
+        .expect("write first");
+        fs::write(
+            incoming_dir.join("00002_slack_meta.json"),
+            r#"{"channel":"slack","thread_id":"1700000000.002"}"#,
+        )
+        .expect("write second");
+
+        let context = load_reply_context(temp.path());
+        assert_eq!(context.subject, "Slack reply");
+        assert_eq!(context.in_reply_to.as_deref(), Some("1700000000.002"));
     }
 }

--- a/DoWhiz_service/scheduler_module/tests/scheduler_retry_notifications_slack_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_retry_notifications_slack_e2e.rs
@@ -54,8 +54,7 @@ fn success_body(to: &str) -> String {
 fn slack_failure_retries_and_notifies() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
 
-    let Some(mut server) =
-        test_support::start_mockito_server("slack_failure_retries_and_notifies")
+    let Some(mut server) = test_support::start_mockito_server("slack_failure_retries_and_notifies")
     else {
         return Ok(());
     };
@@ -66,6 +65,9 @@ fn slack_failure_retries_and_notifies() -> Result<(), Box<dyn std::error::Error>
         .match_header("authorization", "Bearer xoxb-test")
         .match_header("content-type", "application/json")
         .match_body(Matcher::Regex("\"channel\":\"C123\"".to_string()))
+        .match_body(Matcher::Regex(
+            "\"thread_ts\":\"1700000000.123\"".to_string(),
+        ))
         .match_body(Matcher::Regex(
             "We could not complete your request".to_string(),
         ))
@@ -93,7 +95,12 @@ fn slack_failure_retries_and_notifies() -> Result<(), Box<dyn std::error::Error>
 
     let temp = TempDir::new()?;
     let workspace = temp.path().join("workspace");
-    fs::create_dir_all(&workspace)?;
+    let incoming_dir = workspace.join("incoming_email");
+    fs::create_dir_all(&incoming_dir)?;
+    fs::write(
+        incoming_dir.join("00001_slack_meta.json"),
+        r#"{"channel":"slack","thread_id":"1700000000.123"}"#,
+    )?;
 
     let run_task = RunTaskTask {
         workspace_dir: workspace.clone(),

--- a/DoWhiz_service/scheduler_module/tests/send_reply_outbound_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/send_reply_outbound_e2e.rs
@@ -71,8 +71,7 @@ fn base_send_task(channel: Channel, html_path: PathBuf, attachments_dir: PathBuf
 #[test]
 fn send_reply_slack_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
-    let Some(mut server) = test_support::start_mockito_server("send_reply_slack_uses_mock")
-    else {
+    let Some(mut server) = test_support::start_mockito_server("send_reply_slack_uses_mock") else {
         return Ok(());
     };
 
@@ -97,6 +96,49 @@ fn send_reply_slack_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut task = base_send_task(Channel::Slack, html_path, attachments_dir);
     task.to = vec!["C123".to_string()];
+
+    let db_path = temp.path().join("tasks.db");
+    let mut scheduler = Scheduler::load(&db_path, ModuleExecutor::default())?;
+    scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::SendReply(task))?;
+    scheduler.tick()?;
+
+    slack_mock.assert();
+    Ok(())
+}
+
+#[test]
+fn send_reply_slack_includes_thread_ts_when_present() -> Result<(), Box<dyn std::error::Error>> {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(mut server) =
+        test_support::start_mockito_server("send_reply_slack_includes_thread_ts_when_present")
+    else {
+        return Ok(());
+    };
+
+    let slack_mock = server
+        .mock("POST", "/chat.postMessage")
+        .match_header("authorization", "Bearer xoxb-test")
+        .match_header("content-type", "application/json")
+        .match_body(Matcher::Regex("\\\"channel\\\":\\\"C123\\\"".to_string()))
+        .match_body(Matcher::Regex(
+            "\\\"thread_ts\\\":\\\"1700000000\\.123\\\"".to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"ok":true,"ts":"1700000000.456"}"#)
+        .expect(1)
+        .create();
+
+    let _guard_token = EnvGuard::set("SLACK_BOT_TOKEN", "xoxb-test");
+    let _guard_api = EnvGuard::set("SLACK_API_BASE_URL", server.url());
+
+    let temp = TempDir::new()?;
+    let html_path = write_text_file(&temp, "slack_message.txt", "Hello Slack thread")?;
+    let attachments_dir = create_attachments_dir(&temp)?;
+
+    let mut task = base_send_task(Channel::Slack, html_path, attachments_dir);
+    task.to = vec!["C123".to_string()];
+    task.in_reply_to = Some("1700000000.123".to_string());
 
     let db_path = temp.path().join("tasks.db");
     let mut scheduler = Scheduler::load(&db_path, ModuleExecutor::default())?;
@@ -148,8 +190,7 @@ fn send_reply_discord_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn send_reply_sms_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
-    let Some(mut server) = test_support::start_mockito_server("send_reply_sms_uses_mock")
-    else {
+    let Some(mut server) = test_support::start_mockito_server("send_reply_sms_uses_mock") else {
         return Ok(());
     };
 


### PR DESCRIPTION
## Summary
- Preserve Slack thread context by reading the latest `_slack_meta.json` in `incoming_email` and using its `thread_id` as `in_reply_to`
- Use that thread context when sending Slack run-task failure notices, with a parser fallback for legacy `slack:<channel>:<thread_ts>` thread keys
- Add regression tests for Slack reply context parsing and outbound `thread_ts` propagation
- Update Slack retry notification test to assert threaded posting

## Root Cause
Slack inbound events were stored with thread metadata, but reply context extraction only supported Discord/Google Docs/email headers. As a result, Slack auto-replies and failure notices were sent without `thread_ts` (or with an invalid composite key), causing replies to post out of thread.

## Testing
- `cargo test -p scheduler_module load_reply_context_prefers_latest_slack_thread_id -- --nocapture`
- `cargo test -p scheduler_module send_reply_slack_includes_thread_ts_when_present -- --nocapture`
- `cargo test -p scheduler_module slack_failure_retries_and_notifies -- --nocapture`

Fixes #454