### PR TITLE
Account for ACI create latency in run_task timeout budget

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -1025,6 +1025,7 @@ fn run_azure_aci_execution(
         .collect::<Vec<_>>()
         .join("\n");
     let bypass_enabled = if bypass_sandbox { "1" } else { "0" };
+    let execution_started = Instant::now();
 
     let script = format!(
         "set -euo pipefail\n\
@@ -1119,7 +1120,19 @@ exit \"$status\"\n",
         Err(err) => return Err(err),
     }
 
-    let container_state = poll_aci_state(config, container_name, timeout)?;
+    let elapsed_after_create = execution_started.elapsed();
+    if elapsed_after_create >= timeout {
+        return Err(RunTaskError::CommandTimeout {
+            command: "az container create",
+            timeout_secs: timeout.as_secs(),
+            output: format!(
+                "container create consumed run_task timeout budget before polling (elapsed={}s)",
+                elapsed_after_create.as_secs()
+            ),
+        });
+    }
+    let poll_timeout = timeout.saturating_sub(elapsed_after_create);
+    let container_state = poll_aci_state(config, container_name, poll_timeout)?;
     let logs = fetch_aci_logs(config, container_name).unwrap_or_default();
     Ok((container_state, logs))
 }


### PR DESCRIPTION
## Summary
- make Azure ACI run_task timeout budget cover both container creation and state polling
- subtract elapsed create time before polling so total execution honors `run_task_timeout()`
- fail fast if container creation alone consumes the run_task budget

## Why
Staging E2E showed watchdog stale-release while ACI container was still legitimately running. This happened because polling timeout started after container creation, so total run time could exceed watchdog timeout despite `RUN_TASK_TIMEOUT_SECS` headroom.

## Validation
- `cargo check -p run_task_module`
- staging live email E2E reproduced stale-release path before this patch
