### PR TITLE
Add WAL mode to scheduler/user stores to fix SQLite lock errors

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
@@ -317,7 +317,10 @@ impl SqliteSchedulerStore {
         }
         self.quarantine_zero_byte_db_if_needed()?;
         let conn = Connection::open(&self.path)?;
-        conn.busy_timeout(Duration::from_secs(5))?;
+        // Enable WAL mode for better concurrent access (reduces "database is locked" errors)
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+        // Increase busy timeout for concurrent access from multiple workers
+        conn.busy_timeout(Duration::from_secs(30))?;
         conn.execute_batch(SCHEDULER_SCHEMA)?;
         ensure_tasks_columns(&conn)?;
         ensure_send_email_task_columns(&conn)?;

--- a/DoWhiz_service/scheduler_module/src/user_store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/user_store/mod.rs
@@ -212,6 +212,8 @@ impl UserStore {
             fs::create_dir_all(parent)?;
         }
         let conn = Connection::open(&self.path)?;
+        // Enable WAL mode for better concurrent access (reduces "database is locked" errors)
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
         conn.busy_timeout(Duration::from_secs(30))?;
         conn.execute_batch(USERS_SCHEMA)?;
         Ok(conn)


### PR DESCRIPTION
## Summary
- Enables SQLite WAL (Write-Ahead Logging) mode for `scheduler/store/mod.rs` and `user_store/mod.rs`
- Increases `busy_timeout` from 5s to 30s for scheduler store to match other modules
- Applies the same fix pattern that resolved Google Docs SQLite "database is locked" errors

## Context
Production VM logs showed frequent SQLite errors:
- `sqlite error: database is locked` for user tasks.db files
- `WARN quarantined zero-byte sqlite db` indicating corrupted databases

The Google Docs/Workspace pollers already use WAL mode + 30s timeout and their errors have stopped, confirming this approach works.

## Changes
| File | Change |
|------|--------|
| `scheduler/store/mod.rs` | Add `PRAGMA journal_mode=WAL`, increase busy_timeout 5s→30s |
| `user_store/mod.rs` | Add `PRAGMA journal_mode=WAL` (already had 30s timeout) |

## Test plan
- [x] `cargo build -p scheduler_module` passes
- [x] `cargo test -p scheduler_module` passes (170 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)