### PR TITLE
Align ngrok usage with local-only VM policy

### DIFF
--- a/DoWhiz_service/OPERATIONS.md
+++ b/DoWhiz_service/OPERATIONS.md
@@ -21,6 +21,7 @@ Runtime environment policy:
 - VM `.env` is generated from `ENV_COMMON + ENV_STAGING/ENV_PROD` in CI/CD.
 - Runtime `.env` must not include `STAGING_*`/`PROD_*` keys.
 - `DEPLOY_TARGET` is optional and used for runtime policy decisions.
+- `POSTMARK_INBOUND_HOOK_URL` should point to the VM public endpoint; ngrok is local-only and should not run on staging/production VMs.
 
 ## 2) Expected Config Selection
 
@@ -56,8 +57,10 @@ PM2 logs (if PM2-managed):
 ```bash
 cd /home/azureuser/server/.dowhiz/DoWhiz
 ./DoWhiz_service/scripts/run_gateway_local.sh
-./DoWhiz_service/scripts/run_employee.sh little_bear 9001 --skip-hook --skip-ngrok
+./DoWhiz_service/scripts/run_employee.sh <employee_id> 9001 --skip-hook --skip-ngrok
 ```
+
+Use `boiled_egg` on staging and `little_bear` on production.
 
 ### 4.2 PM2-based (recommended on VM)
 

--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -71,9 +71,9 @@ Key scripts:
 | Script | Purpose |
 |---|---|
 | `scripts/run_gateway_local.sh` | Start `inbound_gateway` |
-| `scripts/run_employee.sh` | Start `rust_service` for one employee (optional ngrok/hook) |
-| `scripts/start_all.sh` | Convenience local stack bootstrap (gateway + worker + ngrok + hook) |
-| `scripts/run_e2e.sh` | Live email E2E harness |
+| `scripts/run_employee.sh` | Start `rust_service` for one employee (uses configured public hook URL; ngrok optional for local only) |
+| `scripts/start_all.sh` | Local-only stack bootstrap (gateway + worker + ngrok + hook) |
+| `scripts/run_e2e.sh` | Live email E2E harness (uses `POSTMARK_TEST_HOOK_URL`/`POSTMARK_INBOUND_HOOK_URL` when available) |
 | `scripts/ensure_aci_share_mount.sh` | Validate/mount Azure Files for ACI backend |
 
 ## 3) Config Files
@@ -255,6 +255,9 @@ Runtime env policy:
 Expected config selections:
 - staging: `GATEWAY_CONFIG_PATH=gateway.staging.toml`, `EMPLOYEE_CONFIG_PATH=employee.staging.toml`
 - production: `GATEWAY_CONFIG_PATH=gateway.toml`, `EMPLOYEE_CONFIG_PATH=employee.toml`
+- staging expected worker identity: `boiled_egg`
+- production expected worker identity: `little_bear`
+- on staging/production VMs, use existing public webhook endpoint (`POSTMARK_INBOUND_HOOK_URL`) and do not run ngrok
 
 Use these runbooks:
 - `DoWhiz_service/OPERATIONS.md`
@@ -286,6 +289,8 @@ Full email E2E helper script:
 ```bash
 ./DoWhiz_service/scripts/run_e2e.sh
 ```
+
+On staging/production, prefer configured public hook URL via `POSTMARK_TEST_HOOK_URL` or `POSTMARK_INBOUND_HOOK_URL` (or pass `--public-url`) and keep ngrok disabled.
 
 Manual live run example:
 

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -53,7 +53,8 @@ cd /home/azureuser/server/.dowhiz/DoWhiz
 git fetch origin
 git checkout dev
 git pull --ff-only origin dev
-./DoWhiz_service/scripts/start_all.sh
+./DoWhiz_service/scripts/run_gateway_local.sh
+./DoWhiz_service/scripts/run_employee.sh boiled_egg 9001 --skip-hook --skip-ngrok
 ```
 
 ### Production (`main`)
@@ -66,6 +67,8 @@ git pull --ff-only origin main
 ./DoWhiz_service/scripts/run_gateway_local.sh
 ./DoWhiz_service/scripts/run_employee.sh little_bear 9001 --skip-hook --skip-ngrok
 ```
+
+Do not use `scripts/start_all.sh` on staging/production VMs; it is local-only and will start ngrok plus rewrite Postmark inbound hook.
 
 ## 4) CI/CD Expectations
 

--- a/DoWhiz_service/employees/boiled_egg/AGENTS.md
+++ b/DoWhiz_service/employees/boiled_egg/AGENTS.md
@@ -13,8 +13,9 @@ Runtime state lives under `.workspace/` (Mongo-backed state, user archives, and 
 - `cargo build`: build the full workspace.
 - `cargo test`: run all unit and integration tests.
 - `cargo run -p scheduler_module --bin rust_service -- --host 0.0.0.0 --port 9001`: start the service locally.
-- `ngrok http 9001`: expose the service for Postmark inbound webhooks.
-- `cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://<ngrok>/postmark/inbound`: update Postmark to the new URL.
+- `(Local only) ngrok http 9001`: expose the service for Postmark inbound webhook tests.
+- `(Staging/Prod) use existing public endpoint via POSTMARK_INBOUND_HOOK_URL; do not run ngrok on VM.`
+- `cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://<public-domain>/postmark/inbound`: update Postmark to the target public URL.
 - `RUST_SERVICE_LIVE_TEST=1 POSTMARK_INBOUND_HOOK_URL=... POSTMARK_TEST_FROM=... cargo test -p scheduler_module --test service_real_email -- --nocapture`: run the real email end-to-end test.
 
 ## Coding Style & Naming Conventions

--- a/DoWhiz_service/employees/little_bear/AGENTS.md
+++ b/DoWhiz_service/employees/little_bear/AGENTS.md
@@ -13,8 +13,9 @@ Runtime state lives under `.workspace/` (Mongo-backed state, user archives, and 
 - `cargo build`: build the full workspace.
 - `cargo test`: run all unit and integration tests.
 - `cargo run -p scheduler_module --bin rust_service -- --host 0.0.0.0 --port 9001`: start the service locally.
-- `ngrok http 9001`: expose the service for Postmark inbound webhooks.
-- `cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://<ngrok>/postmark/inbound`: update Postmark to the new URL.
+- `(Local only) ngrok http 9001`: expose the service for Postmark inbound webhook tests.
+- `(Staging/Prod) use existing public endpoint via POSTMARK_INBOUND_HOOK_URL; do not run ngrok on VM.`
+- `cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://<public-domain>/postmark/inbound`: update Postmark to the target public URL.
 - `RUST_SERVICE_LIVE_TEST=1 POSTMARK_INBOUND_HOOK_URL=... POSTMARK_TEST_FROM=... cargo test -p scheduler_module --test service_real_email -- --nocapture`: run the real email end-to-end test.
 
 ## Coding Style & Naming Conventions

--- a/DoWhiz_service/employees/mini_mouse/AGENTS.md
+++ b/DoWhiz_service/employees/mini_mouse/AGENTS.md
@@ -13,8 +13,9 @@ Runtime state lives under `.workspace/` (Mongo-backed state, user archives, and 
 - `cargo build`: build the full workspace.
 - `cargo test`: run all unit and integration tests.
 - `cargo run -p scheduler_module --bin rust_service -- --host 0.0.0.0 --port 9001`: start the service locally.
-- `ngrok http 9001`: expose the service for Postmark inbound webhooks.
-- `cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://<ngrok>/postmark/inbound`: update Postmark to the new URL.
+- `(Local only) ngrok http 9001`: expose the service for Postmark inbound webhook tests.
+- `(Staging/Prod) use existing public endpoint via POSTMARK_INBOUND_HOOK_URL; do not run ngrok on VM.`
+- `cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://<public-domain>/postmark/inbound`: update Postmark to the target public URL.
 - `RUST_SERVICE_LIVE_TEST=1 POSTMARK_INBOUND_HOOK_URL=... POSTMARK_TEST_FROM=... cargo test -p scheduler_module --test service_real_email -- --nocapture`: run the real email end-to-end test.
 
 ## Coding Style & Naming Conventions

--- a/DoWhiz_service/employees/sticky_octopus/AGENTS.md
+++ b/DoWhiz_service/employees/sticky_octopus/AGENTS.md
@@ -13,8 +13,9 @@ Runtime state lives under `.workspace/` (Mongo-backed state, user archives, and 
 - `cargo build`: build the full workspace.
 - `cargo test`: run all unit and integration tests.
 - `cargo run -p scheduler_module --bin rust_service -- --host 0.0.0.0 --port 9001`: start the service locally.
-- `ngrok http 9001`: expose the service for Postmark inbound webhooks.
-- `cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://<ngrok>/postmark/inbound`: update Postmark to the new URL.
+- `(Local only) ngrok http 9001`: expose the service for Postmark inbound webhook tests.
+- `(Staging/Prod) use existing public endpoint via POSTMARK_INBOUND_HOOK_URL; do not run ngrok on VM.`
+- `cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://<public-domain>/postmark/inbound`: update Postmark to the target public URL.
 - `RUST_SERVICE_LIVE_TEST=1 POSTMARK_INBOUND_HOOK_URL=... POSTMARK_TEST_FROM=... cargo test -p scheduler_module --test service_real_email -- --nocapture`: run the real email end-to-end test.
 
 ## Coding Style & Naming Conventions

--- a/DoWhiz_service/scheduler_module/src/bin/set_postmark_inbound_hook.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/set_postmark_inbound_hook.rs
@@ -27,7 +27,7 @@ fn help_text() -> String {
         "Set Postmark inbound hook URL",
         "",
         "Usage:",
-        "  cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://YOUR-NGROK-URL.ngrok-free.dev/postmark/inbound",
+        "  cargo run -p scheduler_module --bin set_postmark_inbound_hook -- --hook-url https://YOUR-PUBLIC-DOMAIN/postmark/inbound",
         "",
         "Environment:",
         "  POSTMARK_SERVER_TOKEN (required)",

--- a/DoWhiz_service/scheduler_module/tests/service_real_email.rs
+++ b/DoWhiz_service/scheduler_module/tests/service_real_email.rs
@@ -22,7 +22,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
-const DEFAULT_NGROK_HOOK_URL: &str =
+const DEFAULT_PUBLIC_HOOK_URL: &str =
     "https://shayne-laminar-lillian.ngrok-free.dev/postmark/inbound";
 const E2E_ATTACHMENT_NAME: &str = "e2e_note.txt";
 const E2E_ATTACHMENT_CONTENT: &[u8] = b"dowhiz-e2e-attachment";
@@ -157,7 +157,7 @@ fn resolve_postmark_hook_url() -> String {
             return trimmed.to_string();
         }
     }
-    DEFAULT_NGROK_HOOK_URL.to_string()
+    DEFAULT_PUBLIC_HOOK_URL.to_string()
 }
 
 fn env_with_scale_oliver(key: &str) -> Option<String> {
@@ -506,7 +506,7 @@ fn check_public_health(base_url: &str, local_host: &str, port: u16) -> Result<()
     match response {
         Ok(response) if response.status().is_success() => Ok(()),
         Ok(response) => Err(format!(
-            "public health check failed: {} {} (ensure ngrok forwards to http://{}:{})",
+            "public health check failed: {} {} (ensure public endpoint forwards to http://{}:{})",
             response.status(),
             health_url,
             local_host,
@@ -514,7 +514,7 @@ fn check_public_health(base_url: &str, local_host: &str, port: u16) -> Result<()
         )
         .into()),
         Err(err) => Err(format!(
-            "public health check error: {} {} (ensure ngrok forwards to http://{}:{})",
+            "public health check error: {} {} (ensure public endpoint forwards to http://{}:{})",
             err, health_url, local_host, port
         )
         .into()),

--- a/DoWhiz_service/scripts/run_e2e.sh
+++ b/DoWhiz_service/scripts/run_e2e.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Run the live Rust email service E2E test with ngrok.
+Run the live Rust email service E2E test with a public inbound hook URL.
 
 Usage:
   scripts/run_e2e.sh [--port <port>] [--public-url <url>] [--skip-ngrok]
@@ -11,7 +11,8 @@ Usage:
 Options:
   --port, -p       Port to bind (default: 9001)
   --public-url     Public base URL (or full /postmark/inbound). Skips ngrok.
-  --skip-ngrok     Do not start ngrok (requires --public-url).
+                   If omitted, POSTMARK_TEST_HOOK_URL/POSTMARK_INBOUND_HOOK_URL are used when set.
+  --skip-ngrok     Do not start ngrok (requires --public-url or env hook URL).
   --help, -h       Show this help.
 
 Examples:
@@ -139,15 +140,35 @@ PY
 
 cd "$service_root"
 
+deploy_target="$(echo "${DEPLOY_TARGET:-}" | tr '[:upper:]' '[:lower:]')"
 hook_base_url=""
 if [[ -n "$public_url" ]]; then
   hook_base_url="$public_url"
   skip_ngrok="true"
 fi
 
+if [[ -z "$hook_base_url" ]] && [[ -n "${POSTMARK_TEST_HOOK_URL:-}" ]]; then
+  hook_base_url="${POSTMARK_TEST_HOOK_URL}"
+  skip_ngrok="true"
+fi
+
+if [[ -z "$hook_base_url" ]] && [[ -n "${POSTMARK_INBOUND_HOOK_URL:-}" ]]; then
+  hook_base_url="${POSTMARK_INBOUND_HOOK_URL}"
+  skip_ngrok="true"
+fi
+
+if [[ "$skip_ngrok" != "true" ]] && [[ "$deploy_target" == "staging" || "$deploy_target" == "production" ]]; then
+  echo "DEPLOY_TARGET=${deploy_target}: skipping ngrok and expecting configured public hook URL."
+  skip_ngrok="true"
+fi
+
 if [[ "$skip_ngrok" != "true" ]]; then
   if ! command -v ngrok >/dev/null 2>&1; then
-    echo "ngrok not found. Install ngrok or pass --public-url to skip it." >&2
+    echo "ngrok not found. Install ngrok or set --public-url/POSTMARK_TEST_HOOK_URL/POSTMARK_INBOUND_HOOK_URL." >&2
+    exit 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 not found. Install python3 or set --public-url/POSTMARK_TEST_HOOK_URL/POSTMARK_INBOUND_HOOK_URL." >&2
     exit 1
   fi
   echo "Starting ngrok on port ${port}..."
@@ -163,7 +184,7 @@ if [[ "$skip_ngrok" != "true" ]]; then
 fi
 
 if [[ -z "$hook_base_url" ]]; then
-  echo "No public URL available. Pass --public-url or remove --skip-ngrok." >&2
+  echo "No public URL available. Provide --public-url or set POSTMARK_TEST_HOOK_URL/POSTMARK_INBOUND_HOOK_URL." >&2
   exit 1
 fi
 

--- a/DoWhiz_service/scripts/run_employee.sh
+++ b/DoWhiz_service/scripts/run_employee.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Run the Rust email service for a single employee with optional ngrok + Postmark hook.
+Run the Rust email service for a single employee with optional Postmark hook update.
 
 Usage:
   scripts/run_employee.sh <employee_id> [port]
@@ -14,8 +14,9 @@ Options:
   --port, -p       Port to bind (default: 9001)
   --host           Host to bind (default: 0.0.0.0)
   --public-url     Public base URL (or full /postmark/inbound). Skips ngrok.
+                   If omitted, POSTMARK_INBOUND_HOOK_URL is used when set.
   --skip-hook      Do not update Postmark inbound hook.
-  --skip-ngrok     Do not start ngrok (requires --public-url or --skip-hook).
+  --skip-ngrok     Do not start ngrok (local-only fallback).
   --help, -h       Show this help.
 
 Examples:
@@ -156,9 +157,20 @@ PY
 
 cd "$service_root"
 
+deploy_target="$(echo "${DEPLOY_TARGET:-}" | tr '[:upper:]' '[:lower:]')"
 hook_base_url=""
 if [[ -n "$public_url" ]]; then
   hook_base_url="$public_url"
+  skip_ngrok="true"
+fi
+
+if [[ -z "$hook_base_url" ]] && [[ -n "${POSTMARK_INBOUND_HOOK_URL:-}" ]]; then
+  hook_base_url="${POSTMARK_INBOUND_HOOK_URL}"
+  skip_ngrok="true"
+fi
+
+if [[ "$skip_ngrok" != "true" ]] && [[ "$deploy_target" == "staging" || "$deploy_target" == "production" ]]; then
+  echo "DEPLOY_TARGET=${deploy_target}: skipping ngrok and expecting configured public hook URL."
   skip_ngrok="true"
 fi
 
@@ -168,11 +180,11 @@ fi
 
 if [[ "$skip_ngrok" != "true" ]]; then
   if ! command -v ngrok >/dev/null 2>&1; then
-    echo "ngrok not found. Install ngrok or pass --public-url to skip it." >&2
+    echo "ngrok not found. Install ngrok or set --public-url/POSTMARK_INBOUND_HOOK_URL." >&2
     exit 1
   fi
   if ! command -v python3 >/dev/null 2>&1; then
-    echo "python3 not found. Install python3 or pass --public-url to skip ngrok." >&2
+    echo "python3 not found. Install python3 or set --public-url/POSTMARK_INBOUND_HOOK_URL." >&2
     exit 1
   fi
 
@@ -204,7 +216,7 @@ if [[ -n "$hook_base_url" ]]; then
   fi
 else
   if [[ "$skip_hook" != "true" ]]; then
-    echo "No public URL available for hook. Pass --public-url or remove --skip-ngrok." >&2
+    echo "No public URL available for hook. Set --public-url, POSTMARK_INBOUND_HOOK_URL, or use --skip-hook." >&2
     exit 1
   fi
 fi

--- a/DoWhiz_service/scripts/setup_postmark_webhook.sh
+++ b/DoWhiz_service/scripts/setup_postmark_webhook.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Setup Postmark inbound webhook with ngrok
+# Setup Postmark inbound webhook with ngrok (local debugging helper)
 # Usage: ./scripts/setup_postmark_webhook.sh [gateway_port]
 
 PORT="${1:-9100}"
@@ -10,6 +10,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Load .env.
 # shellcheck source=./load_env_target.sh
 source "${SCRIPT_DIR}/load_env_target.sh"
+
+DEPLOY_TARGET_NORMALIZED="$(echo "${DEPLOY_TARGET:-}" | tr '[:upper:]' '[:lower:]')"
+if [[ "$DEPLOY_TARGET_NORMALIZED" == "staging" || "$DEPLOY_TARGET_NORMALIZED" == "production" ]]; then
+    echo "ERROR: setup_postmark_webhook.sh is local-only because it rewrites Postmark to an ngrok URL."
+    echo "Set POSTMARK_INBOUND_HOOK_URL to your VM public endpoint and use set_postmark_inbound_hook instead."
+    exit 1
+fi
 
 POSTMARK_TOKEN="${POSTMARK_SERVER_TOKEN:-}"
 

--- a/DoWhiz_service/scripts/start_all.sh
+++ b/DoWhiz_service/scripts/start_all.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# DoWhiz 服务一键启动脚本
+# DoWhiz 本地一键启动脚本（仅本地调试）
 # 启动顺序：Gateway → Worker → Ngrok → 更新 Postmark Webhook
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,6 +11,16 @@ SERVICE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=./load_env_target.sh
 source "${SCRIPT_DIR}/load_env_target.sh"
 echo "✓ 已加载环境变量: ${ENV_FILE:-<shell environment only>}"
+
+DEPLOY_TARGET_NORMALIZED="$(echo "${DEPLOY_TARGET:-}" | tr '[:upper:]' '[:lower:]')"
+if [[ "$DEPLOY_TARGET_NORMALIZED" == "staging" || "$DEPLOY_TARGET_NORMALIZED" == "production" ]]; then
+    echo "✗ start_all.sh 仅用于本地调试：它会启动 ngrok 并改写 Postmark inbound hook。"
+    echo "  staging/production 请改用："
+    echo "  ./DoWhiz_service/scripts/run_gateway_local.sh"
+    echo "  ./DoWhiz_service/scripts/run_employee.sh <employee_id> 9001 --skip-hook --skip-ngrok"
+    echo "  (staging: boiled_egg, production: little_bear)"
+    exit 1
+fi
 
 # Azure ACI backend requires VM-side shared mount before worker starts.
 "${SCRIPT_DIR}/ensure_aci_share_mount.sh"

--- a/DoWhiz_service/scripts/status.sh
+++ b/DoWhiz_service/scripts/status.sh
@@ -26,7 +26,7 @@ if pgrep -f "ngrok http" > /dev/null; then
     NGROK_URL=$(curl -s http://127.0.0.1:4040/api/tunnels 2>/dev/null | python3 -c "import sys,json; print([t['public_url'] for t in json.load(sys.stdin).get('tunnels',[]) if t.get('public_url','').startswith('https')][0])" 2>/dev/null || echo "无法获取")
     echo "✅ Ngrok:   运行中 → $NGROK_URL"
 else
-    echo "❌ Ngrok:   未运行"
+    echo "Ngrok:      未运行（可选，本地 webhook 调试时才需要）"
 fi
 
 # 2. 健康检查
@@ -56,5 +56,5 @@ echo ""
 echo "=========================================="
 echo "监控命令："
 echo "  实时日志: tail -f $SERVICE_DIR/worker.log"
-echo "  Ngrok:    http://127.0.0.1:4040"
+echo "  Ngrok(可选): http://127.0.0.1:4040"
 echo "=========================================="

--- a/reference_documentation/test_plans/DoWhiz_service_tests.md
+++ b/reference_documentation/test_plans/DoWhiz_service_tests.md
@@ -45,7 +45,7 @@ Status legend:
 
 | Test ID | Command / Script | Scope | Required Env |
 |---|---|---|---|
-| LIVE-SCH-01 | `cargo test -p scheduler_module --test service_real_email -- --nocapture` | real inbound/outbound email flow | `RUST_SERVICE_LIVE_TEST=1` + Postmark/ngrok/public hook |
+| LIVE-SCH-01 | `cargo test -p scheduler_module --test service_real_email -- --nocapture` | real inbound/outbound email flow | `RUST_SERVICE_LIVE_TEST=1` + Postmark + public hook URL (`POSTMARK_TEST_HOOK_URL`/`POSTMARK_INBOUND_HOOK_URL`; ngrok only for local tunneling) |
 | LIVE-SCH-02 | `cargo test -p scheduler_module --test google_docs_cli_e2e -- --nocapture` | real Google Docs CLI behavior | Google OAuth creds + target docs |
 | LIVE-SCH-03 | `cargo test -p scheduler_module --test unified_memo_e2e -- --ignored --nocapture` | unified memo/account/blob flow | service URL + supabase + azure blob creds + test account |
 | LIVE-SCH-04 | `cargo test -p scheduler_module --test billing_e2e -- --nocapture` | billing/account db logic vs real DB | `SUPABASE_DB_URL` + test account data |


### PR DESCRIPTION
## Summary
- enforce local-only behavior for ngrok helper scripts on DEPLOY_TARGET=staging|production
- make run_employee.sh and run_e2e.sh prefer configured public hook URLs (POSTMARK_INBOUND_HOOK_URL / POSTMARK_TEST_HOOK_URL) and auto-skip ngrok on staging/prod
- update deployment/operations/test/docs guidance so staging/prod uses existing public endpoints and ngrok remains optional for local tunneling

## Validation
- bash -n DoWhiz_service/scripts/run_employee.sh DoWhiz_service/scripts/run_e2e.sh DoWhiz_service/scripts/start_all.sh DoWhiz_service/scripts/setup_postmark_webhook.sh DoWhiz_service/scripts/status.sh
- cd DoWhiz_service && cargo test -p scheduler_module --test service_real_email --no-run
