### PR TITLE
Add workspace bootstrap profile management

### DIFF
--- a/DoWhiz_service/scheduler_module/src/blob_store.rs
+++ b/DoWhiz_service/scheduler_module/src/blob_store.rs
@@ -7,6 +7,7 @@ use tracing::{error, info};
 use uuid::Uuid;
 
 use crate::memory_store::DEFAULT_MEMO_CONTENT;
+use crate::workspace_bootstrap::WorkspaceBootstrapProfile;
 
 #[derive(Debug, thiserror::Error)]
 pub enum BlobStoreError {
@@ -86,6 +87,23 @@ impl BlobStore {
         format!("{}/memo.md", account_id)
     }
 
+    /// Get the blob path for an account's workspace bootstrap profile.
+    fn workspace_bootstrap_profile_blob_path(account_id: Uuid) -> String {
+        format!("{}/workspace_bootstrap/profile.json", account_id)
+    }
+
+    /// Get the blob path for an account's workspace bootstrap file.
+    fn workspace_bootstrap_file_blob_path(
+        account_id: Uuid,
+        file_id: &str,
+    ) -> Result<String, BlobStoreError> {
+        validate_workspace_bootstrap_file_id(file_id)?;
+        Ok(format!(
+            "{}/workspace_bootstrap/files/{}",
+            account_id, file_id
+        ))
+    }
+
     /// Read memo.md for an account, returns default content if not found
     pub async fn read_memo(&self, account_id: Uuid) -> Result<String, BlobStoreError> {
         let blob_path = Self::memo_blob_path(account_id);
@@ -139,6 +157,105 @@ impl BlobStore {
             content.len()
         );
         Ok(())
+    }
+
+    /// Read workspace bootstrap profile.json for an account.
+    /// Returns an empty profile if not found.
+    pub async fn read_workspace_bootstrap_profile(
+        &self,
+        account_id: Uuid,
+    ) -> Result<WorkspaceBootstrapProfile, BlobStoreError> {
+        let blob_path = Self::workspace_bootstrap_profile_blob_path(account_id);
+        let blob_client = self.container_client.blob_client(&blob_path);
+
+        match blob_client.get_content().await {
+            Ok(data) => serde_json::from_slice::<WorkspaceBootstrapProfile>(&data)
+                .map_err(|e| BlobStoreError::Azure(format!("invalid profile json: {}", e))),
+            Err(e) => {
+                let error_str = e.to_string();
+                if error_str.contains("BlobNotFound") || error_str.contains("404") {
+                    Ok(WorkspaceBootstrapProfile::default())
+                } else {
+                    Err(BlobStoreError::Azure(e.to_string()))
+                }
+            }
+        }
+    }
+
+    /// Write workspace bootstrap profile.json for an account.
+    pub async fn write_workspace_bootstrap_profile(
+        &self,
+        account_id: Uuid,
+        profile: &WorkspaceBootstrapProfile,
+    ) -> Result<(), BlobStoreError> {
+        let blob_path = Self::workspace_bootstrap_profile_blob_path(account_id);
+        let blob_client = self.container_client.blob_client(&blob_path);
+        let payload =
+            serde_json::to_vec_pretty(profile).map_err(|e| BlobStoreError::Azure(e.to_string()))?;
+
+        blob_client
+            .put_block_blob(payload)
+            .content_type("application/json")
+            .await
+            .map_err(|e| BlobStoreError::Azure(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Read workspace bootstrap file bytes for an account.
+    pub async fn read_workspace_bootstrap_file(
+        &self,
+        account_id: Uuid,
+        file_id: &str,
+    ) -> Result<Vec<u8>, BlobStoreError> {
+        let blob_path = Self::workspace_bootstrap_file_blob_path(account_id, file_id)?;
+        let blob_client = self.container_client.blob_client(&blob_path);
+        blob_client
+            .get_content()
+            .await
+            .map_err(|e| BlobStoreError::Azure(e.to_string()))
+    }
+
+    /// Write workspace bootstrap file bytes for an account.
+    pub async fn write_workspace_bootstrap_file(
+        &self,
+        account_id: Uuid,
+        file_id: &str,
+        content: &[u8],
+        content_type: Option<&str>,
+    ) -> Result<(), BlobStoreError> {
+        let blob_path = Self::workspace_bootstrap_file_blob_path(account_id, file_id)?;
+        let blob_client = self.container_client.blob_client(&blob_path);
+
+        blob_client
+            .put_block_blob(content.to_vec())
+            .content_type(content_type.unwrap_or("application/octet-stream"))
+            .await
+            .map_err(|e| BlobStoreError::Azure(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Delete workspace bootstrap file for an account.
+    pub async fn delete_workspace_bootstrap_file(
+        &self,
+        account_id: Uuid,
+        file_id: &str,
+    ) -> Result<(), BlobStoreError> {
+        let blob_path = Self::workspace_bootstrap_file_blob_path(account_id, file_id)?;
+        let blob_client = self.container_client.blob_client(&blob_path);
+
+        match blob_client.delete().await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let error_str = e.to_string();
+                if error_str.contains("BlobNotFound") || error_str.contains("404") {
+                    Ok(())
+                } else {
+                    Err(BlobStoreError::Azure(e.to_string()))
+                }
+            }
+        }
     }
 
     /// Delete memo.md for an account (used when account is deleted)
@@ -202,6 +319,27 @@ impl BlobStore {
 
         Ok(account_ids)
     }
+}
+
+fn validate_workspace_bootstrap_file_id(file_id: &str) -> Result<(), BlobStoreError> {
+    let trimmed = file_id.trim();
+    if trimmed.is_empty() {
+        return Err(BlobStoreError::Azure(
+            "workspace bootstrap file_id cannot be empty".to_string(),
+        ));
+    }
+
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+    {
+        return Err(BlobStoreError::Azure(format!(
+            "workspace bootstrap file_id contains unsupported characters: {}",
+            file_id
+        )));
+    }
+
+    Ok(())
 }
 
 /// Lazy-initialized global BlobStore for unified accounts

--- a/DoWhiz_service/scheduler_module/src/lib.rs
+++ b/DoWhiz_service/scheduler_module/src/lib.rs
@@ -30,6 +30,7 @@ pub mod past_emails;
 pub mod secrets_store;
 pub mod service;
 pub mod user_store;
+pub mod workspace_bootstrap;
 
 mod scheduler;
 

--- a/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
@@ -24,6 +24,7 @@ use crate::secrets_store::{
     resolve_user_secrets_path, sync_user_secrets_to_workspace, sync_workspace_secrets_to_user,
 };
 use crate::thread_state::{current_thread_epoch, find_thread_state_path};
+use crate::workspace_bootstrap::{apply_workspace_bootstrap, load_workspace_bootstrap_profile};
 use run_task_module::UserIdentities;
 use uuid::Uuid;
 
@@ -853,6 +854,34 @@ impl TaskExecutor for ModuleExecutor {
                         task.workspace_dir.display()
                     );
                 }
+
+                if let Some((bootstrap_profile, bootstrap_source)) =
+                    load_workspace_bootstrap_profile(account_id, user_memory_dir.as_deref())
+                {
+                    match apply_workspace_bootstrap(
+                        &task.workspace_dir,
+                        &bootstrap_profile,
+                        &bootstrap_source,
+                    ) {
+                        Ok(result) => {
+                            if result.applied {
+                                info!(
+                                    "workspace bootstrap applied workspace={} files={} commands={}",
+                                    task.workspace_dir.display(),
+                                    result.files_applied,
+                                    result.commands_applied
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            return Err(SchedulerError::TaskFailed(format!(
+                                "workspace bootstrap failed: {}",
+                                err
+                            )));
+                        }
+                    }
+                }
+
                 // Check balance before running task (only for unified accounts)
                 if let Some(account_id) = account_id {
                     if let Some(store) = get_global_account_store() {

--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::account_store::{AccountStore, AccountStoreError};
 use crate::blob_store::BlobStore;
 use crate::user_store::UserStore;
+use crate::workspace_bootstrap::WorkspaceBootstrapProfile;
 use crate::{load_tasks_with_status, TaskStatusSummary};
 
 /// State for auth routes
@@ -142,6 +143,64 @@ pub fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
         .map(|s| s.to_string())
+}
+
+async fn resolve_account_from_headers(
+    state: &AuthState,
+    headers: &HeaderMap,
+) -> Result<crate::account_store::Account, axum::response::Response> {
+    let token = match extract_bearer_token(headers) {
+        Some(t) => t,
+        None => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": "Missing Authorization header"
+                })),
+            )
+                .into_response());
+        }
+    };
+
+    let auth_user_id = match validate_supabase_token(&state.supabase_url, &token).await {
+        Ok(user) => user.id,
+        Err((status, msg)) => {
+            return Err((status, Json(serde_json::json!({ "error": msg }))).into_response());
+        }
+    };
+
+    let store = state.account_store.clone();
+    let account_result = task::spawn_blocking(move || store.get_account_by_auth_user(auth_user_id))
+        .await
+        .map_err(|e| {
+            error!("spawn_blocking panicked: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Internal error" })),
+            )
+                .into_response()
+        })?;
+
+    match account_result {
+        Ok(Some(account)) => Ok(account),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "Account not found. Please sign up first."
+            })),
+        )
+            .into_response()),
+        Err(e) => {
+            error!("Failed to get account: {}", e);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "Database error"
+                })),
+            )
+                .into_response())
+        }
+    }
 }
 
 // ============================================================================
@@ -1208,6 +1267,260 @@ pub async fn update_memo(
 }
 
 // ============================================================================
+// Workspace Bootstrap
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+pub struct WorkspaceBootstrapResponse {
+    pub account_id: Uuid,
+    pub profile: WorkspaceBootstrapProfile,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceBootstrapFileUploadRequest {
+    pub file_id: String,
+    pub content_base64: String,
+    #[serde(default)]
+    pub content_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceBootstrapFileDeleteRequest {
+    pub file_id: String,
+}
+
+/// GET /auth/workspace-bootstrap
+/// Returns the workspace bootstrap profile for the current user's account.
+pub async fn get_workspace_bootstrap(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let account = match resolve_account_from_headers(&state, &headers).await {
+        Ok(account) => account,
+        Err(response) => return response,
+    };
+
+    let blob_store = match &state.blob_store {
+        Some(store) => store.clone(),
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "Workspace bootstrap storage not configured"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    match blob_store.read_workspace_bootstrap_profile(account.id).await {
+        Ok(profile) => (
+            StatusCode::OK,
+            Json(WorkspaceBootstrapResponse {
+                account_id: account.id,
+                profile,
+            }),
+        )
+            .into_response(),
+        Err(e) => {
+            error!(
+                "Failed to read workspace bootstrap profile for account {}: {}",
+                account.id, e
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "Failed to read workspace bootstrap profile"
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// POST /auth/workspace-bootstrap
+/// Updates the workspace bootstrap profile for the current user's account.
+pub async fn update_workspace_bootstrap(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Json(profile): Json<WorkspaceBootstrapProfile>,
+) -> impl IntoResponse {
+    let account = match resolve_account_from_headers(&state, &headers).await {
+        Ok(account) => account,
+        Err(response) => return response,
+    };
+
+    let blob_store = match &state.blob_store {
+        Some(store) => store.clone(),
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "Workspace bootstrap storage not configured"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    match blob_store
+        .write_workspace_bootstrap_profile(account.id, &profile)
+        .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "success": true,
+                "account_id": account.id
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            error!(
+                "Failed to write workspace bootstrap profile for account {}: {}",
+                account.id, e
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "Failed to save workspace bootstrap profile"
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// POST /auth/workspace-bootstrap/files
+/// Uploads/overwrites one bootstrap file for the current user's account.
+pub async fn upload_workspace_bootstrap_file(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Json(payload): Json<WorkspaceBootstrapFileUploadRequest>,
+) -> impl IntoResponse {
+    let account = match resolve_account_from_headers(&state, &headers).await {
+        Ok(account) => account,
+        Err(response) => return response,
+    };
+
+    let blob_store = match &state.blob_store {
+        Some(store) => store.clone(),
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "Workspace bootstrap storage not configured"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let content = match base64::engine::general_purpose::STANDARD
+        .decode(payload.content_base64.as_bytes())
+    {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!("Invalid base64 content: {}", e)
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    match blob_store
+        .write_workspace_bootstrap_file(
+            account.id,
+            &payload.file_id,
+            &content,
+            payload.content_type.as_deref(),
+        )
+        .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "success": true,
+                "account_id": account.id,
+                "file_id": payload.file_id,
+                "size_bytes": content.len()
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            error!(
+                "Failed to write workspace bootstrap file for account {}: {}",
+                account.id, e
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "Failed to upload workspace bootstrap file"
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// DELETE /auth/workspace-bootstrap/files
+/// Deletes one bootstrap file for the current user's account.
+pub async fn delete_workspace_bootstrap_file(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Json(payload): Json<WorkspaceBootstrapFileDeleteRequest>,
+) -> impl IntoResponse {
+    let account = match resolve_account_from_headers(&state, &headers).await {
+        Ok(account) => account,
+        Err(response) => return response,
+    };
+
+    let blob_store = match &state.blob_store {
+        Some(store) => store.clone(),
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "Workspace bootstrap storage not configured"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    match blob_store
+        .delete_workspace_bootstrap_file(account.id, &payload.file_id)
+        .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "success": true,
+                "account_id": account.id,
+                "file_id": payload.file_id
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            error!(
+                "Failed to delete workspace bootstrap file for account {}: {}",
+                account.id, e
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "Failed to delete workspace bootstrap file"
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+// ============================================================================
 // Discord OAuth
 // ============================================================================
 
@@ -2066,6 +2379,14 @@ pub fn auth_router(state: AuthState) -> Router {
         .route("/auth/verify-email", get(verify_email))
         .route("/auth/unlink", delete(unlink_identifier))
         .route("/auth/memo", get(get_memo).post(update_memo))
+        .route(
+            "/auth/workspace-bootstrap",
+            get(get_workspace_bootstrap).post(update_workspace_bootstrap),
+        )
+        .route(
+            "/auth/workspace-bootstrap/files",
+            post(upload_workspace_bootstrap_file).delete(delete_workspace_bootstrap_file),
+        )
         .route("/auth/discord", get(discord_oauth_start))
         .route("/auth/discord/callback", get(discord_oauth_callback))
         .route("/auth/slack", get(slack_oauth_start))

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -613,6 +613,8 @@ mod tests {
             state_dir: user_root.join("state"),
             tasks_db_path: user_root.join("state/tasks.db"),
             memory_dir: user_root.join("memory"),
+            bootstrap_dir: user_root.join("bootstrap"),
+            bootstrap_files_dir: user_root.join("bootstrap/files"),
             secrets_dir: user_root.join("secrets"),
             mail_root: user_root.join("mail"),
             workspaces_root: user_root.join("workspaces"),

--- a/DoWhiz_service/scheduler_module/src/user_store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/user_store/mod.rs
@@ -36,6 +36,8 @@ pub struct UserPaths {
     pub state_dir: PathBuf,
     pub tasks_db_path: PathBuf,
     pub memory_dir: PathBuf,
+    pub bootstrap_dir: PathBuf,
+    pub bootstrap_files_dir: PathBuf,
     pub secrets_dir: PathBuf,
     pub mail_root: PathBuf,
     pub workspaces_root: PathBuf,
@@ -90,6 +92,8 @@ impl UserStore {
         let state_dir = root.join("state");
         let tasks_db_path = state_dir.join("tasks.db");
         let memory_dir = root.join("memory");
+        let bootstrap_dir = root.join("bootstrap");
+        let bootstrap_files_dir = bootstrap_dir.join("files");
         let secrets_dir = root.join("secrets");
         let mail_root = root.join("mail");
         let workspaces_root = root.join("workspaces");
@@ -98,6 +102,8 @@ impl UserStore {
             state_dir,
             tasks_db_path,
             memory_dir,
+            bootstrap_dir,
+            bootstrap_files_dir,
             secrets_dir,
             mail_root,
             workspaces_root,
@@ -107,6 +113,8 @@ impl UserStore {
     pub fn ensure_user_dirs(&self, paths: &UserPaths) -> Result<(), UserStoreError> {
         fs::create_dir_all(&paths.state_dir)?;
         fs::create_dir_all(&paths.memory_dir)?;
+        fs::create_dir_all(&paths.bootstrap_dir)?;
+        fs::create_dir_all(&paths.bootstrap_files_dir)?;
         fs::create_dir_all(&paths.secrets_dir)?;
         fs::create_dir_all(&paths.mail_root)?;
         fs::create_dir_all(&paths.workspaces_root)?;

--- a/DoWhiz_service/scheduler_module/src/workspace_bootstrap.rs
+++ b/DoWhiz_service/scheduler_module/src/workspace_bootstrap.rs
@@ -1,0 +1,713 @@
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::blob_store::get_blob_store;
+
+const STATE_DIR_NAME: &str = ".bootstrap";
+const STATE_FILE_NAME: &str = "bootstrap_state.json";
+const DEFAULT_COMMAND_TIMEOUT_SECS: u64 = 300;
+const MAX_OUTPUT_PREVIEW_CHARS: usize = 2_000;
+
+const DEFAULT_ALLOWED_COMMANDS: &[&str] = &[
+    "npm", "pnpm", "yarn", "cargo", "rustup", "pip", "pip3", "uv", "python", "python3",
+    "node", "npx", "go", "git", "bash", "sh",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkspaceBootstrapProfile {
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub commands: Vec<WorkspaceBootstrapCommand>,
+    #[serde(default)]
+    pub files: Vec<WorkspaceBootstrapFile>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkspaceBootstrapCommand {
+    pub cmd: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkspaceBootstrapFile {
+    pub file_id: String,
+    pub path: String,
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum WorkspaceBootstrapSource {
+    Account { account_id: Uuid },
+    Local { bootstrap_root: PathBuf },
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceBootstrapApplyResult {
+    pub applied: bool,
+    pub skipped: bool,
+    pub files_applied: usize,
+    pub commands_applied: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkspaceBootstrapState {
+    pub applied_at: String,
+    pub profile_version: String,
+    pub profile_hash: String,
+    pub status: String,
+    pub source: String,
+    pub files_applied: usize,
+    pub commands_applied: usize,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+    #[serde(default)]
+    pub errors: Vec<String>,
+    #[serde(default)]
+    pub command_results: Vec<WorkspaceBootstrapCommandResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkspaceBootstrapCommandResult {
+    pub command: String,
+    pub success: bool,
+    pub exit_code: Option<i32>,
+    pub duration_ms: u128,
+    pub stdout_preview: Option<String>,
+    pub stderr_preview: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorkspaceBootstrapError {
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid bootstrap path: {0}")]
+    InvalidPath(String),
+    #[error("invalid bootstrap file id: {0}")]
+    InvalidFileId(String),
+    #[error("bootstrap command is not allowed: {0}")]
+    CommandBlocked(String),
+    #[error("bootstrap command failed: {0}")]
+    CommandFailed(String),
+    #[error("bootstrap command timed out: {0}")]
+    CommandTimeout(String),
+    #[error("bootstrap profile source unavailable")]
+    ProfileSourceUnavailable,
+    #[error("blob store error: {0}")]
+    Blob(String),
+    #[error("runtime error: {0}")]
+    Runtime(String),
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl WorkspaceBootstrapProfile {
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty() && self.files.is_empty() && self.version.trim().is_empty()
+    }
+}
+
+pub fn load_workspace_bootstrap_profile(
+    account_id: Option<Uuid>,
+    user_memory_dir: Option<&Path>,
+) -> Option<(WorkspaceBootstrapProfile, WorkspaceBootstrapSource)> {
+    if let Some(account_id) = account_id {
+        match load_account_profile(account_id) {
+            Ok(Some(profile)) => {
+                return Some((profile, WorkspaceBootstrapSource::Account { account_id }));
+            }
+            Ok(None) => {
+                // No account-level profile. Fall through to local fallback.
+            }
+            Err(err) => {
+                warn!(
+                    "failed to load account workspace bootstrap profile account_id={}: {}",
+                    account_id, err
+                );
+            }
+        }
+    }
+
+    let bootstrap_root = match user_memory_dir
+        .and_then(Path::parent)
+        .map(|user_root| user_root.join("bootstrap"))
+    {
+        Some(path) => path,
+        None => return None,
+    };
+
+    match load_local_profile(&bootstrap_root) {
+        Ok(Some(profile)) => Some((profile, WorkspaceBootstrapSource::Local { bootstrap_root })),
+        Ok(None) => None,
+        Err(err) => {
+            warn!(
+                "failed to load local workspace bootstrap profile path={}: {}",
+                bootstrap_root.display(),
+                err
+            );
+            None
+        }
+    }
+}
+
+pub fn apply_workspace_bootstrap(
+    workspace_dir: &Path,
+    profile: &WorkspaceBootstrapProfile,
+    source: &WorkspaceBootstrapSource,
+) -> Result<WorkspaceBootstrapApplyResult, WorkspaceBootstrapError> {
+    if profile.is_empty() {
+        return Ok(WorkspaceBootstrapApplyResult {
+            applied: false,
+            skipped: true,
+            files_applied: 0,
+            commands_applied: 0,
+        });
+    }
+
+    let state_path = workspace_dir.join(STATE_DIR_NAME).join(STATE_FILE_NAME);
+    let profile_version = normalized_profile_version(profile);
+    let profile_hash = hash_profile(profile)?;
+
+    if let Some(existing) = load_state(&state_path) {
+        if existing.status == "success"
+            && existing.profile_hash == profile_hash
+            && existing.profile_version == profile_version
+        {
+            info!(
+                "workspace bootstrap skipped workspace={} version={} hash={}",
+                workspace_dir.display(),
+                profile_version,
+                profile_hash
+            );
+            return Ok(WorkspaceBootstrapApplyResult {
+                applied: false,
+                skipped: true,
+                files_applied: 0,
+                commands_applied: 0,
+            });
+        }
+    }
+
+    let mut state = WorkspaceBootstrapState {
+        applied_at: Utc::now().to_rfc3339(),
+        profile_version,
+        profile_hash,
+        status: "running".to_string(),
+        source: source_label(source).to_string(),
+        ..WorkspaceBootstrapState::default()
+    };
+
+    fs::create_dir_all(workspace_dir.join(STATE_DIR_NAME))?;
+
+    for file in &profile.files {
+        if let Err(err) = validate_file_id(&file.file_id) {
+            if file.required {
+                state.errors.push(err.to_string());
+                state.status = "failed".to_string();
+                write_state(&state_path, &state)?;
+                return Err(err);
+            }
+            state.warnings.push(err.to_string());
+            continue;
+        }
+
+        let relative_path = match sanitize_relative_path(&file.path) {
+            Ok(path) => path,
+            Err(err) => {
+                if file.required {
+                    state.errors.push(err.to_string());
+                    state.status = "failed".to_string();
+                    write_state(&state_path, &state)?;
+                    return Err(err);
+                }
+                state.warnings.push(err.to_string());
+                continue;
+            }
+        };
+
+        let file_bytes = match read_bootstrap_file_bytes(source, &file.file_id) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                let message = format!(
+                    "failed to load bootstrap file {} for {}: {}",
+                    file.file_id, file.path, err
+                );
+                if file.required {
+                    state.errors.push(message);
+                    state.status = "failed".to_string();
+                    write_state(&state_path, &state)?;
+                    return Err(err);
+                }
+                state.warnings.push(message);
+                continue;
+            }
+        };
+
+        let target_path = workspace_dir.join(&relative_path);
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&target_path, &file_bytes)?;
+        state.files_applied += 1;
+    }
+
+    for command in &profile.commands {
+        let command_display = render_command(command);
+        match run_bootstrap_command(workspace_dir, command) {
+            Ok(result) => {
+                state.commands_applied += 1;
+                state.command_results.push(result);
+            }
+            Err(err) => {
+                let message = format!("{} ({})", command_display, err);
+                if command.required {
+                    state.errors.push(message);
+                    state.status = "failed".to_string();
+                    write_state(&state_path, &state)?;
+                    return Err(err);
+                }
+                state.warnings.push(message);
+            }
+        }
+    }
+
+    state.status = "success".to_string();
+    write_state(&state_path, &state)?;
+
+    info!(
+        "workspace bootstrap applied workspace={} source={} files={} commands={} version={} hash={}",
+        workspace_dir.display(),
+        state.source,
+        state.files_applied,
+        state.commands_applied,
+        state.profile_version,
+        state.profile_hash
+    );
+
+    Ok(WorkspaceBootstrapApplyResult {
+        applied: true,
+        skipped: false,
+        files_applied: state.files_applied,
+        commands_applied: state.commands_applied,
+    })
+}
+
+fn load_account_profile(
+    account_id: Uuid,
+) -> Result<Option<WorkspaceBootstrapProfile>, WorkspaceBootstrapError> {
+    let blob_store = get_blob_store().ok_or(WorkspaceBootstrapError::ProfileSourceUnavailable)?;
+    let runtime =
+        tokio::runtime::Runtime::new().map_err(|e| WorkspaceBootstrapError::Runtime(e.to_string()))?;
+
+    let profile = runtime
+        .block_on(blob_store.read_workspace_bootstrap_profile(account_id))
+        .map_err(|e| WorkspaceBootstrapError::Blob(e.to_string()))?;
+
+    if profile.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(profile))
+}
+
+fn load_local_profile(
+    bootstrap_root: &Path,
+) -> Result<Option<WorkspaceBootstrapProfile>, WorkspaceBootstrapError> {
+    let profile_path = bootstrap_root.join("profile.json");
+    if !profile_path.exists() {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(&profile_path)?;
+    let profile: WorkspaceBootstrapProfile = serde_json::from_str(&raw)?;
+    if profile.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(profile))
+}
+
+fn read_bootstrap_file_bytes(
+    source: &WorkspaceBootstrapSource,
+    file_id: &str,
+) -> Result<Vec<u8>, WorkspaceBootstrapError> {
+    match source {
+        WorkspaceBootstrapSource::Local { bootstrap_root } => {
+            let path = bootstrap_root.join("files").join(file_id);
+            fs::read(path).map_err(WorkspaceBootstrapError::Io)
+        }
+        WorkspaceBootstrapSource::Account { account_id } => {
+            let blob_store = get_blob_store().ok_or(WorkspaceBootstrapError::ProfileSourceUnavailable)?;
+            let runtime = tokio::runtime::Runtime::new()
+                .map_err(|e| WorkspaceBootstrapError::Runtime(e.to_string()))?;
+            runtime
+                .block_on(blob_store.read_workspace_bootstrap_file(*account_id, file_id))
+                .map_err(|e| WorkspaceBootstrapError::Blob(e.to_string()))
+        }
+    }
+}
+
+fn run_bootstrap_command(
+    workspace_dir: &Path,
+    command: &WorkspaceBootstrapCommand,
+) -> Result<WorkspaceBootstrapCommandResult, WorkspaceBootstrapError> {
+    if command.cmd.trim().is_empty() {
+        return Err(WorkspaceBootstrapError::CommandFailed(
+            "empty command".to_string(),
+        ));
+    }
+
+    let command_base = command_basename(&command.cmd);
+    if !is_command_allowed(&command_base) {
+        return Err(WorkspaceBootstrapError::CommandBlocked(command_base));
+    }
+
+    let cwd = match command.cwd.as_deref() {
+        Some(raw) => workspace_dir.join(sanitize_relative_path(raw)?),
+        None => workspace_dir.to_path_buf(),
+    };
+
+    let mut proc = Command::new(&command.cmd);
+    proc.args(&command.args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    for (key, value) in &command.env {
+        if valid_env_name(key) {
+            proc.env(key, value);
+        }
+    }
+
+    let timeout_secs = command
+        .timeout_secs
+        .unwrap_or(DEFAULT_COMMAND_TIMEOUT_SECS)
+        .max(1);
+    let timeout = Duration::from_secs(timeout_secs);
+
+    let start = Instant::now();
+    let mut child = proc.spawn().map_err(|e| {
+        WorkspaceBootstrapError::CommandFailed(format!("failed to spawn {}: {}", command.cmd, e))
+    })?;
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let output = child.wait_with_output().map_err(|e| {
+                    WorkspaceBootstrapError::CommandFailed(format!(
+                        "failed to collect output for {}: {}",
+                        command.cmd, e
+                    ))
+                })?;
+
+                let stdout_preview = preview_output(&output.stdout);
+                let stderr_preview = preview_output(&output.stderr);
+                let result = WorkspaceBootstrapCommandResult {
+                    command: render_command(command),
+                    success: status.success(),
+                    exit_code: status.code(),
+                    duration_ms: start.elapsed().as_millis(),
+                    stdout_preview,
+                    stderr_preview: stderr_preview.clone(),
+                };
+
+                if status.success() {
+                    return Ok(result);
+                }
+
+                let message = format!(
+                    "{} exited with code {:?}: {}",
+                    command.cmd,
+                    status.code(),
+                    stderr_preview.unwrap_or_else(|| "no stderr".to_string())
+                );
+                return Err(WorkspaceBootstrapError::CommandFailed(message));
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let output = child.wait_with_output().ok();
+                    let stderr_preview = output
+                        .as_ref()
+                        .and_then(|value| preview_output(&value.stderr))
+                        .unwrap_or_else(|| "no stderr".to_string());
+                    return Err(WorkspaceBootstrapError::CommandTimeout(format!(
+                        "{} timed out after {}s: {}",
+                        command.cmd, timeout_secs, stderr_preview
+                    )));
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => {
+                return Err(WorkspaceBootstrapError::CommandFailed(format!(
+                    "failed waiting for {}: {}",
+                    command.cmd, e
+                )));
+            }
+        }
+    }
+}
+
+fn sanitize_relative_path(raw: &str) -> Result<PathBuf, WorkspaceBootstrapError> {
+    let candidate = raw.trim();
+    if candidate.is_empty() {
+        return Err(WorkspaceBootstrapError::InvalidPath(
+            "path cannot be empty".to_string(),
+        ));
+    }
+
+    let path = Path::new(candidate);
+    if path.is_absolute() {
+        return Err(WorkspaceBootstrapError::InvalidPath(format!(
+            "absolute paths are not allowed: {}",
+            raw
+        )));
+    }
+
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(value) => out.push(value),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(WorkspaceBootstrapError::InvalidPath(format!(
+                    "path traversal is not allowed: {}",
+                    raw
+                )));
+            }
+        }
+    }
+
+    if out.as_os_str().is_empty() {
+        return Err(WorkspaceBootstrapError::InvalidPath(format!(
+            "invalid relative path: {}",
+            raw
+        )));
+    }
+
+    Ok(out)
+}
+
+fn validate_file_id(file_id: &str) -> Result<(), WorkspaceBootstrapError> {
+    let trimmed = file_id.trim();
+    if trimmed.is_empty() {
+        return Err(WorkspaceBootstrapError::InvalidFileId(
+            "file_id cannot be empty".to_string(),
+        ));
+    }
+
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+    {
+        return Err(WorkspaceBootstrapError::InvalidFileId(format!(
+            "file_id contains unsupported characters: {}",
+            file_id
+        )));
+    }
+
+    Ok(())
+}
+
+fn command_basename(command: &str) -> String {
+    Path::new(command)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_else(|| command.to_ascii_lowercase())
+}
+
+fn is_command_allowed(command: &str) -> bool {
+    let allowed = allowed_commands();
+    allowed.contains(&command.to_ascii_lowercase())
+}
+
+fn allowed_commands() -> HashSet<String> {
+    if let Ok(raw) = std::env::var("WORKSPACE_BOOTSTRAP_ALLOWED_COMMANDS") {
+        let parsed: HashSet<String> = raw
+            .split(',')
+            .map(|item| item.trim().to_ascii_lowercase())
+            .filter(|item| !item.is_empty())
+            .collect();
+        if !parsed.is_empty() {
+            return parsed;
+        }
+    }
+
+    DEFAULT_ALLOWED_COMMANDS
+        .iter()
+        .map(|value| value.to_string())
+        .collect()
+}
+
+fn valid_env_name(raw: &str) -> bool {
+    !raw.trim().is_empty()
+        && raw
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+fn preview_output(bytes: &[u8]) -> Option<String> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(bytes).trim().to_string();
+    if text.is_empty() {
+        return None;
+    }
+
+    if text.chars().count() <= MAX_OUTPUT_PREVIEW_CHARS {
+        return Some(text);
+    }
+
+    let preview: String = text.chars().take(MAX_OUTPUT_PREVIEW_CHARS).collect();
+    Some(format!("{}...", preview))
+}
+
+fn load_state(state_path: &Path) -> Option<WorkspaceBootstrapState> {
+    let raw = fs::read_to_string(state_path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn write_state(state_path: &Path, state: &WorkspaceBootstrapState) -> Result<(), WorkspaceBootstrapError> {
+    let encoded = serde_json::to_string_pretty(state)?;
+    fs::write(state_path, encoded)?;
+    Ok(())
+}
+
+fn normalized_profile_version(profile: &WorkspaceBootstrapProfile) -> String {
+    let value = profile.version.trim();
+    if value.is_empty() {
+        "unversioned".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn hash_profile(profile: &WorkspaceBootstrapProfile) -> Result<String, WorkspaceBootstrapError> {
+    let payload = serde_json::to_vec(profile)?;
+    let mut hasher = Sha256::new();
+    hasher.update(payload);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn render_command(command: &WorkspaceBootstrapCommand) -> String {
+    if command.args.is_empty() {
+        return command.cmd.clone();
+    }
+    format!("{} {}", command.cmd, command.args.join(" "))
+}
+
+fn source_label(source: &WorkspaceBootstrapSource) -> &'static str {
+    match source {
+        WorkspaceBootstrapSource::Account { .. } => "account",
+        WorkspaceBootstrapSource::Local { .. } => "local",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sanitize_relative_path_rejects_parent_segments() {
+        let err = sanitize_relative_path("../etc/passwd").expect_err("must reject");
+        assert!(matches!(err, WorkspaceBootstrapError::InvalidPath(_)));
+    }
+
+    #[test]
+    fn apply_workspace_bootstrap_writes_files_and_skips_when_unchanged() {
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let bootstrap_root = tmp.path().join("bootstrap");
+        fs::create_dir_all(bootstrap_root.join("files")).expect("bootstrap files");
+        fs::create_dir_all(&workspace).expect("workspace");
+
+        fs::write(bootstrap_root.join("files").join("script"), b"echo hello\n")
+            .expect("bootstrap file");
+
+        let profile = WorkspaceBootstrapProfile {
+            version: "v1".to_string(),
+            files: vec![WorkspaceBootstrapFile {
+                file_id: "script".to_string(),
+                path: "scripts/setup.sh".to_string(),
+                required: true,
+            }],
+            ..WorkspaceBootstrapProfile::default()
+        };
+
+        let source = WorkspaceBootstrapSource::Local {
+            bootstrap_root: bootstrap_root.clone(),
+        };
+
+        let first = apply_workspace_bootstrap(&workspace, &profile, &source).expect("first apply");
+        assert!(first.applied);
+        assert!(!first.skipped);
+        assert_eq!(first.files_applied, 1);
+
+        let contents = fs::read_to_string(workspace.join("scripts/setup.sh")).expect("file copied");
+        assert_eq!(contents, "echo hello\n");
+
+        let second = apply_workspace_bootstrap(&workspace, &profile, &source).expect("second apply");
+        assert!(!second.applied);
+        assert!(second.skipped);
+    }
+
+    #[test]
+    fn apply_workspace_bootstrap_allows_non_required_command_failure() {
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("workspace");
+
+        let profile = WorkspaceBootstrapProfile {
+            version: "v2".to_string(),
+            commands: vec![WorkspaceBootstrapCommand {
+                cmd: "definitely_not_a_real_binary".to_string(),
+                required: false,
+                ..WorkspaceBootstrapCommand::default()
+            }],
+            ..WorkspaceBootstrapProfile::default()
+        };
+
+        let source = WorkspaceBootstrapSource::Local {
+            bootstrap_root: tmp.path().join("bootstrap"),
+        };
+
+        let applied = apply_workspace_bootstrap(&workspace, &profile, &source).expect("apply");
+        assert!(applied.applied);
+
+        let state_raw = fs::read_to_string(workspace.join(STATE_DIR_NAME).join(STATE_FILE_NAME))
+            .expect("state file");
+        let state: WorkspaceBootstrapState = serde_json::from_str(&state_raw).expect("parse state");
+        assert_eq!(state.status, "success");
+        assert!(!state.warnings.is_empty());
+    }
+}

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -844,12 +844,13 @@
               <aside class="dashboard-sidebar">
                 <p class="sidebar-eyebrow">Dashboard</p>
                 <h2 class="sidebar-title">Workspace Settings</h2>
-                <p class="sidebar-description">Navigate quickly to channels, tasks, memo, and account controls.</p>
+                <p class="sidebar-description">Navigate quickly to channels, tasks, memo, bootstrap assets, and account controls.</p>
                 <nav class="sidebar-nav" aria-label="Dashboard Sections">
                   <a class="sidebar-link is-active" href="#section-overview">Overview</a>
                   <a class="sidebar-link" href="#section-channels">Channels</a>
                   <a class="sidebar-link" href="#section-tasks">Tasks</a>
                   <a class="sidebar-link" href="#section-memo">Memo</a>
+                  <a class="sidebar-link" href="#section-bootstrap">Workspace Bootstrap</a>
                   <a class="sidebar-link" href="#section-settings">Settings</a>
                 </nav>
                 <div class="sidebar-note">
@@ -935,6 +936,47 @@
                         Refresh
                       </button>
                       <span id="memo-status" class="memo-status"></span>
+                    </div>
+                  </div>
+                </section>
+
+                <section id="section-bootstrap" class="legal-card dashboard-section">
+                  <h2>Workspace Bootstrap</h2>
+                  <p>Configure files and commands that are applied when a workspace starts.</p>
+                  <div id="workspace-bootstrap-container" style="margin-top: 1rem;">
+                    <textarea id="workspace-bootstrap-profile" style="
+                      background: var(--surface, #1a1a1a);
+                      border: 1px solid var(--border, #333);
+                      border-radius: 8px;
+                      padding: 1rem;
+                      width: 100%;
+                      min-height: 260px;
+                      resize: vertical;
+                      font-family: monospace;
+                      font-size: 0.9rem;
+                      color: var(--text, #fff);
+                      box-sizing: border-box;
+                    ">Loading bootstrap profile...</textarea>
+                    <div class="memo-actions">
+                      <button id="save-workspace-bootstrap-btn" class="auth-btn auth-btn-primary">
+                        Save Profile
+                      </button>
+                      <button id="refresh-workspace-bootstrap-btn" class="auth-btn auth-btn-oauth">
+                        Refresh
+                      </button>
+                      <span id="workspace-bootstrap-status" class="memo-status"></span>
+                    </div>
+
+                    <div style="margin-top: 1rem;">
+                      <h3 style="margin-bottom: 0.5rem;">Upload Bootstrap File</h3>
+                      <div style="display: grid; gap: 0.5rem;">
+                        <input id="workspace-bootstrap-target-path" class="auth-input" type="text" placeholder="Target workspace path, e.g. .vscode/settings.json" />
+                        <input id="workspace-bootstrap-file-input" class="auth-input" type="file" />
+                        <button id="upload-workspace-bootstrap-file-btn" class="auth-btn auth-btn-oauth">
+                          Upload File And Add To Profile Draft
+                        </button>
+                        <span id="workspace-bootstrap-upload-status" class="memo-status"></span>
+                      </div>
                     </div>
                   </div>
                 </section>
@@ -1559,15 +1601,16 @@
         hideExistingAccountOptions();
         dashboardContainer.classList.remove('hidden');
         pageTitle.textContent = 'Your Dashboard';
-        pageSubtitle.textContent = 'Manage channels, tasks, memo, and settings from one unified dashboard.';
+        pageSubtitle.textContent = 'Manage channels, tasks, memo, workspace bootstrap, and settings from one unified dashboard.';
 
         document.getElementById('account-id').textContent = accountData.account_id;
         document.getElementById('user-email').textContent = session.user.email;
 
-        // Load identifiers, memo, and tasks in parallel
+        // Load identifiers, memo, workspace bootstrap, and tasks in parallel
         await Promise.all([
           loadIdentifiers(session.access_token),
           loadMemo(session.access_token),
+          loadWorkspaceBootstrap(session.access_token),
           loadTasks(session.access_token)
         ]);
 
@@ -1715,6 +1758,221 @@
         if (session) {
           document.getElementById('memo-content').value = 'Loading...';
           await loadMemo(session.access_token);
+        }
+      });
+
+      function defaultWorkspaceBootstrapProfile() {
+        return {
+          version: '',
+          commands: [],
+          files: [],
+          updated_at: null
+        };
+      }
+
+      function setWorkspaceBootstrapStatus(message, color = 'var(--text-muted, #888)') {
+        const status = document.getElementById('workspace-bootstrap-status');
+        status.textContent = message;
+        status.style.color = color;
+      }
+
+      function setWorkspaceBootstrapUploadStatus(message, color = 'var(--text-muted, #888)') {
+        const status = document.getElementById('workspace-bootstrap-upload-status');
+        status.textContent = message;
+        status.style.color = color;
+      }
+
+      function readFileAsBase64(file) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const result = reader.result || '';
+            const commaIndex = String(result).indexOf(',');
+            if (commaIndex === -1) {
+              reject(new Error('Failed to encode file.'));
+              return;
+            }
+            resolve(String(result).slice(commaIndex + 1));
+          };
+          reader.onerror = () => reject(new Error('Failed to read file.'));
+          reader.readAsDataURL(file);
+        });
+      }
+
+      function generateWorkspaceBootstrapFileId(fileName) {
+        const normalized = (fileName || 'file')
+          .toLowerCase()
+          .replace(/[^a-z0-9._-]/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-|-$/g, '');
+        const safeBase = normalized || 'file';
+        return `${safeBase}-${Date.now()}`;
+      }
+
+      function parseWorkspaceBootstrapProfileFromEditor() {
+        const editor = document.getElementById('workspace-bootstrap-profile');
+        const parsed = JSON.parse(editor.value);
+        if (!parsed || typeof parsed !== 'object') {
+          throw new Error('Profile must be a JSON object.');
+        }
+        if (!Array.isArray(parsed.commands)) {
+          parsed.commands = [];
+        }
+        if (!Array.isArray(parsed.files)) {
+          parsed.files = [];
+        }
+        if (typeof parsed.version !== 'string') {
+          parsed.version = '';
+        }
+        if (!Object.prototype.hasOwnProperty.call(parsed, 'updated_at')) {
+          parsed.updated_at = null;
+        }
+        return parsed;
+      }
+
+      // Load workspace bootstrap profile
+      async function loadWorkspaceBootstrap(accessToken) {
+        const editor = document.getElementById('workspace-bootstrap-profile');
+        setWorkspaceBootstrapStatus('Loading...');
+        try {
+          const res = await fetch(`${DOWHIZ_API_URL}/auth/workspace-bootstrap`, {
+            headers: { 'Authorization': `Bearer ${accessToken}` }
+          });
+
+          if (!res.ok) {
+            const err = await res.json();
+            throw new Error(err.error || 'Failed to load workspace bootstrap profile');
+          }
+
+          const data = await res.json();
+          const profile = data.profile || defaultWorkspaceBootstrapProfile();
+          editor.value = JSON.stringify(profile, null, 2);
+          setWorkspaceBootstrapStatus('Loaded.', '#22c55e');
+          setTimeout(() => setWorkspaceBootstrapStatus(''), 2000);
+        } catch (err) {
+          console.error('Failed to load workspace bootstrap profile:', err);
+          editor.value = JSON.stringify(defaultWorkspaceBootstrapProfile(), null, 2);
+          setWorkspaceBootstrapStatus(`Error: ${err.message}`, '#ef4444');
+        }
+      }
+
+      // Save workspace bootstrap profile
+      async function saveWorkspaceBootstrap(accessToken) {
+        setWorkspaceBootstrapStatus('Saving...');
+
+        let profile;
+        try {
+          profile = parseWorkspaceBootstrapProfileFromEditor();
+        } catch (err) {
+          setWorkspaceBootstrapStatus(`Error: ${err.message}`, '#ef4444');
+          return;
+        }
+
+        profile.updated_at = new Date().toISOString();
+
+        try {
+          const res = await fetch(`${DOWHIZ_API_URL}/auth/workspace-bootstrap`, {
+            method: 'POST',
+            headers: {
+              'Authorization': `Bearer ${accessToken}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(profile)
+          });
+
+          if (!res.ok) {
+            const err = await res.json();
+            throw new Error(err.error || 'Failed to save workspace bootstrap profile');
+          }
+
+          document.getElementById('workspace-bootstrap-profile').value = JSON.stringify(profile, null, 2);
+          setWorkspaceBootstrapStatus('Saved!', '#22c55e');
+          setTimeout(() => setWorkspaceBootstrapStatus(''), 3000);
+        } catch (err) {
+          console.error('Failed to save workspace bootstrap profile:', err);
+          setWorkspaceBootstrapStatus(`Error: ${err.message}`, '#ef4444');
+        }
+      }
+
+      // Upload one bootstrap file and append it to profile draft
+      async function uploadWorkspaceBootstrapFile(accessToken) {
+        const fileInput = document.getElementById('workspace-bootstrap-file-input');
+        const pathInput = document.getElementById('workspace-bootstrap-target-path');
+        const targetPath = (pathInput.value || '').trim();
+        const selectedFile = fileInput.files && fileInput.files[0];
+
+        if (!targetPath) {
+          setWorkspaceBootstrapUploadStatus('Please provide a target workspace path.', '#ef4444');
+          return;
+        }
+        if (!selectedFile) {
+          setWorkspaceBootstrapUploadStatus('Please choose a file to upload.', '#ef4444');
+          return;
+        }
+
+        setWorkspaceBootstrapUploadStatus('Uploading...');
+        const fileId = generateWorkspaceBootstrapFileId(selectedFile.name);
+
+        try {
+          const contentBase64 = await readFileAsBase64(selectedFile);
+          const res = await fetch(`${DOWHIZ_API_URL}/auth/workspace-bootstrap/files`, {
+            method: 'POST',
+            headers: {
+              'Authorization': `Bearer ${accessToken}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              file_id: fileId,
+              content_base64: contentBase64,
+              content_type: selectedFile.type || 'application/octet-stream'
+            })
+          });
+
+          if (!res.ok) {
+            const err = await res.json();
+            throw new Error(err.error || 'Failed to upload bootstrap file');
+          }
+
+          const profile = parseWorkspaceBootstrapProfileFromEditor();
+          profile.files = profile.files.filter((item) => item.path !== targetPath);
+          profile.files.push({
+            file_id: fileId,
+            path: targetPath,
+            required: true
+          });
+          profile.updated_at = new Date().toISOString();
+          document.getElementById('workspace-bootstrap-profile').value = JSON.stringify(profile, null, 2);
+
+          setWorkspaceBootstrapUploadStatus('Uploaded. Profile draft updated; click "Save Profile" to persist.', '#22c55e');
+          fileInput.value = '';
+        } catch (err) {
+          console.error('Failed to upload workspace bootstrap file:', err);
+          setWorkspaceBootstrapUploadStatus(`Error: ${err.message}`, '#ef4444');
+        }
+      }
+
+      // Save workspace bootstrap button
+      document.getElementById('save-workspace-bootstrap-btn').addEventListener('click', async () => {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session) {
+          await saveWorkspaceBootstrap(session.access_token);
+        }
+      });
+
+      // Refresh workspace bootstrap button
+      document.getElementById('refresh-workspace-bootstrap-btn').addEventListener('click', async () => {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session) {
+          document.getElementById('workspace-bootstrap-profile').value = 'Loading bootstrap profile...';
+          await loadWorkspaceBootstrap(session.access_token);
+        }
+      });
+
+      // Upload workspace bootstrap file button
+      document.getElementById('upload-workspace-bootstrap-file-btn').addEventListener('click', async () => {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session) {
+          await uploadWorkspaceBootstrapFile(session.access_token);
         }
       });
 


### PR DESCRIPTION
## Summary
- add unified workspace bootstrap profile support (commands + files + state tracking)
- add `/auth/workspace-bootstrap` and `/auth/workspace-bootstrap/files` endpoints
- add auth dashboard UI for editing bootstrap profile and uploading bootstrap files
- apply bootstrap in scheduler task execution with idempotent state checks and safety validation
- add local user bootstrap directory support under `users/<user_id>/bootstrap`

## Testing
- not run (Rust toolchain unavailable in this environment: `cargo`, `rustc`, and `rustfmt` not found)

Requested-by: @bingran-you