### PR TITLE
Document staging dedicated ingest storage keys

### DIFF
--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -44,6 +44,12 @@ Raw payload download auth for Azure Blob can use any one of:
 - `AZURE_STORAGE_CONTAINER_INGEST` + `AZURE_STORAGE_SAS_TOKEN` + `AZURE_STORAGE_ACCOUNT`
 - `AZURE_STORAGE_CONNECTION_STRING_INGEST` (or `AZURE_STORAGE_CONNECTION_STRING`)
 
+Staging ingest isolation policy:
+- Use a staging-dedicated storage account for raw payload ingress.
+- Current staging account: `dwhzoliverstg26261234`
+- Current staging container: `ingestion-raw`
+- In `ENV_STAGING`, explicitly set `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_CONTAINER_SAS_URL` so staging does not fall back to shared/common storage credentials.
+
 ## 3) VM Deployment
 
 ### Staging (`dev`)


### PR DESCRIPTION
## Summary\n- document staging ingest isolation settings in deployment guide\n- record staging dedicated account/container for raw payload ingest\n- require explicit \ and \ in \\n\n## Notes\n- secret material was updated only in local \ and is intentionally not committed\n