### PR TITLE
Ensure Playwright deps for web auth bootstrap on VM

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -275,6 +275,9 @@ jobs:
           # so ACI tasks share workspace/memory paths correctly.
           bash "$APP_DIR/scripts/ensure_aci_share_mount.sh"
 
+          # Ensure web auth bootstrap can use Playwright for Notion/Google sign-in.
+          bash "$APP_DIR/scripts/install_web_auth_bootstrap_deps.sh"
+
           worker_running=0
           for service in dw_worker dowhiz_rust_service dowhiz-rust-service; do
             if pm2 describe "$service" >/dev/null 2>&1; then

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -275,6 +275,9 @@ jobs:
           # so ACI tasks share workspace/memory paths correctly.
           bash "$APP_DIR/scripts/ensure_aci_share_mount.sh"
 
+          # Ensure web auth bootstrap can use Playwright for Notion/Google sign-in.
+          bash "$APP_DIR/scripts/install_web_auth_bootstrap_deps.sh"
+
           worker_running=0
           for service in dw_worker dowhiz_rust_service dowhiz-rust-service; do
             if pm2 describe "$service" >/dev/null 2>&1; then

--- a/DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh
+++ b/DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for web auth bootstrap dependencies" >&2
+  exit 1
+fi
+
+set +e
+python3 - <<'PY'
+import importlib.util
+import os
+import sys
+
+if importlib.util.find_spec("playwright") is None:
+    sys.exit(1)
+
+try:
+    from playwright.sync_api import sync_playwright
+except Exception:
+    sys.exit(3)
+
+try:
+    with sync_playwright() as playwright:
+        chromium_path = playwright.chromium.executable_path
+except Exception:
+    sys.exit(2)
+
+if not chromium_path or not os.path.exists(chromium_path):
+    sys.exit(2)
+
+sys.exit(0)
+PY
+check_status=$?
+set -e
+
+install_pkg=0
+install_browser=0
+
+case "$check_status" in
+  0)
+    echo "Playwright Python package and Chromium are already available."
+    ;;
+  1)
+    echo "Playwright Python package is missing; installing."
+    install_pkg=1
+    install_browser=1
+    ;;
+  2)
+    echo "Playwright Chromium browser is missing; installing."
+    install_browser=1
+    ;;
+  3)
+    echo "Playwright Python package is present but unusable; reinstalling."
+    install_pkg=1
+    install_browser=1
+    ;;
+  *)
+    echo "Unexpected Playwright check status (${check_status}); reinstalling."
+    install_pkg=1
+    install_browser=1
+    ;;
+esac
+
+if [[ "$install_pkg" -eq 1 ]]; then
+  if ! python3 -m pip --version >/dev/null 2>&1; then
+    python3 -m ensurepip --upgrade
+  fi
+  python3 -m pip install --user --upgrade playwright
+fi
+
+if [[ "$install_browser" -eq 1 ]]; then
+  python3 -m playwright install chromium
+fi


### PR DESCRIPTION
## Summary
- add `DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh` to ensure Python Playwright + Chromium exist on VM
- invoke the script during both staging and production deploy restart flow
- fix runtime blocker where web auth bootstrap failed with `No module named 'playwright'`

## Validation
- `bash -n DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh`
- verified workflow files call the script in restart sequence
