### PR TITLE
fix: harden Service Bus lock handling and Discord quick-response idempotency

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -304,6 +304,8 @@ az servicebus queue create -g <rg> --namespace-name <sb-namespace> -n ingestion-
 az apim create -g <rg> -n <apim> --location westus2 --publisher-email proto@dowhiz.com --publisher-name DoWhiz --sku-name Consumption
 ```
 
+For production workers, set queue `LockDuration` to `PT5M` (5 minutes) to reduce lock-expiry risk during slow processing bursts.
+
 **Step 2: Configure gateway + worker configs**
 Update `DoWhiz_service/gateway.toml` and `DoWhiz_service/employee.toml` with your service addresses and routing targets. These same files are used by the gateway and by workers.
 
@@ -1221,6 +1223,7 @@ sudo mount /home/azureuser/server/.dowhiz/DoWhiz/run_task
 | `SERVICE_BUS_QUEUE_NAME` | `ingestion` | Shared queue name for all employees |
 | `SERVICE_BUS_TEST_QUEUE_NAME` | `ingestion-test` | Queue used by Service Bus tests |
 | `SERVICE_BUS_PEEK_LOCK_TIMEOUT_SECS` | `30` | Peek-lock timeout for Service Bus receive |
+| `SERVICE_BUS_LOCK_RENEW_INTERVAL_SECS` | `15` | Worker lock-renew cadence for claimed messages (bounded to 5-60s) |
 | `RAW_PAYLOAD_STORAGE_BACKEND` | `supabase` | `supabase` or `azure` (`azure` recommended for gateway production flow) |
 | `AZURE_STORAGE_ACCOUNT` | - | Azure Storage account name |
 | `AZURE_STORAGE_CONNECTION_STRING_INGEST` | - | Optional connection string (used to derive account name for ingestion SAS URLs) |

--- a/DoWhiz_service/scheduler_module/src/service/inbound/quick_responses.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/quick_responses.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use crate::account_store::lookup_account_by_channel;
@@ -19,6 +21,24 @@ use super::super::config::ServiceConfig;
 use super::super::BoxError;
 use super::discord_context::build_discord_router_context;
 use super::persist_discord_ingest_context;
+
+const DISCORD_QUICK_RESPONSE_DEDUPE_FILE: &str = "discord_quick_response_dedupe.json";
+const DISCORD_QUICK_RESPONSE_MAX_THREADS: usize = 512;
+const DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD: usize = 256;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DiscordQuickResponseDedupeStore {
+    #[serde(default)]
+    threads: HashMap<String, DiscordQuickResponseThreadStore>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DiscordQuickResponseThreadStore {
+    #[serde(default)]
+    message_ids: Vec<String>,
+    #[serde(default)]
+    updated_at_unix_secs: i64,
+}
 
 /// Read memo.md from a user's memory directory (local file)
 fn read_user_memo_local(memory_dir: &Path) -> Option<String> {
@@ -80,6 +100,127 @@ fn write_memory_update(
     global_memory_queue()
         .submit(request)
         .map_err(|e| e.to_string())
+}
+
+fn discord_quick_response_dedupe_path(state_dir: &Path) -> std::path::PathBuf {
+    state_dir.join(DISCORD_QUICK_RESPONSE_DEDUPE_FILE)
+}
+
+fn discord_quick_response_scope_key(message: &crate::channel::InboundMessage) -> Option<String> {
+    let channel_id = message.metadata.discord_channel_id?;
+    let guild = message
+        .metadata
+        .discord_guild_id
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "dm".to_string());
+    Some(format!(
+        "discord:{}:{}:{}",
+        guild, channel_id, message.thread_id
+    ))
+}
+
+fn discord_inbound_message_id(message: &crate::channel::InboundMessage) -> Option<&str> {
+    message
+        .message_id
+        .as_deref()
+        .or(message.metadata.discord_message_id.as_deref())
+}
+
+fn discord_quick_response_already_sent(
+    state_dir: &Path,
+    scope_key: &str,
+    message_id: &str,
+) -> bool {
+    let path = discord_quick_response_dedupe_path(state_dir);
+    let store = load_discord_quick_response_dedupe_store(&path);
+    store
+        .threads
+        .get(scope_key)
+        .map(|thread| thread.message_ids.iter().any(|entry| entry == message_id))
+        .unwrap_or(false)
+}
+
+fn record_discord_quick_response_sent(
+    state_dir: &Path,
+    scope_key: &str,
+    message_id: &str,
+) -> Result<(), BoxError> {
+    let path = discord_quick_response_dedupe_path(state_dir);
+    let mut store = load_discord_quick_response_dedupe_store(&path);
+
+    let thread = store.threads.entry(scope_key.to_string()).or_default();
+    if !thread.message_ids.iter().any(|entry| entry == message_id) {
+        thread.message_ids.push(message_id.to_string());
+    }
+    let overflow = thread
+        .message_ids
+        .len()
+        .saturating_sub(DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD);
+    if overflow > 0 {
+        thread.message_ids.drain(0..overflow);
+    }
+    thread.updated_at_unix_secs = now_unix_secs();
+
+    prune_discord_quick_response_store(&mut store);
+    write_discord_quick_response_dedupe_store(&path, &store)?;
+    Ok(())
+}
+
+fn load_discord_quick_response_dedupe_store(path: &Path) -> DiscordQuickResponseDedupeStore {
+    let Ok(raw) = std::fs::read(path) else {
+        return DiscordQuickResponseDedupeStore::default();
+    };
+    match serde_json::from_slice::<DiscordQuickResponseDedupeStore>(&raw) {
+        Ok(store) => store,
+        Err(err) => {
+            warn!(
+                "failed to parse discord quick response dedupe store at {}: {}",
+                path.display(),
+                err
+            );
+            DiscordQuickResponseDedupeStore::default()
+        }
+    }
+}
+
+fn write_discord_quick_response_dedupe_store(
+    path: &Path,
+    store: &DiscordQuickResponseDedupeStore,
+) -> Result<(), BoxError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
+    let serialized = serde_json::to_vec_pretty(store)?;
+    std::fs::write(&tmp, serialized)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+fn prune_discord_quick_response_store(store: &mut DiscordQuickResponseDedupeStore) {
+    if store.threads.len() <= DISCORD_QUICK_RESPONSE_MAX_THREADS {
+        return;
+    }
+    let mut thread_by_age = store
+        .threads
+        .iter()
+        .map(|(key, value)| (key.clone(), value.updated_at_unix_secs))
+        .collect::<Vec<_>>();
+    thread_by_age.sort_by_key(|(_, updated_at)| *updated_at);
+    let overflow = store
+        .threads
+        .len()
+        .saturating_sub(DISCORD_QUICK_RESPONSE_MAX_THREADS);
+    for (key, _) in thread_by_age.into_iter().take(overflow) {
+        store.threads.remove(&key);
+    }
+}
+
+fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 pub(crate) fn try_quick_response_slack(
@@ -295,6 +436,18 @@ pub(crate) fn try_quick_response_discord(
     let user = user_store.get_or_create_user("discord", &message.sender)?;
     let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
     let memory = read_user_memo(runtime, account_id, &user_paths.memory_dir);
+    let dedupe_scope = discord_quick_response_scope_key(message);
+    let inbound_message_id = discord_inbound_message_id(message);
+
+    if let (Some(scope), Some(inbound_id)) = (dedupe_scope.as_deref(), inbound_message_id) {
+        if discord_quick_response_already_sent(&user_paths.state_dir, scope, inbound_id) {
+            info!(
+                "discord quick response dedupe hit employee={} sender={} scope={} message_id={}",
+                config.employee_profile.id, message.sender, scope, inbound_id
+            );
+            return Ok(true);
+        }
+    }
 
     let router_context = match build_discord_router_context(config, message, raw_payload) {
         Ok(context) => Some(context),
@@ -340,6 +493,18 @@ pub(crate) fn try_quick_response_discord(
                 send_quick_discord_response_simple(&token, channel_id, message_id, &response)
                     .is_ok();
             if sent {
+                if let (Some(scope), Some(inbound_id)) =
+                    (dedupe_scope.as_deref(), inbound_message_id)
+                {
+                    if let Err(err) =
+                        record_discord_quick_response_sent(&user_paths.state_dir, scope, inbound_id)
+                    {
+                        warn!(
+                            "failed to record discord quick response dedupe key scope={} message_id={}: {}",
+                            scope, inbound_id, err
+                        );
+                    }
+                }
                 if let Err(err) = persist_discord_ingest_context(
                     config,
                     user_store,
@@ -572,5 +737,107 @@ pub(crate) fn try_quick_response_whatsapp(
             Ok(false)
         }
         RouterDecision::Complex | RouterDecision::Passthrough => Ok(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::{Channel, ChannelMetadata, InboundMessage};
+    use tempfile::TempDir;
+
+    fn build_discord_message(
+        thread_id: &str,
+        message_id: Option<&str>,
+        metadata_message_id: Option<&str>,
+        guild_id: Option<u64>,
+        channel_id: Option<u64>,
+    ) -> InboundMessage {
+        InboundMessage {
+            channel: Channel::Discord,
+            sender: "1234".to_string(),
+            sender_name: Some("Bingran".to_string()),
+            recipient: "oliver-bot".to_string(),
+            subject: None,
+            text_body: Some("Hi".to_string()),
+            html_body: None,
+            thread_id: thread_id.to_string(),
+            message_id: message_id.map(str::to_string),
+            attachments: Vec::new(),
+            reply_to: Vec::new(),
+            raw_payload: Vec::new(),
+            metadata: ChannelMetadata {
+                discord_guild_id: guild_id,
+                discord_channel_id: channel_id,
+                discord_message_id: metadata_message_id.map(str::to_string),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn discord_quick_response_dedupe_records_and_matches() -> Result<(), BoxError> {
+        let temp = TempDir::new()?;
+        let state_dir = temp.path().join("state");
+        let scope = "discord:guild-1:42:thread-1";
+        let message_id = "msg-1";
+
+        assert!(!discord_quick_response_already_sent(
+            &state_dir, scope, message_id
+        ));
+
+        record_discord_quick_response_sent(&state_dir, scope, message_id)?;
+
+        assert!(discord_quick_response_already_sent(
+            &state_dir, scope, message_id
+        ));
+
+        let path = discord_quick_response_dedupe_path(&state_dir);
+        let store = load_discord_quick_response_dedupe_store(&path);
+        let entries = &store.threads.get(scope).expect("thread entry").message_ids;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0], "msg-1");
+
+        Ok(())
+    }
+
+    #[test]
+    fn discord_quick_response_dedupe_prunes_old_message_ids() -> Result<(), BoxError> {
+        let temp = TempDir::new()?;
+        let state_dir = temp.path().join("state");
+        let scope = "discord:guild-1:42:thread-1";
+
+        for index in 0..(DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD + 5) {
+            let message_id = format!("msg-{}", index);
+            record_discord_quick_response_sent(&state_dir, scope, &message_id)?;
+        }
+
+        let path = discord_quick_response_dedupe_path(&state_dir);
+        let store = load_discord_quick_response_dedupe_store(&path);
+        let entries = &store.threads.get(scope).expect("thread entry").message_ids;
+
+        assert_eq!(
+            entries.len(),
+            DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD
+        );
+        assert!(!entries.iter().any(|entry| entry == "msg-0"));
+        assert!(entries.iter().any(|entry| entry
+            == &format!(
+                "msg-{}",
+                DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD + 4
+            )));
+
+        Ok(())
+    }
+
+    #[test]
+    fn discord_scope_key_and_message_id_fallback_work() {
+        let message = build_discord_message("thread-1", None, Some("meta-msg-id"), None, Some(42));
+
+        let scope = discord_quick_response_scope_key(&message).expect("scope key");
+        assert_eq!(scope, "discord:dm:42:thread-1");
+
+        let message_id = discord_inbound_message_id(&message).expect("message id");
+        assert_eq!(message_id, "meta-msg-id");
     }
 }

--- a/DoWhiz_service/scheduler_module/src/service_bus_queue.rs
+++ b/DoWhiz_service/scheduler_module/src/service_bus_queue.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::env;
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
 use std::time::Duration;
 
 use azure_core::{auth::Secret, error::Error as AzureError, HttpClient};
@@ -9,6 +10,7 @@ use azure_messaging_servicebus::service_bus::{
     PeekLockResponse, SendMessageOptions, SettableBrokerProperties,
 };
 use tokio::runtime::Runtime;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::env_alias::var_with_scale_oliver;
@@ -22,6 +24,7 @@ pub struct ServiceBusConfig {
     pub policy_key: String,
     pub queue_name: String,
     pub peek_lock_timeout: Duration,
+    pub lock_renew_interval: Duration,
 }
 
 pub struct ServiceBusIngestionQueue {
@@ -31,9 +34,42 @@ pub struct ServiceBusIngestionQueue {
     policy_key: String,
     queue_name: String,
     peek_lock_timeout: Duration,
+    lock_renew_interval: Duration,
     runtime: Option<Runtime>,
     clients: Mutex<HashMap<String, QueueClient>>,
-    pending: Mutex<HashMap<Uuid, PeekLockResponse>>,
+    pending: Mutex<HashMap<Uuid, PendingLock>>,
+}
+
+struct PendingLock {
+    response: Arc<PeekLockResponse>,
+    renewer: Option<LockRenewer>,
+}
+
+impl PendingLock {
+    fn new(response: Arc<PeekLockResponse>, renewer: LockRenewer) -> Self {
+        Self {
+            response,
+            renewer: Some(renewer),
+        }
+    }
+
+    fn stop_renewer(&mut self) {
+        if let Some(renewer) = self.renewer.take() {
+            renewer.stop();
+        }
+    }
+}
+
+struct LockRenewer {
+    stop_tx: mpsc::Sender<()>,
+    handle: thread::JoinHandle<()>,
+}
+
+impl LockRenewer {
+    fn stop(self) {
+        let _ = self.stop_tx.send(());
+        let _ = self.handle.join();
+    }
 }
 
 impl ServiceBusIngestionQueue {
@@ -53,6 +89,7 @@ impl ServiceBusIngestionQueue {
             policy_key: config.policy_key,
             queue_name: config.queue_name,
             peek_lock_timeout: config.peek_lock_timeout,
+            lock_renew_interval: config.lock_renew_interval,
             runtime: Some(runtime),
             clients: Mutex::new(HashMap::new()),
             pending: Mutex::new(HashMap::new()),
@@ -133,11 +170,21 @@ impl ServiceBusIngestionQueue {
             return Ok(None);
         }
         let handle_id = Uuid::new_v4();
+        let response = Arc::new(response);
+        let renewer = match self.spawn_lock_renewer(handle_id, response.clone()) {
+            Ok(renewer) => renewer,
+            Err(err) => {
+                self.runtime()?
+                    .block_on(response.unlock_message())
+                    .map_err(map_service_bus_error)?;
+                return Err(err);
+            }
+        };
         let mut pending = self
             .pending
             .lock()
             .map_err(|_| IngestionQueueError::ServiceBus("pending lock poisoned".to_string()))?;
-        pending.insert(handle_id, response);
+        pending.insert(handle_id, PendingLock::new(response, renewer));
         Ok(Some(QueuedEnvelope {
             id: handle_id,
             envelope,
@@ -145,22 +192,24 @@ impl ServiceBusIngestionQueue {
     }
 
     pub fn mark_done(&self, id: &Uuid) -> Result<(), IngestionQueueError> {
-        let response = self.take_pending(id)?;
+        let mut pending = self.take_pending(id)?;
+        pending.stop_renewer();
         self.runtime()?
-            .block_on(response.delete_message())
+            .block_on(pending.response.delete_message())
             .map_err(map_service_bus_error)?;
         Ok(())
     }
 
     pub fn mark_failed(&self, id: &Uuid, _error: &str) -> Result<(), IngestionQueueError> {
-        let response = self.take_pending(id)?;
+        let mut pending = self.take_pending(id)?;
+        pending.stop_renewer();
         self.runtime()?
-            .block_on(response.unlock_message())
+            .block_on(pending.response.unlock_message())
             .map_err(map_service_bus_error)?;
         Ok(())
     }
 
-    fn take_pending(&self, id: &Uuid) -> Result<PeekLockResponse, IngestionQueueError> {
+    fn take_pending(&self, id: &Uuid) -> Result<PendingLock, IngestionQueueError> {
         let mut pending = self
             .pending
             .lock()
@@ -168,6 +217,75 @@ impl ServiceBusIngestionQueue {
         pending
             .remove(id)
             .ok_or_else(|| IngestionQueueError::ServiceBus("missing pending lock".to_string()))
+    }
+
+    fn spawn_lock_renewer(
+        &self,
+        handle_id: Uuid,
+        response: Arc<PeekLockResponse>,
+    ) -> Result<LockRenewer, IngestionQueueError> {
+        let runtime_handle = self.runtime()?.handle().clone();
+        let renew_interval = self.lock_renew_interval;
+        let queue_name = self.queue_name.clone();
+        let message_id = response
+            .broker_properties()
+            .map(|properties| properties.message_id);
+        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+        let thread_name = format!("sb-lock-renew-{}", &handle_id.to_string()[..8]);
+
+        let handle = thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || {
+                debug!(
+                    "service bus lock renewer started queue={} handle_id={} message_id={:?} interval_secs={}",
+                    queue_name,
+                    handle_id,
+                    message_id,
+                    renew_interval.as_secs()
+                );
+                loop {
+                    match stop_rx.recv_timeout(renew_interval) {
+                        Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                        Err(mpsc::RecvTimeoutError::Timeout) => {
+                            match runtime_handle.block_on(response.renew_message_lock()) {
+                                Ok(()) => {
+                                    debug!(
+                                        "service bus lock renewed queue={} handle_id={} message_id={:?}",
+                                        queue_name, handle_id, message_id
+                                    );
+                                }
+                                Err(err) => {
+                                    warn!(
+                                        "service bus lock renew failed queue={} handle_id={} message_id={:?}: {}",
+                                        queue_name, handle_id, message_id, err
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                debug!(
+                    "service bus lock renewer stopped queue={} handle_id={} message_id={:?}",
+                    queue_name, handle_id, message_id
+                );
+            })
+            .map_err(|err| {
+                IngestionQueueError::ServiceBus(format!(
+                    "failed to spawn service bus lock renewer: {}",
+                    err
+                ))
+            })?;
+
+        Ok(LockRenewer { stop_tx, handle })
+    }
+
+    fn stop_all_pending_renewers(&self) {
+        let Ok(mut pending) = self.pending.lock() else {
+            return;
+        };
+        for (_, mut lock) in pending.drain() {
+            lock.stop_renewer();
+        }
     }
 }
 
@@ -191,6 +309,7 @@ impl IngestionQueue for ServiceBusIngestionQueue {
 
 impl Drop for ServiceBusIngestionQueue {
     fn drop(&mut self) {
+        self.stop_all_pending_renewers();
         if let Some(runtime) = self.runtime.take() {
             runtime.shutdown_background();
         }
@@ -202,6 +321,13 @@ fn map_service_bus_error(err: AzureError) -> IngestionQueueError {
 }
 
 pub fn resolve_service_bus_config_from_env() -> Result<ServiceBusConfig, IngestionQueueError> {
+    let timeout_secs = resolve_i64_env("SERVICE_BUS_PEEK_LOCK_TIMEOUT_SECS", 30);
+    let renew_secs = resolve_i64_env(
+        "SERVICE_BUS_LOCK_RENEW_INTERVAL_SECS",
+        default_lock_renew_interval_secs(timeout_secs),
+    );
+    let lock_renew_interval_secs = clamp_lock_renew_interval_secs(renew_secs);
+
     if let Some(conn_str) = var_with_scale_oliver("SERVICE_BUS_CONNECTION_STRING") {
         let parts = parse_service_bus_connection_string(&conn_str)?;
         let queue_name = var_with_scale_oliver("SERVICE_BUS_QUEUE_NAME")
@@ -212,13 +338,13 @@ pub fn resolve_service_bus_config_from_env() -> Result<ServiceBusConfig, Ingesti
                         .to_string(),
                 )
             })?;
-        let timeout_secs = resolve_i64_env("SERVICE_BUS_PEEK_LOCK_TIMEOUT_SECS", 30);
         return Ok(ServiceBusConfig {
             namespace: parts.namespace,
             policy_name: parts.policy_name,
             policy_key: parts.policy_key,
             queue_name,
             peek_lock_timeout: Duration::from_secs(timeout_secs as u64),
+            lock_renew_interval: Duration::from_secs(lock_renew_interval_secs as u64),
         });
     }
 
@@ -242,13 +368,13 @@ pub fn resolve_service_bus_config_from_env() -> Result<ServiceBusConfig, Ingesti
             "missing SCALE_OLIVER_SERVICE_BUS_QUEUE_NAME/SERVICE_BUS_QUEUE_NAME".to_string(),
         )
     })?;
-    let timeout_secs = resolve_i64_env("SERVICE_BUS_PEEK_LOCK_TIMEOUT_SECS", 30);
     Ok(ServiceBusConfig {
         namespace,
         policy_name,
         policy_key,
         queue_name,
         peek_lock_timeout: Duration::from_secs(timeout_secs as u64),
+        lock_renew_interval: Duration::from_secs(lock_renew_interval_secs as u64),
     })
 }
 
@@ -323,4 +449,47 @@ fn resolve_i64_env(key: &str, default_value: i64) -> i64 {
         .and_then(|value| value.parse::<i64>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(default_value)
+}
+
+fn default_lock_renew_interval_secs(peek_lock_timeout_secs: i64) -> i64 {
+    clamp_lock_renew_interval_secs(peek_lock_timeout_secs / 2)
+}
+
+fn clamp_lock_renew_interval_secs(interval_secs: i64) -> i64 {
+    interval_secs.clamp(5, 60)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_lock_renew_interval_is_half_peek_lock_timeout() {
+        assert_eq!(default_lock_renew_interval_secs(30), 15);
+        assert_eq!(default_lock_renew_interval_secs(120), 60);
+    }
+
+    #[test]
+    fn clamp_lock_renew_interval_enforces_bounds() {
+        assert_eq!(clamp_lock_renew_interval_secs(1), 5);
+        assert_eq!(clamp_lock_renew_interval_secs(5), 5);
+        assert_eq!(clamp_lock_renew_interval_secs(22), 22);
+        assert_eq!(clamp_lock_renew_interval_secs(500), 60);
+    }
+
+    #[test]
+    fn parse_connection_string_extracts_required_parts() {
+        let parsed = parse_service_bus_connection_string(
+            "Endpoint=sb://my-namespace.servicebus.windows.net/;\
+             SharedAccessKeyName=my-policy;\
+             SharedAccessKey=top-secret;\
+             EntityPath=ingestion-little_bear",
+        )
+        .expect("parse connection string");
+
+        assert_eq!(parsed.namespace, "my-namespace");
+        assert_eq!(parsed.policy_name, "my-policy");
+        assert_eq!(parsed.policy_key, "top-secret");
+        assert_eq!(parsed.entity_path.as_deref(), Some("ingestion-little_bear"));
+    }
 }


### PR DESCRIPTION
## Summary
- add background lock renewal for each claimed Service Bus message and stop renewers cleanly on done/failed/drop
- add configurable SERVICE_BUS_LOCK_RENEW_INTERVAL_SECS with bounded defaults
- add persistent Discord quick-response idempotency guard keyed by thread scope + message id
- document LockDuration=PT5M recommendation and new renew-interval env var

## Testing
- cargo fmt --manifest-path DoWhiz_service/Cargo.toml --all
- cargo test -p scheduler_module --manifest-path DoWhiz_service/Cargo.toml -- --test-threads=1
- cargo test -p scheduler_module --manifest-path DoWhiz_service/Cargo.toml service_bus_queue::tests
- cargo test -p scheduler_module --manifest-path DoWhiz_service/Cargo.toml service::inbound::quick_responses::tests
