### PR TITLE
Back off thread-busy run_task retries

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -159,6 +159,42 @@ impl<E: TaskExecutor> Scheduler<E> {
         Ok(self.tasks.last().unwrap().id)
     }
 
+    /// Pushes a one-shot task into the future to avoid hot-loop retries.
+    pub fn defer_one_shot_task_by_id(
+        &mut self,
+        task_id: Uuid,
+        delay: chrono::Duration,
+    ) -> Result<bool, SchedulerError> {
+        let index = match self.tasks.iter().position(|task| task.id == task_id) {
+            Some(index) => index,
+            None => return Ok(false),
+        };
+        if !self.tasks[index].enabled {
+            return Ok(false);
+        }
+
+        let min_delay = chrono::Duration::seconds(1);
+        let effective_delay = if delay > chrono::Duration::zero() {
+            delay
+        } else {
+            min_delay
+        };
+
+        match &mut self.tasks[index].schedule {
+            Schedule::OneShot { run_at } => {
+                let deferred_until = Utc::now() + effective_delay;
+                if *run_at >= deferred_until {
+                    return Ok(false);
+                }
+                *run_at = deferred_until;
+                let updated_task = self.tasks[index].clone();
+                self.store.update_task(&updated_task)?;
+                Ok(true)
+            }
+            Schedule::Cron { .. } => Ok(false),
+        }
+    }
+
     pub fn execute_task_by_id(&mut self, task_id: Uuid) -> Result<bool, SchedulerError> {
         let now = Utc::now();
         let index = match self.tasks.iter().position(|task| task.id == task_id) {
@@ -214,8 +250,13 @@ impl<E: TaskExecutor> Scheduler<E> {
                         task_id, err
                     );
                 }
-                self.store
-                    .record_execution_finish(task_id, execution_id, executed_at, "success", None)?;
+                self.store.record_execution_finish(
+                    task_id,
+                    execution_id,
+                    executed_at,
+                    "success",
+                    None,
+                )?;
                 self.tasks[index].last_run = Some(executed_at);
                 match &mut self.tasks[index].schedule {
                     Schedule::Cron {

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -83,6 +83,72 @@ fn force_one_shot_due<E: TaskExecutor>(scheduler: &mut Scheduler<E>, task_id: Uu
 }
 
 #[test]
+fn defer_one_shot_task_by_id_pushes_run_at_forward_and_persists() {
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = temp.path().join("tasks.db");
+    let mut scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("load");
+
+    let task_id = scheduler
+        .add_one_shot_in(Duration::from_secs(0), TaskKind::Noop)
+        .expect("add task");
+    force_one_shot_due(&mut scheduler, task_id);
+
+    let changed = scheduler
+        .defer_one_shot_task_by_id(task_id, chrono::Duration::seconds(15))
+        .expect("defer");
+    assert!(changed, "expected defer to update one-shot run_at");
+
+    let deferred_run_at = match &scheduler
+        .tasks()
+        .iter()
+        .find(|task| task.id == task_id)
+        .expect("task exists")
+        .schedule
+    {
+        Schedule::OneShot { run_at } => *run_at,
+        _ => panic!("expected one-shot schedule"),
+    };
+    assert!(
+        deferred_run_at >= Utc::now() + chrono::Duration::seconds(10),
+        "deferred run_at should be pushed into the future"
+    );
+
+    let reloaded = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("reload");
+    let persisted_run_at = match &reloaded
+        .tasks()
+        .iter()
+        .find(|task| task.id == task_id)
+        .expect("task exists after reload")
+        .schedule
+    {
+        Schedule::OneShot { run_at } => *run_at,
+        _ => panic!("expected one-shot schedule"),
+    };
+    assert_eq!(
+        persisted_run_at, deferred_run_at,
+        "deferred run_at should persist to storage"
+    );
+}
+
+#[test]
+fn defer_one_shot_task_by_id_is_noop_for_cron_tasks() {
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = temp.path().join("tasks.db");
+    let mut scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("load");
+
+    let task_id = scheduler
+        .add_cron_task("0 * * * * *", TaskKind::Noop)
+        .expect("add cron task");
+    let changed = scheduler
+        .defer_one_shot_task_by_id(task_id, chrono::Duration::seconds(15))
+        .expect("defer should not fail");
+    assert!(
+        !changed,
+        "cron tasks should not be deferred via one-shot API"
+    );
+}
+
+#[test]
 fn build_scheduler_snapshot_limits_to_window() {
     let now = Utc::now();
     let in_window = ScheduledTask {
@@ -676,7 +742,13 @@ fn full_slack_flow_task_sync_and_status_update() {
             .record_execution_start(task_id, executed_at)
             .expect("record start");
         workspace_store
-            .record_execution_finish(task_id, execution_id, executed_at, "failed", Some(error_message))
+            .record_execution_finish(
+                task_id,
+                execution_id,
+                executed_at,
+                "failed",
+                Some(error_message),
+            )
             .expect("record finish");
     }
 
@@ -688,7 +760,13 @@ fn full_slack_flow_task_sync_and_status_update() {
             .record_execution_start(task_id, executed_at)
             .expect("record start");
         account_store
-            .record_execution_finish(task_id, execution_id, executed_at, "failed", Some(error_message))
+            .record_execution_finish(
+                task_id,
+                execution_id,
+                executed_at,
+                "failed",
+                Some(error_message),
+            )
             .expect("record finish");
     }
 

--- a/DoWhiz_service/scheduler_module/src/service/scheduler.rs
+++ b/DoWhiz_service/scheduler_module/src/service/scheduler.rs
@@ -28,6 +28,8 @@ const RETRY_BACKOFF_SECS: [u64; 3] = [10, 100, 1000];
 const WATCHDOG_INTERVAL_SECS: u64 = 30;
 /// Minimum interval between busy logs for the same task
 const BUSY_LOG_THROTTLE_SECS: u64 = 10;
+/// Delay before retrying a run_task when the workspace thread is still busy
+const THREAD_BUSY_DEFER_SECS: i64 = 15;
 
 struct RunningThreadGuard {
     running_threads: Arc<Mutex<HashSet<String>>>,
@@ -459,27 +461,53 @@ fn execute_due_task(
         task_ref.task_id, task_ref.user_id, kind_label, status_label
     );
     let mut thread_guard: Option<RunningThreadGuard> = None;
-    if let Some(task) = scheduler.tasks().iter().find(|task| task.id == task_id) {
-        if let TaskKind::RunTask(run) = &task.kind {
-            let key = run.workspace_dir.to_string_lossy().into_owned();
-            let mut running = running_threads
-                .lock()
-                .expect("running thread lock poisoned");
-            if running.contains(&key) {
-                let log_key = format!("thread_busy:{}@{}", task_ref.task_id, task_ref.user_id);
-                if should_log_busy(&log_key) {
-                    info!(
-                        "scheduler deferred run_task task_id={} user_id={} workspace_dir={} (thread busy)",
-                        task_ref.task_id,
-                        task_ref.user_id,
-                        run.workspace_dir.display()
-                    );
-                }
-                return Ok(());
+    if let Some((key, workspace_dir_display)) = scheduler
+        .tasks()
+        .iter()
+        .find(|task| task.id == task_id)
+        .and_then(|task| match &task.kind {
+            TaskKind::RunTask(run) => Some((
+                run.workspace_dir.to_string_lossy().into_owned(),
+                run.workspace_dir.display().to_string(),
+            )),
+            _ => None,
+        })
+    {
+        let mut running = running_threads
+            .lock()
+            .expect("running thread lock poisoned");
+        if running.contains(&key) {
+            drop(running);
+            let defer_result = scheduler.defer_one_shot_task_by_id(
+                task_id,
+                chrono::Duration::seconds(THREAD_BUSY_DEFER_SECS),
+            );
+            let log_key = format!("thread_busy:{}@{}", task_ref.task_id, task_ref.user_id);
+            if should_log_busy(&log_key) {
+                info!(
+                    "scheduler deferred run_task task_id={} user_id={} workspace_dir={} (thread busy, next_attempt_in={}s)",
+                    task_ref.task_id,
+                    task_ref.user_id,
+                    workspace_dir_display,
+                    THREAD_BUSY_DEFER_SECS
+                );
             }
-            running.insert(key.clone());
-            thread_guard = Some(RunningThreadGuard::new(running_threads.clone(), key));
+            if let Err(err) = defer_result {
+                warn!(
+                    "failed to defer busy run_task task_id={} user_id={}: {}",
+                    task_ref.task_id, task_ref.user_id, err
+                );
+            }
+            if let Err(err) = index_store.sync_user_tasks(&task_ref.user_id, scheduler.tasks()) {
+                warn!(
+                    "scheduler sync failed after thread-busy defer task_id={} user_id={} error={}",
+                    task_ref.task_id, task_ref.user_id, err
+                );
+            }
+            return Ok(());
         }
+        running.insert(key.clone());
+        thread_guard = Some(RunningThreadGuard::new(running_threads.clone(), key));
     }
 
     let executed = scheduler.execute_task_by_id(task_id);


### PR DESCRIPTION
## Summary
- add `Scheduler::defer_one_shot_task_by_id` to push a due one-shot task into the future
- when `execute_due_task` hits `thread busy`, defer the one-shot by 15s and sync the index store
- include regression tests for one-shot defer behavior and cron no-op behavior

## Validation
- `cargo check -p scheduler_module` (PASS)
- `cargo test -p scheduler_module defer_one_shot_task_by_id -- --nocapture` (FAIL: local env missing `MONGODB_URI`)

## Why
After watchdog force-release, stale run_task entries could hot-loop claim/execute every poll while workspace thread was still busy. This patch adds a backoff window to prevent that storm and reduce scheduler churn.
