### PR TITLE
Unify subpage navbar and style with homepage

### DIFF
--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -530,45 +530,7 @@
         color: var(--text);
       }
     </style>
-    <script>
-      // Time-based theme switching (7 AM - 7 PM = light, 7 PM - 7 AM = dark)
-      const DAY_START_HOUR = 7;
-      const NIGHT_START_HOUR = 19;
-
-      function getThemeForLocalTime() {
-        const hour = new Date().getHours();
-        return hour >= DAY_START_HOUR && hour < NIGHT_START_HOUR ? 'light' : 'dark';
-      }
-
-      function applyTheme() {
-        document.documentElement.setAttribute('data-theme', getThemeForLocalTime());
-      }
-
-      function scheduleNextThemeSwitch() {
-        const now = new Date();
-        const hour = now.getHours();
-        const next = new Date(now);
-
-        if (hour >= DAY_START_HOUR && hour < NIGHT_START_HOUR) {
-          next.setHours(NIGHT_START_HOUR, 0, 0, 0);
-        } else {
-          next.setHours(DAY_START_HOUR, 0, 0, 0);
-          if (hour >= NIGHT_START_HOUR) {
-            next.setDate(next.getDate() + 1);
-          }
-        }
-
-        const delay = Math.max(next.getTime() - now.getTime(), 0);
-        setTimeout(() => {
-          applyTheme();
-          scheduleNextThemeSwitch();
-        }, delay);
-      }
-
-      // Apply theme immediately
-      applyTheme();
-      scheduleNextThemeSwitch();
-    </script>
+    <script src="/theme.js"></script>
   </head>
   <body>
     <div class="page">

--- a/website/public/shared-nav.css
+++ b/website/public/shared-nav.css
@@ -1,0 +1,314 @@
+body.dw-shared-nav {
+  --dw-nav-bg: var(--navbar-bg, oklch(0.145 0 0 / 0.85));
+  --dw-nav-border: var(--glass-border, var(--border-color, var(--border, oklch(0.3 0 0))));
+  --dw-nav-border-hover: var(--card-hover-border, var(--border-hover, oklch(0.45 0 0)));
+  --dw-nav-text: var(--text-primary, var(--text, oklch(0.985 0 0)));
+  --dw-nav-muted: var(--text-secondary, var(--muted, oklch(0.708 0 0)));
+  --dw-nav-muted-bg: var(--color-muted, var(--muted-bg, oklch(0.269 0 0)));
+  --dw-nav-radius-full: var(--radius-full, 9999px);
+  --dw-nav-radius-2xl: var(--radius-2xl, 1.5rem);
+  --dw-nav-blur: var(--glass-blur, blur(12px));
+}
+
+[data-theme='light'] body.dw-shared-nav {
+  --dw-nav-bg: var(--navbar-bg, oklch(0.98 0.001 286.375 / 0.85));
+}
+
+body.dw-shared-nav .navbar {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 2rem);
+  max-width: 72rem;
+  z-index: 3000;
+  isolation: isolate;
+  background: var(--dw-nav-bg);
+  backdrop-filter: var(--dw-nav-blur);
+  -webkit-backdrop-filter: var(--dw-nav-blur);
+  border: 1px solid var(--dw-nav-border);
+  border-radius: var(--dw-nav-radius-full);
+  transition: transform 0.3s ease, opacity 0.3s ease, background 0.3s ease;
+}
+
+body.dw-shared-nav .navbar a,
+body.dw-shared-nav .navbar button {
+  pointer-events: auto;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+body.dw-shared-nav .navbar .nav-content {
+  position: relative;
+  z-index: 1;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0 1.25rem;
+}
+
+body.dw-shared-nav .navbar .logo {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1;
+  color: var(--dw-nav-text);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+  min-width: max-content;
+  flex: 0 0 auto;
+}
+
+body.dw-shared-nav .navbar .brand-mark {
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 0.45rem;
+  flex: 0 0 auto;
+}
+
+body.dw-shared-nav .navbar .logo .text-gradient {
+  display: inline;
+  padding-bottom: 0;
+  line-height: 1;
+}
+
+body.dw-shared-nav .navbar .nav-links {
+  display: flex;
+  flex: 1;
+  gap: 0.25rem;
+  justify-content: center;
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+
+body.dw-shared-nav .navbar .nav-btn {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--dw-nav-muted);
+  padding: 0.5rem 0.875rem;
+  border-radius: var(--dw-nav-radius-full);
+  transition: color 0.2s ease, background-color 0.2s ease;
+  white-space: nowrap;
+}
+
+body.dw-shared-nav .navbar .nav-btn:hover {
+  color: var(--dw-nav-text);
+  background: var(--dw-nav-muted-bg);
+}
+
+body.dw-shared-nav .navbar .nav-btn[aria-current='page'] {
+  color: var(--dw-nav-text);
+  background: var(--dw-nav-muted-bg);
+}
+
+body.dw-shared-nav .navbar .nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+}
+
+body.dw-shared-nav .navbar .social-links {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
+body.dw-shared-nav .navbar .btn-small {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: var(--dw-nav-radius-full);
+  border: 1px solid var(--dw-nav-border);
+  background: transparent;
+  color: var(--dw-nav-muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+body.dw-shared-nav .navbar .btn-small:hover {
+  color: var(--dw-nav-text);
+  background: var(--dw-nav-muted-bg);
+  border-color: var(--dw-nav-border-hover);
+}
+
+body.dw-shared-nav .navbar .social-links .btn-small {
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: var(--dw-nav-radius-full);
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+body.dw-shared-nav .navbar .social-links .btn-small svg {
+  width: 18px;
+  height: 18px;
+}
+
+body.dw-shared-nav .navbar + .demo-main .demo-hero {
+  padding-top: 8rem;
+}
+
+@media (max-width: 1280px) {
+  body.dw-shared-nav .navbar .nav-content {
+    gap: 0.75rem;
+  }
+
+  body.dw-shared-nav .navbar .nav-links {
+    gap: 0.35rem;
+  }
+
+  body.dw-shared-nav .navbar .nav-btn {
+    font-size: 0.82rem;
+    padding: 0.42rem 0.62rem;
+  }
+
+  body.dw-shared-nav .navbar .nav-actions {
+    gap: 0.6rem;
+  }
+
+  body.dw-shared-nav .navbar .social-links .btn-small {
+    width: 36px;
+    height: 36px;
+  }
+
+  body.dw-shared-nav .navbar .social-links .btn-small svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+@media (max-width: 1024px) {
+  body.dw-shared-nav .navbar .nav-content {
+    height: auto;
+    min-height: 80px;
+    padding: 0.85rem 0;
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  body.dw-shared-nav .navbar .nav-actions {
+    margin-left: auto;
+  }
+
+  body.dw-shared-nav .navbar .nav-links {
+    width: 100%;
+    order: 3;
+    justify-content: flex-start;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 0.2rem;
+    scrollbar-width: none;
+  }
+
+  body.dw-shared-nav .navbar .nav-links::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  body.dw-shared-nav .navbar {
+    top: 0.75rem;
+    width: calc(100% - 1.5rem);
+    border-radius: var(--dw-nav-radius-2xl);
+    z-index: 4000;
+  }
+
+  body.dw-shared-nav .navbar .nav-content {
+    min-height: auto;
+    height: auto;
+    padding: 0.75rem 0.5rem;
+    display: grid;
+    grid-template-areas:
+      'brand actions'
+      'links links';
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  body.dw-shared-nav .navbar .nav-links {
+    grid-area: links;
+    display: flex;
+    width: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding: 0.25rem 0;
+    gap: 0.25rem;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-x;
+  }
+
+  body.dw-shared-nav .navbar .nav-links::-webkit-scrollbar {
+    display: none;
+  }
+
+  body.dw-shared-nav .navbar .nav-btn {
+    flex: 0 0 auto;
+    font-size: 0.75rem;
+    padding: 0.375rem 0.625rem;
+    border: 1px solid var(--dw-nav-border);
+    border-radius: var(--dw-nav-radius-full);
+    background: transparent;
+  }
+
+  body.dw-shared-nav .navbar .nav-btn:hover {
+    background: var(--dw-nav-muted-bg);
+  }
+
+  body.dw-shared-nav .navbar .nav-actions {
+    grid-area: actions;
+    justify-content: flex-end;
+    gap: 0.375rem;
+    margin-left: 0;
+  }
+
+  body.dw-shared-nav .navbar .social-links {
+    gap: 0.25rem;
+  }
+
+  body.dw-shared-nav .navbar .logo {
+    grid-area: brand;
+    font-size: 1.25rem;
+  }
+
+  body.dw-shared-nav .navbar .brand-mark {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  body.dw-shared-nav .navbar .btn-small {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border-radius: var(--dw-nav-radius-full);
+    justify-content: center;
+    font-size: 0.8rem;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  body.dw-shared-nav .navbar .social-links .btn-small svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  body.dw-shared-nav .navbar .btn-small span {
+    display: none;
+  }
+}

--- a/website/public/theme.js
+++ b/website/public/theme.js
@@ -1,5 +1,4 @@
-// Time-based theme switching (7 AM - 7 PM = light, 7 PM - 7 AM = dark)
-(function() {
+(function () {
   const DAY_START_HOUR = 7;
   const NIGHT_START_HOUR = 19;
 
@@ -27,19 +26,163 @@
     }
 
     const delay = Math.max(next.getTime() - now.getTime(), 0);
-    setTimeout(function() {
+    setTimeout(function () {
       applyTheme();
       scheduleNextThemeSwitch();
     }, delay);
   }
 
-  // Apply theme immediately
+  function ensureSharedNavStyles() {
+    if (document.getElementById('dw-shared-nav-styles')) {
+      return;
+    }
+
+    const link = document.createElement('link');
+    link.id = 'dw-shared-nav-styles';
+    link.rel = 'stylesheet';
+    link.href = '/shared-nav.css';
+    document.head.appendChild(link);
+  }
+
+  function shouldMountSharedNav() {
+    const pathname = window.location.pathname;
+    return pathname !== '/' && pathname !== '/index.html';
+  }
+
+  function getActiveNavHref(pathname) {
+    if (pathname.startsWith('/agents/')) {
+      return '/#roles';
+    }
+
+    if (
+      pathname.startsWith('/solutions/') ||
+      pathname.startsWith('/demo-videos/') ||
+      pathname.startsWith('/integrations/')
+    ) {
+      return '/#workflows';
+    }
+
+    if (pathname.startsWith('/trust-safety/')) {
+      return '/#safety';
+    }
+
+    if (pathname.startsWith('/help-center/')) {
+      return '/#faq';
+    }
+
+    if (pathname.startsWith('/agent-market/')) {
+      return '/#deployment';
+    }
+
+    if (pathname.startsWith('/blog/')) {
+      return '/#blog';
+    }
+
+    if (pathname.startsWith('/user-guide/')) {
+      return '/#how-it-works';
+    }
+
+    if (
+      pathname.startsWith('/privacy/') ||
+      pathname.startsWith('/terms/') ||
+      pathname.startsWith('/auth/')
+    ) {
+      return '/#features';
+    }
+
+    return '';
+  }
+
+  function buildSharedNav() {
+    return [
+      '<div class="nav-content">',
+      '  <a href="/" class="logo" aria-label="DoWhiz homepage">',
+      '    <img src="/assets/DoWhiz.jpeg" alt="" class="brand-mark" aria-hidden="true" />',
+      '    <span>Do<span class="text-gradient">Whiz</span></span>',
+      '  </a>',
+      '  <div class="nav-links">',
+      '    <a href="/#roles" class="nav-btn">Team</a>',
+      '    <a href="/#how-it-works" class="nav-btn">How it works</a>',
+      '    <a href="/#workflows" class="nav-btn">Workflows</a>',
+      '    <a href="/#safety" class="nav-btn">Safety</a>',
+      '    <a href="/#features" class="nav-btn">Features</a>',
+      '    <a href="/#deployment" class="nav-btn">Deployment</a>',
+      '    <a href="/#faq" class="nav-btn">FAQ</a>',
+      '    <a href="/#blog" class="nav-btn">Blog</a>',
+      '  </div>',
+      '  <div class="nav-actions">',
+      '    <div class="social-links">',
+      '      <a href="https://github.com/KnoWhiz/DoWhiz" target="_blank" rel="noopener noreferrer" class="btn-small" aria-label="GitHub">',
+      '        <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">',
+      '          <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>',
+      '        </svg>',
+      '      </a>',
+      '      <a href="https://discord.gg/7ucnweCKk8" target="_blank" rel="noopener noreferrer" class="btn-small" aria-label="Discord">',
+      '        <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">',
+      '          <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path>',
+      '        </svg>',
+      '      </a>',
+      '      <a class="btn-small" href="mailto:admin@dowhiz.com" aria-label="Contact">',
+      '        <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">',
+      '          <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>',
+      '          <polyline points="22,6 12,13 2,6"></polyline>',
+      '        </svg>',
+      '      </a>',
+      '      <a class="btn-small" href="/auth/index.html" aria-label="Sign In">',
+      '        <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">',
+      '          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>',
+      '          <circle cx="12" cy="7" r="4"></circle>',
+      '        </svg>',
+      '      </a>',
+      '    </div>',
+      '  </div>',
+      '</div>'
+    ].join('');
+  }
+
+  function mountSharedNav() {
+    if (!shouldMountSharedNav()) {
+      return;
+    }
+
+    if (!document.body || document.body.dataset.dwSharedNavMounted === '1') {
+      return;
+    }
+
+    ensureSharedNavStyles();
+
+    const existingHeader = document.querySelector('nav.navbar, header.page-header');
+    const nav = document.createElement('nav');
+    nav.className = 'navbar';
+    nav.innerHTML = buildSharedNav();
+
+    if (existingHeader) {
+      existingHeader.replaceWith(nav);
+    } else {
+      document.body.insertBefore(nav, document.body.firstChild);
+    }
+
+    const activeHref = getActiveNavHref(window.location.pathname);
+    if (activeHref) {
+      const activeLink = nav.querySelector('.nav-links a[href="' + activeHref + '"]');
+      if (activeLink) {
+        activeLink.setAttribute('aria-current', 'page');
+      }
+    }
+
+    document.body.classList.add('dw-shared-nav');
+    document.body.dataset.dwSharedNavMounted = '1';
+  }
+
   applyTheme();
 
-  // Schedule next switch when DOM is ready
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', scheduleNextThemeSwitch);
+    document.addEventListener('DOMContentLoaded', function () {
+      scheduleNextThemeSwitch();
+      mountSharedNav();
+    });
   } else {
     scheduleNextThemeSwitch();
+    mountSharedNav();
   }
 })();

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -16,7 +16,18 @@ function servePublicHtml() {
 
         // Check if this is a path that should serve a static HTML file
         const staticPaths = [
-          '/agents/', '/blog/', '/privacy/', '/terms/', '/user-guide/', '/auth/', '/integrations/', '/trust-safety/', '/demo-videos/'
+          '/agent-market/',
+          '/agents/',
+          '/auth/',
+          '/blog/',
+          '/demo-videos/',
+          '/help-center/',
+          '/integrations/',
+          '/privacy/',
+          '/solutions/',
+          '/terms/',
+          '/trust-safety/',
+          '/user-guide/'
         ]
 
         const isStaticPath = staticPaths.some(p => url.startsWith(p))


### PR DESCRIPTION
## Summary
- unify all static subpages to use one shared top navbar matching homepage UI
- add shared navbar stylesheet and auto-mount logic in `theme.js`
- switch `/auth/` page to reuse shared theme/nav script
- update Vite static HTML middleware paths to include all subpage prefixes for local verification

## Validation
- `npm run lint` (website)
- `npm run build` (website)
- Playwright route audit: 30/30 subpages have the same 8 nav menu items and 4 action buttons as homepage
- Captured before/after page-level screenshots for visual verification
