### PR TITLE
Add internal metrics dashboard for platform operations

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -26,6 +26,7 @@ This service layer currently runs as:
 - Worker does **not** host inbound webhook routes; it consumes ingestion queue messages.
 - Both gateway and worker expose account/auth routes (`/auth/*`) and agent market routes.
 - Billing routes (`/billing/*`) are mounted on worker only when Stripe config exists.
+- Worker also exposes an internal metrics API route (`/api/internal/metrics`) for operational dashboarding.
 
 ### 1.2 End-to-end flow
 
@@ -188,6 +189,14 @@ Azure ACI execution path (required vars):
 - Twilio SMS: `TWILIO_*`
 - Google Workspace: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, refresh tokens, `GOOGLE_*_ENABLED`
 - Google Drive push: `GOOGLE_DRIVE_PUSH_ENABLED`, `GOOGLE_DRIVE_WEBHOOK_URL`
+
+### 4.6 Internal dashboard metrics API
+
+- Set `INTERNAL_DASHBOARD_API_KEY` to enable `/api/internal/metrics`.
+- Requests must send one of:
+  - header `x-internal-dashboard-key: <INTERNAL_DASHBOARD_API_KEY>`, or
+  - header `Authorization: Bearer <INTERNAL_DASHBOARD_API_KEY>`
+- If `INTERNAL_DASHBOARD_API_KEY` is not set, the route returns `503` (disabled).
 
 ## 5) Local Run Workflows
 

--- a/DoWhiz_service/scheduler_module/src/account_store.rs
+++ b/DoWhiz_service/scheduler_module/src/account_store.rs
@@ -2,6 +2,8 @@ use chrono::{DateTime, Utc};
 use postgres_native_tls::MakeTlsConnector;
 use r2d2::{Pool, PooledConnection};
 use r2d2_postgres::PostgresConnectionManager;
+use serde::Serialize;
+use std::collections::BTreeMap;
 use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -12,6 +14,20 @@ use crate::env_alias::var_with_scale_oliver;
 
 type PgPool = Pool<PostgresConnectionManager<MakeTlsConnector>>;
 type PgConn = PooledConnection<PostgresConnectionManager<MakeTlsConnector>>;
+
+fn query_count_or_zero_on_missing_table(
+    conn: &mut PgConn,
+    query: &str,
+) -> Result<i64, AccountStoreError> {
+    match conn.query_one(query, &[]) {
+        Ok(row) => Ok(row.get(0)),
+        Err(err) if err.code() == Some(&postgres::error::SqlState::UNDEFINED_TABLE) => {
+            warn!("account_store metrics query skipped missing table: {}", query);
+            Ok(0)
+        }
+        Err(err) => Err(err.into()),
+    }
+}
 
 fn parse_bool_env(value: &str) -> bool {
     matches!(
@@ -66,6 +82,18 @@ pub struct AccountIdentifier {
     pub identifier: String,
     pub verified: bool,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountMetricsSnapshot {
+    pub accounts_total: i64,
+    pub identifiers_total: i64,
+    pub verified_identifiers_total: i64,
+    pub identifiers_by_type: BTreeMap<String, i64>,
+    pub purchased_hours_total: f64,
+    pub used_hours_total: f64,
+    pub payments_total: i64,
+    pub payments_last_24h: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -466,6 +494,80 @@ impl AccountStore {
             &[&tokens, &account_id],
         )?;
         Ok(())
+    }
+
+    /// Return global account metrics for internal dashboarding.
+    pub fn metrics_snapshot(&self) -> Result<AccountMetricsSnapshot, AccountStoreError> {
+        let mut conn = self.conn()?;
+
+        let accounts_total = query_count_or_zero_on_missing_table(
+            &mut conn,
+            "SELECT COUNT(*)::bigint FROM accounts",
+        )?;
+        let identifiers_total = query_count_or_zero_on_missing_table(
+            &mut conn,
+            "SELECT COUNT(*)::bigint FROM account_identifiers",
+        )?;
+        let verified_identifiers_total = query_count_or_zero_on_missing_table(
+            &mut conn,
+            "SELECT COUNT(*)::bigint FROM account_identifiers WHERE verified = true",
+        )?;
+        let payments_total = query_count_or_zero_on_missing_table(
+            &mut conn,
+            "SELECT COUNT(*)::bigint FROM payments",
+        )?;
+        let payments_last_24h = query_count_or_zero_on_missing_table(
+            &mut conn,
+            "SELECT COUNT(*)::bigint FROM payments WHERE created_at >= NOW() - interval '24 hours'",
+        )?;
+
+        let mut identifiers_by_type = BTreeMap::new();
+        match conn.query(
+            "SELECT identifier_type, COUNT(*)::bigint
+             FROM account_identifiers
+             WHERE verified = true
+             GROUP BY identifier_type
+             ORDER BY identifier_type",
+            &[],
+        ) {
+            Ok(rows) => {
+                for row in rows {
+                    let identifier_type: String = row.get(0);
+                    let count: i64 = row.get(1);
+                    identifiers_by_type.insert(identifier_type, count);
+                }
+            }
+            Err(err) if err.code() == Some(&postgres::error::SqlState::UNDEFINED_TABLE) => {
+                warn!("account_store metrics identifier breakdown skipped: missing table");
+            }
+            Err(err) => return Err(err.into()),
+        }
+
+        let (purchased_hours_total, used_hours_total) = match conn.query_one(
+            "SELECT
+                COALESCE(SUM(purchased_hours::float8), 0),
+                COALESCE(SUM(tokens_to_hours::float8), 0)
+             FROM accounts",
+            &[],
+        ) {
+            Ok(row) => (row.get(0), row.get(1)),
+            Err(err) if err.code() == Some(&postgres::error::SqlState::UNDEFINED_TABLE) => {
+                warn!("account_store metrics usage totals skipped: missing accounts table");
+                (0.0, 0.0)
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        Ok(AccountMetricsSnapshot {
+            accounts_total,
+            identifiers_total,
+            verified_identifiers_total,
+            identifiers_by_type,
+            purchased_hours_total,
+            used_hours_total,
+            payments_total,
+            payments_last_24h,
+        })
     }
 
     // =========================================================================

--- a/DoWhiz_service/scheduler_module/src/index_store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/index_store/mod.rs
@@ -6,6 +6,7 @@ use mongodb::options::IndexOptions;
 use mongodb::options::UpdateOptions;
 use mongodb::sync::Collection;
 use mongodb::IndexModel;
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use tracing::warn;
@@ -27,6 +28,14 @@ struct MongoIndexStore {
 pub struct TaskRef {
     pub task_id: String,
     pub user_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskIndexMetricsSnapshot {
+    pub enabled_tasks_total: u64,
+    pub due_now_total: u64,
+    pub due_within_24h_total: u64,
+    pub unique_users_total: u64,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -68,6 +77,13 @@ impl IndexStore {
         limit: usize,
     ) -> Result<Vec<TaskRef>, IndexStoreError> {
         self.mongo.due_task_refs(now, limit)
+    }
+
+    pub fn metrics_snapshot(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<TaskIndexMetricsSnapshot, IndexStoreError> {
+        self.mongo.metrics_snapshot(now)
     }
 }
 
@@ -219,6 +235,33 @@ impl MongoIndexStore {
             refs.push(TaskRef { task_id, user_id });
         }
         Ok(refs)
+    }
+
+    fn metrics_snapshot(&self, now: DateTime<Utc>) -> Result<TaskIndexMetricsSnapshot, IndexStoreError> {
+        let enabled_filter = doc! { "enabled": true };
+        let due_now_filter = doc! {
+            "enabled": true,
+            "next_run": { "$lte": BsonDateTime::from_chrono(now) },
+        };
+        let due_window_filter = doc! {
+            "enabled": true,
+            "next_run": { "$lte": BsonDateTime::from_chrono(now + chrono::Duration::hours(24)) },
+        };
+
+        let enabled_tasks_total = self.task_index.count_documents(enabled_filter.clone(), None)?;
+        let due_now_total = self.task_index.count_documents(due_now_filter, None)?;
+        let due_within_24h_total = self.task_index.count_documents(due_window_filter, None)?;
+        let unique_users_total = self
+            .task_index
+            .distinct("user_id", enabled_filter, None)?
+            .len() as u64;
+
+        Ok(TaskIndexMetricsSnapshot {
+            enabled_tasks_total,
+            due_now_total,
+            due_within_24h_total,
+            unique_users_total,
+        })
     }
 }
 

--- a/DoWhiz_service/scheduler_module/src/ingestion_queue.rs
+++ b/DoWhiz_service/scheduler_module/src/ingestion_queue.rs
@@ -2,6 +2,8 @@ use postgres::types::Type;
 use postgres_native_tls::MakeTlsConnector;
 use r2d2::{Pool, PooledConnection};
 use r2d2_postgres::PostgresConnectionManager;
+use serde::Serialize;
+use std::collections::BTreeMap;
 use std::env;
 use tracing::{error, warn};
 use uuid::Uuid;
@@ -51,6 +53,19 @@ pub struct QueuedEnvelope {
     pub envelope: IngestionEnvelope,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct IngestionQueueMetricsSnapshot {
+    pub total: i64,
+    pub pending: i64,
+    pub processing: i64,
+    pub done: i64,
+    pub failed: i64,
+    pub created_last_24h: i64,
+    pub failed_last_24h: i64,
+    pub status_counts: BTreeMap<String, i64>,
+    pub channel_counts: BTreeMap<String, i64>,
+}
+
 pub trait IngestionQueue: Send + Sync {
     fn enqueue(&self, envelope: &IngestionEnvelope) -> Result<EnqueueResult, IngestionQueueError>;
     fn claim_next(&self, employee_id: &str) -> Result<Option<QueuedEnvelope>, IngestionQueueError>;
@@ -97,6 +112,67 @@ pub fn build_servicebus_queue_from_env(
 ) -> Result<std::sync::Arc<dyn IngestionQueue>, IngestionQueueError> {
     let queue = ServiceBusIngestionQueue::from_env()?;
     Ok(std::sync::Arc::new(queue))
+}
+
+pub fn ingestion_queue_metrics_from_env() -> Result<IngestionQueueMetricsSnapshot, IngestionQueueError> {
+    let db_url = resolve_db_url()?;
+    let table = resolve_table_name()?;
+    let config: postgres::Config = db_url.parse().map_err(IngestionQueueError::Postgres)?;
+
+    let mut tls_builder = native_tls::TlsConnector::builder();
+    if resolve_bool_env("INGESTION_QUEUE_TLS_ALLOW_INVALID_CERTS") {
+        tls_builder.danger_accept_invalid_certs(true);
+        tls_builder.danger_accept_invalid_hostnames(true);
+    }
+    let tls_connector = tls_builder
+        .build()
+        .map_err(|err| IngestionQueueError::Config(err.to_string()))?;
+    let tls = MakeTlsConnector::new(tls_connector);
+    let mut conn = config.connect(tls).map_err(IngestionQueueError::Postgres)?;
+
+    let total = query_table_count(&mut conn, &table, None)?;
+    let pending = query_table_count(&mut conn, &table, Some("status = 'pending'"))?;
+    let processing = query_table_count(&mut conn, &table, Some("status = 'processing'"))?;
+    let done = query_table_count(&mut conn, &table, Some("status = 'done'"))?;
+    let failed = query_table_count(&mut conn, &table, Some("status = 'failed'"))?;
+    let created_last_24h = query_table_count(
+        &mut conn,
+        &table,
+        Some("created_at >= now() - interval '24 hours'"),
+    )?;
+    let failed_last_24h = query_table_count(
+        &mut conn,
+        &table,
+        Some("status = 'failed' AND created_at >= now() - interval '24 hours'"),
+    )?;
+
+    let mut status_counts = BTreeMap::new();
+    let status_query = format!("SELECT status, COUNT(*)::bigint FROM {table} GROUP BY status");
+    for row in conn.query(&status_query, &[])? {
+        let status: String = row.get(0);
+        let count: i64 = row.get(1);
+        status_counts.insert(status, count);
+    }
+
+    let mut channel_counts = BTreeMap::new();
+    let channel_query = format!("SELECT channel, COUNT(*)::bigint FROM {table} GROUP BY channel");
+    for row in conn.query(&channel_query, &[])? {
+        let channel: String = row.get(0);
+        let count: i64 = row.get(1);
+        channel_counts.insert(channel, count);
+    }
+
+    Ok(IngestionQueueMetricsSnapshot {
+        total,
+        pending,
+        processing,
+        done,
+        failed,
+        created_last_24h,
+        failed_last_24h,
+        status_counts,
+        channel_counts,
+    })
 }
 
 impl PostgresIngestionQueue {
@@ -494,6 +570,18 @@ fn resolve_db_url() -> Result<String, IngestionQueueError> {
                 .filter(|value| !value.trim().is_empty())
         })
         .ok_or(IngestionQueueError::MissingDbUrl)
+}
+
+fn query_table_count(
+    conn: &mut postgres::Client,
+    table: &str,
+    predicate: Option<&str>,
+) -> Result<i64, IngestionQueueError> {
+    let statement = match predicate {
+        Some(predicate) => format!("SELECT COUNT(*)::bigint FROM {table} WHERE {predicate}"),
+        None => format!("SELECT COUNT(*)::bigint FROM {table}"),
+    };
+    Ok(conn.query_one(&statement, &[])?.get(0))
 }
 
 fn resolve_table_name() -> Result<String, IngestionQueueError> {

--- a/DoWhiz_service/scheduler_module/src/service.rs
+++ b/DoWhiz_service/scheduler_module/src/service.rs
@@ -6,6 +6,7 @@ mod email;
 mod html;
 mod inbound;
 mod ingestion;
+mod internal_dashboard;
 mod postmark;
 mod recipients;
 mod scheduler;

--- a/DoWhiz_service/scheduler_module/src/service/internal_dashboard.rs
+++ b/DoWhiz_service/scheduler_module/src/service/internal_dashboard.rs
@@ -1,0 +1,224 @@
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tokio::task;
+use tracing::error;
+
+use crate::account_store::{AccountMetricsSnapshot, AccountStore};
+use crate::index_store::{IndexStore, TaskIndexMetricsSnapshot};
+use crate::ingestion_queue::{ingestion_queue_metrics_from_env, IngestionQueueMetricsSnapshot};
+
+#[derive(Clone)]
+pub struct InternalDashboardState {
+    pub account_store: Arc<AccountStore>,
+    pub index_store: Arc<IndexStore>,
+    pub api_key: Option<String>,
+}
+
+impl InternalDashboardState {
+    pub fn from_env(account_store: Arc<AccountStore>, index_store: Arc<IndexStore>) -> Self {
+        Self {
+            account_store,
+            index_store,
+            api_key: std::env::var("INTERNAL_DASHBOARD_API_KEY")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct MetricsSection<T> {
+    pub data: Option<T>,
+    pub error: Option<String>,
+}
+
+impl<T> MetricsSection<T> {
+    fn ok(data: T) -> Self {
+        Self {
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    fn err(message: impl Into<String>) -> Self {
+        Self {
+            data: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct InternalMetricsResponse {
+    pub generated_at: DateTime<Utc>,
+    pub accounts: MetricsSection<AccountMetricsSnapshot>,
+    pub tasks: MetricsSection<TaskIndexMetricsSnapshot>,
+    pub ingestion_queue: MetricsSection<IngestionQueueMetricsSnapshot>,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+pub fn internal_dashboard_router(state: InternalDashboardState) -> Router {
+    Router::new()
+        .route("/api/internal/metrics", get(get_internal_metrics))
+        .with_state(state)
+}
+
+async fn get_internal_metrics(
+    State(state): State<InternalDashboardState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(status) = validate_internal_api_key(&headers, state.api_key.as_deref()) {
+        return (
+            status,
+            Json(ErrorResponse {
+                error: authorization_error(status).to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let account_store = state.account_store.clone();
+    let index_store = state.index_store.clone();
+    let generated_at = Utc::now();
+    let snapshot = task::spawn_blocking(move || {
+        build_metrics_snapshot(account_store, index_store, generated_at)
+    })
+    .await;
+
+    match snapshot {
+        Ok(payload) => (StatusCode::OK, Json(payload)).into_response(),
+        Err(err) => {
+            error!("internal dashboard snapshot task join error: {}", err);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Failed to build internal metrics snapshot".to_string(),
+                }),
+            )
+                .into_response()
+        }
+    }
+}
+
+fn build_metrics_snapshot(
+    account_store: Arc<AccountStore>,
+    index_store: Arc<IndexStore>,
+    generated_at: DateTime<Utc>,
+) -> InternalMetricsResponse {
+    let accounts = match account_store.metrics_snapshot() {
+        Ok(snapshot) => MetricsSection::ok(snapshot),
+        Err(err) => MetricsSection::err(err.to_string()),
+    };
+
+    let tasks = match index_store.metrics_snapshot(generated_at) {
+        Ok(snapshot) => MetricsSection::ok(snapshot),
+        Err(err) => MetricsSection::err(err.to_string()),
+    };
+
+    let ingestion_queue = match ingestion_queue_metrics_from_env() {
+        Ok(snapshot) => MetricsSection::ok(snapshot),
+        Err(err) => MetricsSection::err(err.to_string()),
+    };
+
+    InternalMetricsResponse {
+        generated_at,
+        accounts,
+        tasks,
+        ingestion_queue,
+    }
+}
+
+fn validate_internal_api_key(headers: &HeaderMap, expected_key: Option<&str>) -> Result<(), StatusCode> {
+    let expected_key = expected_key
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let provided_key = extract_internal_dashboard_key(headers).ok_or(StatusCode::UNAUTHORIZED)?;
+    if provided_key == expected_key {
+        Ok(())
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}
+
+fn extract_internal_dashboard_key(headers: &HeaderMap) -> Option<String> {
+    let direct = headers
+        .get("x-internal-dashboard-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string());
+    if direct.is_some() {
+        return direct;
+    }
+
+    headers
+        .get("Authorization")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+}
+
+fn authorization_error(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::SERVICE_UNAVAILABLE => {
+            "Internal dashboard is disabled. Set INTERNAL_DASHBOARD_API_KEY to enable it."
+        }
+        StatusCode::UNAUTHORIZED => {
+            "Missing or invalid credentials. Provide x-internal-dashboard-key or Bearer token."
+        }
+        _ => "Unauthorized",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn validate_internal_api_key_requires_configured_key() {
+        let headers = HeaderMap::new();
+        let status = validate_internal_api_key(&headers, None)
+            .expect_err("expected service unavailable when key is not configured");
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn validate_internal_api_key_accepts_custom_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-internal-dashboard-key", HeaderValue::from_static("secret"));
+        assert!(validate_internal_api_key(&headers, Some("secret")).is_ok());
+    }
+
+    #[test]
+    fn validate_internal_api_key_accepts_bearer_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", HeaderValue::from_static("Bearer secret"));
+        assert!(validate_internal_api_key(&headers, Some("secret")).is_ok());
+    }
+
+    #[test]
+    fn validate_internal_api_key_rejects_wrong_key() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-internal-dashboard-key", HeaderValue::from_static("wrong"));
+        let status = validate_internal_api_key(&headers, Some("secret"))
+            .expect_err("expected unauthorized for incorrect key");
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/service/server.rs
+++ b/DoWhiz_service/scheduler_module/src/service/server.rs
@@ -29,6 +29,7 @@ use tokio::task;
 use super::agent_market::{agent_market_router, AgentMarketState};
 use super::auth::{auth_router, AuthState};
 use super::billing::{billing_router, BillingState};
+use super::internal_dashboard::{internal_dashboard_router, InternalDashboardState};
 
 use super::config::ServiceConfig;
 use super::ingestion::spawn_ingestion_consumer;
@@ -186,6 +187,8 @@ pub async fn run_server(
         users_root: Some(config.users_root.clone()),
     };
     let agent_market_state = AgentMarketState::from_env();
+    let internal_dashboard_state =
+        InternalDashboardState::from_env(auth_state.account_store.clone(), index_store.clone());
 
     let mut app = Router::new()
         .route("/", get(health))
@@ -194,7 +197,8 @@ pub async fn run_server(
         .route("/slack/oauth/callback", get(slack_oauth_callback))
         .with_state(state)
         .merge(auth_router(auth_state))
-        .merge(agent_market_router(agent_market_state));
+        .merge(agent_market_router(agent_market_state))
+        .merge(internal_dashboard_router(internal_dashboard_state));
 
     // Add billing routes if Stripe is configured
     if let Some(billing) = billing_state {

--- a/website/public/internal/metrics/index.html
+++ b/website/public/internal/metrics/index.html
@@ -1,0 +1,460 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DoWhiz Internal Metrics Dashboard</title>
+    <style>
+      :root {
+        --bg: #0d1117;
+        --panel: #161b22;
+        --panel-border: #2d333b;
+        --text: #f0f6fc;
+        --muted: #8b949e;
+        --ok: #3fb950;
+        --warn: #d29922;
+        --bad: #f85149;
+        --accent: #58a6ff;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+        background: radial-gradient(circle at top, #1a2332, var(--bg) 40%);
+        color: var(--text);
+      }
+
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 1rem;
+      }
+
+      .header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+      }
+
+      .header h1 {
+        margin: 0;
+        font-size: 1.4rem;
+      }
+
+      .sub {
+        color: var(--muted);
+        font-size: 0.92rem;
+        margin-top: 0.2rem;
+      }
+
+      .controls {
+        display: grid;
+        gap: 0.5rem;
+        width: min(100%, 640px);
+      }
+
+      .control-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr auto;
+        gap: 0.5rem;
+      }
+
+      input,
+      button {
+        border-radius: 0.5rem;
+        border: 1px solid var(--panel-border);
+        background: var(--panel);
+        color: var(--text);
+        padding: 0.6rem 0.75rem;
+        font-size: 0.92rem;
+      }
+
+      input:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 1px;
+      }
+
+      button {
+        cursor: pointer;
+        border-color: #355f9f;
+        background: linear-gradient(180deg, #2f81f7, #1f6feb);
+      }
+
+      button:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+
+      .status {
+        margin-bottom: 1rem;
+        padding: 0.7rem 0.8rem;
+        border-radius: 0.5rem;
+        border: 1px solid var(--panel-border);
+        background: var(--panel);
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      .status.ok {
+        border-color: rgba(63, 185, 80, 0.5);
+        color: #c7f4cf;
+      }
+
+      .status.err {
+        border-color: rgba(248, 81, 73, 0.6);
+        color: #ffd4d2;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 0.75rem;
+      }
+
+      .card {
+        border: 1px solid var(--panel-border);
+        background: var(--panel);
+        border-radius: 0.75rem;
+        padding: 0.8rem;
+      }
+
+      .card .label {
+        color: var(--muted);
+        font-size: 0.84rem;
+      }
+
+      .card .value {
+        margin-top: 0.3rem;
+        font-size: 1.4rem;
+        font-weight: 700;
+      }
+
+      .sections {
+        display: grid;
+        gap: 1rem;
+        margin-top: 1rem;
+      }
+
+      .section h2 {
+        margin: 0 0 0.6rem;
+        font-size: 1rem;
+      }
+
+      .section-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .pill {
+        font-size: 0.75rem;
+        padding: 0.2rem 0.5rem;
+        border-radius: 999px;
+        border: 1px solid var(--panel-border);
+        color: var(--muted);
+      }
+
+      .pill.ok {
+        border-color: rgba(63, 185, 80, 0.5);
+        color: #b7f0c0;
+      }
+
+      .pill.err {
+        border-color: rgba(248, 81, 73, 0.5);
+        color: #ffd4d2;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th,
+      td {
+        border-top: 1px solid var(--panel-border);
+        padding: 0.45rem 0.2rem;
+        text-align: left;
+        font-size: 0.9rem;
+      }
+
+      th {
+        color: var(--muted);
+        font-weight: 600;
+      }
+
+      .mono {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+      }
+
+      @media (max-width: 700px) {
+        .control-row {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <div>
+          <h1>DoWhiz Internal Metrics</h1>
+          <div class="sub">Accounts, scheduled tasks, and ingestion queue health in one place.</div>
+        </div>
+      </div>
+
+      <div class="controls">
+        <div class="control-row">
+          <input id="api-url" type="text" placeholder="API base URL (e.g. https://api.dowhiz.com)" />
+          <input id="api-key" type="password" placeholder="INTERNAL_DASHBOARD_API_KEY" />
+          <button id="refresh-btn" type="button">Refresh</button>
+        </div>
+      </div>
+
+      <div id="status" class="status">Waiting for first load.</div>
+
+      <div class="grid" id="top-cards"></div>
+
+      <div class="sections">
+        <section class="section card">
+          <div class="section-head">
+            <h2>Accounts</h2>
+            <span id="accounts-pill" class="pill">No data</span>
+          </div>
+          <div class="grid" id="accounts-cards"></div>
+          <table>
+            <thead>
+              <tr>
+                <th>Identifier Type</th>
+                <th>Verified Count</th>
+              </tr>
+            </thead>
+            <tbody id="accounts-identifiers"></tbody>
+          </table>
+        </section>
+
+        <section class="section card">
+          <div class="section-head">
+            <h2>Task Index</h2>
+            <span id="tasks-pill" class="pill">No data</span>
+          </div>
+          <div class="grid" id="tasks-cards"></div>
+        </section>
+
+        <section class="section card">
+          <div class="section-head">
+            <h2>Ingestion Queue</h2>
+            <span id="queue-pill" class="pill">No data</span>
+          </div>
+          <div class="grid" id="queue-cards"></div>
+          <table>
+            <thead>
+              <tr>
+                <th>Status</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody id="queue-status-breakdown"></tbody>
+          </table>
+          <table>
+            <thead>
+              <tr>
+                <th>Channel</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody id="queue-channel-breakdown"></tbody>
+          </table>
+        </section>
+      </div>
+    </div>
+
+    <script>
+      const statusEl = document.getElementById("status");
+      const apiUrlEl = document.getElementById("api-url");
+      const apiKeyEl = document.getElementById("api-key");
+      const refreshBtn = document.getElementById("refresh-btn");
+
+      const topCardsEl = document.getElementById("top-cards");
+      const accountsCardsEl = document.getElementById("accounts-cards");
+      const tasksCardsEl = document.getElementById("tasks-cards");
+      const queueCardsEl = document.getElementById("queue-cards");
+      const accountsIdentifiersEl = document.getElementById("accounts-identifiers");
+      const queueStatusBreakdownEl = document.getElementById("queue-status-breakdown");
+      const queueChannelBreakdownEl = document.getElementById("queue-channel-breakdown");
+      const accountsPillEl = document.getElementById("accounts-pill");
+      const tasksPillEl = document.getElementById("tasks-pill");
+      const queuePillEl = document.getElementById("queue-pill");
+
+      const KEY_STORAGE = "dowhiz_internal_dashboard_key";
+      const URL_STORAGE = "dowhiz_internal_dashboard_api_url";
+
+      function formatInt(value) {
+        const n = Number(value || 0);
+        if (!Number.isFinite(n)) return "-";
+        return new Intl.NumberFormat("en-US").format(n);
+      }
+
+      function formatFloat(value) {
+        const n = Number(value || 0);
+        if (!Number.isFinite(n)) return "-";
+        return new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(n);
+      }
+
+      function card(label, value, mono = false) {
+        return `
+          <div class="card">
+            <div class="label">${label}</div>
+            <div class="value ${mono ? "mono" : ""}">${value}</div>
+          </div>
+        `;
+      }
+
+      function row(label, value) {
+        return `<tr><td>${label}</td><td>${value}</td></tr>`;
+      }
+
+      function setPill(element, ok, errorMessage) {
+        element.className = "pill " + (ok ? "ok" : "err");
+        element.textContent = ok ? "Healthy" : errorMessage || "Unavailable";
+      }
+
+      function setStatus(message, isError) {
+        statusEl.className = "status " + (isError ? "err" : "ok");
+        statusEl.textContent = message;
+      }
+
+      function defaultApiUrl() {
+        if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
+          return "http://localhost:9001";
+        }
+        return window.location.origin;
+      }
+
+      async function loadMetrics() {
+        const apiBase = apiUrlEl.value.trim().replace(/\/+$/, "");
+        const apiKey = apiKeyEl.value.trim();
+        if (!apiBase) {
+          setStatus("Set API URL first.", true);
+          return;
+        }
+        if (!apiKey) {
+          setStatus("Set INTERNAL_DASHBOARD_API_KEY first.", true);
+          return;
+        }
+
+        refreshBtn.disabled = true;
+        setStatus("Loading metrics...", false);
+
+        try {
+          const response = await fetch(`${apiBase}/api/internal/metrics`, {
+            headers: {
+              "x-internal-dashboard-key": apiKey,
+            },
+          });
+
+          const payload = await response.json();
+          if (!response.ok) {
+            throw new Error(payload.error || `Request failed with ${response.status}`);
+          }
+
+          window.localStorage.setItem(KEY_STORAGE, apiKey);
+          window.localStorage.setItem(URL_STORAGE, apiBase);
+          renderMetrics(payload);
+          setStatus(`Updated at ${new Date(payload.generated_at).toLocaleString()}`, false);
+        } catch (error) {
+          setStatus(`Failed to load metrics: ${error.message}`, true);
+        } finally {
+          refreshBtn.disabled = false;
+        }
+      }
+
+      function renderMetrics(payload) {
+        const accounts = payload.accounts || {};
+        const tasks = payload.tasks || {};
+        const queue = payload.ingestion_queue || {};
+
+        const accountsOk = Boolean(accounts.data) && !accounts.error;
+        const tasksOk = Boolean(tasks.data) && !tasks.error;
+        const queueOk = Boolean(queue.data) && !queue.error;
+
+        setPill(accountsPillEl, accountsOk, accounts.error);
+        setPill(tasksPillEl, tasksOk, tasks.error);
+        setPill(queuePillEl, queueOk, queue.error);
+
+        const accountsData = accounts.data || {};
+        const tasksData = tasks.data || {};
+        const queueData = queue.data || {};
+
+        topCardsEl.innerHTML = [
+          card("Accounts", formatInt(accountsData.accounts_total)),
+          card("Verified IDs", formatInt(accountsData.verified_identifiers_total)),
+          card("Enabled Tasks", formatInt(tasksData.enabled_tasks_total)),
+          card("Queue Pending", formatInt(queueData.pending)),
+        ].join("");
+
+        accountsCardsEl.innerHTML = [
+          card("Total Accounts", formatInt(accountsData.accounts_total)),
+          card("Total Identifiers", formatInt(accountsData.identifiers_total)),
+          card("Verified Identifiers", formatInt(accountsData.verified_identifiers_total)),
+          card("Purchased Hours", formatFloat(accountsData.purchased_hours_total)),
+          card("Used Hours", formatFloat(accountsData.used_hours_total)),
+          card("Payments (24h)", formatInt(accountsData.payments_last_24h)),
+        ].join("");
+
+        const identifiersByType = accountsData.identifiers_by_type || {};
+        const identifierRows = Object.keys(identifiersByType).sort();
+        accountsIdentifiersEl.innerHTML = identifierRows.length
+          ? identifierRows.map((key) => row(key, formatInt(identifiersByType[key]))).join("")
+          : row("No data", "-");
+
+        tasksCardsEl.innerHTML = [
+          card("Enabled Tasks", formatInt(tasksData.enabled_tasks_total)),
+          card("Due Now", formatInt(tasksData.due_now_total)),
+          card("Due in 24h", formatInt(tasksData.due_within_24h_total)),
+          card("Users with Tasks", formatInt(tasksData.unique_users_total)),
+        ].join("");
+
+        queueCardsEl.innerHTML = [
+          card("Total Records", formatInt(queueData.total)),
+          card("Pending", formatInt(queueData.pending)),
+          card("Processing", formatInt(queueData.processing)),
+          card("Done", formatInt(queueData.done)),
+          card("Failed", formatInt(queueData.failed)),
+          card("Created (24h)", formatInt(queueData.created_last_24h)),
+          card("Failed (24h)", formatInt(queueData.failed_last_24h)),
+        ].join("");
+
+        const statusCounts = queueData.status_counts || {};
+        const statusRows = Object.keys(statusCounts).sort();
+        queueStatusBreakdownEl.innerHTML = statusRows.length
+          ? statusRows.map((key) => row(key, formatInt(statusCounts[key]))).join("")
+          : row("No data", "-");
+
+        const channelCounts = queueData.channel_counts || {};
+        const channelRows = Object.keys(channelCounts).sort();
+        queueChannelBreakdownEl.innerHTML = channelRows.length
+          ? channelRows.map((key) => row(key, formatInt(channelCounts[key]))).join("")
+          : row("No data", "-");
+      }
+
+      function bootstrapDefaults() {
+        apiUrlEl.value = window.localStorage.getItem(URL_STORAGE) || defaultApiUrl();
+        apiKeyEl.value = window.localStorage.getItem(KEY_STORAGE) || "";
+      }
+
+      refreshBtn.addEventListener("click", loadMetrics);
+      bootstrapDefaults();
+      if (apiKeyEl.value.trim()) {
+        loadMetrics();
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new protected internal API endpoint at `/api/internal/metrics`
- aggregate account, task-index, and ingestion-queue metrics for one snapshot response
- add `INTERNAL_DASHBOARD_API_KEY` auth gate (custom header or bearer token)
- add a lightweight internal dashboard page at `website/public/internal/metrics/index.html`
- document dashboard route + env setup in `DoWhiz_service/README.md`

## Testing
- could not run `cargo fmt` or `cargo test` in this environment because `cargo` is not installed

Closes #713

Requested-by: @bingran-you