### PR TITLE
fix(run_task): cap run_task timeout under watchdog budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ DISCORD_BOT_USER_ID=""
 ADMIN_EMAIL=""
 RUN_TASK_DOCKER_IMAGE="dowhiz-service"
 RUN_TASK_DOCKERFILE=""
+# Scheduler watchdog timeout in seconds (default 600).
+TASK_TIMEOUT_SECS=600
+# Optional run_task timeout in seconds. Capped below TASK_TIMEOUT_SECS.
 RUN_TASK_TIMEOUT_SECS=
 MAGGIE_GITHUB_USERNAME="Devin-DoWhiz"
 MAGGIE_GITHUB_PERSONAL_ACCESS_TOKEN=""

--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -164,6 +164,8 @@ If using Azure raw payload storage (`RAW_PAYLOAD_STORAGE_BACKEND=azure`):
 - `auto` behavior:
   - `DEPLOY_TARGET in {staging,production}` -> Azure ACI
   - otherwise local
+- `TASK_TIMEOUT_SECS` controls scheduler watchdog stale-task detection (default: `600`).
+- `RUN_TASK_TIMEOUT_SECS` (optional) controls command timeout for run_task; runtime caps it below `TASK_TIMEOUT_SECS` to avoid stale-task retry loops (default effective value: `TASK_TIMEOUT_SECS - 30s`).
 
 In staging/production targets, local codex execution is blocked unless you explicitly avoid that policy.
 

--- a/DoWhiz_service/run_task_module/src/run_task/utils.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/utils.rs
@@ -6,6 +6,10 @@ use std::time::{Duration, Instant};
 
 use super::errors::RunTaskError;
 
+const DEFAULT_SCHEDULER_TASK_TIMEOUT_SECS: u64 = 600;
+const WATCHDOG_HEADROOM_SECS: u64 = 30;
+const MIN_RUN_TASK_TIMEOUT_SECS: u64 = 30;
+
 pub(super) fn tail_string(input: &str, max_len: usize) -> String {
     let trimmed = input.trim();
     if trimmed.len() <= max_len {
@@ -18,12 +22,23 @@ pub(super) fn tail_string(input: &str, max_len: usize) -> String {
     trimmed[start..].to_string()
 }
 
-pub(super) fn run_task_timeout() -> Duration {
-    let timeout_secs = std::env::var("RUN_TASK_TIMEOUT_SECS")
+fn parse_timeout_secs(key: &str) -> Option<u64> {
+    std::env::var(key)
         .ok()
         .and_then(|value| value.trim().parse::<u64>().ok())
         .filter(|value| *value > 0)
-        .unwrap_or(36000); // 10 hours
+}
+
+pub(super) fn run_task_timeout() -> Duration {
+    let task_timeout_secs =
+        parse_timeout_secs("TASK_TIMEOUT_SECS").unwrap_or(DEFAULT_SCHEDULER_TASK_TIMEOUT_SECS);
+    // Keep run_task timeout below watchdog timeout to avoid stale-task retry storms.
+    let watchdog_budget_secs = task_timeout_secs
+        .saturating_sub(WATCHDOG_HEADROOM_SECS)
+        .max(MIN_RUN_TASK_TIMEOUT_SECS);
+    let timeout_secs = parse_timeout_secs("RUN_TASK_TIMEOUT_SECS")
+        .map(|value| value.min(watchdog_budget_secs))
+        .unwrap_or(watchdog_budget_secs);
     Duration::from_secs(timeout_secs)
 }
 
@@ -127,4 +142,107 @@ pub(super) fn run_command_with_timeout(
         stdout,
         stderr,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[test]
+    fn run_task_timeout_defaults_to_watchdog_budget_minus_headroom() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guards = vec![
+            EnvVarGuard::unset("RUN_TASK_TIMEOUT_SECS"),
+            EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
+        ];
+
+        assert_eq!(run_task_timeout(), Duration::from_secs(570));
+    }
+
+    #[test]
+    fn run_task_timeout_respects_shorter_explicit_override() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guards = vec![
+            EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "120"),
+            EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
+        ];
+
+        assert_eq!(run_task_timeout(), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn run_task_timeout_caps_explicit_value_to_watchdog_budget() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guards = vec![
+            EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "36000"),
+            EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
+        ];
+
+        assert_eq!(run_task_timeout(), Duration::from_secs(570));
+    }
+
+    #[test]
+    fn run_task_timeout_uses_custom_task_timeout_budget() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guards = vec![
+            EnvVarGuard::unset("RUN_TASK_TIMEOUT_SECS"),
+            EnvVarGuard::set("TASK_TIMEOUT_SECS", "900"),
+        ];
+
+        assert_eq!(run_task_timeout(), Duration::from_secs(870));
+    }
+
+    #[test]
+    fn run_task_timeout_caps_to_custom_task_timeout_budget() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guards = vec![
+            EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "880"),
+            EnvVarGuard::set("TASK_TIMEOUT_SECS", "900"),
+        ];
+
+        assert_eq!(run_task_timeout(), Duration::from_secs(870));
+    }
+
+    #[test]
+    fn run_task_timeout_ignores_invalid_values() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guards = vec![
+            EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "abc"),
+            EnvVarGuard::set("TASK_TIMEOUT_SECS", "0"),
+        ];
+
+        assert_eq!(run_task_timeout(), Duration::from_secs(570));
+    }
 }


### PR DESCRIPTION
## Summary
- align run_task timeout with scheduler watchdog timeout budget
- default effective run_task timeout to TASK_TIMEOUT_SECS - 30s (min 30s)
- cap explicit RUN_TASK_TIMEOUT_SECS so it cannot exceed watchdog budget
- document TASK_TIMEOUT_SECS / RUN_TASK_TIMEOUT_SECS interaction in env example and service README

## Why
When run_task timeout is much larger than watchdog timeout, stale tasks get released/retried while the original run thread is still alive, causing repeated claimed -> deferred (thread busy) loops.

## Test Evidence
- cd DoWhiz_service && cargo test -p run_task_module run_task_timeout -- --nocapture
  - 6 timeout regression tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task-execution timeout behavior based on env vars, which can alter runtime behavior and failure modes for long-running tasks; covered by focused unit tests and docs updates.
> 
> **Overview**
> Aligns `run_task` command timeouts with the scheduler watchdog budget by introducing `TASK_TIMEOUT_SECS` and capping `RUN_TASK_TIMEOUT_SECS` to `TASK_TIMEOUT_SECS - 30s` (min 30s), replacing the prior long fixed default.
> 
> Adds regression tests for timeout parsing/defaulting/capping behavior, and documents the new env vars and their interaction in `.env.example` and `DoWhiz_service/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f57c57bb8fc4aeca7a6806a15fa1d7870b2a8e7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->