### PR TITLE
Fix web auth bootstrap crash on Path join

### DIFF
--- a/DoWhiz_service/scripts/bootstrap_web_auth.py
+++ b/DoWhiz_service/scripts/bootstrap_web_auth.py
@@ -410,7 +410,7 @@ def bootstrap_provider(
         "attempted": False,
         "success": False,
         "cached": False,
-        "state_file": str(auth_dir.join(f"{provider}_state.json")),
+        "state_file": str(auth_dir.joinpath(f"{provider}_state.json")),
         "message": "",
         "updated_at": now_iso(),
     }
@@ -418,8 +418,8 @@ def bootstrap_provider(
         result["message"] = "missing credentials"
         return result
 
-    state_path = auth_dir.join(f"{provider}_state.json")
-    meta_path = auth_dir.join(f"{provider}_state.meta.json")
+    state_path = auth_dir.joinpath(f"{provider}_state.json")
+    meta_path = auth_dir.joinpath(f"{provider}_state.meta.json")
     current_fp = fingerprint(email, password)
     previous_meta = load_json(meta_path)
     previous_fp = previous_meta.get("fingerprint")


### PR DESCRIPTION
## Summary
- fix `bootstrap_web_auth.py` to use `Path.joinpath(...)` instead of non-existent `Path.join(...)`
- resolves staging crash seen as `AttributeError: 'PosixPath' object has no attribute 'join'` during web auth bootstrap

## Validation
- `python3 -m py_compile DoWhiz_service/scripts/bootstrap_web_auth.py`
- `python3 DoWhiz_service/scripts/bootstrap_web_auth.py --workspace <tmpdir> --timeout-secs 30` (verified status JSON is generated)
