### PR TITLE
Add WeChat message channel support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Queue/storage behavior:
 - Account/auth/billing data is stored in Supabase Postgres (`AccountStore`).
 
 Channels in code:
-- email, slack, discord, sms, telegram, whatsapp, google_docs/google_sheets/google_slides, bluebubbles.
+- email, slack, discord, sms, telegram, wechat, whatsapp, google_docs/google_sheets/google_slides, bluebubbles.
 
 ## Runtime Configuration Policy (Source of Truth)
 

--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -30,7 +30,7 @@ This service layer currently runs as:
 ### 1.2 End-to-end flow
 
 ```text
-Inbound (email/slack/discord/sms/telegram/whatsapp/google workspace/bluebubbles)
+Inbound (email/slack/discord/sms/telegram/wechat/whatsapp/google workspace/bluebubbles)
   -> inbound_gateway
   -> build route + dedupe key + raw payload ref
   -> ingestion queue
@@ -184,6 +184,7 @@ Azure ACI execution path (required vars):
 - Slack: `SLACK_*`, `SLACK_SIGNING_SECRET`
 - Discord: `DISCORD_*` and/or employee-specific Discord token envs
 - Telegram: `TELEGRAM_BOT_TOKEN` or employee-derived env keys
+- WeChat: `WECHAT_WEBHOOK_URL` or `WECHAT_WEBHOOK_KEY`
 - WhatsApp: `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_VERIFY_TOKEN`
 - Twilio SMS: `TWILIO_*`
 - Google Workspace: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, refresh tokens, `GOOGLE_*_ENABLED`

--- a/DoWhiz_service/run_task_module/README.md
+++ b/DoWhiz_service/run_task_module/README.md
@@ -16,7 +16,7 @@ Required input directories (relative to `workspace_dir`):
 
 Output files are channel-aware:
 - email/google workspace channels -> `reply_email_draft.html` + `reply_email_attachments/`
-- chat channels (slack/discord/telegram/sms/whatsapp/bluebubbles) -> `reply_message.txt` + `reply_attachments/`
+- chat channels (slack/discord/telegram/wechat/sms/whatsapp/bluebubbles) -> `reply_message.txt` + `reply_attachments/`
 
 ## Execution Backend
 

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -62,6 +62,9 @@ pub(super) fn build_prompt(
             "bluebubbles" => {
                 "2. After finishing the task (step one), write a plain text reply in reply_message.txt in the workspace root. Keep the reply concise and conversational. Do not use HTML or markdown. If there are files to attach, put them in reply_attachments/ and mention them in the reply. Do not pretend the job has been done without actually doing it."
             }
+            "wechat" => {
+                "2. After finishing the task (step one), write a plain text reply in reply_message.txt in the workspace root. Keep the reply concise and conversational. Do not use HTML. If there are files to attach, put them in reply_attachments/ and mention them in the reply. Do not pretend the job has been done without actually doing it."
+            }
             "whatsapp" => {
                 "2. After finishing the task (step one), write a plain text reply in reply_message.txt in the workspace root. Keep the reply concise and conversational. Do not use HTML. If there are files to attach, put them in reply_attachments/ and mention them in the reply. Do not pretend the job has been done without actually doing it."
             }
@@ -163,7 +166,8 @@ fn build_user_identities_section(identities: &UserIdentities) -> String {
         || !identities.slack_user_ids.is_empty()
         || !identities.discord_user_ids.is_empty()
         || !identities.phone_numbers.is_empty()
-        || !identities.telegram_user_ids.is_empty();
+        || !identities.telegram_user_ids.is_empty()
+        || !identities.wechat_user_ids.is_empty();
 
     if !has_any {
         return "Cross-channel routing: Not available (user has no linked DoWhiz account). \
@@ -190,6 +194,9 @@ their accounts at dowhiz.com first.\n".to_string();
     if !identities.telegram_user_ids.is_empty() {
         channels.push(format!("- Telegram User IDs: {}", identities.telegram_user_ids.join(", ")));
     }
+    if !identities.wechat_user_ids.is_empty() {
+        channels.push(format!("- WeChat User IDs: {}", identities.wechat_user_ids.join(", ")));
+    }
 
     format!(
         r#"Cross-channel routing (user's linked channels):
@@ -203,7 +210,7 @@ If no routing file is written, the reply goes to the original inbound channel.
 reply_routing.json schema:
 ```json
 {{
-  "channel": "email" | "slack" | "discord" | "telegram" | "sms" | "whatsapp" | "bluebubbles",
+  "channel": "email" | "slack" | "discord" | "telegram" | "wechat" | "sms" | "whatsapp" | "bluebubbles",
   "identifier": "<target identifier for the channel>"
 }}
 ```
@@ -213,6 +220,7 @@ Identifier format per channel:
 - slack: Slack user ID (e.g., "U1234567890")
 - discord: Discord user ID (e.g., "123456789012345678")
 - telegram: Telegram user ID (e.g., "123456789")
+- wechat: WeChat user ID (e.g., "wxid_abc123")
 - sms/whatsapp/bluebubbles: phone number (e.g., "+15551234567")
 
 IMPORTANT: When using cross-channel routing, write the reply in the TARGET channel's format:
@@ -220,6 +228,7 @@ IMPORTANT: When using cross-channel routing, write the reply in the TARGET chann
 - slack target: reply_message.txt (Slack mrkdwn: *bold*, _italic_, `code`)
 - discord target: reply_message.txt (Discord markdown: **bold**, *italic*, `code`)
 - telegram target: reply_message.txt (MarkdownV2)
+- wechat target: reply_message.txt (plain text)
 - sms/whatsapp/bluebubbles target: reply_message.txt (plain text)
 - Attachments for non-email channels go in reply_attachments/
 
@@ -741,6 +750,7 @@ mod tests {
             discord_user_ids: vec!["987654321".to_string()],
             phone_numbers: vec!["+15551234567".to_string()],
             telegram_user_ids: vec!["12345678".to_string()],
+            wechat_user_ids: vec!["wxid_abc123".to_string()],
         };
         let section = build_user_identities_section(&identities);
 
@@ -749,6 +759,7 @@ mod tests {
         assert!(section.contains("Discord User IDs: 987654321"));
         assert!(section.contains("Phone Numbers: +15551234567"));
         assert!(section.contains("Telegram User IDs: 12345678"));
+        assert!(section.contains("WeChat User IDs: wxid_abc123"));
     }
 
     #[test]
@@ -763,6 +774,7 @@ mod tests {
         assert!(section.contains("IMPORTANT: When using cross-channel routing"));
         assert!(section.contains("email target: reply_email_draft.html"));
         assert!(section.contains("discord target: reply_message.txt"));
+        assert!(section.contains("wechat target: reply_message.txt"));
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/src/run_task/types.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/types.rs
@@ -31,6 +31,9 @@ pub struct UserIdentities {
     /// Telegram user IDs
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub telegram_user_ids: Vec<String>,
+    /// WeChat user IDs
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub wechat_user_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/DoWhiz_service/run_task_module/src/run_task/workspace.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/workspace.rs
@@ -112,9 +112,9 @@ pub(super) fn prepare_workspace(
 
     // Use channel-specific reply file and attachments directory
     // Non-email channels use plain text reply_message.txt
-    // Email and GoogleDocs use HTML reply_email_draft.html
+    // Email and Google Workspace channels use HTML reply_email_draft.html
     let (reply_path, reply_attachments_dir) = match request.channel.to_lowercase().as_str() {
-        "slack" | "discord" | "telegram" | "sms" | "bluebubbles" => (
+        "slack" | "discord" | "telegram" | "wechat" | "sms" | "bluebubbles" => (
             request.workspace_dir.join("reply_message.txt"),
             request.workspace_dir.join("reply_attachments"),
         ),

--- a/DoWhiz_service/scheduler_module/README.md
+++ b/DoWhiz_service/scheduler_module/README.md
@@ -23,7 +23,7 @@ Schedules:
 ## Channels
 
 Supported channel enum values:
-- `email`, `slack`, `discord`, `sms`, `telegram`, `whatsapp`
+- `email`, `slack`, `discord`, `sms`, `telegram`, `wechat`, `whatsapp`
 - `google_docs`, `google_sheets`, `google_slides`
 - `bluebubbles`
 

--- a/DoWhiz_service/scheduler_module/src/account_store.rs
+++ b/DoWhiz_service/scheduler_module/src/account_store.rs
@@ -686,6 +686,7 @@ pub fn channel_to_identifier_type(channel: &crate::channel::Channel) -> &'static
         Channel::Sms => "phone",
         Channel::WhatsApp => "phone",
         Channel::Telegram => "telegram",
+        Channel::WeChat => "wechat",
         Channel::Slack => "slack",
         Channel::Discord => "discord",
         Channel::BlueBubbles => "phone",

--- a/DoWhiz_service/scheduler_module/src/channel.rs
+++ b/DoWhiz_service/scheduler_module/src/channel.rs
@@ -22,6 +22,9 @@ pub enum Channel {
     Telegram,
     /// WhatsApp via Meta Cloud API
     WhatsApp,
+    /// WeChat via inbound/outbound integrations
+    #[serde(rename = "wechat")]
+    WeChat,
     /// Google Docs collaboration via comments
     GoogleDocs,
     /// Google Sheets collaboration via comments
@@ -47,6 +50,7 @@ impl std::fmt::Display for Channel {
             Channel::Sms => write!(f, "sms"),
             Channel::Telegram => write!(f, "telegram"),
             Channel::WhatsApp => write!(f, "whatsapp"),
+            Channel::WeChat => write!(f, "wechat"),
             Channel::GoogleDocs => write!(f, "google_docs"),
             Channel::GoogleSheets => write!(f, "google_sheets"),
             Channel::GoogleSlides => write!(f, "google_slides"),
@@ -66,6 +70,7 @@ impl std::str::FromStr for Channel {
             "sms" => Ok(Channel::Sms),
             "telegram" => Ok(Channel::Telegram),
             "whatsapp" => Ok(Channel::WhatsApp),
+            "wechat" | "weixin" => Ok(Channel::WeChat),
             "google_docs" | "googledocs" => Ok(Channel::GoogleDocs),
             "google_sheets" | "googlesheets" => Ok(Channel::GoogleSheets),
             "google_slides" | "googleslides" => Ok(Channel::GoogleSlides),
@@ -145,6 +150,8 @@ pub struct ChannelMetadata {
     pub telegram_chat_id: Option<i64>,
     /// WhatsApp-specific: Phone number (sender's phone)
     pub whatsapp_phone_number: Option<String>,
+    /// WeChat-specific: recipient/user identifier
+    pub wechat_user_id: Option<String>,
     /// SMS-specific: From phone number
     pub sms_from: Option<String>,
     /// SMS-specific: To phone number

--- a/DoWhiz_service/scheduler_module/src/scheduler/actions.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/actions.rs
@@ -46,6 +46,7 @@ fn parse_channel(channel_str: &str) -> Option<Channel> {
         "slack" => Some(Channel::Slack),
         "discord" => Some(Channel::Discord),
         "telegram" => Some(Channel::Telegram),
+        "wechat" | "weixin" => Some(Channel::WeChat),
         "sms" => Some(Channel::Sms),
         "whatsapp" => Some(Channel::WhatsApp),
         "bluebubbles" => Some(Channel::BlueBubbles),
@@ -168,6 +169,7 @@ pub(crate) fn schedule_auto_reply<E: TaskExecutor>(
         | Channel::Discord
         | Channel::BlueBubbles
         | Channel::Telegram
+        | Channel::WeChat
         | Channel::WhatsApp
         | Channel::Sms => ("reply_message.txt", "reply_attachments"),
         Channel::Email | Channel::GoogleDocs | Channel::GoogleSheets | Channel::GoogleSlides => {
@@ -213,6 +215,7 @@ pub(crate) fn schedule_auto_reply<E: TaskExecutor>(
             | Channel::Discord
             | Channel::BlueBubbles
             | Channel::Telegram
+            | Channel::WeChat
             | Channel::WhatsApp
             | Channel::Sms => ("cross_channel_ack.txt", "reply_attachments"),
             Channel::Email | Channel::GoogleDocs | Channel::GoogleSheets | Channel::GoogleSlides => {
@@ -298,6 +301,7 @@ fn format_channel_name(channel: &Channel) -> &'static str {
         Channel::Slack => "Slack",
         Channel::Discord => "Discord",
         Channel::Telegram => "Telegram",
+        Channel::WeChat => "WeChat",
         Channel::Sms => "SMS",
         Channel::WhatsApp => "WhatsApp",
         Channel::BlueBubbles => "iMessage",
@@ -633,6 +637,8 @@ mod tests {
         assert_eq!(parse_channel("slack"), Some(Channel::Slack));
         assert_eq!(parse_channel("discord"), Some(Channel::Discord));
         assert_eq!(parse_channel("telegram"), Some(Channel::Telegram));
+        assert_eq!(parse_channel("wechat"), Some(Channel::WeChat));
+        assert_eq!(parse_channel("weixin"), Some(Channel::WeChat));
         assert_eq!(parse_channel("sms"), Some(Channel::Sms));
         assert_eq!(parse_channel("whatsapp"), Some(Channel::WhatsApp));
         assert_eq!(parse_channel("bluebubbles"), Some(Channel::BlueBubbles));
@@ -643,6 +649,7 @@ mod tests {
         assert_eq!(parse_channel("EMAIL"), Some(Channel::Email));
         assert_eq!(parse_channel("Slack"), Some(Channel::Slack));
         assert_eq!(parse_channel("DISCORD"), Some(Channel::Discord));
+        assert_eq!(parse_channel("WeChat"), Some(Channel::WeChat));
     }
 
     #[test]
@@ -702,6 +709,7 @@ mod tests {
         assert_eq!(format_channel_name(&Channel::Slack), "Slack");
         assert_eq!(format_channel_name(&Channel::Discord), "Discord");
         assert_eq!(format_channel_name(&Channel::Telegram), "Telegram");
+        assert_eq!(format_channel_name(&Channel::WeChat), "WeChat");
         assert_eq!(format_channel_name(&Channel::Sms), "SMS");
         assert_eq!(format_channel_name(&Channel::WhatsApp), "WhatsApp");
         assert_eq!(format_channel_name(&Channel::BlueBubbles), "iMessage");
@@ -719,6 +727,7 @@ mod tests {
             | Channel::Discord
             | Channel::BlueBubbles
             | Channel::Telegram
+            | Channel::WeChat
             | Channel::WhatsApp
             | Channel::Sms => ("cross_channel_ack.txt", "reply_attachments"),
             Channel::Email | Channel::GoogleDocs | Channel::GoogleSheets | Channel::GoogleSlides => {
@@ -737,6 +746,7 @@ mod tests {
             | Channel::Discord
             | Channel::BlueBubbles
             | Channel::Telegram
+            | Channel::WeChat
             | Channel::WhatsApp
             | Channel::Sms => ("cross_channel_ack.txt", "reply_attachments"),
             Channel::Email | Channel::GoogleDocs | Channel::GoogleSheets | Channel::GoogleSlides => {

--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -660,6 +660,7 @@ mod tests {
         let non_syncable_channels = vec![
             Channel::Email,
             Channel::Sms,
+            Channel::WeChat,
             Channel::WhatsApp,
             Channel::Telegram,
             Channel::BlueBubbles,
@@ -697,6 +698,7 @@ mod tests {
 
         assert_eq!(channel_to_identifier_type(&Channel::Discord), "discord");
         assert_eq!(channel_to_identifier_type(&Channel::Slack), "slack");
+        assert_eq!(channel_to_identifier_type(&Channel::WeChat), "wechat");
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
@@ -77,7 +77,8 @@ fn sync_blob_memo_to_workspace(account_id: Uuid, workspace_memory_dir: &Path) ->
 
 use super::outbound::{
     execute_bluebubbles_send, execute_discord_send, execute_email_send, execute_google_docs_send,
-    execute_slack_send, execute_sms_send, execute_telegram_send, execute_whatsapp_send,
+    execute_slack_send, execute_sms_send, execute_telegram_send, execute_wechat_send,
+    execute_whatsapp_send,
 };
 use super::types::{SchedulerError, SendReplyTask, TaskExecution, TaskKind};
 use super::utils::load_google_access_token_from_service_env;
@@ -180,6 +181,9 @@ fn identifiers_to_user_identities(
             }
             "telegram" | "telegram_user_id" => {
                 result.telegram_user_ids.push(identifier.identifier.clone())
+            }
+            "wechat" | "wechat_user_id" => {
+                result.wechat_user_ids.push(identifier.identifier.clone())
             }
             _ => {
                 // Unknown identifier type, skip
@@ -750,6 +754,9 @@ impl TaskExecutor for ModuleExecutor {
                     Channel::Telegram => {
                         execute_telegram_send(task)?;
                     }
+                    Channel::WeChat => {
+                        execute_wechat_send(task)?;
+                    }
                     Channel::WhatsApp => {
                         execute_whatsapp_send(task)?;
                     }
@@ -1319,6 +1326,19 @@ mod tests {
         let result = identifiers_to_user_identities(account_id, &identifiers);
 
         assert_eq!(result.telegram_user_ids, vec!["12345678"]);
+    }
+
+    #[test]
+    fn identifiers_to_user_identities_maps_wechat() {
+        let account_id = Uuid::new_v4();
+        let identifiers = vec![
+            make_identifier(account_id, "wechat", "wxid_abc123", true),
+            make_identifier(account_id, "wechat_user_id", "wxid_xyz789", true),
+        ];
+
+        let result = identifiers_to_user_identities(account_id, &identifiers);
+
+        assert_eq!(result.wechat_user_ids, vec!["wxid_abc123", "wxid_xyz789"]);
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/outbound.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/outbound.rs
@@ -426,6 +426,14 @@ fn resolve_telegram_bot_token_from_env() -> Option<String> {
         .or_else(|| env_var_non_empty("TELEGRAM_BOT_TOKEN"))
 }
 
+fn resolve_wechat_webhook_url_from_env() -> Option<String> {
+    if let Some(url) = env_var_non_empty("WECHAT_WEBHOOK_URL") {
+        return Some(url);
+    }
+    env_var_non_empty("WECHAT_WEBHOOK_KEY")
+        .map(|key| format!("https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key={key}"))
+}
+
 /// Execute a SendReplyTask via Telegram Bot API.
 pub(crate) fn execute_telegram_send(task: &SendReplyTask) -> Result<(), SchedulerError> {
     use crate::adapters::telegram::TelegramOutboundAdapter;
@@ -481,6 +489,97 @@ pub(crate) fn execute_telegram_send(task: &SendReplyTask) -> Result<(), Schedule
         "sent Telegram message to {:?}, message_id={}",
         task.to, result.message_id
     );
+    Ok(())
+}
+
+/// Execute a SendReplyTask via WeChat Work webhook.
+pub(crate) fn execute_wechat_send(task: &SendReplyTask) -> Result<(), SchedulerError> {
+    dotenvy::dotenv().ok();
+
+    let webhook_url = resolve_wechat_webhook_url_from_env().ok_or_else(|| {
+        SchedulerError::TaskFailed("WECHAT_WEBHOOK_URL or WECHAT_WEBHOOK_KEY not set".to_string())
+    })?;
+
+    let text_body = if task.html_path.exists() {
+        fs::read_to_string(&task.html_path).unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    let content = text_body.trim();
+    if content.is_empty() {
+        return Err(SchedulerError::TaskFailed(
+            "WeChat message body is empty".to_string(),
+        ));
+    }
+
+    let recipient = task
+        .to
+        .first()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if task.attachments_dir.is_dir() {
+        let has_files = fs::read_dir(&task.attachments_dir)
+            .ok()
+            .and_then(|mut entries| entries.next())
+            .is_some();
+        if has_files {
+            warn!(
+                "WeChat webhook adapter currently sends text only; attachments in {} were not sent",
+                task.attachments_dir.display()
+            );
+        }
+    }
+
+    let mut text_payload = serde_json::Map::new();
+    text_payload.insert(
+        "content".to_string(),
+        serde_json::Value::String(content.to_string()),
+    );
+    if let Some(to_user) = recipient.as_ref() {
+        text_payload.insert("mentioned_list".to_string(), serde_json::json!([to_user]));
+    }
+
+    let payload = serde_json::json!({
+        "msgtype": "text",
+        "text": text_payload,
+    });
+
+    let response = reqwest::blocking::Client::new()
+        .post(&webhook_url)
+        .json(&payload)
+        .send()
+        .map_err(|err| SchedulerError::TaskFailed(format!("WeChat send failed: {}", err)))?;
+
+    let status = response.status();
+    let body = response.text().unwrap_or_default();
+    if !status.is_success() {
+        return Err(SchedulerError::TaskFailed(format!(
+            "WeChat API error {}: {}",
+            status, body
+        )));
+    }
+
+    let response_json: serde_json::Value = serde_json::from_str(&body).map_err(|err| {
+        SchedulerError::TaskFailed(format!("WeChat response parse failed: {}", err))
+    })?;
+    let errcode = response_json
+        .get("errcode")
+        .and_then(|value| value.as_i64())
+        .unwrap_or(-1);
+    if errcode != 0 {
+        let errmsg = response_json
+            .get("errmsg")
+            .and_then(|value| value.as_str())
+            .unwrap_or("unknown error");
+        return Err(SchedulerError::TaskFailed(format!(
+            "WeChat API returned errcode {}: {}",
+            errcode, errmsg
+        )));
+    }
+
+    info!("sent WeChat webhook message to {:?}", task.to);
     Ok(())
 }
 

--- a/DoWhiz_service/scheduler_module/src/service/ingestion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/ingestion.rs
@@ -227,6 +227,7 @@ fn process_ingestion_envelope(
             let raw_payload = envelope.raw_payload_bytes();
             process_telegram_event(config, user_store, index_store, &message, &raw_payload)
         }
+        Channel::WeChat => Err("wechat inbound processing is not implemented yet".into()),
         Channel::WhatsApp => {
             let message = envelope.to_inbound_message();
             if try_quick_response_whatsapp(config, user_store, message_router, runtime, &message)? {


### PR DESCRIPTION
## Summary
- add a first-class `wechat` channel in scheduler channel parsing/display and cross-channel reply routing
- add outbound WeChat Work webhook sender (`WECHAT_WEBHOOK_URL` or `WECHAT_WEBHOOK_KEY`) for `SendReply`
- wire WeChat into run-task prompt/workspace output selection and linked identity schema (`wechat_user_ids`)
- update docs for supported channels and channel-specific env configuration

## Testing
- not run in this environment (`cargo`/Rust toolchain unavailable)

Requested-by: @bingran-you