### PR TITLE
Fix deterministic GitHub requester auth for inbound tasks

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -1,8 +1,12 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde_json::Value;
+
 use super::errors::RunTaskError;
 use super::workspace::resolve_rel_dir;
+
+const GITHUB_NOTIFICATIONS_ADDRESS: &str = "notifications@github.com";
 
 /// Check if we've already prompted user to register in this thread.
 /// Returns true if a marker file exists, indicating we've already prompted.
@@ -71,6 +75,7 @@ pub(super) fn build_prompt(
     } else {
         String::new()
     };
+    let github_coauthor_section = build_github_coauthor_section(workspace_dir, input_email_dir);
 
     // Build registration prompt section if user doesn't have a unified account
     // and we haven't prompted them yet in this thread
@@ -107,6 +112,7 @@ Inputs (relative to workspace root):
 - Reference dir (contain all past emails with the current user): {reference}
 
 {discord_context_section}
+{github_coauthor_section}
 
 Memory about the current user:
 ```{memory_section}```
@@ -141,8 +147,192 @@ Rules:
         guidance_section = guidance_section,
         reply_instruction = reply_instruction,
         discord_context_section = discord_context_section,
+        github_coauthor_section = github_coauthor_section,
         registration_section = registration_section,
     )
+}
+
+fn build_github_coauthor_section(workspace_dir: &Path, input_email_dir: &Path) -> String {
+    let Some(login) = load_github_requester_login(workspace_dir, input_email_dir) else {
+        return String::new();
+    };
+    let coauthor_email = format!("{login}@users.noreply.github.com");
+    let trailer = format!("Co-authored-by: {login} <{coauthor_email}>");
+    format!(
+        r#"GitHub Attribution Requirement:
+- This request came from GitHub user @{login}.
+- If you create or amend any git commit for this task, append this trailer exactly once in each relevant commit message: `{trailer}`.
+- If you open or update a PR, include `Requested-by: @{login}` in the PR body.
+- Do not add co-author/requested-by lines when no commit or PR is created.
+
+"#
+    )
+}
+
+fn load_github_requester_login(workspace_dir: &Path, input_email_dir: &Path) -> Option<String> {
+    let payload_path = workspace_dir
+        .join(input_email_dir)
+        .join("postmark_payload.json");
+    let payload_raw = fs::read(payload_path).ok()?;
+    let payload: Value = serde_json::from_slice(&payload_raw).ok()?;
+    let from = payload
+        .get("From")
+        .or_else(|| payload.get("from"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !looks_like_github_notifications_sender(from) {
+        return None;
+    }
+    extract_github_sender_from_headers(&payload)
+        .or_else(|| extract_github_sender_from_bodies(&payload))
+}
+
+fn looks_like_github_notifications_sender(from: &str) -> bool {
+    from.to_ascii_lowercase()
+        .contains(&GITHUB_NOTIFICATIONS_ADDRESS.to_ascii_lowercase())
+}
+
+fn extract_github_sender_from_headers(payload: &Value) -> Option<String> {
+    let headers = payload
+        .get("Headers")
+        .or_else(|| payload.get("headers"))
+        .and_then(Value::as_array)?;
+    for header in headers {
+        let name = header
+            .get("Name")
+            .or_else(|| header.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if !name.eq_ignore_ascii_case("X-GitHub-Sender") {
+            continue;
+        }
+        let value = header
+            .get("Value")
+            .or_else(|| header.get("value"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if let Some(login) = normalize_github_login(value) {
+            return Some(login);
+        }
+    }
+    None
+}
+
+fn extract_github_sender_from_bodies(payload: &Value) -> Option<String> {
+    for field in ["StrippedTextReply", "TextBody", "HtmlBody"] {
+        if let Some(body) = payload.get(field).and_then(Value::as_str) {
+            if let Some(login) = extract_github_sender_from_text(body) {
+                return Some(login);
+            }
+        }
+    }
+    None
+}
+
+fn extract_github_sender_from_text(text: &str) -> Option<String> {
+    if text.trim().is_empty() {
+        return None;
+    }
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(login) = extract_login_from_activity_line(trimmed) {
+            return Some(login);
+        }
+
+        if let Some(login) = extract_login_from_html_activity_line(trimmed) {
+            return Some(login);
+        }
+    }
+
+    None
+}
+
+fn extract_login_from_activity_line(line: &str) -> Option<String> {
+    let (candidate, rest) = line.split_once(char::is_whitespace)?;
+    let rest = rest.trim_start().to_ascii_lowercase();
+    let activity_prefixes = [
+        "left a comment",
+        "created an issue",
+        "opened a pull request",
+        "opened an issue",
+        "closed an issue",
+        "reopened an issue",
+        "reviewed",
+        "requested a review",
+    ];
+    if activity_prefixes
+        .iter()
+        .any(|prefix| rest.starts_with(prefix))
+    {
+        return normalize_github_login(candidate);
+    }
+    None
+}
+
+fn extract_login_from_html_activity_line(line: &str) -> Option<String> {
+    let lower = line.to_ascii_lowercase();
+    let start_idx = lower.find("<strong>")?;
+    let after_start = &line[start_idx + "<strong>".len()..];
+    let after_start_lower = after_start.to_ascii_lowercase();
+    let end_idx = after_start_lower.find("</strong>")?;
+    let candidate = &after_start[..end_idx];
+    let rest = after_start[end_idx + "</strong>".len()..]
+        .trim_start()
+        .to_ascii_lowercase();
+    let activity_prefixes = [
+        "left a comment",
+        "created an issue",
+        "opened a pull request",
+        "opened an issue",
+    ];
+    if activity_prefixes
+        .iter()
+        .any(|prefix| rest.starts_with(prefix))
+    {
+        return normalize_github_login(candidate);
+    }
+    None
+}
+
+fn normalize_github_login(raw: &str) -> Option<String> {
+    let trimmed = raw
+        .trim()
+        .trim_start_matches('@')
+        .trim_matches(|ch: char| matches!(ch, '"' | '\'' | '<' | '>' | '`'));
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let (base, bot_suffix) = if lower.ends_with("[bot]") {
+        (&lower[..lower.len() - "[bot]".len()], true)
+    } else {
+        (lower.as_str(), false)
+    };
+    if base.is_empty() || base.len() > 39 {
+        return None;
+    }
+    let mut chars = base.chars();
+    let first = chars.next()?;
+    if !first.is_ascii_alphanumeric() {
+        return None;
+    }
+    if chars.any(|ch| !(ch.is_ascii_alphanumeric() || ch == '-')) {
+        return None;
+    }
+    if base.ends_with('-') {
+        return None;
+    }
+    if bot_suffix {
+        Some(format!("{base}[bot]"))
+    } else {
+        Some(base.to_string())
+    }
 }
 
 fn build_guidance_section(workspace_dir: &Path, runner: &str) -> String {
@@ -368,5 +558,72 @@ mod tests {
 
         assert!(prompt.contains("Discord context snapshot (auto-generated"));
         assert!(prompt.contains("Quoted + thread context"));
+    }
+
+    #[test]
+    fn build_prompt_includes_github_coauthor_guidance_when_sender_detected() {
+        let temp = TempDir::new().expect("tempdir");
+        let workspace = temp.path();
+        let incoming_dir = workspace.join("incoming_email");
+        fs::create_dir_all(&incoming_dir).expect("incoming_email");
+        fs::write(
+            incoming_dir.join("postmark_payload.json"),
+            r#"{
+  "From": "Bingran You <notifications@github.com>",
+  "Headers": [{"Name":"X-GitHub-Sender","Value":"bingran-you"}]
+}"#,
+        )
+        .expect("postmark payload");
+
+        let prompt = build_prompt(
+            Path::new("incoming_email"),
+            Path::new("incoming_attachments"),
+            Path::new("memory"),
+            Path::new("references"),
+            workspace,
+            "codex",
+            "",
+            true,
+            "email",
+            true,
+        );
+
+        assert!(prompt.contains("GitHub Attribution Requirement"));
+        assert!(
+            prompt.contains("Co-authored-by: bingran-you <bingran-you@users.noreply.github.com>")
+        );
+        assert!(prompt.contains("Requested-by: @bingran-you"));
+    }
+
+    #[test]
+    fn build_prompt_omits_github_coauthor_guidance_for_non_github_email() {
+        let temp = TempDir::new().expect("tempdir");
+        let workspace = temp.path();
+        let incoming_dir = workspace.join("incoming_email");
+        fs::create_dir_all(&incoming_dir).expect("incoming_email");
+        fs::write(
+            incoming_dir.join("postmark_payload.json"),
+            r#"{
+  "From": "Alice <alice@example.com>",
+  "TextBody": "hello"
+}"#,
+        )
+        .expect("postmark payload");
+
+        let prompt = build_prompt(
+            Path::new("incoming_email"),
+            Path::new("incoming_attachments"),
+            Path::new("memory"),
+            Path::new("references"),
+            workspace,
+            "codex",
+            "",
+            true,
+            "email",
+            true,
+        );
+
+        assert!(!prompt.contains("GitHub Attribution Requirement"));
+        assert!(!prompt.contains("Co-authored-by:"));
     }
 }

--- a/DoWhiz_service/scheduler_module/src/account_store.rs
+++ b/DoWhiz_service/scheduler_module/src/account_store.rs
@@ -469,41 +469,91 @@ pub fn channel_to_identifier_type(channel: &crate::channel::Channel) -> &'static
     }
 }
 
+fn identifier_lookup_candidates(identifier_type: &str, identifier: &str) -> Vec<String> {
+    let trimmed = identifier.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates = vec![trimmed.to_string()];
+    match identifier_type {
+        "email" | "github" => {
+            let lower = trimmed.to_ascii_lowercase();
+            if lower != trimmed {
+                candidates.push(lower);
+            }
+        }
+        "slack" => {
+            let upper = trimmed.to_ascii_uppercase();
+            if upper != trimmed {
+                candidates.push(upper);
+            }
+        }
+        "phone" => {
+            if let Some(normalized) = crate::user_store::normalize_phone(trimmed) {
+                if normalized != trimmed {
+                    candidates.push(normalized);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    candidates
+        .into_iter()
+        .filter(|value| seen.insert(value.clone()))
+        .collect()
+}
+
+/// Look up account by identifier type and identifier.
+/// Returns the account_id if found and verified, None otherwise.
+pub fn lookup_account_by_identifier(identifier_type: &str, identifier: &str) -> Option<Uuid> {
+    let store = get_global_account_store()?;
+    let candidates = identifier_lookup_candidates(identifier_type, identifier);
+    if candidates.is_empty() {
+        return None;
+    }
+
+    for candidate in candidates {
+        match store.get_account_by_identifier(identifier_type, &candidate) {
+            Ok(Some(account)) => {
+                tracing::debug!(
+                    "Found account {} for {}:{}",
+                    account.id,
+                    identifier_type,
+                    candidate
+                );
+                return Some(account.id);
+            }
+            Ok(None) => {
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Error looking up account for {}:{}: {}",
+                    identifier_type,
+                    candidate,
+                    e
+                );
+            }
+        }
+    }
+
+    tracing::debug!(
+        "No account found for {}:{}, using local storage",
+        identifier_type,
+        identifier
+    );
+    None
+}
+
 /// Look up account by channel and identifier
 /// Returns the account_id if found and verified, None otherwise
 pub fn lookup_account_by_channel(
     channel: &crate::channel::Channel,
     identifier: &str,
 ) -> Option<Uuid> {
-    let store = get_global_account_store()?;
     let identifier_type = channel_to_identifier_type(channel);
-
-    match store.get_account_by_identifier(identifier_type, identifier) {
-        Ok(Some(account)) => {
-            tracing::debug!(
-                "Found account {} for {}:{}",
-                account.id,
-                identifier_type,
-                identifier
-            );
-            Some(account.id)
-        }
-        Ok(None) => {
-            tracing::debug!(
-                "No account found for {}:{}, using local storage",
-                identifier_type,
-                identifier
-            );
-            None
-        }
-        Err(e) => {
-            tracing::warn!(
-                "Error looking up account for {}:{}: {}, using local storage",
-                identifier_type,
-                identifier,
-                e
-            );
-            None
-        }
-    }
+    lookup_account_by_identifier(identifier_type, identifier)
 }

--- a/DoWhiz_service/scheduler_module/src/github_inbound.rs
+++ b/DoWhiz_service/scheduler_module/src/github_inbound.rs
@@ -1,0 +1,223 @@
+use regex::Regex;
+use serde_json::Value;
+use std::sync::OnceLock;
+
+use crate::user_store::extract_emails;
+
+const GITHUB_NOTIFICATIONS_ADDRESS: &str = "notifications@github.com";
+
+pub(crate) fn extract_github_sender_login_from_postmark_payload(
+    raw_payload: &[u8],
+) -> Option<String> {
+    let payload: Value = serde_json::from_slice(raw_payload).ok()?;
+    extract_github_sender_login_from_value(&payload)
+}
+
+pub(crate) fn is_github_notifications_postmark_payload(raw_payload: &[u8]) -> bool {
+    let payload: Value = match serde_json::from_slice(raw_payload) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    is_github_notifications_payload(&payload)
+}
+
+fn extract_github_sender_login_from_value(payload: &Value) -> Option<String> {
+    if !is_github_notifications_payload(payload) {
+        return None;
+    }
+
+    if let Some(login) = extract_github_sender_from_headers(payload) {
+        return Some(login);
+    }
+
+    for field in ["StrippedTextReply", "TextBody", "HtmlBody"] {
+        if let Some(body) = payload.get(field).and_then(Value::as_str) {
+            if let Some(login) = extract_github_sender_from_text(body) {
+                return Some(login);
+            }
+        }
+    }
+
+    None
+}
+
+fn is_github_notifications_payload(payload: &Value) -> bool {
+    let from = payload
+        .get("From")
+        .or_else(|| payload.get("from"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    is_github_notifications_sender(from)
+}
+
+fn is_github_notifications_sender(from: &str) -> bool {
+    extract_emails(from)
+        .into_iter()
+        .any(|email| email.eq_ignore_ascii_case(GITHUB_NOTIFICATIONS_ADDRESS))
+}
+
+fn extract_github_sender_from_headers(payload: &Value) -> Option<String> {
+    let headers = payload.get("Headers").and_then(Value::as_array)?;
+    for header in headers {
+        let name = header
+            .get("Name")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if !name.eq_ignore_ascii_case("X-GitHub-Sender") {
+            continue;
+        }
+        let value = header
+            .get("Value")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if let Some(login) = normalize_github_login(value) {
+            return Some(login);
+        }
+    }
+    None
+}
+
+fn extract_github_sender_from_text(text: &str) -> Option<String> {
+    if text.trim().is_empty() {
+        return None;
+    }
+
+    if let Some(captures) = github_activity_line_regex().captures(text) {
+        if let Some(login) = captures.get(1).map(|m| m.as_str()) {
+            if let Some(login) = normalize_github_login(login) {
+                return Some(login);
+            }
+        }
+    }
+
+    if let Some(captures) = github_activity_html_regex().captures(text) {
+        if let Some(login) = captures.get(1).map(|m| m.as_str()) {
+            if let Some(login) = normalize_github_login(login) {
+                return Some(login);
+            }
+        }
+    }
+
+    None
+}
+
+fn normalize_github_login(raw: &str) -> Option<String> {
+    let trimmed = raw
+        .trim()
+        .trim_matches(|ch: char| matches!(ch, '"' | '\'' | '<' | '>' | '`'));
+    if trimmed.is_empty() {
+        return None;
+    }
+    if !github_login_regex().is_match(trimmed) {
+        return None;
+    }
+    Some(trimmed.to_ascii_lowercase())
+}
+
+fn github_login_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\[bot\])?$")
+            .expect("valid github login regex")
+    })
+}
+
+fn github_activity_line_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?im)^\s*([A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\[bot\])?)\s+(?:left a comment|created an issue|opened a pull request|opened an issue|closed an issue|reopened an issue|reviewed|requested a review)\b",
+        )
+        .expect("valid github activity line regex")
+    })
+}
+
+fn github_activity_html_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r#"(?i)<strong>\s*([A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\[bot\])?)\s*</strong>\s*(?:left a comment|created an issue|opened a pull request|opened an issue)\b"#,
+        )
+        .expect("valid github activity html regex")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_sender_from_github_header() {
+        let payload = br#"{
+            "From": "Bingran You <notifications@github.com>",
+            "Headers": [{"Name":"X-GitHub-Sender","Value":"bingran-you"}],
+            "TextBody": "something else"
+        }"#;
+        let sender = extract_github_sender_login_from_postmark_payload(payload);
+        assert_eq!(sender, Some("bingran-you".to_string()));
+    }
+
+    #[test]
+    fn falls_back_to_text_activity_line() {
+        let payload = br#"{
+            "From": "notifications@github.com",
+            "TextBody": "bingran-you left a comment (KnoWhiz/DoWhiz#568)"
+        }"#;
+        let sender = extract_github_sender_login_from_postmark_payload(payload);
+        assert_eq!(sender, Some("bingran-you".to_string()));
+    }
+
+    #[test]
+    fn falls_back_to_html_activity_line() {
+        let payload = br#"{
+            "From": "notifications@github.com",
+            "HtmlBody": "<div><strong>bingran-you</strong> left a comment (KnoWhiz/DoWhiz#568)</div>"
+        }"#;
+        let sender = extract_github_sender_login_from_postmark_payload(payload);
+        assert_eq!(sender, Some("bingran-you".to_string()));
+    }
+
+    #[test]
+    fn returns_none_for_non_github_sender() {
+        let payload = br#"{
+            "From": "Alice <alice@example.com>",
+            "Headers": [{"Name":"X-GitHub-Sender","Value":"bingran-you"}],
+            "TextBody": "bingran-you left a comment"
+        }"#;
+        let sender = extract_github_sender_login_from_postmark_payload(payload);
+        assert_eq!(sender, None);
+    }
+
+    #[test]
+    fn normalizes_header_sender_case() {
+        let payload = br#"{
+            "From": "notifications@github.com",
+            "Headers": [{"Name":"X-GitHub-Sender","Value":"Bingran-You"}]
+        }"#;
+        let sender = extract_github_sender_login_from_postmark_payload(payload);
+        assert_eq!(sender, Some("bingran-you".to_string()));
+    }
+
+    #[test]
+    fn rejects_invalid_sender_tokens() {
+        assert_eq!(normalize_github_login("bingran_you"), None);
+        assert_eq!(normalize_github_login("bingran you"), None);
+        assert_eq!(normalize_github_login(""), None);
+    }
+
+    #[test]
+    fn detects_github_notification_sender_from_postmark_payload() {
+        let payload = br#"{
+            "From": "Bingran You <notifications@github.com>"
+        }"#;
+        assert!(is_github_notifications_postmark_payload(payload));
+    }
+
+    #[test]
+    fn detects_github_notification_sender_with_lowercase_from_key() {
+        let payload = br#"{
+            "from": "notifications@github.com"
+        }"#;
+        assert!(is_github_notifications_postmark_payload(payload));
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/lib.rs
+++ b/DoWhiz_service/scheduler_module/src/lib.rs
@@ -5,6 +5,7 @@ pub mod collaboration_store;
 pub mod discord_gateway;
 pub mod employee_config;
 pub mod env_alias;
+pub(crate) mod github_inbound;
 pub mod google_auth;
 pub mod google_docs_poller;
 pub mod google_drive_changes;

--- a/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
@@ -1,9 +1,14 @@
 use std::path::Path;
 use tracing::{info, warn};
 
-use crate::account_store::{get_global_account_store, lookup_account_by_channel};
+use crate::account_store::{
+    get_global_account_store, lookup_account_by_channel, lookup_account_by_identifier,
+};
 use crate::blob_store::get_blob_store;
 use crate::channel::Channel;
+use crate::github_inbound::{
+    extract_github_sender_login_from_postmark_payload, is_github_notifications_postmark_payload,
+};
 use crate::memory_diff::compute_memory_diff;
 use crate::memory_queue::{global_memory_queue, MemoryWriteRequest};
 use crate::memory_store::{
@@ -71,6 +76,105 @@ use super::outbound::{
 use super::types::{SchedulerError, TaskExecution, TaskKind};
 use super::utils::load_google_access_token_from_service_env;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitHubInboundContext {
+    is_github_notification: bool,
+    sender_login: Option<String>,
+}
+
+fn load_github_inbound_context(task: &super::types::RunTaskTask) -> GitHubInboundContext {
+    if task.channel != Channel::Email {
+        return GitHubInboundContext {
+            is_github_notification: false,
+            sender_login: None,
+        };
+    }
+    let payload_path = task
+        .workspace_dir
+        .join(&task.input_email_dir)
+        .join("postmark_payload.json");
+    let payload = match std::fs::read(payload_path) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return GitHubInboundContext {
+                is_github_notification: false,
+                sender_login: None,
+            };
+        }
+    };
+    GitHubInboundContext {
+        is_github_notification: is_github_notifications_postmark_payload(&payload),
+        sender_login: extract_github_sender_login_from_postmark_payload(&payload),
+    }
+}
+
+fn resolve_account_for_run_task(
+    task: &super::types::RunTaskTask,
+    github_sender: Option<&str>,
+) -> Option<Uuid> {
+    if let Some(identifier) = task.reply_to.first() {
+        if let Some(account_id) = lookup_account_by_channel(&task.channel, identifier) {
+            return Some(account_id);
+        }
+    }
+
+    if task.channel == Channel::Email {
+        if let Some(github_sender) = github_sender {
+            return lookup_account_by_identifier("github", github_sender);
+        }
+    }
+
+    None
+}
+
+fn write_github_link_required_reply(
+    task: &super::types::RunTaskTask,
+    github_sender: &str,
+) -> Result<(), SchedulerError> {
+    let reply_path = task.workspace_dir.join("reply_email_draft.html");
+    let attachments_dir = task.workspace_dir.join("reply_email_attachments");
+    std::fs::create_dir_all(&attachments_dir)?;
+
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html>
+<body>
+  <p>Hi there,</p>
+  <p>I received a GitHub request from <strong>@{github_sender}</strong>.</p>
+  <p>Before I can execute GitHub-driven tasks, please link this GitHub account to your DoWhiz account and make sure the account has available balance.</p>
+  <p>You can link it from the DoWhiz auth page by adding identifier type <code>github</code> with identifier <code>{github_sender}</code>.</p>
+  <p>After linking, send the request again and I will continue right away.</p>
+  <p>Thanks!</p>
+</body>
+</html>
+"#
+    );
+    std::fs::write(reply_path, html)?;
+    Ok(())
+}
+
+fn write_github_sender_parse_failed_reply(
+    task: &super::types::RunTaskTask,
+) -> Result<(), SchedulerError> {
+    let reply_path = task.workspace_dir.join("reply_email_draft.html");
+    let attachments_dir = task.workspace_dir.join("reply_email_attachments");
+    std::fs::create_dir_all(&attachments_dir)?;
+
+    let html = r#"<!DOCTYPE html>
+<html>
+<body>
+  <p>Hi there,</p>
+  <p>I received a GitHub notification email, but I could not deterministically extract the requesting GitHub login from the message payload.</p>
+  <p>For security, I did not execute the task. Please resend from the original GitHub notification format (the one that includes lines like <code>&lt;login&gt; left a comment</code> or <code>&lt;login&gt; created an issue</code>).</p>
+  <p>After that, I can reliably identify the requester and continue.</p>
+  <p>Thanks!</p>
+</body>
+</html>
+"#;
+    std::fs::write(reply_path, html)?;
+    Ok(())
+}
+
 pub trait TaskExecutor {
     fn execute(&self, task: &TaskKind) -> Result<TaskExecution, SchedulerError>;
 }
@@ -132,15 +236,34 @@ impl TaskExecutor for ModuleExecutor {
                 Ok(TaskExecution::empty())
             }
             TaskKind::RunTask(task) => {
+                let github_inbound = load_github_inbound_context(task);
+                let account_id =
+                    resolve_account_for_run_task(task, github_inbound.sender_login.as_deref());
+
+                if task.channel == Channel::Email && github_inbound.is_github_notification {
+                    match github_inbound.sender_login.as_deref() {
+                        Some(github_sender) if account_id.is_none() => {
+                            write_github_link_required_reply(task, github_sender)?;
+                            info!(
+                                "skipping run_task for github notification sender={} (no linked github account)",
+                                github_sender
+                            );
+                            return Ok(TaskExecution::empty());
+                        }
+                        Some(_) => {}
+                        None => {
+                            write_github_sender_parse_failed_reply(task)?;
+                            info!(
+                                "skipping run_task for github notification: unable to extract sender login"
+                            );
+                            return Ok(TaskExecution::empty());
+                        }
+                    }
+                }
+
                 let workspace_memory_dir = task.workspace_dir.join(&task.memory_dir);
                 let user_memory_dir = resolve_user_memory_dir(task);
                 let user_secrets_path = resolve_user_secrets_path(task);
-
-                // Try to look up unified account by channel identifier
-                let account_id = task
-                    .reply_to
-                    .first()
-                    .and_then(|identifier| lookup_account_by_channel(&task.channel, identifier));
 
                 // Sync memo to workspace: prefer Azure Blob if account exists, else local storage
                 let original_memo_snapshot = if let Some(account_id) = account_id {
@@ -259,11 +382,6 @@ impl TaskExecutor for ModuleExecutor {
                                     .unwrap_or("unknown")
                                     .to_string();
 
-                                // Try to look up unified account by channel identifier
-                                let account_id = task.reply_to.first().and_then(|identifier| {
-                                    lookup_account_by_channel(&task.channel, identifier)
-                                });
-
                                 let request = MemoryWriteRequest {
                                     account_id,
                                     user_id: user_id.clone(),
@@ -317,5 +435,119 @@ impl TaskExecutor for ModuleExecutor {
             }
             TaskKind::Noop => Ok(TaskExecution::empty()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::RunTaskTask;
+    use super::*;
+    use crate::channel::Channel;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn sample_email_task(workspace_dir: PathBuf) -> RunTaskTask {
+        RunTaskTask {
+            workspace_dir,
+            input_email_dir: PathBuf::from("incoming_email"),
+            input_attachments_dir: PathBuf::from("incoming_attachments"),
+            memory_dir: PathBuf::from("memory"),
+            reference_dir: PathBuf::from("references"),
+            model_name: "gpt-5.3-codex".to_string(),
+            runner: "codex".to_string(),
+            codex_disabled: true,
+            reply_to: vec!["reply@example.com".to_string()],
+            reply_from: Some("service@example.com".to_string()),
+            archive_root: None,
+            thread_id: Some("thread-1".to_string()),
+            thread_epoch: Some(1),
+            thread_state_path: None,
+            channel: Channel::Email,
+            slack_team_id: None,
+            employee_id: Some("little_bear".to_string()),
+        }
+    }
+
+    #[test]
+    fn load_github_inbound_context_reads_postmark_payload() {
+        let temp = TempDir::new().expect("tempdir");
+        let workspace = temp.path().to_path_buf();
+        let incoming_email = workspace.join("incoming_email");
+        fs::create_dir_all(&incoming_email).expect("incoming_email");
+        fs::write(
+            incoming_email.join("postmark_payload.json"),
+            r#"{
+  "From": "notifications@github.com",
+  "Headers": [{"Name": "X-GitHub-Sender", "Value": "bingran-you"}]
+}"#,
+        )
+        .expect("postmark_payload.json");
+
+        let task = sample_email_task(workspace);
+        let context = load_github_inbound_context(&task);
+        assert_eq!(
+            context,
+            GitHubInboundContext {
+                is_github_notification: true,
+                sender_login: Some("bingran-you".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn load_github_inbound_context_detects_unparseable_github_notification() {
+        let temp = TempDir::new().expect("tempdir");
+        let workspace = temp.path().to_path_buf();
+        let incoming_email = workspace.join("incoming_email");
+        fs::create_dir_all(&incoming_email).expect("incoming_email");
+        fs::write(
+            incoming_email.join("postmark_payload.json"),
+            r#"{
+  "From": "notifications@github.com",
+  "TextBody": "No activity line here"
+}"#,
+        )
+        .expect("postmark_payload.json");
+
+        let task = sample_email_task(workspace);
+        let context = load_github_inbound_context(&task);
+        assert_eq!(
+            context,
+            GitHubInboundContext {
+                is_github_notification: true,
+                sender_login: None,
+            }
+        );
+    }
+
+    #[test]
+    fn write_github_link_required_reply_writes_template() {
+        let temp = TempDir::new().expect("tempdir");
+        let workspace = temp.path().to_path_buf();
+        let task = sample_email_task(workspace.clone());
+
+        write_github_link_required_reply(&task, "bingran-you").expect("write template");
+
+        let reply_path = workspace.join("reply_email_draft.html");
+        let body = fs::read_to_string(reply_path).expect("reply body");
+        assert!(body.contains("@bingran-you"));
+        assert!(body.contains("identifier type <code>github</code>"));
+        assert!(workspace.join("reply_email_attachments").is_dir());
+    }
+
+    #[test]
+    fn write_github_sender_parse_failed_reply_writes_template() {
+        let temp = TempDir::new().expect("tempdir");
+        let workspace = temp.path().to_path_buf();
+        let task = sample_email_task(workspace.clone());
+
+        write_github_sender_parse_failed_reply(&task).expect("write template");
+
+        let reply_path = workspace.join("reply_email_draft.html");
+        let body = fs::read_to_string(reply_path).expect("reply body");
+        assert!(body.contains("could not deterministically extract"));
+        assert!(body.contains("did not execute the task"));
+        assert!(workspace.join("reply_email_attachments").is_dir());
     }
 }

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -10,6 +10,9 @@ use tracing::{error, info, warn};
 use crate::artifact_extractor::extract_artifacts_from_email;
 use crate::channel::{Channel, ExtractedArtifactRef};
 use crate::collaboration_store::CollaborationStore;
+use crate::github_inbound::{
+    extract_github_sender_login_from_postmark_payload, is_github_notifications_postmark_payload,
+};
 use crate::google_auth::{GoogleAuth, GoogleAuthConfig};
 use crate::index_store::IndexStore;
 use crate::mailbox;
@@ -43,12 +46,12 @@ pub fn process_inbound_payload(
         info!("skipping blacklisted sender: {}", sender);
         return Ok(());
     }
-    let user_email = payload.from.as_deref().unwrap_or("").trim();
-    let user_email = extract_emails(user_email)
-        .into_iter()
-        .next()
-        .ok_or_else(|| "missing sender email".to_string())?;
-    let user = user_store.get_or_create_user("email", &user_email)?;
+    let requester = resolve_inbound_requester(payload, raw_payload)?;
+    info!(
+        "resolved inbound requester identifier_type={} identifier={}",
+        requester.identifier_type, requester.identifier
+    );
+    let user = user_store.get_or_create_user(requester.identifier_type, &requester.identifier)?;
     let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
     user_store.ensure_user_dirs(&user_paths)?;
 
@@ -244,6 +247,39 @@ fn is_blacklisted_sender(sender: &str, service_addresses: &HashSet<String>) -> b
 
 fn is_blacklisted_address(address: &str, service_addresses: &HashSet<String>) -> bool {
     mailbox::is_service_address(address, service_addresses)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InboundRequester {
+    identifier_type: &'static str,
+    identifier: String,
+}
+
+fn resolve_inbound_requester(
+    payload: &PostmarkInbound,
+    raw_payload: &[u8],
+) -> Result<InboundRequester, BoxError> {
+    if let Some(github_login) = extract_github_sender_login_from_postmark_payload(raw_payload) {
+        return Ok(InboundRequester {
+            identifier_type: "github",
+            identifier: github_login,
+        });
+    }
+    if is_github_notifications_postmark_payload(raw_payload) {
+        warn!(
+            "github notification email did not include a deterministic sender login; falling back to From address"
+        );
+    }
+
+    let user_email = payload.from.as_deref().unwrap_or("").trim();
+    let user_email = extract_emails(user_email)
+        .into_iter()
+        .next()
+        .ok_or_else(|| "missing sender email".to_string())?;
+    Ok(InboundRequester {
+        identifier_type: "email",
+        identifier: user_email,
+    })
 }
 
 fn thread_key(payload: &PostmarkInbound, raw_payload: &[u8]) -> String {
@@ -472,6 +508,41 @@ mod tests {
     use std::collections::HashSet;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn resolve_inbound_requester_uses_github_sender_for_notifications() {
+        let raw = br#"{
+  "From": "Bingran You <notifications@github.com>",
+  "Headers": [{"Name": "X-GitHub-Sender", "Value": "bingran-you"}],
+  "TextBody": "bingran-you left a comment (KnoWhiz/DoWhiz#568)"
+}"#;
+        let payload: PostmarkInbound = serde_json::from_slice(raw).expect("payload");
+        let requester = resolve_inbound_requester(&payload, raw).expect("requester");
+        assert_eq!(
+            requester,
+            InboundRequester {
+                identifier_type: "github",
+                identifier: "bingran-you".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_inbound_requester_falls_back_to_email() {
+        let raw = br#"{
+  "From": "Alice <alice@example.com>",
+  "TextBody": "hello"
+}"#;
+        let payload: PostmarkInbound = serde_json::from_slice(raw).expect("payload");
+        let requester = resolve_inbound_requester(&payload, raw).expect("requester");
+        assert_eq!(
+            requester,
+            InboundRequester {
+                identifier_type: "email",
+                identifier: "alice@example.com".to_string(),
+            }
+        );
+    }
 
     #[test]
     fn create_workspace_hydrates_past_emails() {


### PR DESCRIPTION
## Summary
- add deterministic GitHub sender parsing for Postmark inbound payloads (`X-GitHub-Sender` first, then strict activity-line parsing in text/html bodies)
- route GitHub notifications through `identifier_type=github` requester resolution in inbound email processing
- enforce fail-closed run-task behavior for GitHub notifications:
  - if sender login cannot be extracted, write a security clarification reply and skip execution
  - if sender login is extracted but no linked GitHub identifier exists, write an account-link guidance reply and skip execution
  - only execute task when sender is deterministically parsed and account mapping succeeds
- normalize account lookup candidates for `github` identifiers (case-safe matching)
- include GitHub attribution guidance in run-task prompt (`Co-authored-by` + `Requested-by`) when requester is deterministically detected
- add focused unit/integration coverage for parser behavior, requester resolution, and scheduler gating

## Commit-level changes
- `9d84724` Add deterministic GitHub requester auth flow
  - added `scheduler_module/src/github_inbound.rs` for deterministic GitHub sender extraction and notification detection
  - updated `scheduler_module/src/service/email.rs` to resolve inbound requester as `github` when applicable
  - updated `scheduler_module/src/scheduler/executor.rs` to gate execution for unlinked/unparseable GitHub notifications and generate explicit reply drafts
  - updated `scheduler_module/src/account_store.rs` lookup candidate normalization to support robust github identifier matching
  - updated `run_task_module/src/run_task/prompt.rs` to inject co-author/requested-by guidance from deterministic sender extraction

## Production impact
- prevents ambiguous GitHub notification traffic from being executed under the wrong user identity
- improves safety by failing closed when requester identity cannot be deterministically parsed
- improves user recovery path by sending explicit account-link instructions for unlinked GitHub identities
- existing non-GitHub email flow remains unchanged

## Validation
- `cargo test -p scheduler_module -p run_task_module` (observed env-sensitive parallel test races and live-email env coupling)
- `RUST_SERVICE_LIVE_TEST=0 RUST_TEST_THREADS=1 cargo test -p scheduler_module -p run_task_module -- --skip rust_service_real_email_end_to_end` ✅

## Requested-by
Requested-by: @bingran-you
