### PR TITLE
fix(CICD): start DoWhiz PM2 services when missing

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -156,24 +156,32 @@ jobs:
           if [ -s /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh ]; then
             source /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh
           fi
-          restarted=0
-          for service in \
-            dw_worker \
-            dw_gateway \
-            dowhiz_rust_service \
-            dowhiz_inbound_gateway \
-            dowhiz_gateway \
-            dowhiz-rust-service \
-            dowhiz-inbound-gateway; do
+          APP_DIR=/home/${{ secrets.PROD_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
+
+          worker_running=0
+          for service in dw_worker dowhiz_rust_service dowhiz-rust-service; do
             if pm2 describe "$service" >/dev/null 2>&1; then
               pm2 restart "$service"
-              restarted=1
+              worker_running=1
             fi
           done
-
-          if [ "$restarted" -eq 0 ]; then
-            echo "No known DoWhiz PM2 services found to restart."
-            pm2 list || true
-            exit 1
+          if [ "$worker_running" -eq 0 ]; then
+            echo "No worker process found in PM2, starting dw_worker."
+            pm2 start "$APP_DIR/target/release/rust_service" --name dw_worker --cwd "$APP_DIR" -- --host 0.0.0.0 --port 9001
           fi
+
+          gateway_running=0
+          for service in dw_gateway dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway; do
+            if pm2 describe "$service" >/dev/null 2>&1; then
+              pm2 restart "$service"
+              gateway_running=1
+            fi
+          done
+          if [ "$gateway_running" -eq 0 ]; then
+            echo "No gateway process found in PM2, starting dw_gateway."
+            pm2 start "$APP_DIR/target/release/inbound_gateway" --name dw_gateway --cwd "$APP_DIR"
+          fi
+
+          pm2 save
+          pm2 list
           EOF

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -156,24 +156,32 @@ jobs:
           if [ -s /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh ]; then
             source /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh
           fi
-          restarted=0
-          for service in \
-            dw_worker \
-            dw_gateway \
-            dowhiz_rust_service \
-            dowhiz_inbound_gateway \
-            dowhiz_gateway \
-            dowhiz-rust-service \
-            dowhiz-inbound-gateway; do
+          APP_DIR=/home/${{ secrets.STAGING_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
+
+          worker_running=0
+          for service in dw_worker dowhiz_rust_service dowhiz-rust-service; do
             if pm2 describe "$service" >/dev/null 2>&1; then
               pm2 restart "$service"
-              restarted=1
+              worker_running=1
             fi
           done
-
-          if [ "$restarted" -eq 0 ]; then
-            echo "No known DoWhiz PM2 services found to restart."
-            pm2 list || true
-            exit 1
+          if [ "$worker_running" -eq 0 ]; then
+            echo "No worker process found in PM2, starting dw_worker."
+            pm2 start "$APP_DIR/target/release/rust_service" --name dw_worker --cwd "$APP_DIR" -- --host 0.0.0.0 --port 9001
           fi
+
+          gateway_running=0
+          for service in dw_gateway dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway; do
+            if pm2 describe "$service" >/dev/null 2>&1; then
+              pm2 restart "$service"
+              gateway_running=1
+            fi
+          done
+          if [ "$gateway_running" -eq 0 ]; then
+            echo "No gateway process found in PM2, starting dw_gateway."
+            pm2 start "$APP_DIR/target/release/inbound_gateway" --name dw_gateway --cwd "$APP_DIR"
+          fi
+
+          pm2 save
+          pm2 list
           EOF


### PR DESCRIPTION
## Summary
- update the restart step to be restart-or-start instead of restart-only
- if worker/gateway PM2 processes are missing, start them from release binaries
- keep compatibility with both current and legacy PM2 process names
- save the PM2 process list after restart/start for persistence across reboot

## Why
Run `22499621530` still failed at **Restart DoWhiz services** because the VM had no PM2 processes (`pm2 list` was empty), so there was nothing to restart.

## Validation
- inspected failed logs from job `65183907352`
- updated both workflow files:
  - `.github/workflows/CICD-production.yml`
  - `.github/workflows/CICD-staging.yml`
