### PR TITLE
Add minimal env.example for devin email auto-reply chain

### DIFF
--- a/env.example.least
+++ b/env.example.least
@@ -1,0 +1,69 @@
+# Minimal env template for "devin@dowhiz.com auto-reply" path.
+# Goal: inbound email -> queue -> run_task -> Postmark send.
+#
+# Assumptions:
+# - Agent has Azure CLI permissions and can provision/fill Azure resources.
+# - You manually provide only keys that agent cannot infer/recover.
+#
+# Usage:
+# 1) Copy to DoWhiz_service/.env
+# 2) Fill MANUAL section
+# 3) Let agent provision/fill AUTO-PROVISION section
+
+# ============================================================
+# MANUAL REQUIRED (leave empty here; user must provide)
+# ============================================================
+SUPABASE_DB_URL=
+POSTMARK_SERVER_TOKEN=
+
+# Optional fallback if you prefer pooler instead of SUPABASE_DB_URL
+SUPABASE_POOLER_URL=
+
+# ============================================================
+# REQUIRED RUNTIME KEYS (safe defaults pre-filled)
+# ============================================================
+DEPLOY_TARGET=local
+EMPLOYEE_ID=sticky_octopus
+INGESTION_QUEUE_BACKEND=servicebus
+RUN_TASK_EXECUTION_BACKEND=local
+STORAGE_BACKEND=mongo
+RAW_PAYLOAD_STORAGE_BACKEND=azure
+
+# Optional path overrides (usually do NOT need to set):
+# GATEWAY_CONFIG_PATH=
+# EMPLOYEE_CONFIG_PATH=
+
+# Network defaults
+GATEWAY_HOST=0.0.0.0
+GATEWAY_PORT=9100
+RUST_SERVICE_HOST=0.0.0.0
+RUST_SERVICE_PORT=9001
+
+# ============================================================
+# AUTO-PROVISION (agent can create resources and fill these)
+# ============================================================
+# Queue backend (required by inbound_gateway for servicebus mode)
+SERVICE_BUS_CONNECTION_STRING=
+SERVICE_BUS_QUEUE_NAME=ingestion-sticky-octopus
+
+# Model runtime (required for run_task)
+AZURE_OPENAI_API_KEY_BACKUP=
+# Optional but recommended for router/consistency
+AZURE_OPENAI_ENDPOINT_BACKUP=
+
+# Mongo backend (required)
+MONGODB_URI=
+# Optional explicit DB name; otherwise derived from DEPLOY_TARGET+EMPLOYEE_ID
+MONGODB_DATABASE=dowhiz_local_sticky_octopus
+
+# Raw payload / attachment archival (recommended, not hard-blocking for simple replies)
+AZURE_STORAGE_CONTAINER_INGEST=ingestion-raw
+AZURE_STORAGE_CONTAINER_SAS_URL=
+# Alternative if not using container SAS URL:
+AZURE_STORAGE_ACCOUNT=
+AZURE_STORAGE_SAS_TOKEN=
+AZURE_STORAGE_CONNECTION_STRING_INGEST=
+
+# Optional Postmark inbound automation helper
+POSTMARK_INBOUND_HOOK_URL=
+POSTMARK_INBOUND_TOKEN=


### PR DESCRIPTION
## Summary
- add `env.example.least` focused on the `devin@dowhiz.com` auto-reply chain
- keep only hard-required manual secrets empty: `SUPABASE_DB_URL`, `POSTMARK_SERVER_TOKEN`
- prefill safe runtime defaults (`DEPLOY_TARGET=local`, `EMPLOYEE_ID=sticky_octopus`, service host/port, queue mode)
- include an AUTO-PROVISION section for Azure resources that agents can create/fill

## Static verification (no runtime execution)
- verified gateway requires Service Bus mode and queue config
- verified account store requires `SUPABASE_DB_URL` or `SUPABASE_POOLER_URL`
- verified outbound email requires `POSTMARK_SERVER_TOKEN`
- verified local run_task gating with `DEPLOY_TARGET=local` + `RUN_TASK_EXECUTION_BACKEND=local`
- verified `sticky_octopus` maps to `devin@dowhiz.com` and email routing fallback uses employee address map
- verified raw payload archival failure is non-blocking in gateway envelope build

## Notes
- no service/runtime commands executed
- this PR only adds a template file
