### PR TITLE
ops: enforce Azure Files mount check before ACI worker start

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -157,6 +157,11 @@ jobs:
             source /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh
           fi
           APP_DIR=/home/${{ secrets.PROD_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
+          export DEPLOY_TARGET=production
+
+          # Ensure Azure Files mount is present before starting worker
+          # so ACI tasks share workspace/memory paths correctly.
+          bash "$APP_DIR/scripts/ensure_aci_share_mount.sh"
 
           worker_running=0
           for service in dw_worker dowhiz_rust_service dowhiz-rust-service; do

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -157,6 +157,11 @@ jobs:
             source /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh
           fi
           APP_DIR=/home/${{ secrets.STAGING_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
+          export DEPLOY_TARGET=staging
+
+          # Ensure Azure Files mount is present before starting worker
+          # so ACI tasks share workspace/memory paths correctly.
+          bash "$APP_DIR/scripts/ensure_aci_share_mount.sh"
 
           worker_running=0
           for service in dw_worker dowhiz_rust_service dowhiz-rust-service; do

--- a/DoWhiz_service/OPERATIONS.md
+++ b/DoWhiz_service/OPERATIONS.md
@@ -40,13 +40,46 @@ PM2 logs (if PM2 is used):
 - `/home/azureuser/server/.pm2/logs/dowhiz-rust-service-out.log`
 - `/home/azureuser/server/.pm2/logs/dowhiz-rust-service-error.log`
 
-## 3) Safety Rules
+## 3) Azure Files Mount (Required for ACI Worker)
+
+When `RUN_TASK_EXECUTION_BACKEND=azure_aci`, worker state/workspaces must live on the shared Azure Files mount configured by:
+- `RUN_TASK_AZURE_ACI_HOST_SHARE_ROOT`
+
+One-time bootstrap on VM:
+```bash
+sudo mkdir -p /etc/smbcredentials
+sudo tee /etc/smbcredentials/<storage-account-name> >/dev/null <<'EOF'
+username=<storage-account-name>
+password=<storage-account-key>
+EOF
+sudo chmod 600 /etc/smbcredentials/<storage-account-name>
+
+sudo mkdir -p /home/azureuser/server/.dowhiz/DoWhiz/run_task
+echo '//<storage-account-name>.file.core.windows.net/<file-share> /home/azureuser/server/.dowhiz/DoWhiz/run_task cifs vers=3.0,credentials=/etc/smbcredentials/<storage-account-name>,dir_mode=0777,file_mode=0777,serverino,uid=1000,gid=1000,mfsymlinks,_netdev,nofail 0 0' | sudo tee -a /etc/fstab
+sudo mount /home/azureuser/server/.dowhiz/DoWhiz/run_task
+findmnt -T /home/azureuser/server/.dowhiz/DoWhiz/run_task
+```
+
+Startup guardrails:
+- `DoWhiz_service/scripts/ensure_aci_share_mount.sh` is executed by:
+  - `scripts/run_employee.sh`
+  - `scripts/start_all.sh`
+  - production/staging CI deploy workflows before PM2 restart
+- If backend is `azure_aci`, the script will fail fast when mount is unavailable or `/etc/fstab` is missing the mount entry.
+
+Live migration note (local run_task -> Azure Files):
+- Keep a backup first, e.g. `run_task.local_backup_<timestamp>`.
+- Prefer `rsync --ignore-existing` while services stay online.
+- Exclude transient lock files: `*.db-journal`, `*.db-wal`, `*.db-shm`, `*.lock`.
+- Verify worker health after migration: `curl -sS http://127.0.0.1:9001/health`.
+
+## 4) Safety Rules
 
 - Do not run destructive git commands on shared VMs.
 - Do not restart production processes unless explicitly planned.
 - Do not run `start_all.sh` on production unless you explicitly want to start ngrok and overwrite Postmark inbound hook to ngrok.
 
-## 4) Staging Runbook (`dowhizstaging`)
+## 5) Staging Runbook (`dowhizstaging`)
 
 Default branch for staging deploys: `dev`
 
@@ -79,7 +112,7 @@ Expected staging behavior:
 - default outbound sender is `dowhiz@deep-tutor.com`
 - queue/storage/postmark use `STAGING_` values
 
-## 5) Production Runbook (`dowhizprod1`)
+## 6) Production Runbook (`dowhizprod1`)
 
 Default branch for production deploys: `main`
 
@@ -102,7 +135,7 @@ curl -sS http://127.0.0.1:9100/health
 curl -sS http://127.0.0.1:9001/health
 ```
 
-## 6) Quick Verification
+## 7) Quick Verification
 
 Resolve target-mapped runtime values:
 ```bash
@@ -124,7 +157,7 @@ pm2 logs dowhiz-inbound-gateway
 pm2 logs dowhiz-rust-service
 ```
 
-## 7) Live E2E Notes
+## 8) Live E2E Notes
 
 - `scheduler_module/tests/service_real_email.rs` supports SMTP port override via `POSTMARK_SMTP_PORT`.
 - On cloud VMs where SMTP port `25` is blocked, use `POSTMARK_SMTP_PORT=2525`.
@@ -136,7 +169,7 @@ export DEPLOY_TARGET=staging
 RUN_CODEX_E2E=1 POSTMARK_LIVE_TEST=1 cargo test -p scheduler_module --test service_real_email -- --nocapture
 ```
 
-## 8) Common Failure Patterns
+## 9) Common Failure Patterns
 
 1. Gateway exits with backend error
 - Cause: target-resolved `INGESTION_QUEUE_BACKEND` is not `servicebus`.
@@ -153,7 +186,7 @@ RUN_CODEX_E2E=1 POSTMARK_LIVE_TEST=1 cargo test -p scheduler_module --test servi
 - Cause: SMTP blocked or sender not verified in Postmark.
 - Fix: set SMTP port override and verify sender/domain signatures.
 
-## 9) Rollback
+## 10) Rollback
 
 Use:
 - `DoWhiz_service/docs/staging_production_deploy.md` -> `Rollback (staging -> production)`

--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -1181,6 +1181,29 @@ Single-file env split:
 | `RUN_TASK_AZURE_ACI_REGISTRY_USERNAME` | - | Optional private registry username (set with password) |
 | `RUN_TASK_AZURE_ACI_REGISTRY_PASSWORD` | - | Optional private registry password (set with username) |
 
+Important host prerequisite for `RUN_TASK_EXECUTION_BACKEND=azure_aci`:
+- `RUN_TASK_AZURE_ACI_HOST_SHARE_ROOT` must be a mounted Azure Files path on the VM before worker startup.
+- Startup/deploy scripts now call `DoWhiz_service/scripts/ensure_aci_share_mount.sh` to enforce this.
+- The script behavior:
+  - skip for non-ACI backends,
+  - verify mount already exists,
+  - if not mounted, run `mount <RUN_TASK_AZURE_ACI_HOST_SHARE_ROOT>` from `/etc/fstab`,
+  - fail fast when `/etc/fstab` is missing that mount entry.
+
+One-time bootstrap example on VM (production):
+```bash
+sudo mkdir -p /etc/smbcredentials
+sudo tee /etc/smbcredentials/dwhzoliverdev >/dev/null <<'EOF'
+username=dwhzoliverdev
+password=<storage-account-key>
+EOF
+sudo chmod 600 /etc/smbcredentials/dwhzoliverdev
+
+sudo mkdir -p /home/azureuser/server/.dowhiz/DoWhiz/run_task
+echo '//dwhzoliverdev.file.core.windows.net/dowhiz-run-task-prod /home/azureuser/server/.dowhiz/DoWhiz/run_task cifs vers=3.0,credentials=/etc/smbcredentials/dwhzoliverdev,dir_mode=0777,file_mode=0777,serverino,uid=1000,gid=1000,mfsymlinks,_netdev,nofail 0 0' | sudo tee -a /etc/fstab
+sudo mount /home/azureuser/server/.dowhiz/DoWhiz/run_task
+```
+
 ### Inbound Gateway
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -181,19 +181,40 @@ git fetch origin
 git checkout main
 git pull --ff-only origin main
 ```
-3. Start production target:
+3. One-time Azure Files mount bootstrap (required for ACI backend):
+```bash
+sudo mkdir -p /etc/smbcredentials
+sudo tee /etc/smbcredentials/<storage-account-name> >/dev/null <<'EOF'
+username=<storage-account-name>
+password=<storage-account-key>
+EOF
+sudo chmod 600 /etc/smbcredentials/<storage-account-name>
+
+sudo mkdir -p /home/azureuser/server/.dowhiz/DoWhiz/run_task
+echo '//<storage-account-name>.file.core.windows.net/<prod-file-share> /home/azureuser/server/.dowhiz/DoWhiz/run_task cifs vers=3.0,credentials=/etc/smbcredentials/<storage-account-name>,dir_mode=0777,file_mode=0777,serverino,uid=1000,gid=1000,mfsymlinks,_netdev,nofail 0 0' | sudo tee -a /etc/fstab
+sudo mount /home/azureuser/server/.dowhiz/DoWhiz/run_task
+findmnt -T /home/azureuser/server/.dowhiz/DoWhiz/run_task
+```
+Current prod example:
+- share: `//dwhzoliverdev.file.core.windows.net/dowhiz-run-task-prod`
+- host path: `/home/azureuser/server/.dowhiz/DoWhiz/run_task`
+
+4. Start production target:
 ```bash
 export DEPLOY_TARGET=production
 ./DoWhiz_service/scripts/run_gateway_local.sh
 ./DoWhiz_service/scripts/run_employee.sh little_bear 9001 --skip-hook --skip-ngrok
 ```
-4. Verify:
+`run_employee.sh` now includes `scripts/ensure_aci_share_mount.sh`, which auto-checks the mount and runs `mount <RUN_TASK_AZURE_ACI_HOST_SHARE_ROOT>` from `/etc/fstab` when needed.
+
+5. Verify:
 ```bash
 curl -sS http://127.0.0.1:9100/health
 curl -sS http://127.0.0.1:9001/health
 ```
 - Ensure Postmark inbound hook points to production endpoint
 - Ensure production Service Bus namespace/queue are used
+- Ensure `findmnt -T /home/azureuser/server/.dowhiz/DoWhiz/run_task` returns Azure Files (`cifs`)
 
 ## 6) Webhook notes (current staging URL)
 

--- a/DoWhiz_service/scripts/ensure_aci_share_mount.sh
+++ b/DoWhiz_service/scripts/ensure_aci_share_mount.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./load_env_target.sh
+source "${script_dir}/load_env_target.sh"
+
+backend_raw="${RUN_TASK_EXECUTION_BACKEND:-auto}"
+backend="$(printf '%s' "${backend_raw}" | tr '[:upper:]' '[:lower:]')"
+
+is_mounted() {
+  local mount_path="$1"
+  if command -v mountpoint >/dev/null 2>&1; then
+    mountpoint -q "${mount_path}"
+    return
+  fi
+
+  # Fallback for environments without mountpoint (e.g. macOS dev machines).
+  mount | grep -F " on ${mount_path} " >/dev/null 2>&1
+}
+
+if [[ "${backend}" != "azure_aci" ]]; then
+  echo "ensure_aci_share_mount: skip (RUN_TASK_EXECUTION_BACKEND=${backend_raw})"
+  exit 0
+fi
+
+host_share_root="${RUN_TASK_AZURE_ACI_HOST_SHARE_ROOT:-}"
+if [[ -z "${host_share_root}" ]]; then
+  echo "ensure_aci_share_mount: RUN_TASK_AZURE_ACI_HOST_SHARE_ROOT is required when RUN_TASK_EXECUTION_BACKEND=azure_aci" >&2
+  exit 1
+fi
+
+mkdir -p "${host_share_root}"
+
+if is_mounted "${host_share_root}"; then
+  echo "ensure_aci_share_mount: already mounted at ${host_share_root}"
+  exit 0
+fi
+
+if ! grep -qs "[[:space:]]${host_share_root}[[:space:]]" /etc/fstab; then
+  cat >&2 <<EOF
+ensure_aci_share_mount: ${host_share_root} is not mounted and has no /etc/fstab entry.
+Add an Azure Files CIFS entry in /etc/fstab first, then rerun.
+EOF
+  exit 1
+fi
+
+if command -v sudo >/dev/null 2>&1; then
+  sudo -n mount "${host_share_root}"
+else
+  mount "${host_share_root}"
+fi
+
+if ! is_mounted "${host_share_root}"; then
+  echo "ensure_aci_share_mount: mount failed for ${host_share_root}" >&2
+  exit 1
+fi
+
+echo "ensure_aci_share_mount: mounted ${host_share_root}"

--- a/DoWhiz_service/scripts/run_employee.sh
+++ b/DoWhiz_service/scripts/run_employee.sh
@@ -89,6 +89,9 @@ service_root="$(cd "${script_dir}/.." && pwd)"
 # shellcheck source=./load_env_target.sh
 source "${script_dir}/load_env_target.sh"
 
+# For Azure ACI backend, ensure the shared run_task mount is present on host.
+"${script_dir}/ensure_aci_share_mount.sh"
+
 ngrok_pid=""
 service_pid=""
 

--- a/DoWhiz_service/scripts/start_all.sh
+++ b/DoWhiz_service/scripts/start_all.sh
@@ -13,6 +13,9 @@ source "${SCRIPT_DIR}/load_env_target.sh"
 echo "✓ 已加载环境变量: ${ENV_FILE:-<shell environment only>}"
 echo "✓ DEPLOY_TARGET=${DEPLOY_TARGET:-production}"
 
+# Azure ACI backend requires VM-side shared mount before worker starts.
+"${SCRIPT_DIR}/ensure_aci_share_mount.sh"
+
 GATEWAY_CONFIG_PATH="${GATEWAY_CONFIG_PATH:-gateway.toml}"
 GATEWAY_HOST="${GATEWAY_HOST:-0.0.0.0}"
 GATEWAY_PORT="${GATEWAY_PORT:-9100}"


### PR DESCRIPTION
## Summary
- add `DoWhiz_service/scripts/ensure_aci_share_mount.sh` to enforce Azure Files mount for `RUN_TASK_EXECUTION_BACKEND=azure_aci`
- call mount check from `DoWhiz_service/scripts/run_employee.sh` and `DoWhiz_service/scripts/start_all.sh`
- run mount precheck in prod/staging CI deploy workflows before PM2 service restart
- document one-time VM mount bootstrap + migration notes in README/OPERATIONS/deploy guide

## Validation
- `bash -n` for updated shell scripts
- YAML parse for updated GitHub workflow files
- verified prod VM mount + health endpoints (`9100`/`9001`)
