### PR TITLE
Use env-backed Azure endpoint for Codex OpenAI calls

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -136,6 +136,7 @@ cp .env.example DoWhiz_service/.env
 | `MONGODB_URI` | Scheduler/user/index persistence |
 | `SUPABASE_DB_URL` (or `SUPABASE_POOLER_URL` fallback in some paths) | Account/auth/billing store |
 | `AZURE_OPENAI_API_KEY_BACKUP` | Required by Codex/Claude task execution |
+| `AZURE_OPENAI_ENDPOINT_BACKUP` | Required by Codex task execution (Azure OpenAI endpoint) |
 | `POSTMARK_SERVER_TOKEN` | Email outbound and webhook utility |
 | `INGESTION_QUEUE_BACKEND=servicebus` | Required by gateway |
 | `SERVICE_BUS_CONNECTION_STRING` **or** `SERVICE_BUS_NAMESPACE` + `SERVICE_BUS_POLICY_NAME` + `SERVICE_BUS_POLICY_KEY` | Service Bus queue auth |

--- a/DoWhiz_service/run_task_module/README.md
+++ b/DoWhiz_service/run_task_module/README.md
@@ -38,6 +38,7 @@ Optional dockerized local path:
 
 Minimum practical requirement:
 - `AZURE_OPENAI_API_KEY_BACKUP`
+- `AZURE_OPENAI_ENDPOINT_BACKUP` (required for `codex` runner; for example `https://<resource>.openai.azure.com/`)
 
 Common optional controls:
 - `CODEX_MODEL`, `CLAUDE_MODEL`

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -10,8 +10,8 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use super::constants::{
-    CODEX_BASE_URL, CODEX_CONFIG_BLOCK_TEMPLATE, CODEX_CONFIG_MARKER, CODEX_MODEL_NAME,
-    CODEX_SANDBOX_MODE, DOCKER_CODEX_HOME_DIR, DOCKER_WORKSPACE_DIR,
+    CODEX_CONFIG_BASE_URL_PLACEHOLDER, CODEX_CONFIG_BLOCK_TEMPLATE, CODEX_CONFIG_MARKER,
+    CODEX_MODEL_NAME, CODEX_SANDBOX_MODE, DOCKER_CODEX_HOME_DIR, DOCKER_WORKSPACE_DIR,
 };
 use super::docker::{docker_cli_available, ensure_docker_image_available};
 use super::env::{env_enabled, normalize_env_prefix, read_env_list, read_env_trimmed};
@@ -252,7 +252,7 @@ pub(super) fn run_codex_task(
             key: "AZURE_OPENAI_API_KEY_BACKUP",
         });
     }
-    let azure_endpoint = normalize_azure_endpoint(CODEX_BASE_URL);
+    let azure_endpoint = azure_endpoint_from_env()?;
     // Use model from request/database, fallback to env var, then constant
     let model_name = if request.model_name.trim().is_empty() {
         env::var("CODEX_MODEL").unwrap_or_else(|_| CODEX_MODEL_NAME.to_string())
@@ -273,9 +273,13 @@ pub(super) fn run_codex_task(
             .as_ref()
             .map(|dir| dir.join(DOCKER_CODEX_HOME_DIR))
             .unwrap_or_else(|| request.workspace_dir.join(DOCKER_CODEX_HOME_DIR));
-        ensure_codex_config_at(&codex_home, Path::new(DOCKER_WORKSPACE_DIR))?;
+        ensure_codex_config_at(
+            &codex_home,
+            Path::new(DOCKER_WORKSPACE_DIR),
+            &azure_endpoint,
+        )?;
     } else {
-        ensure_codex_config(request.workspace_dir)?;
+        ensure_codex_config(request.workspace_dir, &azure_endpoint)?;
     }
     ensure_github_cli_auth(&github_auth)?;
     let payment_env_overrides = collect_payment_env_overrides();
@@ -542,7 +546,8 @@ pub(super) fn run_codex_task(
 
     // Only check for reply file if a reply was expected
     // Use cross-channel routing to determine actual expected path
-    let expected_reply_path = resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
+    let expected_reply_path =
+        resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
     if !request.reply_to.is_empty() && !expected_reply_path.exists() {
         return Err(RunTaskError::OutputMissing {
             path: expected_reply_path,
@@ -631,7 +636,7 @@ fn run_codex_task_azure_aci(
         });
     }
 
-    let azure_endpoint = normalize_azure_endpoint(CODEX_BASE_URL);
+    let azure_endpoint = azure_endpoint_from_env()?;
     let model_name = if request.model_name.trim().is_empty() {
         env::var("CODEX_MODEL").unwrap_or_else(|_| CODEX_MODEL_NAME.to_string())
     } else {
@@ -646,7 +651,7 @@ fn run_codex_task_azure_aci(
 
     let add_dirs = codex_add_dirs_remote(&host_workspace_dir, &container_workspace_dir)?;
     let codex_home = host_workspace_dir.join(DOCKER_CODEX_HOME_DIR);
-    ensure_codex_config_at(&codex_home, &container_workspace_dir)?;
+    ensure_codex_config_at(&codex_home, &container_workspace_dir, &azure_endpoint)?;
     let payment_env_overrides = collect_payment_env_overrides();
     let web_auth_env_overrides = collect_web_auth_env_overrides();
 
@@ -811,7 +816,8 @@ fn run_codex_task_azure_aci(
     }
 
     // Use cross-channel routing to determine actual expected path
-    let expected_reply_path = resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
+    let expected_reply_path =
+        resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
     if !request.reply_to.is_empty() && !expected_reply_path.exists() {
         return Err(RunTaskError::OutputMissing {
             path: expected_reply_path,
@@ -1454,15 +1460,16 @@ fn shell_quote(value: &str) -> String {
     out
 }
 
-fn ensure_codex_config(workspace_dir: &Path) -> Result<(), RunTaskError> {
+fn ensure_codex_config(workspace_dir: &Path, azure_endpoint: &str) -> Result<(), RunTaskError> {
     let home = env::var("HOME").map_err(|_| RunTaskError::MissingEnv { key: "HOME" })?;
     let config_dir = PathBuf::from(home).join(".codex");
-    ensure_codex_config_at(&config_dir, workspace_dir)
+    ensure_codex_config_at(&config_dir, workspace_dir, azure_endpoint)
 }
 
 fn ensure_codex_config_at(
     config_dir: &Path,
     trust_workspace_dir: &Path,
+    azure_endpoint: &str,
 ) -> Result<(), RunTaskError> {
     let config_path = config_dir.join("config.toml");
     let config_dir = config_path.parent().ok_or(RunTaskError::InvalidPath {
@@ -1472,7 +1479,7 @@ fn ensure_codex_config_at(
     })?;
     fs::create_dir_all(config_dir)?;
 
-    let block = CODEX_CONFIG_BLOCK_TEMPLATE;
+    let block = build_codex_config_block(azure_endpoint);
 
     let existing = if config_path.exists() {
         fs::read_to_string(&config_path)?
@@ -1601,6 +1608,18 @@ fn codex_add_dirs(workspace_dir: &Path, use_docker: bool) -> Result<Vec<String>,
         add_dirs.push(gh_config_dir.to_string_lossy().into_owned());
     }
     Ok(add_dirs)
+}
+
+fn azure_endpoint_from_env() -> Result<String, RunTaskError> {
+    let endpoint =
+        read_env_trimmed("AZURE_OPENAI_ENDPOINT_BACKUP").ok_or(RunTaskError::MissingEnv {
+            key: "AZURE_OPENAI_ENDPOINT_BACKUP",
+        })?;
+    Ok(normalize_azure_endpoint(&endpoint))
+}
+
+fn build_codex_config_block(azure_endpoint: &str) -> String {
+    CODEX_CONFIG_BLOCK_TEMPLATE.replace(CODEX_CONFIG_BASE_URL_PLACEHOLDER, azure_endpoint)
 }
 
 fn normalize_azure_endpoint(endpoint: &str) -> String {
@@ -2485,7 +2504,9 @@ mod tests {
             .arg("--output")
             .arg("json");
 
-        let create_output = create_cmd.output().expect("failed to run az container create");
+        let create_output = create_cmd
+            .output()
+            .expect("failed to run az container create");
         if !create_output.status.success() {
             let stderr = String::from_utf8_lossy(&create_output.stderr);
             panic!("Failed to create test container: {}", stderr);
@@ -2496,7 +2517,10 @@ mod tests {
         register_aci_container(&container_name);
         {
             let containers = ACTIVE_ACI_CONTAINERS.lock().unwrap();
-            assert!(containers.contains(&container_name), "Container should be registered");
+            assert!(
+                containers.contains(&container_name),
+                "Container should be registered"
+            );
         }
 
         // Now call cleanup (simulating shutdown without normal deletion)
@@ -2507,7 +2531,10 @@ mod tests {
         // Verify the registry is empty
         {
             let containers = ACTIVE_ACI_CONTAINERS.lock().unwrap();
-            assert!(containers.is_empty(), "Registry should be empty after cleanup");
+            assert!(
+                containers.is_empty(),
+                "Registry should be empty after cleanup"
+            );
         }
 
         // Verify container is actually deleted by trying to show it

--- a/DoWhiz_service/run_task_module/src/run_task/constants.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/constants.rs
@@ -1,8 +1,7 @@
 pub(super) const CODEX_CONFIG_MARKER: &str = "# IMPORTANT: Use your Azure *deployment name* here";
 pub(super) const CODEX_MODEL_NAME: &str = "gpt-5.4";
 pub(super) const CODEX_SANDBOX_MODE: &str = "workspace-write";
-pub(super) const CODEX_BASE_URL: &str =
-    "https://knowhiz-service-openai-backup-2.openai.azure.com/openai/v1";
+pub(super) const CODEX_CONFIG_BASE_URL_PLACEHOLDER: &str = "__AZURE_OPENAI_BASE_URL__";
 pub(super) const CODEX_CONFIG_BLOCK_TEMPLATE: &str = r#"# IMPORTANT: Use your Azure *deployment name* here (e.g., "gpt-5.4")
 model = "gpt-5.4"
 model_provider = "azure"
@@ -16,7 +15,7 @@ network_access=true
 
 [model_providers.azure]
 name = "Azure OpenAI"
-base_url = "https://knowhiz-service-openai-backup-2.openai.azure.com/openai/v1"
+base_url = "__AZURE_OPENAI_BASE_URL__"
 env_key = "AZURE_OPENAI_API_KEY_BACKUP"
 wire_api = "responses"
 "#;

--- a/DoWhiz_service/run_task_module/tests/README.md
+++ b/DoWhiz_service/run_task_module/tests/README.md
@@ -23,6 +23,7 @@ Primary coverage includes:
 cd DoWhiz_service
 RUN_CODEX_E2E=1 \
 AZURE_OPENAI_API_KEY_BACKUP=... \
+AZURE_OPENAI_ENDPOINT_BACKUP=https://<resource>.openai.azure.com/ \
 cargo test -p run_task_module --test run_task_tests -- --nocapture
 ```
 

--- a/DoWhiz_service/run_task_module/tests/run_task_basic.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_basic.rs
@@ -7,7 +7,9 @@ use support::{
     build_params, create_workspace, write_fake_codex, EnvGuard, FakeCodexMode, TempDir, ENV_MUTEX,
 };
 
-const EXPECTED_CODEX_BLOCK: &str = r#"# IMPORTANT: Use your Azure *deployment name* here (e.g., "gpt-5.4")
+fn expected_codex_block(base_url: &str) -> String {
+    format!(
+        r#"# IMPORTANT: Use your Azure *deployment name* here (e.g., "gpt-5.4")
 model = "gpt-5.4"
 model_provider = "azure"
 model_reasoning_effort = "xhigh"
@@ -20,9 +22,11 @@ network_access=true
 
 [model_providers.azure]
 name = "Azure OpenAI"
-base_url = "https://knowhiz-service-openai-backup-2.openai.azure.com/openai/v1"
+base_url = "{base_url}"
 env_key = "AZURE_OPENAI_API_KEY_BACKUP"
-wire_api = "responses""#;
+wire_api = "responses""#
+    )
+}
 
 #[test]
 #[cfg(unix)]
@@ -81,9 +85,8 @@ value = "still"
     assert!(updated.contains("model = \"gpt-5.4\""));
     assert!(!updated.contains("model = \"old-model\""));
     assert!(!updated.contains("model = \"override-model\""));
-    assert!(updated.contains("https://knowhiz-service-openai-backup-2.openai.azure.com/openai/v1"));
+    assert!(updated.contains("https://example.azure.com/openai/v1"));
     assert!(!updated.contains("https://old.azure.com/openai/v1"));
-    assert!(!updated.contains("https://example.azure.com/openai/v1"));
 }
 
 #[test]
@@ -105,6 +108,7 @@ fn run_task_writes_expected_codex_block() {
         ("HOME", home_dir.to_str().unwrap()),
         ("PATH", &new_path),
         ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
         ("GH_AUTH_DISABLED", "1"),
     ]);
 
@@ -113,8 +117,9 @@ fn run_task_writes_expected_codex_block() {
 
     let config_path = home_dir.join(".codex").join("config.toml");
     let config = fs::read_to_string(&config_path).unwrap();
+    let expected = expected_codex_block("https://example.azure.com/openai/v1");
     assert!(
-        config.contains(EXPECTED_CODEX_BLOCK),
+        config.contains(&expected),
         "codex config block should match the expected canonical content"
     );
 }

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -52,9 +52,9 @@ fn run_task_success_with_fake_codex() {
     let config_path = home_dir.join(".codex").join("config.toml");
     let config = fs::read_to_string(config_path).unwrap();
     assert!(config.contains("model = \"gpt-5.4\""));
-    assert!(config.contains("https://knowhiz-service-openai-backup-2.openai.azure.com/openai/v1"));
+    assert!(config.contains("https://example.azure.com/openai/v1"));
     assert!(!config.contains("model = \"override-model\""));
-    assert!(!config.contains("https://example.azure.com/openai/v1"));
+    assert!(!config.contains("https://knowhiz-service-openai-backup-2.openai.azure.com/openai/v1"));
 }
 
 #[test]
@@ -76,6 +76,7 @@ fn run_task_skips_yolo_without_bypass() {
         ("HOME", home_dir.to_str().unwrap()),
         ("PATH", &new_path),
         ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
         ("CODEX_BYPASS_SANDBOX", "0"),
         ("GH_AUTH_DISABLED", "1"),
     ]);
@@ -105,6 +106,7 @@ fn run_task_uses_yolo_with_bypass() {
         ("HOME", home_dir.to_str().unwrap()),
         ("PATH", &new_path),
         ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
         ("CODEX_BYPASS_SANDBOX", "1"),
         ("GH_AUTH_DISABLED", "1"),
     ]);
@@ -134,6 +136,7 @@ fn run_task_uses_danger_sandbox_with_bypass() {
         ("HOME", home_dir.to_str().unwrap()),
         ("PATH", &new_path),
         ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
         ("CODEX_BYPASS_SANDBOX", "1"),
         ("GH_AUTH_DISABLED", "1"),
     ]);
@@ -166,6 +169,7 @@ fn run_task_passes_add_dir_for_gh_config() {
         ("HOME", home_dir.to_str().unwrap()),
         ("PATH", &new_path),
         ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
         ("GH_AUTH_DISABLED", "1"),
         ("EXPECTED_ADD_DIR", expected_add_dir),
     ]);
@@ -291,6 +295,7 @@ fn run_task_times_out_with_codex() {
         ("HOME", home_dir.to_str().unwrap()),
         ("PATH", &new_path),
         ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
         ("GH_AUTH_DISABLED", "1"),
         ("RUN_TASK_TIMEOUT_SECS", "1"),
         ("SLEEP_SECS", "2"),
@@ -498,6 +503,7 @@ GOATX402_API_SECRET="secret_direct"
         ("HOME", home_dir.to_str().unwrap()),
         ("PATH", &new_path),
         ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
         ("GH_AUTH_DISABLED", "1"),
         ("EXPECTED_GOATX402_API_URL", "https://x402-api.example.test"),
         ("EXPECTED_GOATX402_MERCHANT_ID", "dowhiz_agent"),
@@ -551,6 +557,7 @@ OLIVER_GOATX402_API_SECRET="secret_prefixed"
         ("HOME", home_dir.to_str().unwrap()),
         ("PATH", &new_path),
         ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
         ("GH_AUTH_DISABLED", "1"),
         ("EMPLOYEE_ID", "little_bear"),
         (
@@ -670,6 +677,7 @@ fn run_task_real_codex_e2e_when_enabled() {
     }
 
     require_env("AZURE_OPENAI_API_KEY_BACKUP");
+    require_env("AZURE_OPENAI_ENDPOINT_BACKUP");
 
     let temp = TempDir::new("codex_task_real_e2e").unwrap();
     let workspace = create_workspace(&temp.path).unwrap();

--- a/DoWhiz_service/scripts/run_e2e.sh
+++ b/DoWhiz_service/scripts/run_e2e.sh
@@ -74,6 +74,10 @@ if [[ "${RUN_CODEX_E2E:-0}" == "1" ]]; then
     echo "AZURE_OPENAI_API_KEY_BACKUP is required when RUN_CODEX_E2E=1." >&2
     exit 1
   fi
+  if [[ -z "${AZURE_OPENAI_ENDPOINT_BACKUP:-}" ]]; then
+    echo "AZURE_OPENAI_ENDPOINT_BACKUP is required when RUN_CODEX_E2E=1." >&2
+    exit 1
+  fi
 fi
 
 if [[ -z "${RUN_TASK_DOCKERFILE:-}" ]] && [[ -f "${repo_root}/Dockerfile" ]]; then


### PR DESCRIPTION
## Summary
- remove hardcoded Azure OpenAI backup endpoint from Codex runtime constants
- require and normalize `AZURE_OPENAI_ENDPOINT_BACKUP` for Codex execution paths and generated `.codex/config.toml`
- update run_task tests and docs/scripts to reflect endpoint requirement

## Test Evidence
- `cd DoWhiz_service && cargo test -p run_task_module`
