### PR TITLE
fix(staging): harden account TLS and email ingestion skip

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -1144,6 +1144,7 @@ Environment policy:
 | `INGESTION_QUEUE_LEASE_SECS` | `60` | Lease timeout before reclaiming stuck jobs |
 | `INGESTION_QUEUE_MAX_ATTEMPTS` | `5` | Max retry attempts before marking failed |
 | `INGESTION_QUEUE_TLS_ALLOW_INVALID_CERTS` | `0` | Set to `1` to allow self-signed Postgres certificates (local/dev only) |
+| `ACCOUNT_STORE_TLS_ALLOW_INVALID_CERTS` | `staging:1 / production:0` | Optional override for AccountStore TLS validation; when unset, it follows `INGESTION_QUEUE_TLS_ALLOW_INVALID_CERTS` and defaults to enabled in staging |
 | `INGESTION_POLL_INTERVAL_SECS` | `1` | Poll interval for ingestion consumer |
 
 ### Account/Auth/Billing (Supabase)

--- a/DoWhiz_service/scheduler_module/src/account_store.rs
+++ b/DoWhiz_service/scheduler_module/src/account_store.rs
@@ -8,10 +8,30 @@ use std::sync::Arc;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use crate::env_alias::bool_with_scale_oliver;
+use crate::env_alias::var_with_scale_oliver;
 
 type PgPool = Pool<PostgresConnectionManager<MakeTlsConnector>>;
 type PgConn = PooledConnection<PostgresConnectionManager<MakeTlsConnector>>;
+
+fn parse_bool_env(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn account_store_allow_invalid_certs() -> bool {
+    if let Some(value) = var_with_scale_oliver("ACCOUNT_STORE_TLS_ALLOW_INVALID_CERTS") {
+        return parse_bool_env(&value);
+    }
+    if let Some(value) = var_with_scale_oliver("INGESTION_QUEUE_TLS_ALLOW_INVALID_CERTS") {
+        return parse_bool_env(&value);
+    }
+    env::var("DEPLOY_TARGET")
+        .ok()
+        .map(|value| value.trim().eq_ignore_ascii_case("staging"))
+        .unwrap_or(false)
+}
 
 #[derive(Debug, Clone)]
 pub struct Account {
@@ -163,7 +183,11 @@ impl AccountStore {
         let config: postgres::Config = db_url.parse()?;
 
         let mut tls_builder = native_tls::TlsConnector::builder();
-        if bool_with_scale_oliver("INGESTION_QUEUE_TLS_ALLOW_INVALID_CERTS", false) {
+        if account_store_allow_invalid_certs() {
+            warn!(
+                "account_store {} TLS verification relaxed (invalid certs/hostnames allowed)",
+                pool_name
+            );
             tls_builder.danger_accept_invalid_certs(true);
             tls_builder.danger_accept_invalid_hostnames(true);
         }
@@ -756,4 +780,54 @@ pub fn lookup_account_by_channel(
 ) -> Option<Uuid> {
     let identifier_type = channel_to_identifier_type(channel);
     lookup_account_by_identifier(identifier_type, identifier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::account_store_allow_invalid_certs;
+    use std::env;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn reset_tls_env() {
+        env::remove_var("DEPLOY_TARGET");
+        env::remove_var("INGESTION_QUEUE_TLS_ALLOW_INVALID_CERTS");
+        env::remove_var("ACCOUNT_STORE_TLS_ALLOW_INVALID_CERTS");
+        env::remove_var("SCALE_OLIVER_INGESTION_QUEUE_TLS_ALLOW_INVALID_CERTS");
+        env::remove_var("SCALE_OLIVER_ACCOUNT_STORE_TLS_ALLOW_INVALID_CERTS");
+    }
+
+    #[test]
+    fn account_store_tls_defaults_enabled_on_staging() {
+        let _guard = env_lock().lock().expect("env lock");
+        reset_tls_env();
+        env::set_var("DEPLOY_TARGET", "staging");
+        assert!(account_store_allow_invalid_certs());
+        reset_tls_env();
+    }
+
+    #[test]
+    fn account_store_tls_defaults_disabled_on_production() {
+        let _guard = env_lock().lock().expect("env lock");
+        reset_tls_env();
+        env::set_var("DEPLOY_TARGET", "production");
+        assert!(!account_store_allow_invalid_certs());
+        reset_tls_env();
+    }
+
+    #[test]
+    fn account_store_tls_respects_explicit_override() {
+        let _guard = env_lock().lock().expect("env lock");
+        reset_tls_env();
+        env::set_var("DEPLOY_TARGET", "staging");
+        env::set_var("ACCOUNT_STORE_TLS_ALLOW_INVALID_CERTS", "0");
+        assert!(!account_store_allow_invalid_certs());
+        env::set_var("ACCOUNT_STORE_TLS_ALLOW_INVALID_CERTS", "1");
+        assert!(account_store_allow_invalid_certs());
+        reset_tls_env();
+    }
 }

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -290,7 +290,7 @@ pub fn process_inbound_payload(
     Ok(())
 }
 
-fn is_blacklisted_sender(sender: &str, service_addresses: &HashSet<String>) -> bool {
+pub(super) fn is_blacklisted_sender(sender: &str, service_addresses: &HashSet<String>) -> bool {
     if sender.is_empty() {
         return false;
     }

--- a/DoWhiz_service/scheduler_module/src/service/ingestion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/ingestion.rs
@@ -127,6 +127,11 @@ fn process_ingestion_envelope(
 ) -> Result<(), BoxError> {
     match envelope.channel {
         Channel::Email => {
+            let sender = envelope.payload.sender.trim();
+            if is_blacklisted_email_sender(sender, &config.employee_directory.service_addresses) {
+                info!("skipping blacklisted sender: {}", sender);
+                return Ok(());
+            }
             let (payload, raw_payload) = resolve_email_payload(envelope)?;
             process_inbound_payload(config, user_store, index_store, &payload, &raw_payload)
         }
@@ -233,6 +238,13 @@ fn process_ingestion_envelope(
     }
 }
 
+fn is_blacklisted_email_sender(
+    sender: &str,
+    service_addresses: &std::collections::HashSet<String>,
+) -> bool {
+    super::email::is_blacklisted_sender(sender, service_addresses)
+}
+
 fn resolve_email_payload(
     envelope: &IngestionEnvelope,
 ) -> Result<(PostmarkInbound, Vec<u8>), BoxError> {
@@ -295,10 +307,11 @@ fn resolve_email_payload(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_email_payload;
+    use super::{is_blacklisted_email_sender, resolve_email_payload};
     use crate::channel::{Attachment, Channel, ChannelMetadata};
     use crate::ingestion::{IngestionEnvelope, IngestionPayload};
     use chrono::Utc;
+    use std::collections::HashSet;
     use uuid::Uuid;
 
     #[test]
@@ -348,5 +361,25 @@ mod tests {
             Some("<message-1@example.com>")
         );
         assert_eq!(payload.attachments.as_ref().map(|v| v.len()), Some(1));
+    }
+
+    #[test]
+    fn blacklisted_email_sender_detects_service_address() {
+        let mut service_addresses = HashSet::new();
+        service_addresses.insert("dowhiz@deep-tutor.com".to_string());
+        assert!(is_blacklisted_email_sender(
+            "DoWhiz <dowhiz@deep-tutor.com>",
+            &service_addresses
+        ));
+    }
+
+    #[test]
+    fn blacklisted_email_sender_allows_external_sender() {
+        let mut service_addresses = HashSet::new();
+        service_addresses.insert("dowhiz@deep-tutor.com".to_string());
+        assert!(!is_blacklisted_email_sender(
+            "user@example.com",
+            &service_addresses
+        ));
     }
 }


### PR DESCRIPTION
## Summary\n- add AccountStore TLS policy with explicit env override support and staging-safe default\n- prevent blacklisted email envelopes from downloading raw payload before skip decision\n- add focused unit tests for both behaviors\n- document  in README\n\n## Tests\n- 
running 2 tests
test service::ingestion::tests::blacklisted_email_sender_detects_service_address ... ok
test service::ingestion::tests::blacklisted_email_sender_allows_external_sender ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 198 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 18 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s\n- 
running 3 tests
test account_store::tests::account_store_tls_defaults_disabled_on_production ... ok
test account_store::tests::account_store_tls_defaults_enabled_on_staging ... ok
test account_store::tests::account_store_tls_respects_explicit_override ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 197 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 18 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s