### PR TITLE
fix(cicd): target env keys override ENV_COMMON duplicates

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -144,11 +144,47 @@ jobs:
           set -e
           APP_DIR=/home/${{ secrets.PROD_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
           mkdir -p "$APP_DIR"
-          cat << 'ENVEOF' > "$APP_DIR/.env"
+          COMMON_ENV_FILE="$APP_DIR/.env.common.tmp"
+          TARGET_ENV_FILE="$APP_DIR/.env.target.tmp"
+          cat << 'ENV_COMMON_EOF' > "$COMMON_ENV_FILE"
           ${{ secrets.ENV_COMMON }}
+          ENV_COMMON_EOF
+          cat << 'ENV_TARGET_EOF' > "$TARGET_ENV_FILE"
           ${{ secrets.ENV_PROD }}
-          ENVEOF
+          ENV_TARGET_EOF
+
           ENV_FILE="$APP_DIR/.env"
+          # Merge key/value pairs with target env taking precedence over common env.
+          awk '
+            function trim(value) {
+              gsub(/^[[:space:]]+|[[:space:]]+$/, "", value);
+              return value;
+            }
+            {
+              line = $0;
+              sub(/\r$/, "", line);
+              if (line ~ /^[[:space:]]*($|#)/) next;
+              if (line ~ /^export[[:space:]]+/) sub(/^export[[:space:]]+/, "", line);
+              pos = index(line, "=");
+              if (pos == 0) next;
+              key = trim(substr(line, 1, pos - 1));
+              if (key == "") next;
+              value = substr(line, pos + 1);
+              if (!(key in seen)) {
+                seen[key] = 1;
+                order[++count] = key;
+              }
+              env[key] = value;
+            }
+            END {
+              for (i = 1; i <= count; i++) {
+                key = order[i];
+                print key "=" env[key];
+              }
+            }
+          ' "$COMMON_ENV_FILE" "$TARGET_ENV_FILE" > "$ENV_FILE"
+          rm -f "$COMMON_ENV_FILE" "$TARGET_ENV_FILE"
+
           if grep -Eq '^(STAGING_|PROD_)' "$ENV_FILE"; then
             echo "ERROR: Prefixed env keys are not allowed in deployment .env" >&2
             grep -En '^(STAGING_|PROD_)' "$ENV_FILE" >&2 || true

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -144,11 +144,47 @@ jobs:
           set -e
           APP_DIR=/home/${{ secrets.STAGING_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
           mkdir -p "$APP_DIR"
-          cat << 'ENVEOF' > "$APP_DIR/.env"
+          COMMON_ENV_FILE="$APP_DIR/.env.common.tmp"
+          TARGET_ENV_FILE="$APP_DIR/.env.target.tmp"
+          cat << 'ENV_COMMON_EOF' > "$COMMON_ENV_FILE"
           ${{ secrets.ENV_COMMON }}
+          ENV_COMMON_EOF
+          cat << 'ENV_TARGET_EOF' > "$TARGET_ENV_FILE"
           ${{ secrets.ENV_STAGING }}
-          ENVEOF
+          ENV_TARGET_EOF
+
           ENV_FILE="$APP_DIR/.env"
+          # Merge key/value pairs with target env taking precedence over common env.
+          awk '
+            function trim(value) {
+              gsub(/^[[:space:]]+|[[:space:]]+$/, "", value);
+              return value;
+            }
+            {
+              line = $0;
+              sub(/\r$/, "", line);
+              if (line ~ /^[[:space:]]*($|#)/) next;
+              if (line ~ /^export[[:space:]]+/) sub(/^export[[:space:]]+/, "", line);
+              pos = index(line, "=");
+              if (pos == 0) next;
+              key = trim(substr(line, 1, pos - 1));
+              if (key == "") next;
+              value = substr(line, pos + 1);
+              if (!(key in seen)) {
+                seen[key] = 1;
+                order[++count] = key;
+              }
+              env[key] = value;
+            }
+            END {
+              for (i = 1; i <= count; i++) {
+                key = order[i];
+                print key "=" env[key];
+              }
+            }
+          ' "$COMMON_ENV_FILE" "$TARGET_ENV_FILE" > "$ENV_FILE"
+          rm -f "$COMMON_ENV_FILE" "$TARGET_ENV_FILE"
+
           if grep -Eq '^(STAGING_|PROD_)' "$ENV_FILE"; then
             echo "ERROR: Prefixed env keys are not allowed in deployment .env" >&2
             grep -En '^(STAGING_|PROD_)' "$ENV_FILE" >&2 || true


### PR DESCRIPTION
## Summary
- update staging/production workflow env composition to merge key/value pairs from ENV_COMMON and target env (ENV_STAGING/ENV_PROD)
- when duplicate keys exist, target env value now overwrites common value deterministically
- keep prefixed-key fail-fast checks unchanged

## Validation
- YAML parse check for both workflows
- local merge simulation confirmed duplicate key override behavior
