### PR TITLE
fix(website): rename avatar menu item to Dashboard

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1360,7 +1360,7 @@ function App() {
                           <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" strokeWidth="2" fill="none">
                             <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
                           </svg>
-                          Integrations
+                          Dashboard
                         </a>
                         <button className="dropdown-item" onClick={async () => {
                           await supabase.auth.signOut();


### PR DESCRIPTION
## Summary
- Rename the avatar dropdown item label from `Integrations` to `Dashboard` in the website navbar user menu.
- Keep existing click behavior and destination unchanged.

## Testing
- npm run lint (website)
