### PR TITLE
Fix Discord reply attachment blob links

### DIFF
--- a/DoWhiz_service/scheduler_module/src/raw_payload_store.rs
+++ b/DoWhiz_service/scheduler_module/src/raw_payload_store.rs
@@ -437,6 +437,12 @@ pub fn download_raw_payload(reference: &str) -> Result<Vec<u8>, RawPayloadStoreE
     Ok(bytes)
 }
 
+pub fn resolve_azure_blob_url(reference: &str) -> Result<String, RawPayloadStoreError> {
+    let (_container, path) = parse_azure_ref(reference)?;
+    let container_sas_url = resolve_azure_container_sas_url()?;
+    Ok(build_azure_blob_url(&container_sas_url, &path))
+}
+
 fn is_azure_blob_url(url: &str) -> bool {
     let lower = url.to_ascii_lowercase();
     lower.contains("blob.core.windows.net") || lower.contains("sig=")

--- a/DoWhiz_service/scheduler_module/src/scheduler/outbound.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/outbound.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tracing::{info, warn};
 
@@ -149,6 +149,134 @@ fn resolve_discord_bot_token_for_employee(
         .map_err(|_| SchedulerError::TaskFailed("DISCORD_BOT_TOKEN not set".to_string()))
 }
 
+fn read_cached_azure_url(sidecar_path: &Path) -> Option<String> {
+    fs::read_to_string(sidecar_path)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| value.starts_with("http://") || value.starts_with("https://"))
+}
+
+fn collect_discord_attachment_links(attachments_dir: &Path) -> Vec<(String, String)> {
+    if !attachments_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut attachment_paths = match fs::read_dir(attachments_dir) {
+        Ok(entries) => entries
+            .filter_map(|entry| entry.ok().map(|value| value.path()))
+            .filter(|path| path.is_file())
+            .collect::<Vec<_>>(),
+        Err(err) => {
+            warn!(
+                "failed to read Discord attachments dir {}: {}",
+                attachments_dir.display(),
+                err
+            );
+            return Vec::new();
+        }
+    };
+    attachment_paths.sort();
+
+    let envelope_id = uuid::Uuid::new_v4();
+    let received_at = chrono::Utc::now();
+    let mut links = Vec::new();
+
+    for (index, path) in attachment_paths.into_iter().enumerate() {
+        let file_name = path
+            .file_name()
+            .map(|value| value.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if file_name.is_empty() || file_name.ends_with(".azure_url") {
+            continue;
+        }
+
+        let sidecar_path = path.with_file_name(format!("{}.azure_url", file_name));
+        if let Some(url) = read_cached_azure_url(&sidecar_path) {
+            links.push((file_name, url));
+            continue;
+        }
+
+        let bytes = match fs::read(&path) {
+            Ok(value) if !value.is_empty() => value,
+            Ok(_) => {
+                warn!(
+                    "skipping empty Discord attachment for blob upload: {}",
+                    path.display()
+                );
+                continue;
+            }
+            Err(err) => {
+                warn!(
+                    "failed to read Discord attachment {}: {}",
+                    path.display(),
+                    err
+                );
+                continue;
+            }
+        };
+
+        let storage_ref = match crate::raw_payload_store::upload_attachment_azure_blocking(
+            envelope_id,
+            received_at,
+            index,
+            &file_name,
+            &bytes,
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                warn!(
+                    "failed to upload Discord attachment {} to Azure: {}",
+                    path.display(),
+                    err
+                );
+                continue;
+            }
+        };
+
+        let blob_url = match crate::raw_payload_store::resolve_azure_blob_url(&storage_ref) {
+            Ok(value) => value,
+            Err(err) => {
+                warn!(
+                    "failed to resolve Azure URL for Discord attachment {}: {}",
+                    path.display(),
+                    err
+                );
+                continue;
+            }
+        };
+
+        if let Err(err) = fs::write(&sidecar_path, &blob_url) {
+            warn!(
+                "failed to write Discord attachment URL sidecar {}: {}",
+                sidecar_path.display(),
+                err
+            );
+        }
+
+        links.push((file_name, blob_url));
+    }
+
+    links
+}
+
+fn append_discord_attachment_links(base_text: &str, attachments_dir: &Path) -> String {
+    let links = collect_discord_attachment_links(attachments_dir);
+    if links.is_empty() {
+        return base_text.to_string();
+    }
+
+    let mut suffix = String::from("Attachments:\n");
+    for (name, url) in links {
+        suffix.push_str(&format!("- {}: {}\n", name, url));
+    }
+
+    if base_text.trim().is_empty() {
+        suffix.trim_end().to_string()
+    } else {
+        format!("{}\n\n{}", base_text.trim_end(), suffix.trim_end())
+    }
+}
+
 /// Execute a SendReplyTask via Discord.
 pub(crate) fn execute_discord_send(task: &SendReplyTask) -> Result<(), SchedulerError> {
     use crate::adapters::discord::DiscordOutboundAdapter;
@@ -159,11 +287,12 @@ pub(crate) fn execute_discord_send(task: &SendReplyTask) -> Result<(), Scheduler
 
     let adapter = DiscordOutboundAdapter::new(bot_token);
 
-    let text_body = if task.html_path.exists() {
+    let base_text_body = if task.html_path.exists() {
         fs::read_to_string(&task.html_path).unwrap_or_default()
     } else {
         String::new()
     };
+    let text_body = append_discord_attachment_links(&base_text_body, &task.attachments_dir);
 
     let channel_id = task.to.first().and_then(|value| value.parse::<u64>().ok());
 

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/task_rows.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/task_rows.rs
@@ -330,12 +330,17 @@ impl SqliteSchedulerStore {
                     task_id
                 ))
             })?;
+        let text_path_buf = PathBuf::from(&text_path);
+        let attachments_dir = text_path_buf
+            .parent()
+            .map(|parent| parent.join("reply_attachments"))
+            .unwrap_or_default();
 
         Ok(SendReplyTask {
             channel: Channel::Discord,
             subject: String::new(), // Discord doesn't use subject
-            html_path: PathBuf::from(text_path),
-            attachments_dir: PathBuf::new(), // Discord attachments handled differently
+            html_path: text_path_buf,
+            attachments_dir,
             from: None,
             to: vec![discord_channel_id], // channel_id stored in to[0]
             cc: Vec::new(),

--- a/DoWhiz_service/scheduler_module/tests/send_reply_outbound_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/send_reply_outbound_e2e.rs
@@ -188,6 +188,78 @@ fn send_reply_discord_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn send_reply_discord_uploads_attachments_and_includes_blob_links(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(mut server) = test_support::start_mockito_server(
+        "send_reply_discord_uploads_attachments_and_includes_blob_links",
+    ) else {
+        return Ok(());
+    };
+
+    let azure_mock = server
+        .mock("PUT", Matcher::Regex("^/ingestion-raw/.+".to_string()))
+        .match_header("x-ms-blob-type", "BlockBlob")
+        .with_status(201)
+        .expect(1)
+        .create();
+
+    let discord_mock = server
+        .mock("POST", "/api/v10/channels/987654/messages")
+        .match_header("authorization", "Bot discord-test")
+        .match_header("content-type", "application/json")
+        .match_body(Matcher::Regex("Hello Discord".to_string()))
+        .match_body(Matcher::Regex("diagram\\.png".to_string()))
+        .match_body(Matcher::Regex("ingestion-raw".to_string()))
+        .match_body(Matcher::Regex("sig=test".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"msg-1000","timestamp":"2024-01-01T00:00:00Z","channel_id":"987654"}"#)
+        .expect(1)
+        .create();
+
+    let _guard_token = EnvGuard::set("DISCORD_BOT_TOKEN", "discord-test");
+    let _guard_api = EnvGuard::set("DISCORD_API_BASE_URL", format!("{}/api/v10", server.url()));
+    let _guard_container = EnvGuard::set("AZURE_STORAGE_CONTAINER_INGEST", "ingestion-raw");
+    let _guard_container_prefixed = EnvGuard::set(
+        "SCALE_OLIVER_AZURE_STORAGE_CONTAINER_INGEST",
+        "ingestion-raw",
+    );
+    let _guard_path_prefix = EnvGuard::set("RAW_PAYLOAD_PATH_PREFIX", "ingestion_raw");
+    let _guard_path_prefix_prefixed =
+        EnvGuard::set("SCALE_OLIVER_RAW_PAYLOAD_PATH_PREFIX", "ingestion_raw");
+    let container_sas_url = format!("{}/ingestion-raw?sig=test", server.url());
+    let _guard_container_sas_url =
+        EnvGuard::set("AZURE_STORAGE_CONTAINER_SAS_URL", &container_sas_url);
+    let _guard_container_sas_url_prefixed = EnvGuard::set(
+        "SCALE_OLIVER_AZURE_STORAGE_CONTAINER_SAS_URL",
+        &container_sas_url,
+    );
+
+    let temp = TempDir::new()?;
+    let html_path = write_text_file(&temp, "discord_message.txt", "Hello Discord")?;
+    let attachments_dir = create_attachments_dir(&temp)?;
+    fs::write(attachments_dir.join("diagram.png"), b"fake-png-bytes")?;
+
+    let mut task = base_send_task(Channel::Discord, html_path, attachments_dir.clone());
+    task.to = vec!["987654".to_string()];
+
+    let db_path = temp.path().join("tasks.db");
+    let mut scheduler = Scheduler::load(&db_path, ModuleExecutor::default())?;
+    scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::SendReply(task))?;
+    scheduler.tick()?;
+
+    azure_mock.assert();
+    discord_mock.assert();
+
+    let sidecar = fs::read_to_string(attachments_dir.join("diagram.png.azure_url"))?;
+    assert!(sidecar.contains("/ingestion-raw/"));
+    assert!(sidecar.contains("sig=test"));
+
+    Ok(())
+}
+
+#[test]
 fn send_reply_sms_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
     let Some(mut server) = test_support::start_mockito_server("send_reply_sms_uses_mock") else {


### PR DESCRIPTION
## Summary
- upload Discord reply attachments in `reply_attachments/` to Azure Blob when sending outbound Discord replies
- append public blob links to Discord message text so users can open/download attachments directly
- cache generated blob URLs in `.azure_url` sidecar files to avoid re-uploading the same artifacts
- add e2e coverage for upload + link-inclusion behavior

## Testing
- `cargo test -p scheduler_module --test send_reply_outbound_e2e -- --nocapture` (pass)
- `cargo test -p scheduler_module` (fails in unrelated existing tests: `email_flow_injects_x402_env`, `email_flow_injects_employee_prefixed_x402_env` in `github_env_e2e`)

Requested-by: @bingran-you
