### PR TITLE
fix(run_task): parse scheduler blocks from assistant JSONL (#579)

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -318,11 +318,19 @@ pub(super) fn run_codex_task(
         }
     };
 
+    let stdout_output = String::from_utf8_lossy(&output.stdout);
+    let stderr_output = String::from_utf8_lossy(&output.stderr);
     let mut combined_output = String::new();
-    combined_output.push_str(&String::from_utf8_lossy(&output.stdout));
-    combined_output.push_str(&String::from_utf8_lossy(&output.stderr));
-    let (scheduled_tasks, scheduled_tasks_error) = extract_scheduled_tasks(&combined_output);
-    let (scheduler_actions, scheduler_actions_error) = extract_scheduler_actions(&combined_output);
+    combined_output.push_str(&stdout_output);
+    combined_output.push_str(&stderr_output);
+
+    let (scheduled_tasks, scheduled_tasks_error, scheduler_actions, scheduler_actions_error) =
+        parse_scheduling_from_outputs(
+            &stdout_output,
+            &stderr_output,
+            &combined_output,
+            request.workspace_dir,
+        );
     let token_usage = extract_token_usage(&combined_output);
     let output_tail = tail_string(&combined_output, 2000);
 
@@ -537,9 +545,247 @@ fn extract_token_usage(output: &str) -> Option<TokenUsage> {
     None
 }
 
+fn parse_scheduling_from_outputs(
+    stdout_output: &str,
+    stderr_output: &str,
+    combined_output: &str,
+    workspace_dir: &Path,
+) -> (
+    Vec<super::types::ScheduledTaskRequest>,
+    Option<String>,
+    Vec<super::types::SchedulerActionRequest>,
+    Option<String>,
+) {
+    // In --json mode, assistant text lives inside JSON fields with escaping.
+    // Decode assistant message payloads first, then parse scheduler blocks.
+    // Codex may emit JSONL to stdout or stderr depending on runtime environment.
+    let assistant_output = extract_assistant_text_from_jsonl(stdout_output)
+        .or_else(|| extract_assistant_text_from_jsonl(stderr_output))
+        .or_else(|| extract_assistant_text_from_jsonl(combined_output));
+    let scheduling_output = assistant_output.as_deref().unwrap_or("");
+    let (mut scheduled_tasks, mut scheduled_tasks_error) = extract_scheduled_tasks(scheduling_output);
+    let (mut scheduler_actions, mut scheduler_actions_error) =
+        extract_scheduler_actions(scheduling_output);
+
+    if assistant_output.is_none() {
+        // Avoid parsing prompt scaffolding as scheduler JSON when assistant extraction fails.
+        // Fall back to raw output only if it yields concrete tasks/actions.
+        let (fallback_tasks, fallback_tasks_error) = extract_scheduled_tasks(combined_output);
+        let (fallback_actions, fallback_actions_error) = extract_scheduler_actions(combined_output);
+        if !fallback_tasks.is_empty() || !fallback_actions.is_empty() {
+            scheduled_tasks = fallback_tasks;
+            scheduled_tasks_error = fallback_tasks_error;
+            scheduler_actions = fallback_actions;
+            scheduler_actions_error = fallback_actions_error;
+        } else {
+            scheduled_tasks_error = None;
+            scheduler_actions_error = None;
+        }
+    }
+
+    if scheduled_tasks.is_empty()
+        && scheduler_actions.is_empty()
+        && (scheduled_tasks_error.is_some() || scheduler_actions_error.is_some())
+    {
+        if let Some(session_output) = extract_assistant_text_from_recent_session(workspace_dir) {
+            let (session_tasks, session_tasks_error) = extract_scheduled_tasks(&session_output);
+            let (session_actions, session_actions_error) =
+                extract_scheduler_actions(&session_output);
+            if !session_tasks.is_empty() || !session_actions.is_empty() {
+                scheduled_tasks = session_tasks;
+                scheduled_tasks_error = session_tasks_error;
+                scheduler_actions = session_actions;
+                scheduler_actions_error = session_actions_error;
+            }
+        }
+    }
+
+    (
+        scheduled_tasks,
+        scheduled_tasks_error,
+        scheduler_actions,
+        scheduler_actions_error,
+    )
+}
+
+fn extract_assistant_text_from_recent_session(workspace_dir: &Path) -> Option<String> {
+    let home = env::var("HOME").ok()?;
+    let sessions_root = PathBuf::from(home).join(".codex").join("sessions");
+    if !sessions_root.exists() {
+        return None;
+    }
+
+    let mut session_files = Vec::new();
+    collect_session_jsonl_files(&sessions_root, &mut session_files).ok()?;
+    session_files.sort_by(|a, b| {
+        let a_time = a
+            .metadata()
+            .and_then(|meta| meta.modified())
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        let b_time = b
+            .metadata()
+            .and_then(|meta| meta.modified())
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        b_time.cmp(&a_time)
+    });
+
+    let workspace_marker = workspace_dir.to_string_lossy();
+    for session_path in session_files.into_iter().take(40) {
+        let Ok(contents) = fs::read_to_string(&session_path) else {
+            continue;
+        };
+        if !contents.contains(workspace_marker.as_ref()) {
+            continue;
+        }
+        let Some(assistant_output) = extract_assistant_text_from_jsonl(&contents) else {
+            continue;
+        };
+        if assistant_output.contains("SCHEDULED_TASKS_JSON_BEGIN")
+            || assistant_output.contains("SCHEDULER_ACTIONS_JSON_BEGIN")
+        {
+            return Some(assistant_output);
+        }
+    }
+    None
+}
+
+fn collect_session_jsonl_files(dir: &Path, files: &mut Vec<PathBuf>) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_session_jsonl_files(&path, files)?;
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn extract_assistant_text_from_jsonl(output: &str) -> Option<String> {
+    let mut collected = String::new();
+    let mut found = false;
+
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+
+        if collect_item_completed_agent_message(&value, &mut collected) {
+            found = true;
+        }
+        if collect_event_msg_agent_message(&value, &mut collected) {
+            found = true;
+        }
+        if collect_response_item_assistant_message(&value, &mut collected) {
+            found = true;
+        }
+    }
+
+    found.then_some(collected)
+}
+
+fn append_collected_text(target: &mut String, text: &str) {
+    if text.trim().is_empty() {
+        return;
+    }
+    if !target.is_empty() {
+        target.push('\n');
+    }
+    target.push_str(text);
+}
+
+fn collect_item_completed_agent_message(value: &serde_json::Value, target: &mut String) -> bool {
+    if value.get("type").and_then(|v| v.as_str()) != Some("item.completed") {
+        return false;
+    }
+    let Some(item) = value.get("item") else {
+        return false;
+    };
+    if item.get("type").and_then(|v| v.as_str()) != Some("agent_message") {
+        return false;
+    }
+    let Some(text) = item.get("text").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    append_collected_text(target, text);
+    true
+}
+
+fn collect_event_msg_agent_message(value: &serde_json::Value, target: &mut String) -> bool {
+    if value.get("type").and_then(|v| v.as_str()) != Some("event_msg") {
+        return false;
+    }
+    let Some(payload) = value.get("payload") else {
+        return false;
+    };
+    match payload.get("type").and_then(|v| v.as_str()) {
+        Some("agent_message") => {
+            let Some(text) = payload.get("message").and_then(|v| v.as_str()) else {
+                return false;
+            };
+            append_collected_text(target, text);
+            true
+        }
+        Some("task_complete") => {
+            let Some(text) = payload.get("last_agent_message").and_then(|v| v.as_str()) else {
+                return false;
+            };
+            append_collected_text(target, text);
+            true
+        }
+        _ => false,
+    }
+}
+
+fn collect_response_item_assistant_message(
+    value: &serde_json::Value,
+    target: &mut String,
+) -> bool {
+    if value.get("type").and_then(|v| v.as_str()) != Some("response_item") {
+        return false;
+    }
+    let Some(payload) = value.get("payload") else {
+        return false;
+    };
+    if payload.get("type").and_then(|v| v.as_str()) != Some("message") {
+        return false;
+    }
+    if payload.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+        return false;
+    }
+
+    let mut appended = false;
+    if let Some(content) = payload.get("content").and_then(|v| v.as_array()) {
+        for part in content {
+            if part.get("type").and_then(|v| v.as_str()) == Some("output_text") {
+                if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                    append_collected_text(target, text);
+                    appended = true;
+                }
+            }
+        }
+    }
+    appended
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::Path;
     use std::sync::{Mutex, OnceLock};
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -639,6 +885,90 @@ mod tests {
         let usage = usage.unwrap();
         assert_eq!(usage.input_tokens, 1000);
         assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn test_extract_assistant_text_from_jsonl_item_completed() {
+        let output = r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hello\nSCHEDULED_TASKS_JSON_BEGIN\n[{\"type\":\"send_email\",\"delay_seconds\":60,\"subject\":\"x\",\"html_path\":\"x.html\"}]\nSCHEDULED_TASKS_JSON_END"}}"#;
+
+        let parsed = extract_assistant_text_from_jsonl(output);
+        assert!(parsed.is_some());
+        let parsed = parsed.unwrap();
+        assert!(parsed.contains("SCHEDULED_TASKS_JSON_BEGIN"));
+        assert!(parsed.contains("\"delay_seconds\":60"));
+    }
+
+    #[test]
+    fn test_extract_assistant_text_from_jsonl_response_item_message() {
+        let output = r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"SCHEDULER_ACTIONS_JSON_BEGIN\n[{\"action\":\"cancel\",\"task_ids\":[\"a\"]}]\nSCHEDULER_ACTIONS_JSON_END"}]}}"#;
+
+        let parsed = extract_assistant_text_from_jsonl(output);
+        assert!(parsed.is_some());
+        let parsed = parsed.unwrap();
+        assert!(parsed.contains("SCHEDULER_ACTIONS_JSON_BEGIN"));
+        assert!(parsed.contains("\"action\":\"cancel\""));
+    }
+
+    #[test]
+    fn test_parse_scheduling_from_outputs_reads_stderr_jsonl() {
+        let stderr = r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"SCHEDULED_TASKS_JSON_BEGIN\n[{\"type\":\"send_email\",\"delay_seconds\":60,\"subject\":\"x\",\"html_path\":\"x.html\"}]\nSCHEDULED_TASKS_JSON_END"}}"#;
+        let combined = format!("{stderr}\n");
+        let (tasks, task_error, actions, action_error) =
+            parse_scheduling_from_outputs("", stderr, &combined, Path::new("/tmp/workspace"));
+        assert_eq!(tasks.len(), 1);
+        assert!(task_error.is_none());
+        assert!(actions.is_empty());
+        assert!(action_error.is_none());
+    }
+
+    #[test]
+    fn test_parse_scheduling_from_outputs_ignores_prompt_markers_without_assistant() {
+        let prompt_like = concat!(
+            "SCHEDULED_TASKS_JSON_BEGIN\n",
+            "<JSON array here>\n",
+            "SCHEDULED_TASKS_JSON_END\n",
+            "SCHEDULER_ACTIONS_JSON_BEGIN\n",
+            "<JSON array here>\n",
+            "SCHEDULER_ACTIONS_JSON_END\n"
+        );
+        let (tasks, task_error, actions, action_error) =
+            parse_scheduling_from_outputs("", "", prompt_like, Path::new("/tmp/workspace"));
+        assert!(tasks.is_empty());
+        assert!(actions.is_empty());
+        assert!(task_error.is_none());
+        assert!(action_error.is_none());
+    }
+
+    #[test]
+    fn test_parse_scheduling_from_outputs_falls_back_to_recent_session_file() {
+        let _lock = env_lock();
+        let temp_root = std::env::temp_dir().join(format!(
+            "codex-session-fallback-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&temp_root);
+        let session_dir = temp_root.join(".codex/sessions/2026/03/01");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let workspace = Path::new("/tmp/fallback-workspace");
+
+        let session_path = session_dir.join("rollout-test.jsonl");
+        let session_jsonl = format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"user\",\"content\":[{{\"type\":\"input_text\",\"text\":\"workspace: {}\"}}]}}}}\n{{\"type\":\"item.completed\",\"item\":{{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"SCHEDULED_TASKS_JSON_BEGIN\\n[{{\\\"type\\\":\\\"send_email\\\",\\\"delay_seconds\\\":60,\\\"subject\\\":\\\"fallback\\\",\\\"html_path\\\":\\\"x.html\\\"}}]\\nSCHEDULED_TASKS_JSON_END\"}}}}\n",
+            workspace.display()
+        );
+        fs::write(&session_path, session_jsonl).expect("write session");
+
+        let _home_guard = EnvVarGuard::set("HOME", temp_root.to_string_lossy().as_ref());
+        let invalid_stdout = r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"SCHEDULED_TASKS_JSON_BEGIN\n<JSON>\nSCHEDULED_TASKS_JSON_END"}}"#;
+        let (tasks, task_error, actions, action_error) =
+            parse_scheduling_from_outputs(invalid_stdout, "", invalid_stdout, workspace);
+
+        assert_eq!(tasks.len(), 1);
+        assert!(task_error.is_none());
+        assert!(actions.is_empty());
+        assert!(action_error.is_none());
+
+        let _ = fs::remove_dir_all(&temp_root);
     }
 
     #[test]


### PR DESCRIPTION
Prefer assistant text extracted from Codex JSONL output (stdout/stderr), avoid parsing prompt scaffolding as scheduler JSON, and fall back to recent session JSONL when parse errors occur with empty scheduling results.