### PR TITLE
Fix set-e handling in web auth dependency health checks

### DIFF
--- a/DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh
+++ b/DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh
@@ -57,8 +57,11 @@ PY
   return "$status"
 }
 
-check_playwright_health
-check_status=$?
+if check_playwright_health; then
+  check_status=0
+else
+  check_status=$?
+fi
 
 install_pkg=0
 install_browser=0
@@ -163,8 +166,11 @@ if [[ "$install_browser" -eq 1 ]]; then
   python3 -m playwright install chromium
 fi
 
-check_playwright_health
-final_status=$?
+if check_playwright_health; then
+  final_status=0
+else
+  final_status=$?
+fi
 if [[ "$final_status" -ne 0 ]]; then
   echo "Playwright bootstrap dependencies are still not healthy after install (status=${final_status})." >&2
   exit 1


### PR DESCRIPTION
## Summary
- fix `set -e` flow in `install_web_auth_bootstrap_deps.sh` so non-zero Playwright health checks are captured into status variables instead of causing immediate script exit
- allow dependency repair branches (`install_pkg/install_browser/install_system_deps`) to execute as intended when health check returns non-zero

## Validation
- `bash -n DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh`

## Context
Previous deploy failed in `Restart DoWhiz services` because the script exited immediately on health check status `4` (missing runtime deps), before running the repair logic.
