### PR TITLE
Polish auth page into dashboard-style settings layout

### DIFF
--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Sign in to DoWhiz to manage your digital employee integrations." />
+    <meta name="description" content="Sign in to DoWhiz and manage your dashboard settings, channels, and tasks." />
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260301" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260301" />
@@ -529,6 +529,209 @@
         background: rgba(0, 0, 0, 0.05);
         color: var(--text);
       }
+
+      @media (prefers-reduced-motion: no-preference) {
+        html {
+          scroll-behavior: smooth;
+        }
+      }
+
+      .dashboard-mode .auth-container {
+        max-width: 1240px;
+        padding-left: 0;
+        padding-right: 0;
+      }
+
+      .dashboard-shell {
+        display: grid;
+        grid-template-columns: 260px minmax(0, 1fr);
+        gap: 1rem;
+        align-items: start;
+      }
+
+      .dashboard-sidebar {
+        position: sticky;
+        top: 6.2rem;
+        padding: 1.1rem;
+        border-radius: 1rem;
+        border: 1px solid var(--border, #333);
+        background:
+          linear-gradient(165deg, rgba(56, 189, 248, 0.08), transparent 45%),
+          var(--card, rgba(255, 255, 255, 0.02));
+      }
+
+      .sidebar-eyebrow {
+        font-size: 0.72rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--text-muted, #888);
+        margin: 0;
+      }
+
+      .sidebar-title {
+        margin: 0.45rem 0 0;
+        font-size: 1.2rem;
+        line-height: 1.2;
+      }
+
+      .sidebar-description {
+        margin: 0.65rem 0 0;
+        font-size: 0.9rem;
+        color: var(--text-muted, #888);
+      }
+
+      .sidebar-nav {
+        margin-top: 1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .sidebar-link {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.55rem 0.7rem;
+        border-radius: 0.65rem;
+        border: 1px solid transparent;
+        color: var(--text-muted, #888);
+        font-weight: 600;
+        font-size: 0.9rem;
+      }
+
+      .sidebar-link:hover {
+        color: var(--text, #fff);
+        border-color: var(--border, #333);
+        background: color-mix(in srgb, var(--surface, #1a1a1a) 70%, transparent);
+      }
+
+      .sidebar-link.is-active {
+        color: var(--text, #fff);
+        border-color: color-mix(in srgb, var(--accent, #38bdf8) 35%, var(--border, #333));
+        background: color-mix(in srgb, var(--accent, #38bdf8) 13%, transparent);
+      }
+
+      .sidebar-note {
+        margin-top: 1rem;
+        padding: 0.8rem;
+        border-radius: 0.75rem;
+        border: 1px solid var(--border, #333);
+        background: color-mix(in srgb, var(--surface, #1a1a1a) 84%, transparent);
+      }
+
+      .sidebar-note-title {
+        font-size: 0.82rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--text-muted, #888);
+        margin-bottom: 0.35rem;
+      }
+
+      .sidebar-signout {
+        width: 100%;
+        margin-top: 0.8rem;
+      }
+
+      .dashboard-main {
+        display: grid;
+        gap: 1rem;
+        min-width: 0;
+      }
+
+      .dashboard-section {
+        margin-top: 0;
+        scroll-margin-top: 8.2rem;
+      }
+
+      .dashboard-overview-copy {
+        margin-bottom: 1rem;
+      }
+
+      .account-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.75rem;
+      }
+
+      .account-meta-item {
+        padding: 0.75rem;
+        border-radius: 0.7rem;
+        border: 1px solid var(--border, #333);
+        background: color-mix(in srgb, var(--surface, #1a1a1a) 80%, transparent);
+      }
+
+      .account-meta-label {
+        margin: 0 0 0.35rem;
+        font-size: 0.78rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--text-muted, #888);
+      }
+
+      .settings-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1rem;
+      }
+
+      .settings-panel {
+        padding: 1rem;
+        border-radius: 0.8rem;
+        border: 1px solid var(--border, #333);
+        background: color-mix(in srgb, var(--surface, #1a1a1a) 82%, transparent);
+      }
+
+      .settings-panel h3 {
+        margin: 0 0 0.45rem;
+      }
+
+      .settings-panel p {
+        margin-bottom: 0.75rem;
+      }
+
+      .settings-status-stack span {
+        display: block;
+        margin-top: 0.35rem;
+        font-size: 0.88rem;
+      }
+
+      @media (max-width: 1080px) {
+        .dashboard-mode .auth-container {
+          max-width: 920px;
+          padding-left: 1rem;
+          padding-right: 1rem;
+        }
+
+        .dashboard-shell {
+          grid-template-columns: 1fr;
+        }
+
+        .dashboard-sidebar {
+          position: static;
+        }
+
+        .sidebar-nav {
+          display: flex;
+          overflow-x: auto;
+          padding-bottom: 0.15rem;
+          scrollbar-width: none;
+        }
+
+        .sidebar-nav::-webkit-scrollbar {
+          display: none;
+        }
+
+        .sidebar-link {
+          flex: 0 0 auto;
+          white-space: nowrap;
+        }
+      }
+
+      @media (max-width: 780px) {
+        .account-grid,
+        .settings-grid {
+          grid-template-columns: 1fr;
+        }
+      }
     </style>
     <script src="/theme.js"></script>
   </head>
@@ -547,7 +750,7 @@
           <div class="eyebrow">Account</div>
           <h1 id="page-title">Sign in to DoWhiz</h1>
           <p class="lead" id="page-subtitle">
-            Connect your channels to sync your memo across all devices.
+            Open your account dashboard to manage channels, tasks, and settings in one place.
           </p>
         </section>
 
@@ -637,16 +840,163 @@
 
           <!-- Dashboard (shown after auth) -->
           <div id="dashboard-container" class="hidden">
-            <section class="legal-card dashboard-section">
-              <div class="dashboard-header">
-                <h2>Your Account</h2>
-                <button id="info-btn" class="auth-btn auth-btn-primary" style="padding: 0.5rem 1rem; font-size: 0.85rem;">
-                  Add Employee Hours
+            <div class="dashboard-shell">
+              <aside class="dashboard-sidebar">
+                <p class="sidebar-eyebrow">Dashboard</p>
+                <h2 class="sidebar-title">Workspace Settings</h2>
+                <p class="sidebar-description">Navigate quickly to channels, tasks, memo, and account controls.</p>
+                <nav class="sidebar-nav" aria-label="Dashboard Sections">
+                  <a class="sidebar-link is-active" href="#section-overview">Overview</a>
+                  <a class="sidebar-link" href="#section-channels">Channels</a>
+                  <a class="sidebar-link" href="#section-tasks">Tasks</a>
+                  <a class="sidebar-link" href="#section-memo">Memo</a>
+                  <a class="sidebar-link" href="#section-settings">Settings</a>
+                </nav>
+                <div class="sidebar-note">
+                  <div class="sidebar-note-title">Support</div>
+                  <a class="auth-link" href="mailto:admin@dowhiz.com">admin@dowhiz.com</a>
+                </div>
+                <button id="signout-btn" class="auth-btn auth-btn-oauth sidebar-signout">
+                  Sign Out
                 </button>
+              </aside>
+
+              <div class="dashboard-main">
+                <section id="section-overview" class="legal-card dashboard-section">
+                  <div class="dashboard-header">
+                    <h2>Account Overview</h2>
+                    <button id="info-btn" class="auth-btn auth-btn-primary" style="padding: 0.5rem 1rem; font-size: 0.85rem;">
+                      Add Employee Hours
+                    </button>
+                  </div>
+                  <p class="dashboard-overview-copy">Your core dashboard identity and billing controls.</p>
+                  <div class="account-grid">
+                    <div class="account-meta-item">
+                      <p class="account-meta-label">Account ID</p>
+                      <code id="account-id">Loading...</code>
+                    </div>
+                    <div class="account-meta-item">
+                      <p class="account-meta-label">Primary Email</p>
+                      <code id="user-email">Loading...</code>
+                    </div>
+                  </div>
+                </section>
+
+                <section id="section-channels" class="legal-card dashboard-section">
+                  <h2>Connected Channels</h2>
+                  <p>Channels currently linked to your unified account workspace.</p>
+                  <ul id="identifier-list" class="identifier-list">
+                    <li class="identifier-item">Loading...</li>
+                  </ul>
+                </section>
+
+                <section id="section-tasks" class="legal-card dashboard-section">
+                  <h2>Task Center</h2>
+                  <p>Scheduled tasks from all connected channels.</p>
+                  <div class="tasks-header">
+                    <div class="tasks-controls">
+                      <button id="refresh-tasks-btn" class="auth-btn auth-btn-oauth">
+                        Refresh
+                      </button>
+                      <div class="polling-indicator">
+                        <span class="polling-dot"></span>
+                        <span>Auto-updating</span>
+                      </div>
+                    </div>
+                    <span id="tasks-status" class="tasks-status"></span>
+                  </div>
+                  <ul id="task-list" class="identifier-list">
+                    <li class="task-item" style="text-align: center; color: var(--text-muted, #888);">Loading tasks...</li>
+                  </ul>
+                </section>
+
+                <section id="section-memo" class="legal-card dashboard-section">
+                  <h2>Unified Memo</h2>
+                  <p>Edit and save the memo shared across your channels.</p>
+                  <div id="memo-container" style="margin-top: 1rem;">
+                    <textarea id="memo-content" style="
+                      background: var(--surface, #1a1a1a);
+                      border: 1px solid var(--border, #333);
+                      border-radius: 8px;
+                      padding: 1rem;
+                      width: 100%;
+                      min-height: 300px;
+                      resize: vertical;
+                      font-family: monospace;
+                      font-size: 0.9rem;
+                      color: var(--text, #fff);
+                      box-sizing: border-box;
+                    ">Loading memo...</textarea>
+                    <div class="memo-actions">
+                      <button id="save-memo-btn" class="auth-btn auth-btn-primary">
+                        Save Changes
+                      </button>
+                      <button id="refresh-memo-btn" class="auth-btn auth-btn-oauth">
+                        Refresh
+                      </button>
+                      <span id="memo-status" class="memo-status"></span>
+                    </div>
+                  </div>
+                </section>
+
+                <section id="section-settings" class="legal-card dashboard-section">
+                  <h2>Channel Settings</h2>
+                  <p>Connect channels with OAuth, or configure channel IDs manually.</p>
+                  <div class="settings-grid">
+                    <div class="settings-panel">
+                      <h3>Quick Connect</h3>
+                      <p>Use one-click OAuth for supported channels.</p>
+                      <div class="channel-connect-actions">
+                        <button id="discord-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+                          </svg>
+                          Connect Discord
+                        </button>
+                        <button id="slack-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
+                          </svg>
+                          Connect Slack
+                        </button>
+                        <button id="github-connect-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 0C5.37 0 0 5.37 0 12a12 12 0 0 0 8.2 11.4c.6.1.8-.2.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.6-1.4-1.3-1.8-1.3-1.8-1.1-.8.1-.8.1-.8 1.2.1 1.9 1.3 1.9 1.3 1.1 1.9 2.9 1.3 3.6 1 .1-.8.4-1.3.8-1.7-2.7-.3-5.5-1.3-5.5-6a4.7 4.7 0 0 1 1.3-3.3c-.1-.3-.6-1.5.1-3.2 0 0 1-.3 3.4 1.3a11.7 11.7 0 0 1 6.2 0c2.4-1.6 3.4-1.3 3.4-1.3.7 1.7.2 2.9.1 3.2a4.7 4.7 0 0 1 1.3 3.3c0 4.7-2.8 5.7-5.5 6 .4.4.8 1 .8 2.1v3.1c0 .4.2.7.8.6A12 12 0 0 0 24 12C24 5.37 18.63 0 12 0z"/>
+                          </svg>
+                          Connect GitHub
+                        </button>
+                      </div>
+                      <div class="settings-status-stack">
+                        <span id="discord-oauth-status"></span>
+                        <span id="slack-oauth-status"></span>
+                        <span id="github-connect-status"></span>
+                      </div>
+                    </div>
+
+                    <div class="settings-panel">
+                      <h3>Manual Linking</h3>
+                      <p>Link a channel by entering your identifier directly.</p>
+                      <form id="link-form" class="auth-form">
+                        <select id="link-type" class="auth-input">
+                          <option value="email">Email</option>
+                          <option value="phone">Phone (SMS)</option>
+                          <option value="discord">Discord</option>
+                          <option value="slack">Slack</option>
+                          <option value="github">GitHub</option>
+                          <option value="telegram">Telegram</option>
+                        </select>
+                        <input type="text" id="link-identifier" class="auth-input" placeholder="e.g., you@example.com" required />
+                        <p id="link-help" style="font-size: 0.85rem; color: var(--text-muted, #888); margin: 0;">
+                          Enter the email address you want to link. A verification email will be sent to confirm ownership.
+                        </p>
+                        <button type="submit" class="auth-btn auth-btn-primary">Link Channel</button>
+                        <div id="link-message" class="auth-message hidden" style="margin-top: 0.5rem; margin-bottom: 0;"></div>
+                      </form>
+                    </div>
+                  </div>
+                </section>
               </div>
-              <p>Account ID: <code id="account-id">Loading...</code></p>
-              <p>Email: <code id="user-email">Loading...</code></p>
-            </section>
+            </div>
 
             <!-- Settings Modal -->
             <div id="settings-modal" class="settings-modal hidden">
@@ -687,116 +1037,6 @@
                 </div>
               </div>
             </div>
-
-            <section class="legal-card dashboard-section">
-              <h2>Linked Channels</h2>
-              <p>These channels are connected to your unified memo.</p>
-              <ul id="identifier-list" class="identifier-list">
-                <li class="identifier-item">Loading...</li>
-              </ul>
-            </section>
-
-            <section class="legal-card dashboard-section">
-              <h2>Your Tasks</h2>
-              <p>Tasks scheduled by your digital employee.</p>
-              <div class="tasks-header">
-                <div class="tasks-controls">
-                  <button id="refresh-tasks-btn" class="auth-btn auth-btn-oauth">
-                    Refresh
-                  </button>
-                  <div class="polling-indicator">
-                    <span class="polling-dot"></span>
-                    <span>Auto-updating</span>
-                  </div>
-                </div>
-                <span id="tasks-status" class="tasks-status"></span>
-              </div>
-              <ul id="task-list" class="identifier-list">
-                <li class="task-item" style="text-align: center; color: var(--text-muted, #888);">Loading tasks...</li>
-              </ul>
-            </section>
-
-            <section class="legal-card dashboard-section">
-              <h2>Your Memo</h2>
-              <p>This is your unified memo synced across all channels. If you want to make changes, please edit below and save.</p>
-              <div id="memo-container" style="margin-top: 1rem;">
-                <textarea id="memo-content" style="
-                  background: var(--surface, #1a1a1a);
-                  border: 1px solid var(--border, #333);
-                  border-radius: 8px;
-                  padding: 1rem;
-                  width: 100%;
-                  min-height: 300px;
-                  resize: vertical;
-                  font-family: monospace;
-                  font-size: 0.9rem;
-                  color: var(--text, #fff);
-                  box-sizing: border-box;
-                ">Loading memo...</textarea>
-                <div class="memo-actions">
-                  <button id="save-memo-btn" class="auth-btn auth-btn-primary">
-                    Save Changes
-                  </button>
-                  <button id="refresh-memo-btn" class="auth-btn auth-btn-oauth">
-                    Refresh
-                  </button>
-                  <span id="memo-status" class="memo-status"></span>
-                </div>
-              </div>
-            </section>
-
-            <section class="legal-card dashboard-section">
-              <h2>Connect Channels</h2>
-              <p style="margin-bottom: 1rem;">Connect your accounts with one click:</p>
-              <div class="channel-connect-actions">
-                <button id="discord-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
-                  </svg>
-                  Connect Discord
-                </button>
-                <button id="slack-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
-                  </svg>
-                  Connect Slack
-                </button>
-                <button id="github-connect-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M12 0C5.37 0 0 5.37 0 12a12 12 0 0 0 8.2 11.4c.6.1.8-.2.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.6-1.4-1.3-1.8-1.3-1.8-1.1-.8.1-.8.1-.8 1.2.1 1.9 1.3 1.9 1.3 1.1 1.9 2.9 1.3 3.6 1 .1-.8.4-1.3.8-1.7-2.7-.3-5.5-1.3-5.5-6a4.7 4.7 0 0 1 1.3-3.3c-.1-.3-.6-1.5.1-3.2 0 0 1-.3 3.4 1.3a11.7 11.7 0 0 1 6.2 0c2.4-1.6 3.4-1.3 3.4-1.3.7 1.7.2 2.9.1 3.2a4.7 4.7 0 0 1 1.3 3.3c0 4.7-2.8 5.7-5.5 6 .4.4.8 1 .8 2.1v3.1c0 .4.2.7.8.6A12 12 0 0 0 24 12C24 5.37 18.63 0 12 0z"/>
-                  </svg>
-                  Connect GitHub
-                </button>
-              </div>
-              <span id="discord-oauth-status" style="display: block; margin-top: 0.5rem; font-size: 0.9rem;"></span>
-              <span id="slack-oauth-status" style="display: block; margin-top: 0.25rem; font-size: 0.9rem;"></span>
-              <span id="github-connect-status" style="display: block; margin-top: 0.25rem; font-size: 0.9rem;"></span>
-            </section>
-
-            <section class="legal-card dashboard-section">
-              <h2>Link Channel Manually</h2>
-              <p style="margin-bottom: 0.5rem; font-size: 0.9rem; color: var(--text-muted, #888);">Or enter your channel ID directly:</p>
-              <form id="link-form" class="auth-form">
-                <select id="link-type" class="auth-input">
-                  <option value="email">Email</option>
-                  <option value="phone">Phone (SMS)</option>
-                  <option value="discord">Discord</option>
-                  <option value="slack">Slack</option>
-                  <option value="github">GitHub</option>
-                  <option value="telegram">Telegram</option>
-                </select>
-                <input type="text" id="link-identifier" class="auth-input" placeholder="e.g., you@example.com" required />
-                <p id="link-help" style="font-size: 0.85rem; color: var(--text-muted, #888); margin: 0;">
-                  Enter the email address you want to link. A verification email will be sent to confirm ownership.
-                </p>
-                <button type="submit" class="auth-btn auth-btn-primary">Link Channel</button>
-                <div id="link-message" class="auth-message hidden" style="margin-top: 0.5rem; margin-bottom: 0;"></div>
-              </form>
-            </section>
-
-            <button id="signout-btn" class="auth-btn auth-btn-oauth" style="width: 100%; margin-top: 2rem;">
-              Sign Out
-            </button>
           </div>
         </div>
       </main>
@@ -842,6 +1082,10 @@
       const backToSigninLink = document.getElementById('back-to-signin');
       const forgotPasswordLink = document.getElementById('forgot-password-link');
       const setPasswordLink = document.getElementById('set-password-link');
+      const dashboardSidebarLinks = Array.from(document.querySelectorAll('.sidebar-link'));
+      const dashboardSidebarTargets = dashboardSidebarLinks
+        .map((link) => document.querySelector(link.getAttribute('href')))
+        .filter(Boolean);
 
       let lastSignupEmail = null;
       let recoverySession = null;
@@ -853,6 +1097,7 @@
       // If expecting dashboard, keep everything hidden until ready
       // If not, show sign-in form immediately
       if (!expectingDashboard) {
+        setDashboardMode(false);
         signinFormContainer.classList.remove('hidden');
       }
 
@@ -884,6 +1129,28 @@
         }
       }
 
+      function setDashboardMode(enabled) {
+        document.body.classList.toggle('dashboard-mode', enabled);
+      }
+
+      function updateSidebarNavigation() {
+        if (dashboardContainer.classList.contains('hidden') || dashboardSidebarLinks.length === 0) {
+          return;
+        }
+
+        let activeIndex = 0;
+        for (let i = 0; i < dashboardSidebarTargets.length; i += 1) {
+          const rectTop = dashboardSidebarTargets[i].getBoundingClientRect().top;
+          if (rectTop <= 170) {
+            activeIndex = i;
+          }
+        }
+
+        dashboardSidebarLinks.forEach((link, index) => {
+          link.classList.toggle('is-active', index === activeIndex);
+        });
+      }
+
       function hideExistingAccountOptions() {
         existingAccountContainer?.classList.add('hidden');
       }
@@ -901,6 +1168,7 @@
         if (passwordResetEmail) {
           passwordResetEmail.textContent = email || 'your account';
         }
+        setDashboardMode(false);
         loadingContainer.classList.add('hidden');
         signinFormContainer.classList.add('hidden');
         signupFormContainer.classList.add('hidden');
@@ -987,6 +1255,7 @@
       // Switch between forms
       document.getElementById('show-signup').addEventListener('click', (e) => {
         e.preventDefault();
+        setDashboardMode(false);
         signinFormContainer.classList.add('hidden');
         signupFormContainer.classList.remove('hidden');
         passwordResetContainer.classList.add('hidden');
@@ -996,6 +1265,7 @@
 
       document.getElementById('show-signin').addEventListener('click', (e) => {
         e.preventDefault();
+        setDashboardMode(false);
         signupFormContainer.classList.add('hidden');
         signinFormContainer.classList.remove('hidden');
         passwordResetContainer.classList.add('hidden');
@@ -1005,6 +1275,7 @@
 
       backToSigninLink?.addEventListener('click', (e) => {
         e.preventDefault();
+        setDashboardMode(false);
         passwordResetContainer.classList.add('hidden');
         signinFormContainer.classList.remove('hidden');
         hideMessage();
@@ -1045,6 +1316,17 @@
           sendOtpEmailBtn.disabled = false;
         }
       });
+
+      dashboardSidebarLinks.forEach((link) => {
+        link.addEventListener('click', () => {
+          dashboardSidebarLinks.forEach((item) => {
+            item.classList.toggle('is-active', item === link);
+          });
+        });
+      });
+
+      window.addEventListener('scroll', updateSidebarNavigation, { passive: true });
+      window.addEventListener('resize', updateSidebarNavigation);
 
       // Sign in with email/password
       document.getElementById('signin-form').addEventListener('submit', async (e) => {
@@ -1109,6 +1391,7 @@
       document.getElementById('signout-btn').addEventListener('click', async () => {
         stopTaskPolling();
         cachedIdentifiers = [];
+        setDashboardMode(false);
         await supabase.auth.signOut();
         window.location.reload();
       });
@@ -1256,6 +1539,7 @@
           showDashboard(session, accountData);
         } catch (err) {
           // On error, show sign-in form with error message
+          setDashboardMode(false);
           signinFormContainer.classList.remove('hidden');
           showMessage(err.message);
         }
@@ -1263,6 +1547,7 @@
 
       // Show dashboard
       async function showDashboard(session, accountData) {
+        setDashboardMode(true);
         loadingContainer.classList.add('hidden');
         signinFormContainer.classList.add('hidden');
         signupFormContainer.classList.add('hidden');
@@ -1270,7 +1555,7 @@
         hideExistingAccountOptions();
         dashboardContainer.classList.remove('hidden');
         pageTitle.textContent = 'Your Dashboard';
-        pageSubtitle.textContent = 'Manage your linked channels and integrations.';
+        pageSubtitle.textContent = 'Manage channels, tasks, memo, and settings from one unified dashboard.';
 
         document.getElementById('account-id').textContent = accountData.account_id;
         document.getElementById('user-email').textContent = session.user.email;
@@ -1284,6 +1569,7 @@
 
         // Start polling for task updates
         startTaskPolling(session.access_token);
+        updateSidebarNavigation();
       }
 
       // Load linked identifiers
@@ -1943,6 +2229,7 @@
           await handleAuthSuccess(session);
         } else {
           // No session - show sign-in form
+          setDashboardMode(false);
           signinFormContainer.classList.remove('hidden');
         }
       }


### PR DESCRIPTION
## Summary
- refactor `website/public/auth/index.html` into a dashboard shell with sidebar navigation and sectioned content
- improve information density and navigation with Overview/Channels/Tasks/Memo/Settings sections
- replace integration-oriented wording with dashboard/settings wording across meta and runtime copy
- add scroll/click active state behavior for sidebar section links while preserving existing auth and channel actions

## Validation
- `cd website && npm run lint`
- `cd website && npm run build`
