### PR TITLE
fix(run_task): reduce stale retries after ACI timeout

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -762,13 +762,23 @@ fn run_codex_task_azure_aci(
         timeout,
     );
     eprintln!(
-        "[run_task] azure_aci delete container={} resource_group={}",
+        "[run_task] azure_aci delete-request container={} resource_group={}",
         container_name, config.resource_group
     );
-    if let Err(cleanup_err) = delete_aci_container_with_retry(&config, &container_name) {
+    if let Err(cleanup_err) =
+        delete_aci_container_with_timeout(&config, &container_name, Duration::from_secs(20))
+    {
+        if !is_aci_not_found_error(&cleanup_err) {
+            eprintln!(
+                "[run_task] azure_aci delete-request failed container={} resource_group={} error={}",
+                container_name, config.resource_group, cleanup_err
+            );
+        }
+    }
+    if execution.is_err() {
         eprintln!(
-            "[run_task] azure_aci delete failed container={} resource_group={} error={}",
-            container_name, config.resource_group, cleanup_err
+            "[run_task] azure_aci execution failed for container={} (cleanup requested)",
+            container_name
         );
     }
     deregister_aci_container(&container_name);
@@ -1121,6 +1131,17 @@ fn poll_aci_state(
 ) -> Result<String, RunTaskError> {
     let start = Instant::now();
     loop {
+        let elapsed = start.elapsed();
+        if elapsed >= timeout {
+            return Err(RunTaskError::CommandTimeout {
+                command: "az container show",
+                timeout_secs: timeout.as_secs(),
+                output: "container did not reach terminal state before timeout".to_string(),
+            });
+        }
+        let remaining = timeout.saturating_sub(elapsed);
+        let show_timeout = remaining.min(Duration::from_secs(60));
+
         let mut show_cmd = Command::new("az");
         show_cmd
             .arg("container")
@@ -1134,8 +1155,7 @@ fn poll_aci_state(
             .arg("--output")
             .arg("tsv")
             .arg("--only-show-errors");
-        let output =
-            run_command_with_timeout(show_cmd, Duration::from_secs(60), "az container show")?;
+        let output = run_command_with_timeout(show_cmd, show_timeout, "az container show")?;
         if !output.status.success() {
             let mut combined = String::new();
             combined.push_str(&String::from_utf8_lossy(&output.stdout));
@@ -1160,7 +1180,10 @@ fn poll_aci_state(
                 output: format!("last_state={state}"),
             });
         }
-        thread::sleep(Duration::from_secs(5));
+        let sleep_for = Duration::from_secs(5).min(timeout.saturating_sub(start.elapsed()));
+        if !sleep_for.is_zero() {
+            thread::sleep(sleep_for);
+        }
     }
 }
 
@@ -1318,7 +1341,11 @@ fn cleanup_stale_aci_containers(config: &AzureAciConfig) -> Result<usize, RunTas
     Ok(cleaned)
 }
 
-fn delete_aci_container(config: &AzureAciConfig, container_name: &str) -> Result<(), RunTaskError> {
+fn delete_aci_container_with_timeout(
+    config: &AzureAciConfig,
+    container_name: &str,
+    command_timeout: Duration,
+) -> Result<(), RunTaskError> {
     let mut delete_cmd = Command::new("az");
     delete_cmd
         .arg("container")
@@ -1329,8 +1356,7 @@ fn delete_aci_container(config: &AzureAciConfig, container_name: &str) -> Result
         .arg(&config.resource_group)
         .arg("--yes")
         .arg("--only-show-errors");
-    let output =
-        run_command_with_timeout(delete_cmd, Duration::from_secs(120), "az container delete")?;
+    let output = run_command_with_timeout(delete_cmd, command_timeout, "az container delete")?;
     if !output.status.success() {
         let mut combined = String::new();
         combined.push_str(&String::from_utf8_lossy(&output.stdout));
@@ -1341,6 +1367,10 @@ fn delete_aci_container(config: &AzureAciConfig, container_name: &str) -> Result
         });
     }
     Ok(())
+}
+
+fn delete_aci_container(config: &AzureAciConfig, container_name: &str) -> Result<(), RunTaskError> {
+    delete_aci_container_with_timeout(config, container_name, Duration::from_secs(120))
 }
 
 fn delete_aci_container_with_retry(


### PR DESCRIPTION
## Summary
- make ACI state polling honor remaining timeout budget, so `az container show` cannot overrun overall run_task timeout
- switch post-execution ACI cleanup in run_task path to quick delete request (non-blocking wait)
- keep stale-cleanup retry path for batch cleanup logic unchanged

## Why
After the previous timeout cap fix, run_task still went stale in staging because:
1. `poll_aci_state` could exceed the nominal timeout by running a full 60s `az container show` near deadline
2. after timeout, synchronous container-delete waiting could hold the run thread long enough for watchdog to release/retry

That produced repeated `claimed -> deferred (thread busy)` loops for the same task.

## Test Evidence
- cd DoWhiz_service && cargo test -p run_task_module run_task_timeout -- --nocapture
- cd DoWhiz_service && cargo test -p run_task_module --no-run

## Staging Repro Evidence (before this patch)
- task_id: add3b4b9-ae05-4e5f-82ee-189ccdcf279c
- workspace: thread_21f287ce92ed1df24f4be34c76c59a59
- watchdog stale at ~00:16 followed by repeated deferred(thread busy) before final timeout handling
