### PR TITLE
Fix Playwright deps install path in staging deploy

### DIFF
--- a/DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh
+++ b/DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh
@@ -140,16 +140,24 @@ ensure_pip() {
 }
 
 run_playwright_install_deps() {
-  local deps_cmd=(python3 -m playwright install-deps chromium)
-  if [[ "$(id -u)" -eq 0 ]]; then
-    "${deps_cmd[@]}"
-    return $?
+  if python3 -m playwright install-deps chromium; then
+    return 0
   fi
+
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-    sudo "${deps_cmd[@]}"
+    local user_site
+    user_site="$(
+      python3 - <<'PY'
+import site
+print(site.getusersitepackages())
+PY
+    )"
+    sudo -n env "PYTHONPATH=${user_site}${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 -m playwright install-deps chromium
     return $?
   fi
-  echo "Unable to install Playwright system dependencies automatically (requires passwordless sudo)." >&2
+
+  echo "Unable to install Playwright system dependencies automatically (requires sudo access)." >&2
   return 1
 }
 


### PR DESCRIPTION
## Summary
- fix Playwright deps installation when deploy runs with sudo: avoid invoking root Python without Playwright module
- try `python3 -m playwright install-deps chromium` as current user first
- if needed, retry via `sudo -n` while forwarding user `PYTHONPATH` so module resolution still works

## Validation
- `bash -n DoWhiz_service/scripts/install_web_auth_bootstrap_deps.sh`

## Context
Staging deploy still failed in `Restart DoWhiz services` with `/usr/bin/python3: No module named playwright` when trying to install runtime deps under sudo.
