### PR TITLE
feat(staging): add Google Workspace routes for staging (#641)

### DIFF
--- a/DoWhiz_service/gateway.staging.toml
+++ b/DoWhiz_service/gateway.staging.toml
@@ -7,3 +7,22 @@ channel = "email"
 key = "dowhiz@deep-tutor.com"
 employee_id = "boiled_egg"
 tenant_id = "staging"
+
+# Google Workspace routing for staging (using dowhiz@deep-tutor.com account)
+[[routes]]
+channel = "google_docs"
+key = "*"
+employee_id = "boiled_egg"
+tenant_id = "staging"
+
+[[routes]]
+channel = "google_sheets"
+key = "*"
+employee_id = "boiled_egg"
+tenant_id = "staging"
+
+[[routes]]
+channel = "google_slides"
+key = "*"
+employee_id = "boiled_egg"
+tenant_id = "staging"


### PR DESCRIPTION
* cleanup: remove unused CollaborationStore and add --release guidance

- Remove dead CollaborationStore code (never used in production)
- The memo.md approach handles per-user context aggregation
- Add --release flag guidance to prevent debug artifacts bloating storage



* feat(staging): add Google Workspace routes for staging

- Use boiled_egg (Proto) as default employee for staging
- Add Google Docs, Sheets, Slides routing to boiled_egg
- Add Notion routing to little_bear
- Uses dowhiz@deep-tutor.com account for Google Workspace



* chore(staging): remove Notion routing temporarily

Will add back after local Notion testing is complete.



---------