### PR TITLE
fix(cicd): fix quoted env parsing in deploy restart step

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -211,7 +211,10 @@ jobs:
             local key="$1"
             local value
             value="$(grep -E "^${key}=" "$ENV_FILE" | tail -n1 | cut -d= -f2- || true)"
-            value="$(printf '%s' "$value" | sed -e 's/^\"//' -e 's/\"$//' -e \"s/^'//\" -e \"s/'$//\")"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
             printf '%s' "$value"
           }
           GATEWAY_CONFIG_PATH="$(read_env_value GATEWAY_CONFIG_PATH)"

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -211,7 +211,10 @@ jobs:
             local key="$1"
             local value
             value="$(grep -E "^${key}=" "$ENV_FILE" | tail -n1 | cut -d= -f2- || true)"
-            value="$(printf '%s' "$value" | sed -e 's/^\"//' -e 's/\"$//' -e \"s/^'//\" -e \"s/'$//\")"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
             printf '%s' "$value"
           }
           GATEWAY_CONFIG_PATH="$(read_env_value GATEWAY_CONFIG_PATH)"


### PR DESCRIPTION
## Summary
- replace fragile sed quoting in `read_env_value` with bash parameter expansion
- apply the fix in both staging and production CICD workflows
- prevent deploy failures where `GATEWAY_CONFIG_PATH` / `EMPLOYEE_CONFIG_PATH` are parsed as empty

## Validation
- reproduced old sed expression failure locally
- verified new logic parses unquoted, single-quoted, and double-quoted values
