### PR TITLE
Handle pip bootstrap for Playwright dependency install

### DIFF
--- a/DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh
+++ b/DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh
@@ -62,10 +62,27 @@ case "$check_status" in
     ;;
 esac
 
-if [[ "$install_pkg" -eq 1 ]]; then
-  if ! python3 -m pip --version >/dev/null 2>&1; then
-    python3 -m ensurepip --upgrade
+ensure_pip() {
+  if python3 -m pip --version >/dev/null 2>&1; then
+    return 0
   fi
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required to bootstrap pip for Playwright installation." >&2
+    return 1
+  fi
+
+  echo "pip is missing; bootstrapping with get-pip.py."
+  tmp_dir="$(mktemp -d)"
+  curl -fsSL https://bootstrap.pypa.io/get-pip.py -o "$tmp_dir/get-pip.py"
+  python3 "$tmp_dir/get-pip.py" --user
+  rm -rf "$tmp_dir"
+
+  python3 -m pip --version >/dev/null 2>&1
+}
+
+if [[ "$install_pkg" -eq 1 ]]; then
+  ensure_pip
   python3 -m pip install --user --upgrade playwright
 fi
 


### PR DESCRIPTION
## Summary
- update `install_web_auth_bootstrap_deps.sh` to handle VMs without `pip` and without `ensurepip`
- bootstrap pip via `get-pip.py` when needed, then install Python Playwright package
- keeps deploy restart flow resilient on minimal Ubuntu images

## Validation
- `bash -n DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh`
- inspected failed staging run logs (`No module named ensurepip`) and verified this change addresses that path
