### PR TITLE
Fix Discord DM intake and keep guild mention gating

### DIFF
--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/discord.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/discord.rs
@@ -87,6 +87,14 @@ fn has_discord_routes(config: &GatewayConfig) -> bool {
             .any(|route| route.channel == Channel::Discord)
 }
 
+fn should_enqueue_discord_message(
+    is_direct_message: bool,
+    is_mention: bool,
+    is_reply_to_bot: bool,
+) -> bool {
+    is_direct_message || is_mention || is_reply_to_bot
+}
+
 pub(super) async fn spawn_discord_gateway(state: Arc<GatewayState>) {
     if !has_discord_routes(&state.config) {
         info!("discord gateway: no Discord routes configured, skipping");
@@ -202,6 +210,18 @@ mod tests {
 
         assert!(has_discord_routes(&config));
     }
+
+    #[test]
+    fn should_enqueue_discord_message_allows_direct_messages_without_mentions() {
+        assert!(should_enqueue_discord_message(true, false, false));
+    }
+
+    #[test]
+    fn should_enqueue_discord_message_requires_signal_in_guild_channels() {
+        assert!(!should_enqueue_discord_message(false, false, false));
+        assert!(should_enqueue_discord_message(false, true, false));
+        assert!(should_enqueue_discord_message(false, false, true));
+    }
 }
 
 struct DiscordIngressState {
@@ -242,8 +262,11 @@ impl serenity::all::EventHandler for DiscordIngressHandler {
             .as_ref()
             .map(|ref_msg| self.inner.bot_user_ids.contains(&ref_msg.author.id.get()))
             .unwrap_or(false);
+        let is_direct_message = msg.guild_id.is_none();
 
-        if !is_mention && !is_reply_to_bot {
+        // In DMs, users typically send plain text without mentioning the bot.
+        // Mention/reply gating is only needed in guild channels.
+        if !should_enqueue_discord_message(is_direct_message, is_mention, is_reply_to_bot) {
             return;
         }
 
@@ -254,8 +277,11 @@ impl serenity::all::EventHandler for DiscordIngressHandler {
         };
 
         info!(
-            "discord gateway routing message to employee={} (bot was mentioned/replied)",
-            self.inner.employee_id
+            "discord gateway routing message to employee={} (dm={}, mention={}, reply_to_bot={})",
+            self.inner.employee_id,
+            is_direct_message,
+            is_mention,
+            is_reply_to_bot
         );
 
         let external_message_id = inbound.message_id.clone();

--- a/DoWhiz_service/scheduler_module/src/discord_gateway.rs
+++ b/DoWhiz_service/scheduler_module/src/discord_gateway.rs
@@ -93,6 +93,14 @@ impl DiscordEventHandler {
     }
 }
 
+fn should_enqueue_discord_message(
+    is_direct_message: bool,
+    is_mention: bool,
+    is_reply_to_bot: bool,
+) -> bool {
+    is_direct_message || is_mention || is_reply_to_bot
+}
+
 #[async_trait]
 impl EventHandler for DiscordEventHandler {
     async fn ready(&self, _ctx: Context, ready: Ready) {
@@ -112,9 +120,10 @@ impl EventHandler for DiscordEventHandler {
             }
         };
 
-        // Only respond to:
-        // 1. Messages that @ mention the bot
-        // 2. Messages that are replies to the bot's messages
+        // Enqueue messages for:
+        // 1. DM or group DM conversations (no guild_id)
+        // 2. Guild messages that @ mention the bot
+        // 3. Guild messages that reply to the bot
         let is_mention = msg
             .mentions
             .iter()
@@ -124,16 +133,18 @@ impl EventHandler for DiscordEventHandler {
             .as_ref()
             .map(|ref_msg| self.adapter.bot_user_ids.contains(&ref_msg.author.id.get()))
             .unwrap_or(false);
+        let is_direct_message = msg.guild_id.is_none();
 
-        if !is_mention && !is_reply_to_bot {
+        if !should_enqueue_discord_message(is_direct_message, is_mention, is_reply_to_bot) {
             return;
         }
 
         let msg_len = inbound.text_body.as_ref().map(|t| t.len()).unwrap_or(0);
         info!(
-            "Discord message from {} in channel {:?} (mention={}, reply_to_bot={}, len={}): {:?}",
+            "Discord message from {} in channel {:?} (dm={}, mention={}, reply_to_bot={}, len={}): {:?}",
             inbound.sender,
             inbound.metadata.discord_channel_id,
+            is_direct_message,
             is_mention,
             is_reply_to_bot,
             msg_len,
@@ -570,4 +581,21 @@ pub async fn start_discord_client(
     client.start().await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_enqueue_discord_message;
+
+    #[test]
+    fn should_enqueue_discord_message_allows_direct_messages_without_mentions() {
+        assert!(should_enqueue_discord_message(true, false, false));
+    }
+
+    #[test]
+    fn should_enqueue_discord_message_requires_signal_in_guild_channels() {
+        assert!(!should_enqueue_discord_message(false, false, false));
+        assert!(should_enqueue_discord_message(false, true, false));
+        assert!(should_enqueue_discord_message(false, false, true));
+    }
 }


### PR DESCRIPTION
## Summary
- allow Discord DM and group DM messages to be enqueued even when the bot is not explicitly mentioned
- keep guild-channel behavior unchanged: messages still require either a bot mention or a reply-to-bot signal
- add focused unit tests for the enqueue predicate in both Discord gateway paths (`scheduler_module/src/discord_gateway.rs` and `scheduler_module/src/bin/inbound_gateway/discord.rs`)
- improve gateway routing log fields so DM / mention / reply signals are explicit in runtime logs

## Why this fixes #566
Discord DM and group DM messages do not include `guild_id`, and users typically send plain text without mentioning the bot. Previously those messages were dropped by mention/reply-only filtering. This change accepts private-channel messages while preserving mention/reply gating for guild channels.

Requester identity validation remains consistent for DM and group DM because sender identity still comes from `message.sender` (Discord user ID) and is passed through unchanged for downstream account lookup/verification logic.

## Testing
- `cargo test -p scheduler_module should_enqueue_discord_message -- --nocapture`

## Production Impact
- positive: Discord DM and group DM messages now reach the existing task + reply pipeline
- scope: limited to Discord ingress enqueue filtering and logging; no schema changes and no external API contract changes
- compatibility/safety: guild-channel noise protection is preserved (still mention/reply-gated)

Closes #566
