### PR TITLE
Fix workspace web auth bootstrap resolution on staging

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -47,6 +47,12 @@ const PAYMENT_ENV_KEYS: &[&str] = &[
     "X402_API_KEY",
     "X402_API_SECRET",
 ];
+const WEB_AUTH_ENV_KEYS: &[&str] = &[
+    "NOTION_ACCOUNT_EMAIL",
+    "NOTION_PASSWORD",
+    "GOOGLE_ACCOUNT_EMAIL",
+    "GOOGLE_PASSWORD",
+];
 
 const REMOTE_OUTPUT_FILENAME: &str = ".codex_remote_output.log";
 const REMOTE_EXIT_CODE_FILENAME: &str = ".codex_remote_exit_code";
@@ -273,6 +279,7 @@ pub(super) fn run_codex_task(
     }
     ensure_github_cli_auth(&github_auth)?;
     let payment_env_overrides = collect_payment_env_overrides();
+    let web_auth_env_overrides = collect_web_auth_env_overrides();
 
     let memory_context = load_memory_context(request.workspace_dir, request.memory_dir)?;
     let prompt = build_prompt(
@@ -349,6 +356,9 @@ pub(super) fn run_codex_task(
             }
         }
         for (key, value) in &payment_env_overrides {
+            cmd.arg("-e").arg(format!("{}={}", key, value));
+        }
+        for (key, value) in &web_auth_env_overrides {
             cmd.arg("-e").arg(format!("{}={}", key, value));
         }
         for (key, value) in &github_auth.env_overrides {
@@ -454,6 +464,9 @@ pub(super) fn run_codex_task(
             }
         }
         for (key, value) in &payment_env_overrides {
+            cmd.env(key, value);
+        }
+        for (key, value) in &web_auth_env_overrides {
             cmd.env(key, value);
         }
         for (key, value) in github_auth.env_overrides {
@@ -635,6 +648,7 @@ fn run_codex_task_azure_aci(
     let codex_home = host_workspace_dir.join(DOCKER_CODEX_HOME_DIR);
     ensure_codex_config_at(&codex_home, &container_workspace_dir)?;
     let payment_env_overrides = collect_payment_env_overrides();
+    let web_auth_env_overrides = collect_web_auth_env_overrides();
 
     let memory_context = load_memory_context(request.workspace_dir, request.memory_dir)?;
     let prompt = build_prompt(
@@ -703,6 +717,9 @@ fn run_codex_task_azure_aci(
         ("DEPLOY_TARGET".to_string(), "azure_aci_runner".to_string()),
     ];
     for (key, value) in payment_env_overrides {
+        env_overrides.push((key, value));
+    }
+    for (key, value) in web_auth_env_overrides {
         env_overrides.push((key, value));
     }
     for (key, value) in github_auth.env_overrides {
@@ -1533,9 +1550,31 @@ fn resolve_payment_env_prefix() -> Option<String> {
         })
 }
 
+fn resolve_web_auth_env_prefix() -> Option<String> {
+    read_env_trimmed("EMPLOYEE_WEB_AUTH_ENV_PREFIX")
+        .or_else(|| read_env_trimmed("WEB_AUTH_ENV_PREFIX"))
+        .or_else(resolve_payment_env_prefix)
+}
+
 fn collect_payment_env_overrides() -> Vec<(String, String)> {
     let prefix = resolve_payment_env_prefix();
     PAYMENT_ENV_KEYS
+        .iter()
+        .filter_map(|key| {
+            read_env_trimmed(key)
+                .or_else(|| {
+                    prefix
+                        .as_ref()
+                        .and_then(|prefix| read_env_trimmed(&format!("{}_{}", prefix, key)))
+                })
+                .map(|value| ((*key).to_string(), value))
+        })
+        .collect()
+}
+
+fn collect_web_auth_env_overrides() -> Vec<(String, String)> {
+    let prefix = resolve_web_auth_env_prefix();
+    WEB_AUTH_ENV_KEYS
         .iter()
         .filter_map(|key| {
             read_env_trimmed(key)
@@ -2200,6 +2239,47 @@ mod tests {
         assert!(overrides
             .iter()
             .any(|(k, v)| k == "GOATX402_API_KEY" && v == "api-key-global"));
+    }
+
+    #[test]
+    fn test_collect_web_auth_env_overrides_uses_employee_prefix_fallback() {
+        let _lock = env_lock();
+        let _guards = vec![
+            EnvVarGuard::unset("NOTION_ACCOUNT_EMAIL"),
+            EnvVarGuard::unset("NOTION_PASSWORD"),
+            EnvVarGuard::unset("EMPLOYEE_WEB_AUTH_ENV_PREFIX"),
+            EnvVarGuard::unset("WEB_AUTH_ENV_PREFIX"),
+            EnvVarGuard::unset("EMPLOYEE_PAYMENT_ENV_PREFIX"),
+            EnvVarGuard::unset("PAYMENT_ENV_PREFIX"),
+            EnvVarGuard::unset("EMPLOYEE_GITHUB_ENV_PREFIX"),
+            EnvVarGuard::unset("GITHUB_ENV_PREFIX"),
+            EnvVarGuard::set("EMPLOYEE_ID", "boiled_egg"),
+            EnvVarGuard::set("PROTO_NOTION_ACCOUNT_EMAIL", "proto-notion@example.com"),
+            EnvVarGuard::set("PROTO_NOTION_PASSWORD", "proto-password"),
+        ];
+
+        let overrides = collect_web_auth_env_overrides();
+        assert!(overrides
+            .iter()
+            .any(|(k, v)| k == "NOTION_ACCOUNT_EMAIL" && v == "proto-notion@example.com"));
+        assert!(overrides
+            .iter()
+            .any(|(k, v)| k == "NOTION_PASSWORD" && v == "proto-password"));
+    }
+
+    #[test]
+    fn test_collect_web_auth_env_overrides_prefers_unprefixed_values() {
+        let _lock = env_lock();
+        let _guards = vec![
+            EnvVarGuard::set("EMPLOYEE_WEB_AUTH_ENV_PREFIX", "PROTO"),
+            EnvVarGuard::set("NOTION_ACCOUNT_EMAIL", "global-notion@example.com"),
+            EnvVarGuard::set("PROTO_NOTION_ACCOUNT_EMAIL", "prefixed-notion@example.com"),
+        ];
+
+        let overrides = collect_web_auth_env_overrides();
+        assert!(overrides
+            .iter()
+            .any(|(k, v)| k == "NOTION_ACCOUNT_EMAIL" && v == "global-notion@example.com"));
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -186,6 +186,10 @@ fn build_web_auth_capabilities_section() -> &'static str {
 - Before opening a private page, load the state file if it exists:
   - `playwright-cli state-load .auth/notion_state.json`
   - `playwright-cli state-load .auth/google_state.json`
+- If state files are missing or stale, try signing in with credentials from environment variables:
+  - Notion: `NOTION_ACCOUNT_EMAIL`, `NOTION_PASSWORD`
+  - Google: `GOOGLE_ACCOUNT_EMAIL`, `GOOGLE_PASSWORD`
+- Never include raw credentials in any user-facing reply.
 - Do not conclude "cannot access due to sign-in" until you tried loading available state files.
 
 "#

--- a/DoWhiz_service/scheduler_module/src/web_auth_bootstrap.rs
+++ b/DoWhiz_service/scheduler_module/src/web_auth_bootstrap.rs
@@ -5,7 +5,10 @@ use std::process::Command;
 use tracing::{info, warn};
 
 const DEFAULT_TIMEOUT_SECS: u64 = 90;
-const DEFAULT_SCRIPT_REL_PATH: &str = "DoWhiz_service/scripts/bootstrap_web_auth.py";
+const DEFAULT_SCRIPT_REL_PATHS: &[&str] = &[
+    "DoWhiz_service/scripts/bootstrap_web_auth.py",
+    "scripts/bootstrap_web_auth.py",
+];
 
 pub(crate) fn bootstrap_workspace_web_auth(workspace_dir: &Path) {
     if !env_flag_enabled("WEB_AUTH_BOOTSTRAP_ENABLED", true) {
@@ -95,30 +98,40 @@ fn resolve_bootstrap_script_path() -> Option<PathBuf> {
     }
 
     if let Ok(cwd) = env::current_dir() {
-        let candidate = cwd.join(DEFAULT_SCRIPT_REL_PATH);
-        if candidate.exists() {
-            return Some(candidate);
+        if let Some(path) = find_script_in_ancestors(&cwd) {
+            return Some(path);
         }
     }
 
     if let Ok(exe_path) = env::current_exe() {
         if let Some(exe_dir) = exe_path.parent() {
-            let candidate = exe_dir.join(DEFAULT_SCRIPT_REL_PATH);
-            if candidate.exists() {
-                return Some(candidate);
-            }
-            if let Some(parent) = exe_dir.parent() {
-                let candidate = parent.join(DEFAULT_SCRIPT_REL_PATH);
-                if candidate.exists() {
-                    return Some(candidate);
-                }
+            if let Some(path) = find_script_in_ancestors(exe_dir) {
+                return Some(path);
             }
         }
     }
 
-    let fallback = Path::new("/app").join(DEFAULT_SCRIPT_REL_PATH);
-    if fallback.exists() {
-        return Some(fallback);
+    if let Some(path) = find_script_in_ancestors(Path::new("/app")) {
+        return Some(path);
+    }
+    None
+}
+
+fn find_script_in_ancestors(start: &Path) -> Option<PathBuf> {
+    for base in start.ancestors().take(8) {
+        if let Some(path) = find_script_under(base) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn find_script_under(base: &Path) -> Option<PathBuf> {
+    for rel in DEFAULT_SCRIPT_REL_PATHS {
+        let candidate = base.join(rel);
+        if candidate.exists() {
+            return Some(candidate);
+        }
     }
     None
 }
@@ -138,7 +151,26 @@ fn tail_utf8(bytes: &[u8], max_chars: usize) -> String {
 mod tests {
     use super::*;
     use std::fs;
+    use std::path::PathBuf;
     use tempfile::TempDir;
+
+    struct CwdGuard {
+        prev: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn set(path: &Path) -> Self {
+            let prev = env::current_dir().expect("current dir");
+            env::set_current_dir(path).expect("set current dir");
+            Self { prev }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = env::set_current_dir(&self.prev);
+        }
+    }
 
     #[test]
     fn parse_env_bool_understands_common_values() {
@@ -175,5 +207,31 @@ mod tests {
         }
 
         assert_eq!(resolved.as_deref(), Some(script.as_path()));
+    }
+
+    #[test]
+    fn resolve_bootstrap_script_path_supports_service_working_dir() {
+        let temp = TempDir::new().expect("tempdir");
+        let service_root = temp.path().join("DoWhiz_service");
+        let scripts_dir = service_root.join("scripts");
+        fs::create_dir_all(&scripts_dir).expect("scripts dir");
+        let script = scripts_dir.join("bootstrap_web_auth.py");
+        fs::write(&script, "print('ok')").expect("write script");
+
+        let _cwd_guard = CwdGuard::set(&service_root);
+        let prev = env::var("WEB_AUTH_BOOTSTRAP_SCRIPT").ok();
+        env::remove_var("WEB_AUTH_BOOTSTRAP_SCRIPT");
+
+        let resolved = resolve_bootstrap_script_path();
+
+        match prev {
+            Some(value) => env::set_var("WEB_AUTH_BOOTSTRAP_SCRIPT", value),
+            None => env::remove_var("WEB_AUTH_BOOTSTRAP_SCRIPT"),
+        }
+
+        let resolved = resolved.expect("resolved path");
+        let resolved_canon = resolved.canonicalize().expect("canonical resolved");
+        let script_canon = script.canonicalize().expect("canonical script");
+        assert_eq!(resolved_canon, script_canon);
     }
 }


### PR DESCRIPTION
## Summary
- fix web auth bootstrap script discovery to work when worker cwd is `DoWhiz_service` (staging layout)
- add robust ancestor-based script lookup for bootstrap entrypoint
- pass Notion/Google web auth credentials into codex execution envs (docker + Azure ACI)
- add prompt fallback guidance to sign in via env credentials when `.auth` state files are absent/stale
- add tests for script path resolution and web auth env override resolution

## Root cause observed in staging
Worker logs showed repeated:
`web auth bootstrap script not found (checked WEB_AUTH_BOOTSTRAP_SCRIPT and default paths)`

This prevented `.auth/bootstrap_status.json` and session state generation.

## Verification
- `cargo test -p scheduler_module web_auth_bootstrap::tests`
- `cargo test -p run_task_module collect_web_auth_env_overrides`
