### PR TITLE
Fix SQLite database locking in Google Workspace pollers

### DIFF
--- a/DoWhiz_service/scheduler_module/src/google_docs_poller.rs
+++ b/DoWhiz_service/scheduler_module/src/google_docs_poller.rs
@@ -154,13 +154,18 @@ impl GoogleDocsProcessedStore {
             std::fs::create_dir_all(parent)?;
         }
         let conn = Connection::open(&self.path)?;
+        // Enable WAL mode for better concurrent access
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
         conn.execute_batch(GOOGLE_DOCS_SCHEMA)?;
         Ok(())
     }
 
     fn open(&self) -> Result<Connection, SchedulerError> {
         let conn = Connection::open(&self.path)?;
-        conn.busy_timeout(Duration::from_secs(5))?;
+        // Enable WAL mode in case it wasn't set during init (e.g., existing DB)
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+        // Increase busy timeout for concurrent access
+        conn.busy_timeout(Duration::from_secs(30))?;
         Ok(conn)
     }
 

--- a/DoWhiz_service/scheduler_module/src/google_workspace_poller.rs
+++ b/DoWhiz_service/scheduler_module/src/google_workspace_poller.rs
@@ -323,13 +323,18 @@ impl GoogleWorkspaceProcessedStore {
             std::fs::create_dir_all(parent)?;
         }
         let conn = Connection::open(&self.path)?;
+        // Enable WAL mode for better concurrent access (multiple poller threads)
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
         conn.execute_batch(WORKSPACE_SCHEMA)?;
         Ok(())
     }
 
     fn open(&self) -> Result<Connection, SchedulerError> {
         let conn = Connection::open(&self.path)?;
-        conn.busy_timeout(Duration::from_secs(5))?;
+        // Enable WAL mode in case it wasn't set during init (e.g., existing DB)
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+        // Increase busy timeout for concurrent access from multiple poller threads
+        conn.busy_timeout(Duration::from_secs(30))?;
         Ok(conn)
     }
 


### PR DESCRIPTION
## Summary

- Enable WAL (Write-Ahead Logging) mode for SQLite databases used by Google Docs/Sheets/Slides pollers
- Increase busy timeout from 5s to 30s for better concurrent handling

## Root Cause

Multiple poller threads (Docs, Sheets, Slides) were accessing `google_workspace_processed.db` concurrently. Without WAL mode, SQLite uses rollback journal which causes exclusive locking issues with concurrent writers, resulting in "database is locked" errors.

## Changes

- Enable `PRAGMA journal_mode=WAL` in both `init()` and `open()` methods
- Increase `busy_timeout` from 5s to 30s
- Applied to both `GoogleWorkspaceProcessedStore` and `GoogleDocsProcessedStore`

## Test Plan

- [ ] Deploy to staging and verify no more "database is locked" errors in gateway logs
- [ ] Monitor Google Docs/Sheets/Slides polling functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)