### PR TITLE
fix(slack): gate channel events and dedupe quick responses

### DIFF
--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 use scheduler_module::adapters::bluebubbles::BlueBubblesInboundAdapter;
 use scheduler_module::adapters::postmark::PostmarkInboundPayload;
 use scheduler_module::adapters::slack::{
-    is_url_verification, SlackChallengeResponse, SlackInboundAdapter,
+    is_url_verification, SlackChallengeResponse, SlackEventWrapper, SlackInboundAdapter,
 };
 use scheduler_module::adapters::telegram::TelegramInboundAdapter;
 use scheduler_module::adapters::whatsapp::WhatsAppInboundAdapter;
@@ -121,25 +121,19 @@ pub(super) async fn ingest_slack(
         return (StatusCode::UNAUTHORIZED, Json(json!({"status": reason})));
     }
 
-    let wrapper: serde_json::Value = match serde_json::from_slice(&body) {
+    let wrapper: SlackEventWrapper = match serde_json::from_slice(&body) {
         Ok(value) => value,
         Err(_) => return (StatusCode::BAD_REQUEST, Json(json!({"status": "bad_json"}))),
     };
 
     // Extract api_app_id for routing (each Slack app has unique app_id)
-    let api_app_id = wrapper
-        .get("api_app_id")
-        .and_then(|value| value.as_str())
-        .unwrap_or("");
+    let api_app_id = wrapper.api_app_id.as_deref().unwrap_or("");
     if api_app_id.is_empty() {
         info!("gateway no api_app_id in slack payload");
         return (StatusCode::OK, Json(json!({"status": "no_route"})));
     }
 
-    let event_id = wrapper
-        .get("event_id")
-        .and_then(|value| value.as_str())
-        .map(|value| value.to_string());
+    let event_id = wrapper.event_id.clone();
 
     let Some(route) = resolve_route(Channel::Slack, api_app_id, &state) else {
         info!("gateway no route for slack api_app_id={}", api_app_id);
@@ -151,7 +145,20 @@ pub(super) async fn ingest_slack(
         api_app_id, route.employee_id
     );
 
-    let adapter = SlackInboundAdapter::new(HashSet::new());
+    let bot_user_id = resolve_slack_bot_user_id_for_employee(&route.employee_id);
+    if !should_enqueue_slack_message(&wrapper, bot_user_id.as_deref()) {
+        info!(
+            "gateway ignoring slack event for employee={} api_app_id={} (not dm/app_mention/mention)",
+            route.employee_id, api_app_id
+        );
+        return (StatusCode::OK, Json(json!({"status": "ignored"})));
+    }
+
+    let mut bot_user_ids = HashSet::new();
+    if let Some(id) = bot_user_id {
+        bot_user_ids.insert(id);
+    }
+    let adapter = SlackInboundAdapter::new(bot_user_ids);
     let message = match adapter.parse(&body) {
         Ok(message) => message,
         Err(err) => {
@@ -171,6 +178,50 @@ pub(super) async fn ingest_slack(
         }
     };
     enqueue_envelope(state.queue.clone(), envelope).await
+}
+
+fn resolve_slack_bot_user_id_for_employee(employee_id: &str) -> Option<String> {
+    let employee_env = employee_id.to_uppercase().replace('-', "_");
+    let employee_key = format!("{}_SLACK_BOT_USER_ID", employee_env);
+
+    std::env::var(&employee_key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var("SLACK_BOT_USER_ID")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+}
+
+fn should_enqueue_slack_message(wrapper: &SlackEventWrapper, bot_user_id: Option<&str>) -> bool {
+    let Some(event) = wrapper.event.as_ref() else {
+        return false;
+    };
+    if event.subtype.is_some() {
+        return false;
+    }
+
+    match event.event_type.as_str() {
+        "app_mention" => true,
+        "message" => {
+            if matches!(event.channel_type.as_deref(), Some("im") | Some("mpim")) {
+                return true;
+            }
+            let Some(bot_user_id) = bot_user_id else {
+                return false;
+            };
+            let mention = format!("<@{}>", bot_user_id.trim());
+            event
+                .text
+                .as_deref()
+                .map(|text| text.contains(&mention))
+                .unwrap_or(false)
+        }
+        _ => false,
+    }
 }
 
 pub(super) async fn ingest_bluebubbles(
@@ -715,6 +766,7 @@ pub(super) async fn build_envelope(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use scheduler_module::adapters::slack::{SlackEventWrapper, SlackMessageEvent};
     use scheduler_module::channel::Attachment;
 
     #[test]
@@ -787,6 +839,93 @@ mod tests {
         };
         let payload = build_queue_payload(Channel::Slack, &message);
         assert_eq!(payload.attachments.len(), 1);
+    }
+
+    #[test]
+    fn should_enqueue_slack_message_accepts_app_mention() {
+        let wrapper = SlackEventWrapper {
+            event_type: "event_callback".to_string(),
+            challenge: None,
+            token: None,
+            team_id: Some("T1".to_string()),
+            api_app_id: Some("A1".to_string()),
+            event: Some(SlackMessageEvent {
+                event_type: "app_mention".to_string(),
+                subtype: None,
+                channel: Some("C1".to_string()),
+                user: Some("U1".to_string()),
+                text: Some("<@B1> hi".to_string()),
+                ts: "1.01".to_string(),
+                thread_ts: None,
+                bot_id: None,
+                app_id: None,
+                files: None,
+                channel_type: Some("channel".to_string()),
+                event_ts: None,
+            }),
+            event_id: Some("Ev1".to_string()),
+            event_time: None,
+        };
+
+        assert!(should_enqueue_slack_message(&wrapper, Some("B1")));
+    }
+
+    #[test]
+    fn should_enqueue_slack_message_rejects_channel_message_without_bot_mention() {
+        let wrapper = SlackEventWrapper {
+            event_type: "event_callback".to_string(),
+            challenge: None,
+            token: None,
+            team_id: Some("T1".to_string()),
+            api_app_id: Some("A1".to_string()),
+            event: Some(SlackMessageEvent {
+                event_type: "message".to_string(),
+                subtype: None,
+                channel: Some("C1".to_string()),
+                user: Some("U1".to_string()),
+                text: Some("hello world".to_string()),
+                ts: "1.02".to_string(),
+                thread_ts: None,
+                bot_id: None,
+                app_id: None,
+                files: None,
+                channel_type: Some("channel".to_string()),
+                event_ts: None,
+            }),
+            event_id: Some("Ev2".to_string()),
+            event_time: None,
+        };
+
+        assert!(!should_enqueue_slack_message(&wrapper, Some("B1")));
+    }
+
+    #[test]
+    fn should_enqueue_slack_message_accepts_dm_message() {
+        let wrapper = SlackEventWrapper {
+            event_type: "event_callback".to_string(),
+            challenge: None,
+            token: None,
+            team_id: Some("T1".to_string()),
+            api_app_id: Some("A1".to_string()),
+            event: Some(SlackMessageEvent {
+                event_type: "message".to_string(),
+                subtype: None,
+                channel: Some("D1".to_string()),
+                user: Some("U1".to_string()),
+                text: Some("hello in dm".to_string()),
+                ts: "1.03".to_string(),
+                thread_ts: None,
+                bot_id: None,
+                app_id: None,
+                files: None,
+                channel_type: Some("im".to_string()),
+                event_ts: None,
+            }),
+            event_id: Some("Ev3".to_string()),
+            event_time: None,
+        };
+
+        assert!(should_enqueue_slack_message(&wrapper, None));
     }
 }
 

--- a/DoWhiz_service/scheduler_module/src/service/inbound/quick_responses.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/quick_responses.rs
@@ -25,6 +25,23 @@ use super::persist_discord_ingest_context;
 const DISCORD_QUICK_RESPONSE_DEDUPE_FILE: &str = "discord_quick_response_dedupe.json";
 const DISCORD_QUICK_RESPONSE_MAX_THREADS: usize = 512;
 const DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD: usize = 256;
+const SLACK_QUICK_RESPONSE_DEDUPE_FILE: &str = "slack_quick_response_dedupe.json";
+const SLACK_QUICK_RESPONSE_MAX_THREADS: usize = 512;
+const SLACK_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD: usize = 256;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct SlackQuickResponseDedupeStore {
+    #[serde(default)]
+    threads: HashMap<String, SlackQuickResponseThreadStore>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct SlackQuickResponseThreadStore {
+    #[serde(default)]
+    message_ids: Vec<String>,
+    #[serde(default)]
+    updated_at_unix_secs: i64,
+}
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct DiscordQuickResponseDedupeStore {
@@ -100,6 +117,113 @@ fn write_memory_update(
     global_memory_queue()
         .submit(request)
         .map_err(|e| e.to_string())
+}
+
+fn slack_quick_response_dedupe_path(state_dir: &Path) -> std::path::PathBuf {
+    state_dir.join(SLACK_QUICK_RESPONSE_DEDUPE_FILE)
+}
+
+fn slack_quick_response_scope_key(message: &crate::channel::InboundMessage) -> Option<String> {
+    let channel_id = message.metadata.slack_channel_id.as_deref()?;
+    let team = message
+        .metadata
+        .slack_team_id
+        .as_deref()
+        .unwrap_or("unknown");
+    Some(format!(
+        "slack:{}:{}:{}",
+        team, channel_id, message.thread_id
+    ))
+}
+
+fn slack_inbound_message_id(message: &crate::channel::InboundMessage) -> Option<&str> {
+    message.message_id.as_deref()
+}
+
+fn slack_quick_response_already_sent(state_dir: &Path, scope_key: &str, message_id: &str) -> bool {
+    let path = slack_quick_response_dedupe_path(state_dir);
+    let store = load_slack_quick_response_dedupe_store(&path);
+    store
+        .threads
+        .get(scope_key)
+        .map(|thread| thread.message_ids.iter().any(|entry| entry == message_id))
+        .unwrap_or(false)
+}
+
+fn record_slack_quick_response_sent(
+    state_dir: &Path,
+    scope_key: &str,
+    message_id: &str,
+) -> Result<(), BoxError> {
+    let path = slack_quick_response_dedupe_path(state_dir);
+    let mut store = load_slack_quick_response_dedupe_store(&path);
+
+    let thread = store.threads.entry(scope_key.to_string()).or_default();
+    if !thread.message_ids.iter().any(|entry| entry == message_id) {
+        thread.message_ids.push(message_id.to_string());
+    }
+    let overflow = thread
+        .message_ids
+        .len()
+        .saturating_sub(SLACK_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD);
+    if overflow > 0 {
+        thread.message_ids.drain(0..overflow);
+    }
+    thread.updated_at_unix_secs = now_unix_secs();
+
+    prune_slack_quick_response_store(&mut store);
+    write_slack_quick_response_dedupe_store(&path, &store)?;
+    Ok(())
+}
+
+fn load_slack_quick_response_dedupe_store(path: &Path) -> SlackQuickResponseDedupeStore {
+    let Ok(raw) = std::fs::read(path) else {
+        return SlackQuickResponseDedupeStore::default();
+    };
+    match serde_json::from_slice::<SlackQuickResponseDedupeStore>(&raw) {
+        Ok(store) => store,
+        Err(err) => {
+            warn!(
+                "failed to parse slack quick response dedupe store at {}: {}",
+                path.display(),
+                err
+            );
+            SlackQuickResponseDedupeStore::default()
+        }
+    }
+}
+
+fn write_slack_quick_response_dedupe_store(
+    path: &Path,
+    store: &SlackQuickResponseDedupeStore,
+) -> Result<(), BoxError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
+    let serialized = serde_json::to_vec_pretty(store)?;
+    std::fs::write(&tmp, serialized)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+fn prune_slack_quick_response_store(store: &mut SlackQuickResponseDedupeStore) {
+    if store.threads.len() <= SLACK_QUICK_RESPONSE_MAX_THREADS {
+        return;
+    }
+    let mut thread_by_age = store
+        .threads
+        .iter()
+        .map(|(key, value)| (key.clone(), value.updated_at_unix_secs))
+        .collect::<Vec<_>>();
+    thread_by_age.sort_by_key(|(_, updated_at)| *updated_at);
+    let overflow = store
+        .threads
+        .len()
+        .saturating_sub(SLACK_QUICK_RESPONSE_MAX_THREADS);
+    for (key, _) in thread_by_age.into_iter().take(overflow) {
+        store.threads.remove(&key);
+    }
 }
 
 fn discord_quick_response_dedupe_path(state_dir: &Path) -> std::path::PathBuf {
@@ -244,6 +368,18 @@ pub(crate) fn try_quick_response_slack(
     let user = user_store.get_or_create_user("slack", &message.sender)?;
     let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
     let memory = read_user_memo(runtime, account_id, &user_paths.memory_dir);
+    let dedupe_scope = slack_quick_response_scope_key(message);
+    let inbound_message_id = slack_inbound_message_id(message);
+
+    if let (Some(scope), Some(inbound_id)) = (dedupe_scope.as_deref(), inbound_message_id) {
+        if slack_quick_response_already_sent(&user_paths.state_dir, scope, inbound_id) {
+            info!(
+                "slack quick response dedupe hit employee={} sender={} scope={} message_id={}",
+                config.employee_profile.id, message.sender, scope, inbound_id
+            );
+            return Ok(true);
+        }
+    }
 
     let cleaned_text = text
         .split_whitespace()
@@ -289,6 +425,20 @@ pub(crate) fn try_quick_response_slack(
                     ))
                     .is_ok()
                 {
+                    if let (Some(scope), Some(inbound_id)) =
+                        (dedupe_scope.as_deref(), inbound_message_id)
+                    {
+                        if let Err(err) = record_slack_quick_response_sent(
+                            &user_paths.state_dir,
+                            scope,
+                            inbound_id,
+                        ) {
+                            warn!(
+                                "failed to record slack quick response dedupe key scope={} message_id={}: {}",
+                                scope, inbound_id, err
+                            );
+                        }
+                    }
                     return Ok(true);
                 }
             }
@@ -746,6 +896,33 @@ mod tests {
     use crate::channel::{Channel, ChannelMetadata, InboundMessage};
     use tempfile::TempDir;
 
+    fn build_slack_message(
+        thread_id: &str,
+        message_id: Option<&str>,
+        team_id: Option<&str>,
+        channel_id: Option<&str>,
+    ) -> InboundMessage {
+        InboundMessage {
+            channel: Channel::Slack,
+            sender: "U1234".to_string(),
+            sender_name: Some("Bingran".to_string()),
+            recipient: "C1234".to_string(),
+            subject: None,
+            text_body: Some("Hi".to_string()),
+            html_body: None,
+            thread_id: thread_id.to_string(),
+            message_id: message_id.map(str::to_string),
+            attachments: Vec::new(),
+            reply_to: Vec::new(),
+            raw_payload: Vec::new(),
+            metadata: ChannelMetadata {
+                slack_team_id: team_id.map(str::to_string),
+                slack_channel_id: channel_id.map(str::to_string),
+                ..Default::default()
+            },
+        }
+    }
+
     fn build_discord_message(
         thread_id: &str,
         message_id: Option<&str>,
@@ -839,5 +1016,41 @@ mod tests {
 
         let message_id = discord_inbound_message_id(&message).expect("message id");
         assert_eq!(message_id, "meta-msg-id");
+    }
+
+    #[test]
+    fn slack_quick_response_dedupe_records_and_matches() -> Result<(), BoxError> {
+        let temp = TempDir::new()?;
+        let state_dir = temp.path().join("state");
+        let scope = "slack:T123:C123:thread-1";
+        let message_id = "1712345678.000100";
+
+        assert!(!slack_quick_response_already_sent(
+            &state_dir, scope, message_id
+        ));
+
+        record_slack_quick_response_sent(&state_dir, scope, message_id)?;
+
+        assert!(slack_quick_response_already_sent(
+            &state_dir, scope, message_id
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn slack_scope_key_uses_team_channel_thread() {
+        let message = build_slack_message(
+            "1712345678.000100",
+            Some("1712345678.000100"),
+            Some("T123"),
+            Some("C123"),
+        );
+
+        let scope = slack_quick_response_scope_key(&message).expect("scope key");
+        assert_eq!(scope, "slack:T123:C123:1712345678.000100");
+
+        let message_id = slack_inbound_message_id(&message).expect("message id");
+        assert_eq!(message_id, "1712345678.000100");
     }
 }


### PR DESCRIPTION
## Summary
- gate Slack ingress handling so channel `message` events are ignored unless they are DMs or explicitly mention the target bot user
- keep `app_mention` events enabled
- add persistent Slack quick-response dedupe (per user state dir) keyed by team/channel/thread/message-id
- add unit tests for Slack ingress gating and Slack dedupe helpers

## Root Cause Addressed
- bots could reply on generic channel messages not targeted at them
- duplicated inbound processing could trigger repeated quick replies for the same Slack message

## Tests
- cargo test -p scheduler_module --bin inbound_gateway
- cargo test -p scheduler_module slack_quick_response
- cargo test -p scheduler_module slack_scope_key_uses_team_channel_thread
