### PR TITLE
Fix Notion bootstrap and run_task timeout budget in staging

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/utils.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/utils.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use super::errors::RunTaskError;
 
 const DEFAULT_SCHEDULER_TASK_TIMEOUT_SECS: u64 = 600;
+const DEFAULT_RUN_TASK_TIMEOUT_SECS: u64 = 36000;
 const WATCHDOG_HEADROOM_SECS: u64 = 30;
 const MIN_RUN_TASK_TIMEOUT_SECS: u64 = 30;
 
@@ -30,15 +31,20 @@ fn parse_timeout_secs(key: &str) -> Option<u64> {
 }
 
 pub(super) fn run_task_timeout() -> Duration {
-    let task_timeout_secs =
-        parse_timeout_secs("TASK_TIMEOUT_SECS").unwrap_or(DEFAULT_SCHEDULER_TASK_TIMEOUT_SECS);
+    let requested_timeout_secs =
+        parse_timeout_secs("RUN_TASK_TIMEOUT_SECS").unwrap_or(DEFAULT_RUN_TASK_TIMEOUT_SECS);
+    let task_timeout_secs = parse_timeout_secs("TASK_TIMEOUT_SECS").unwrap_or_else(|| {
+        DEFAULT_SCHEDULER_TASK_TIMEOUT_SECS.max(
+            requested_timeout_secs
+                .saturating_add(WATCHDOG_HEADROOM_SECS)
+                .max(MIN_RUN_TASK_TIMEOUT_SECS),
+        )
+    });
     // Keep run_task timeout below watchdog timeout to avoid stale-task retry storms.
     let watchdog_budget_secs = task_timeout_secs
         .saturating_sub(WATCHDOG_HEADROOM_SECS)
         .max(MIN_RUN_TASK_TIMEOUT_SECS);
-    let timeout_secs = parse_timeout_secs("RUN_TASK_TIMEOUT_SECS")
-        .map(|value| value.min(watchdog_budget_secs))
-        .unwrap_or(watchdog_budget_secs);
+    let timeout_secs = requested_timeout_secs.min(watchdog_budget_secs);
     Duration::from_secs(timeout_secs)
 }
 

--- a/DoWhiz_service/scheduler_module/src/service/scheduler.rs
+++ b/DoWhiz_service/scheduler_module/src/service/scheduler.rs
@@ -20,6 +20,8 @@ use super::BoxError;
 
 /// Default task timeout in seconds (10 minutes)
 const DEFAULT_TASK_TIMEOUT_SECS: u64 = 600;
+/// Keep run_task timeout below watchdog timeout by this margin.
+const WATCHDOG_TIMEOUT_HEADROOM_SECS: u64 = 30;
 /// Maximum number of retries before giving up
 const MAX_TASK_RETRIES: u32 = 3;
 /// Exponential backoff delays in seconds: 10s, 100s, 1000s
@@ -30,6 +32,23 @@ const WATCHDOG_INTERVAL_SECS: u64 = 30;
 const BUSY_LOG_THROTTLE_SECS: u64 = 10;
 /// Delay before retrying a run_task when the workspace thread is still busy
 const THREAD_BUSY_DEFER_SECS: i64 = 15;
+
+fn parse_timeout_secs_env(key: &str) -> Option<u64> {
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+}
+
+fn resolve_watchdog_task_timeout_secs() -> u64 {
+    if let Some(explicit_timeout) = parse_timeout_secs_env("TASK_TIMEOUT_SECS") {
+        return explicit_timeout;
+    }
+
+    let run_task_timeout =
+        parse_timeout_secs_env("RUN_TASK_TIMEOUT_SECS").unwrap_or(DEFAULT_TASK_TIMEOUT_SECS);
+    DEFAULT_TASK_TIMEOUT_SECS.max(run_task_timeout.saturating_add(WATCHDOG_TIMEOUT_HEADROOM_SECS))
+}
 
 struct RunningThreadGuard {
     running_threads: Arc<Mutex<HashSet<String>>>,
@@ -242,10 +261,7 @@ pub(super) fn start_scheduler_threads(
         let scheduler_stop = scheduler_stop.clone();
         let user_store = user_store.clone();
         let users_root = config.users_root.clone();
-        let task_timeout_secs = std::env::var("TASK_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_TASK_TIMEOUT_SECS);
+        let task_timeout_secs = resolve_watchdog_task_timeout_secs();
         let watchdog_interval_ms = std::env::var("WATCHDOG_INTERVAL_MS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())

--- a/DoWhiz_service/scripts/bootstrap_web_auth.py
+++ b/DoWhiz_service/scripts/bootstrap_web_auth.py
@@ -200,26 +200,32 @@ def first_text_snippet(text: str, max_len: int = 200) -> str:
 
 
 def fill_first(page, selectors: Sequence[str], value: str, timeout_ms: int) -> bool:
-    for selector in selectors:
-        try:
-            handle = page.query_selector(selector)
-            if handle:
-                handle.fill(value, timeout=timeout_ms)
-                return True
-        except Exception:
-            continue
+    deadline = time.time() + (timeout_ms / 1000.0)
+    while time.time() < deadline:
+        for selector in selectors:
+            try:
+                handle = page.query_selector(selector)
+                if handle:
+                    handle.fill(value, timeout=min(3000, timeout_ms))
+                    return True
+            except Exception:
+                continue
+        page.wait_for_timeout(150)
     return False
 
 
 def click_first(page, selectors: Sequence[str], timeout_ms: int) -> bool:
-    for selector in selectors:
-        try:
-            handle = page.query_selector(selector)
-            if handle:
-                handle.click(timeout=timeout_ms)
-                return True
-        except Exception:
-            continue
+    deadline = time.time() + (timeout_ms / 1000.0)
+    while time.time() < deadline:
+        for selector in selectors:
+            try:
+                handle = page.query_selector(selector)
+                if handle:
+                    handle.click(timeout=min(3000, timeout_ms))
+                    return True
+            except Exception:
+                continue
+        page.wait_for_timeout(150)
     return False
 
 
@@ -246,13 +252,27 @@ def notion_login(page, context, email: str, password: str, timeout_ms: int) -> T
     if has_cookie(context, "https://www.notion.so", ("token_v2",)):
         return True, "already authenticated"
 
-    if not fill_first(
-        page,
-        ("input[type='email']", "input[name='email']", "input[placeholder*='mail']"),
-        email,
-        3000,
-    ):
-        return False, "email input not found"
+    email_selectors = (
+        "#notion-email-input-1",
+        "input[id^='notion-email-input']",
+        "input[type='email']",
+        "input[name='email']",
+        "input[placeholder*='mail']",
+    )
+
+    if not fill_first(page, email_selectors, email, 8000):
+        click_first(
+            page,
+            (
+                "button:has-text('Continue with email')",
+                "button:has-text('Email')",
+                "button:has-text('Sign in')",
+                "a:has-text('Sign in')",
+            ),
+            4000,
+        )
+        if not fill_first(page, email_selectors, email, 8000):
+            return False, "email input not found"
 
     click_first(
         page,


### PR DESCRIPTION
## Summary
- harden bootstrap_web_auth.py Notion login flow by waiting/polling for dynamic email UI before failing
- derive run_task timeout from RUN_TASK_TIMEOUT_SECS when TASK_TIMEOUT_SECS is unset, so ACI runs are not unintentionally clamped to ~10 minutes
- align scheduler watchdog default timeout derivation with the same rule to avoid stale-claim retries during long run_task executions

## Validation
- cargo fmt --all (in DoWhiz_service/)
- cargo test -p run_task_module --test run_task_tests
- cargo test -p scheduler_module stop_and_join_returns_quickly_with_short_watchdog_interval -- --nocapture
- python3 -m py_compile DoWhiz_service/scripts/bootstrap_web_auth.py

## Context
This addresses staging E2E failures for the Notion task flow triggered via inbound email to dowhiz@deep-tutor.com: bootstrap was failing with "email input not found", and ACI polling was timing out around 475s/570s due timeout budget mismatch.
