### PR TITLE
fix(CICD): make PM2 service restarts name-compatible

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -156,5 +156,24 @@ jobs:
           if [ -s /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh ]; then
             source /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh
           fi
-          pm2 restart dw_worker dw_gateway
+          restarted=0
+          for service in \
+            dw_worker \
+            dw_gateway \
+            dowhiz_rust_service \
+            dowhiz_inbound_gateway \
+            dowhiz_gateway \
+            dowhiz-rust-service \
+            dowhiz-inbound-gateway; do
+            if pm2 describe "$service" >/dev/null 2>&1; then
+              pm2 restart "$service"
+              restarted=1
+            fi
+          done
+
+          if [ "$restarted" -eq 0 ]; then
+            echo "No known DoWhiz PM2 services found to restart."
+            pm2 list || true
+            exit 1
+          fi
           EOF

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -156,5 +156,24 @@ jobs:
           if [ -s /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh ]; then
             source /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh
           fi
-          pm2 restart dw_worker dw_gateway
+          restarted=0
+          for service in \
+            dw_worker \
+            dw_gateway \
+            dowhiz_rust_service \
+            dowhiz_inbound_gateway \
+            dowhiz_gateway \
+            dowhiz-rust-service \
+            dowhiz-inbound-gateway; do
+            if pm2 describe "$service" >/dev/null 2>&1; then
+              pm2 restart "$service"
+              restarted=1
+            fi
+          done
+
+          if [ "$restarted" -eq 0 ]; then
+            echo "No known DoWhiz PM2 services found to restart."
+            pm2 list || true
+            exit 1
+          fi
           EOF


### PR DESCRIPTION
## Summary
- fix deploy failures caused by hard-coded PM2 process names (`dw_worker` / `dw_gateway`)
- restart DoWhiz services by probing a compatibility set of known PM2 names used across environments
- fail with `pm2 list` output when no known service names exist, so deploy diagnostics are explicit

## Why
Actions run `22498829788` failed on step **Restart DoWhiz services** after merge #521 because the restarted process names do not exist on the VM.

## Validation
- YAML updated in both `.github/workflows/CICD-production.yml` and `.github/workflows/CICD-staging.yml`
- no local runtime tests required (workflow shell change only)

Closes #523
