### PR TITLE
fix(staging): remove local fallback and fix ACI quota retry loop

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -1190,8 +1190,7 @@ Environment policy:
 ### Azure ACI Execution (Serverless Per Task)
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `RUN_TASK_EXECUTION_BACKEND` | `auto` | `azure_aci`/`local`/`auto`. In `DEPLOY_TARGET=staging|production`, direct local Codex execution is blocked unless ACI fallback is enabled. |
-| `RUN_TASK_AZURE_ACI_FALLBACK_TO_LOCAL` | `1` on staging, `0` otherwise | When Azure ACI capacity is exhausted (for example `ContainerGroupQuotaReached`), fallback to local Codex execution. |
+| `RUN_TASK_EXECUTION_BACKEND` | `auto` | `azure_aci`/`local`/`auto`. In `DEPLOY_TARGET=staging|production`, local Codex execution is blocked. |
 | `RUN_TASK_AZURE_ACI_RESOURCE_GROUP` | - | Resource group used by `az container create` |
 | `RUN_TASK_AZURE_ACI_IMAGE` | `RUN_TASK_DOCKER_IMAGE` fallback | Container image for task execution |
 | `RUN_TASK_AZURE_ACI_LOCATION` | - | Optional ACI region override |

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -93,54 +93,9 @@ pub(super) fn run_codex_task(
         }
     }
     if backend == ExecutionBackend::AzureAci {
-        match run_codex_task_azure_aci(
-            &request,
-            runner,
-            reply_html_path.clone(),
-            reply_attachments_dir.clone(),
-        ) {
-            Ok(output) => return Ok(output),
-            Err(err) => {
-                if should_fallback_to_local_on_aci_error(&err) {
-                    if allow_aci_local_fallback() {
-                        eprintln!(
-                            "[run_task] azure_aci capacity error detected; falling back to local execution"
-                        );
-                        return run_codex_task_local(
-                            &request,
-                            runner,
-                            reply_html_path,
-                            reply_attachments_dir,
-                            false,
-                        );
-                    }
-                    eprintln!(
-                        "[run_task] azure_aci capacity error detected; local fallback disabled"
-                    );
-                }
-                return Err(err);
-            }
-        }
+        return run_codex_task_azure_aci(request, runner, reply_html_path, reply_attachments_dir);
     }
-    run_codex_task_local(
-        &request,
-        runner,
-        reply_html_path,
-        reply_attachments_dir,
-        true,
-    )
-}
-
-fn run_codex_task_local(
-    request: &RunTaskRequest<'_>,
-    runner: &str,
-    reply_html_path: PathBuf,
-    reply_attachments_dir: PathBuf,
-    enforce_local_execution_guard: bool,
-) -> Result<RunTaskOutput, RunTaskError> {
-    if enforce_local_execution_guard {
-        ensure_local_execution_allowed()?;
-    }
+    ensure_local_execution_allowed()?;
     let docker_image = read_env_trimmed("RUN_TASK_DOCKER_IMAGE");
     let docker_requested = env_enabled("RUN_TASK_USE_DOCKER");
     let docker_available = docker_requested && docker_cli_available();
@@ -524,33 +479,8 @@ fn ensure_local_execution_allowed() -> Result<(), RunTaskError> {
     Ok(())
 }
 
-fn allow_aci_local_fallback() -> bool {
-    if let Some(raw) = read_env_trimmed("RUN_TASK_AZURE_ACI_FALLBACK_TO_LOCAL") {
-        return matches!(
-            raw.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        );
-    }
-    normalized_deploy_target() == "staging"
-}
-
-fn should_fallback_to_local_on_aci_error(err: &RunTaskError) -> bool {
-    match err {
-        RunTaskError::CodexFailed { output, .. } => is_aci_capacity_error_output(output),
-        RunTaskError::CommandTimeout { output, .. } => is_aci_capacity_error_output(output),
-        _ => false,
-    }
-}
-
-fn is_aci_capacity_error_output(output: &str) -> bool {
-    let lowered = output.to_ascii_lowercase();
-    lowered.contains("containergroupquotareached")
-        || (lowered.contains("container group quota")
-            && lowered.contains("microsoft.containerinstance/containergroups"))
-}
-
 fn run_codex_task_azure_aci(
-    request: &RunTaskRequest<'_>,
+    request: RunTaskRequest<'_>,
     runner: &str,
     reply_html_path: PathBuf,
     reply_attachments_dir: PathBuf,
@@ -699,7 +629,12 @@ fn run_codex_task_azure_aci(
         "[run_task] azure_aci delete container={} resource_group={}",
         container_name, config.resource_group
     );
-    let _ = delete_aci_container(&config, &container_name);
+    if let Err(cleanup_err) = delete_aci_container_with_retry(&config, &container_name) {
+        eprintln!(
+            "[run_task] azure_aci delete failed container={} resource_group={} error={}",
+            container_name, config.resource_group, cleanup_err
+        );
+    }
 
     let (container_state, container_logs) = execution?;
     eprintln!(
@@ -981,78 +916,31 @@ exit \"$status\"\n",
         azure_env_cfg = azure_env_cfg,
     );
 
-    let mut create_cmd = Command::new("az");
-    create_cmd
-        .arg("container")
-        .arg("create")
-        .arg("--name")
-        .arg(container_name)
-        .arg("--resource-group")
-        .arg(&config.resource_group)
-        .arg("--image")
-        .arg(&config.image)
-        .arg("--os-type")
-        .arg("Linux")
-        .arg("--restart-policy")
-        .arg("Never")
-        .arg("--cpu")
-        .arg(&config.cpu)
-        .arg("--memory")
-        .arg(&config.memory_gb)
-        .arg("--azure-file-volume-account-name")
-        .arg(&config.storage_account)
-        .arg("--azure-file-volume-account-key")
-        .arg(&config.storage_key)
-        .arg("--azure-file-volume-share-name")
-        .arg(&config.file_share)
-        .arg("--azure-file-volume-mount-path")
-        .arg(&config.container_share_root)
-        .arg("--command-line")
-        .arg(format!("/bin/bash -lc {}", shell_quote(&script)))
-        .arg("--only-show-errors")
-        .arg("--output")
-        .arg("json");
-    if let Some(location) = &config.location {
-        create_cmd.arg("--location").arg(location);
-    }
-    if let (Some(server), Some(username), Some(password)) = (
-        &config.registry_server,
-        &config.registry_username,
-        &config.registry_password,
-    ) {
-        create_cmd
-            .arg("--registry-login-server")
-            .arg(server)
-            .arg("--registry-username")
-            .arg(username)
-            .arg("--registry-password")
-            .arg(password);
-    }
-
-    if !env_overrides.is_empty() {
-        create_cmd.arg("--environment-variables");
-        for (key, value) in env_overrides {
-            create_cmd.arg(format!("{key}={value}"));
-        }
-    }
-
-    let create_output =
-        match run_command_with_timeout(create_cmd, Duration::from_secs(300), "az container create")
-        {
-            Ok(output) => output,
-            Err(RunTaskError::Io(err)) if err.kind() == io::ErrorKind::NotFound => {
-                return Err(RunTaskError::AzureCliNotFound)
+    let create_command = format!("/bin/bash -lc {}", shell_quote(&script));
+    match create_aci_container(config, container_name, &create_command, env_overrides) {
+        Ok(()) => {}
+        Err(err) if is_aci_quota_error(&err) => {
+            eprintln!(
+                "[run_task] azure_aci quota reached for container={}, attempting stale cleanup",
+                container_name
+            );
+            match cleanup_stale_aci_containers(config) {
+                Ok(cleaned) => {
+                    eprintln!(
+                        "[run_task] azure_aci stale cleanup deleted {} container(s)",
+                        cleaned
+                    );
+                }
+                Err(cleanup_err) => {
+                    eprintln!(
+                        "[run_task] azure_aci stale cleanup failed before retry: {}",
+                        cleanup_err
+                    );
+                }
             }
-            Err(err) => return Err(err),
-        };
-    if !create_output.status.success() {
-        let mut combined = String::new();
-        combined.push_str(&String::from_utf8_lossy(&create_output.stdout));
-        combined.push_str(&String::from_utf8_lossy(&create_output.stderr));
-        return Err(RunTaskError::CodexFailed {
-            status: create_output.status.code(),
-            output: tail_string(&combined, 4000),
-        });
+            create_aci_container(config, container_name, &create_command, env_overrides)?;
+        }
+        Err(err) => return Err(err),
     }
 
     let container_state = poll_aci_state(config, container_name, timeout)?;
@@ -1129,6 +1017,141 @@ fn fetch_aci_logs(config: &AzureAciConfig, container_name: &str) -> Result<Strin
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+fn create_aci_container(
+    config: &AzureAciConfig,
+    container_name: &str,
+    create_command: &str,
+    env_overrides: &[(String, String)],
+) -> Result<(), RunTaskError> {
+    let mut create_cmd = build_aci_create_command(config, container_name, create_command);
+    if !env_overrides.is_empty() {
+        create_cmd.arg("--environment-variables");
+        for (key, value) in env_overrides {
+            create_cmd.arg(format!("{key}={value}"));
+        }
+    }
+
+    let create_output =
+        match run_command_with_timeout(create_cmd, Duration::from_secs(300), "az container create")
+        {
+            Ok(output) => output,
+            Err(RunTaskError::Io(err)) if err.kind() == io::ErrorKind::NotFound => {
+                return Err(RunTaskError::AzureCliNotFound)
+            }
+            Err(err) => return Err(err),
+        };
+    if !create_output.status.success() {
+        let mut combined = String::new();
+        combined.push_str(&String::from_utf8_lossy(&create_output.stdout));
+        combined.push_str(&String::from_utf8_lossy(&create_output.stderr));
+        return Err(RunTaskError::CodexFailed {
+            status: create_output.status.code(),
+            output: tail_string(&combined, 4000),
+        });
+    }
+    Ok(())
+}
+
+fn build_aci_create_command(
+    config: &AzureAciConfig,
+    container_name: &str,
+    create_command: &str,
+) -> Command {
+    let mut create_cmd = Command::new("az");
+    create_cmd
+        .arg("container")
+        .arg("create")
+        .arg("--name")
+        .arg(container_name)
+        .arg("--resource-group")
+        .arg(&config.resource_group)
+        .arg("--image")
+        .arg(&config.image)
+        .arg("--os-type")
+        .arg("Linux")
+        .arg("--restart-policy")
+        .arg("Never")
+        .arg("--cpu")
+        .arg(&config.cpu)
+        .arg("--memory")
+        .arg(&config.memory_gb)
+        .arg("--azure-file-volume-account-name")
+        .arg(&config.storage_account)
+        .arg("--azure-file-volume-account-key")
+        .arg(&config.storage_key)
+        .arg("--azure-file-volume-share-name")
+        .arg(&config.file_share)
+        .arg("--azure-file-volume-mount-path")
+        .arg(&config.container_share_root)
+        .arg("--command-line")
+        .arg(create_command)
+        .arg("--only-show-errors")
+        .arg("--output")
+        .arg("json");
+
+    if let Some(location) = &config.location {
+        create_cmd.arg("--location").arg(location);
+    }
+    if let (Some(server), Some(username), Some(password)) = (
+        &config.registry_server,
+        &config.registry_username,
+        &config.registry_password,
+    ) {
+        create_cmd
+            .arg("--registry-login-server")
+            .arg(server)
+            .arg("--registry-username")
+            .arg(username)
+            .arg("--registry-password")
+            .arg(password);
+    }
+    create_cmd
+}
+
+fn cleanup_stale_aci_containers(config: &AzureAciConfig) -> Result<usize, RunTaskError> {
+    let mut list_cmd = Command::new("az");
+    list_cmd
+        .arg("container")
+        .arg("list")
+        .arg("--resource-group")
+        .arg(&config.resource_group)
+        .arg("--query")
+        .arg("[?starts_with(name, 'dwz-codex-') && (instanceView.state == null || instanceView.state == 'Succeeded' || instanceView.state == 'Failed' || instanceView.state == 'Terminated' || instanceView.state == 'Stopped')].name")
+        .arg("--output")
+        .arg("tsv")
+        .arg("--only-show-errors");
+    let output = run_command_with_timeout(list_cmd, Duration::from_secs(120), "az container list")?;
+    if !output.status.success() {
+        let mut combined = String::new();
+        combined.push_str(&String::from_utf8_lossy(&output.stdout));
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        return Err(RunTaskError::CodexFailed {
+            status: output.status.code(),
+            output: tail_string(&combined, 4000),
+        });
+    }
+    let names = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>();
+
+    let mut cleaned = 0usize;
+    for name in names {
+        match delete_aci_container_with_retry(config, &name) {
+            Ok(()) => cleaned += 1,
+            Err(err) => {
+                eprintln!(
+                    "[run_task] azure_aci stale cleanup delete failed container={} error={}",
+                    name, err
+                );
+            }
+        }
+    }
+    Ok(cleaned)
+}
+
 fn delete_aci_container(config: &AzureAciConfig, container_name: &str) -> Result<(), RunTaskError> {
     let mut delete_cmd = Command::new("az");
     delete_cmd
@@ -1152,6 +1175,105 @@ fn delete_aci_container(config: &AzureAciConfig, container_name: &str) -> Result
         });
     }
     Ok(())
+}
+
+fn delete_aci_container_with_retry(
+    config: &AzureAciConfig,
+    container_name: &str,
+) -> Result<(), RunTaskError> {
+    const DELETE_ATTEMPTS: usize = 3;
+    const DELETE_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
+
+    let mut last_error: Option<RunTaskError> = None;
+    for attempt in 1..=DELETE_ATTEMPTS {
+        match delete_aci_container(config, container_name) {
+            Ok(()) => {
+                match wait_for_aci_container_deleted(config, container_name, DELETE_WAIT_TIMEOUT) {
+                    Ok(()) => return Ok(()),
+                    Err(err) => {
+                        last_error = Some(err);
+                    }
+                }
+            }
+            Err(err) if is_aci_not_found_error(&err) => return Ok(()),
+            Err(err) => {
+                last_error = Some(err);
+            }
+        }
+
+        if attempt < DELETE_ATTEMPTS {
+            thread::sleep(Duration::from_secs((attempt as u64) * 5));
+        }
+    }
+
+    Err(last_error.expect("delete_aci_container_with_retry exhausted without error"))
+}
+
+fn wait_for_aci_container_deleted(
+    config: &AzureAciConfig,
+    container_name: &str,
+    timeout: Duration,
+) -> Result<(), RunTaskError> {
+    let started = Instant::now();
+    loop {
+        let mut show_cmd = Command::new("az");
+        show_cmd
+            .arg("container")
+            .arg("show")
+            .arg("--name")
+            .arg(container_name)
+            .arg("--resource-group")
+            .arg(&config.resource_group)
+            .arg("--only-show-errors")
+            .arg("--output")
+            .arg("json");
+        let output =
+            run_command_with_timeout(show_cmd, Duration::from_secs(60), "az container show")?;
+        if output.status.success() {
+            if started.elapsed() >= timeout {
+                return Err(RunTaskError::CommandTimeout {
+                    command: "az container delete",
+                    timeout_secs: timeout.as_secs(),
+                    output: format!("container {} still exists", container_name),
+                });
+            }
+            thread::sleep(Duration::from_secs(5));
+            continue;
+        }
+
+        let mut combined = String::new();
+        combined.push_str(&String::from_utf8_lossy(&output.stdout));
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        if is_aci_not_found_output(&combined) {
+            return Ok(());
+        }
+        return Err(RunTaskError::CodexFailed {
+            status: output.status.code(),
+            output: tail_string(&combined, 4000),
+        });
+    }
+}
+
+fn is_aci_quota_error(err: &RunTaskError) -> bool {
+    let message = err.to_string().to_ascii_lowercase();
+    message.contains("containergroupquotareached")
+        || (message.contains("container group quota")
+            && message.contains("microsoft.containerinstance/containergroups"))
+        || message.contains("resource quota of container groups")
+}
+
+fn is_aci_not_found_error(err: &RunTaskError) -> bool {
+    match err {
+        RunTaskError::CodexFailed { output, .. } => is_aci_not_found_output(output),
+        _ => false,
+    }
+}
+
+fn is_aci_not_found_output(output: &str) -> bool {
+    let lowered = output.to_ascii_lowercase();
+    lowered.contains("resourcenotfound")
+        || lowered.contains("could not be found")
+        || lowered.contains("was not found")
 }
 
 fn read_remote_exit_code(path: &Path) -> Option<i32> {
@@ -1997,51 +2119,21 @@ mod tests {
     }
 
     #[test]
-    fn test_allow_aci_local_fallback_defaults_true_on_staging() {
-        let _lock = env_lock();
-        let _guards = vec![
-            EnvVarGuard::set("DEPLOY_TARGET", "staging"),
-            EnvVarGuard::unset("RUN_TASK_AZURE_ACI_FALLBACK_TO_LOCAL"),
-        ];
-        assert!(allow_aci_local_fallback());
-    }
-
-    #[test]
-    fn test_allow_aci_local_fallback_defaults_false_on_production() {
-        let _lock = env_lock();
-        let _guards = vec![
-            EnvVarGuard::set("DEPLOY_TARGET", "production"),
-            EnvVarGuard::unset("RUN_TASK_AZURE_ACI_FALLBACK_TO_LOCAL"),
-        ];
-        assert!(!allow_aci_local_fallback());
-    }
-
-    #[test]
-    fn test_allow_aci_local_fallback_respects_env_override() {
-        let _lock = env_lock();
-        let _guards = vec![
-            EnvVarGuard::set("DEPLOY_TARGET", "production"),
-            EnvVarGuard::set("RUN_TASK_AZURE_ACI_FALLBACK_TO_LOCAL", "1"),
-        ];
-        assert!(allow_aci_local_fallback());
-    }
-
-    #[test]
-    fn test_should_fallback_to_local_on_aci_error_detects_quota_error() {
+    fn test_is_aci_quota_error_detects_container_group_quota_reached() {
         let err = RunTaskError::CodexFailed {
             status: Some(1),
             output: "ERROR: (ContainerGroupQuotaReached) quota exceeded".to_string(),
         };
-        assert!(should_fallback_to_local_on_aci_error(&err));
+        assert!(is_aci_quota_error(&err));
     }
 
     #[test]
-    fn test_should_fallback_to_local_on_aci_error_ignores_unrelated_error() {
+    fn test_is_aci_not_found_error_detects_missing_container_group() {
         let err = RunTaskError::CodexFailed {
-            status: Some(1),
-            output: "ERROR: some unrelated failure".to_string(),
+            status: Some(3),
+            output: "ERROR: (ResourceNotFound) The Resource 'Microsoft.ContainerInstance/containerGroups/dwz-codex-abc' under resource group 'rg' was not found.".to_string(),
         };
-        assert!(!should_fallback_to_local_on_aci_error(&err));
+        assert!(is_aci_not_found_error(&err));
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Local, Utc};
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -26,7 +25,6 @@ pub struct Scheduler<E: TaskExecutor> {
     pub(super) tasks: Vec<ScheduledTask>,
     executor: E,
     pub(super) store: SchedulerStore,
-    failure_counts: HashMap<Uuid, u32>,
 }
 
 impl<E: TaskExecutor> Scheduler<E> {
@@ -38,7 +36,6 @@ impl<E: TaskExecutor> Scheduler<E> {
             tasks,
             executor,
             store,
-            failure_counts: HashMap::new(),
         })
     }
 
@@ -211,7 +208,12 @@ impl<E: TaskExecutor> Scheduler<E> {
 
         match result {
             Ok(execution) => {
-                self.failure_counts.remove(&task_id);
+                if let Err(err) = self.store.reset_retry_count(&task_id.to_string()) {
+                    warn!(
+                        "failed to reset retry count for task {} after success: {}",
+                        task_id, err
+                    );
+                }
                 self.store
                     .record_execution_finish(execution_id, executed_at, "success", None)?;
                 self.tasks[index].last_run = Some(executed_at);
@@ -283,20 +285,39 @@ impl<E: TaskExecutor> Scheduler<E> {
                 }
                 // Disable one-shot tasks on failure, but allow a few retries for RunTask.
                 if matches!(self.tasks[index].schedule, Schedule::OneShot { .. }) {
-                    let mut should_disable = true;
+                    let mut disable_task = true;
                     if let TaskKind::RunTask(task) = &self.tasks[index].kind {
-                        let failures = self.failure_counts.entry(task_id).or_insert(0);
-                        *failures += 1;
-                        if *failures < RUN_TASK_FAILURE_LIMIT {
-                            should_disable = false;
+                        let task_id_str = task_id.to_string();
+                        let retry_count = self.store.increment_retry_count(&task_id_str)?;
+                        if retry_count < RUN_TASK_FAILURE_LIMIT {
+                            disable_task = false;
+                            let delay = run_task_retry_delay(retry_count, &message);
+                            if let Schedule::OneShot { run_at } = &mut self.tasks[index].schedule {
+                                *run_at = executed_at + delay;
+                            }
+                            let updated_task = self.tasks[index].clone();
+                            self.store.update_task(&updated_task)?;
+                            warn!(
+                                "run_task one-shot {} failed (attempt {}/{}), retrying in {}s: {}",
+                                task_id,
+                                retry_count,
+                                RUN_TASK_FAILURE_LIMIT,
+                                delay.num_seconds(),
+                                message
+                            );
                         } else {
                             if let Err(err) = notify_run_task_failure(task_id, task, &message) {
                                 warn!("failed to notify run_task failure: {}", err);
                             }
-                            self.failure_counts.remove(&task_id);
+                            if let Err(err) = self.store.reset_retry_count(&task_id_str) {
+                                warn!(
+                                    "failed to reset retry count for disabled task {}: {}",
+                                    task_id, err
+                                );
+                            }
                         }
                     }
-                    if should_disable {
+                    if disable_task {
                         self.tasks[index].enabled = false;
                         let updated_task = self.tasks[index].clone();
                         self.store.update_task(&updated_task)?;
@@ -562,6 +583,32 @@ fn notify_run_task_failure(
     }
 
     Ok(())
+}
+
+fn run_task_retry_delay(retry_count: u32, error_message: &str) -> chrono::Duration {
+    const GENERIC_BASE_DELAY_SECS: i64 = 30;
+    const GENERIC_MAX_DELAY_SECS: i64 = 300;
+    const ACI_QUOTA_BASE_DELAY_SECS: i64 = 180;
+    const ACI_QUOTA_MAX_DELAY_SECS: i64 = 1800;
+
+    let is_aci_quota = is_aci_capacity_error(error_message);
+    let (base_secs, max_secs) = if is_aci_quota {
+        (ACI_QUOTA_BASE_DELAY_SECS, ACI_QUOTA_MAX_DELAY_SECS)
+    } else {
+        (GENERIC_BASE_DELAY_SECS, GENERIC_MAX_DELAY_SECS)
+    };
+    let exponent = retry_count.saturating_sub(1);
+    let multiplier = 2_i64.saturating_pow(exponent.min(10));
+    let secs = (base_secs.saturating_mul(multiplier)).min(max_secs);
+    chrono::Duration::seconds(secs.max(1))
+}
+
+fn is_aci_capacity_error(error_message: &str) -> bool {
+    let lowered = error_message.to_ascii_lowercase();
+    lowered.contains("containergroupquotareached")
+        || (lowered.contains("container group quota")
+            && lowered.contains("microsoft.containerinstance/containergroups"))
+        || lowered.contains("resource quota of container groups")
 }
 
 fn slack_thread_ts_from_thread_key(thread_key: Option<&str>) -> Option<String> {

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -23,6 +23,24 @@ impl TaskExecutor for NoopExecutor {
     }
 }
 
+struct FailingExecutor {
+    message: String,
+}
+
+impl FailingExecutor {
+    fn new(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+        }
+    }
+}
+
+impl TaskExecutor for FailingExecutor {
+    fn execute(&self, _task: &TaskKind) -> Result<TaskExecution, SchedulerError> {
+        Err(SchedulerError::TaskFailed(self.message.clone()))
+    }
+}
+
 fn base_run_task(workspace: &Path, mail_root: &Path) -> RunTaskTask {
     RunTaskTask {
         workspace_dir: workspace.to_path_buf(),
@@ -43,6 +61,23 @@ fn base_run_task(workspace: &Path, mail_root: &Path) -> RunTaskTask {
         slack_team_id: None,
         employee_id: None,
     }
+}
+
+fn force_one_shot_due<E: TaskExecutor>(scheduler: &mut Scheduler<E>, task_id: Uuid) {
+    let index = scheduler
+        .tasks
+        .iter()
+        .position(|task| task.id == task_id)
+        .expect("task exists");
+    scheduler.tasks[index].enabled = true;
+    scheduler.tasks[index].schedule = Schedule::OneShot {
+        run_at: Utc::now() - chrono::Duration::seconds(1),
+    };
+    let updated = scheduler.tasks[index].clone();
+    scheduler
+        .store
+        .update_task(&updated)
+        .expect("persist forced one-shot schedule");
 }
 
 #[test]
@@ -782,6 +817,72 @@ fn multiple_tasks_sync_independently() {
         assert!(task_1.error_message.is_none());
         assert_eq!(task_2.error_message, Some("timeout".to_string()));
     }
+}
+
+#[test]
+fn run_task_failures_persist_retry_count_and_disable_at_limit() {
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = temp.path().join("tasks.db");
+    let workspace = temp.path().join("workspace");
+    let mail_root = temp.path().join("mail");
+    fs::create_dir_all(&workspace).expect("workspace");
+    fs::create_dir_all(&mail_root).expect("mail");
+    let run_task = base_run_task(&workspace, &mail_root);
+    let quota_error = "ContainerGroupQuotaReached: container group quota reached";
+
+    let mut scheduler =
+        Scheduler::load(&tasks_db, FailingExecutor::new(quota_error)).expect("load scheduler");
+    let task_id = scheduler
+        .add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))
+        .expect("add run_task");
+    assert!(scheduler.execute_task_by_id(task_id).is_err());
+
+    let mut scheduler =
+        Scheduler::load(&tasks_db, FailingExecutor::new(quota_error)).expect("reload scheduler");
+    let first_retry_task = scheduler
+        .tasks()
+        .iter()
+        .find(|task| task.id == task_id)
+        .expect("task exists");
+    let first_retry_at = match first_retry_task.schedule {
+        Schedule::OneShot { run_at } => run_at,
+        _ => panic!("expected one-shot schedule"),
+    };
+    assert!(first_retry_task.enabled);
+    assert!(first_retry_at > Utc::now() + chrono::Duration::seconds(120));
+    assert_eq!(
+        scheduler
+            .get_retry_count(&task_id.to_string())
+            .expect("retry count"),
+        1
+    );
+
+    force_one_shot_due(&mut scheduler, task_id);
+    assert!(scheduler.execute_task_by_id(task_id).is_err());
+    assert_eq!(
+        scheduler
+            .get_retry_count(&task_id.to_string())
+            .expect("retry count"),
+        2
+    );
+
+    force_one_shot_due(&mut scheduler, task_id);
+    assert!(scheduler.execute_task_by_id(task_id).is_err());
+
+    let scheduler =
+        Scheduler::load(&tasks_db, FailingExecutor::new(quota_error)).expect("final reload");
+    let final_task = scheduler
+        .tasks()
+        .iter()
+        .find(|task| task.id == task_id)
+        .expect("final task exists");
+    assert!(!final_task.enabled);
+    assert_eq!(
+        scheduler
+            .get_retry_count(&task_id.to_string())
+            .expect("retry count"),
+        0
+    );
 }
 
 #[test]

--- a/DoWhiz_service/scheduler_module/src/service/scheduler.rs
+++ b/DoWhiz_service/scheduler_module/src/service/scheduler.rs
@@ -531,55 +531,16 @@ fn execute_due_task(
             Ok(())
         }
         Err(err) => {
-            // Task execution failed - increment retry count
-            error!(
-                "scheduler task failed task_id={} user_id={} error={}",
-                task_ref.task_id, task_ref.user_id, err
-            );
-
-            match scheduler.increment_retry_count(&task_ref.task_id) {
-                Ok(new_count) => {
-                    if new_count >= MAX_TASK_RETRIES {
-                        warn!(
-                            "Task {} exceeded max retries ({}), disabling task",
-                            task_ref.task_id, MAX_TASK_RETRIES
-                        );
-                        if let Err(disable_err) = scheduler.disable_task_by_id(&task_ref.task_id) {
-                            error!(
-                                "Failed to disable task {} after max retries: {}",
-                                task_ref.task_id, disable_err
-                            );
-                        }
-                    } else {
-                        // Apply exponential backoff before next retry
-                        let backoff_idx = (new_count as usize).saturating_sub(1);
-                        let backoff_secs = RETRY_BACKOFF_SECS
-                            .get(backoff_idx)
-                            .copied()
-                            .unwrap_or(RETRY_BACKOFF_SECS[RETRY_BACKOFF_SECS.len() - 1]);
-                        info!(
-                            "Task {} failed, retry {}/{}, backing off for {}s",
-                            task_ref.task_id, new_count, MAX_TASK_RETRIES, backoff_secs
-                        );
-                        thread::sleep(Duration::from_secs(backoff_secs));
-                    }
-                }
-                Err(retry_err) => {
-                    warn!(
-                        "Failed to increment retry count for task {}: {}",
-                        task_ref.task_id, retry_err
-                    );
-                }
-            }
-
-            // Sync index to reflect any state changes
-            if let Err(sync_err) = index_store.sync_user_tasks(&task_ref.user_id, scheduler.tasks()) {
+            if let Err(sync_err) = index_store.sync_user_tasks(&task_ref.user_id, scheduler.tasks())
+            {
                 warn!(
-                    "scheduler sync failed after task failure task_id={} user_id={} error={}",
+                    "scheduler sync failed after task error task_id={} user_id={} error={}",
                     task_ref.task_id, task_ref.user_id, sync_err
                 );
+            } else {
+                let summary = summarize_tasks(scheduler.tasks(), Utc::now());
+                log_task_snapshot(&task_ref.user_id, "after_execute_failed", &summary);
             }
-
             Err(Box::new(err))
         }
     }


### PR DESCRIPTION
## Summary\n- remove the staging/prod local execution fallback introduced for ACI quota errors\n- persist one-shot RunTask retry counts in storage and apply exponential backoff (quota-specific delays)\n- ensure scheduler syncs index state even when task execution errors\n- harden ACI lifecycle by retrying delete, waiting for deletion completion, and cleaning stale  containers when quota errors occur\n- update README to document that local execution stays blocked on staging/production\n\n## Validation\n- cargo fmt\n- cargo test -p run_task_module --lib\n- source .env.common/.env.staging && cargo test -p scheduler_module run_task_failures_persist_retry_count_and_disable_at_limit -- --nocapture\n- source .env.common/.env.staging && cargo test -p scheduler_module run_task_channel_is_preserved_in_sync -- --nocapture