### PR TITLE
fix(staging): enable discord route in gateway config

### DIFF
--- a/DoWhiz_service/gateway.staging.toml
+++ b/DoWhiz_service/gateway.staging.toml
@@ -8,6 +8,12 @@ key = "dowhiz@deep-tutor.com"
 employee_id = "boiled_egg"
 tenant_id = "staging"
 
+[[routes]]
+channel = "discord"
+key = "*"
+employee_id = "boiled_egg"
+tenant_id = "staging"
+
 # Google Workspace routing for staging (using dowhiz@deep-tutor.com account)
 [[routes]]
 channel = "google_docs"


### PR DESCRIPTION
## Summary
- add a staging Discord wildcard route in DoWhiz_service/gateway.staging.toml
- route Discord ingress to boiled_egg under staging tenant

## Why
- inbound gateway only starts Discord client when Discord routes are present
- staging config previously had no Discord routes, so Discord gateway startup was skipped

## Tests
- cargo test -p scheduler_module --bin inbound_gateway
