### PR TITLE
Fix hero headline descender clipping

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -677,6 +677,7 @@ ul {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   color: var(--accent-color);
+  padding-bottom: 0.16em;
 }
 
 .hero-subtitle {


### PR DESCRIPTION
## Summary
- fix clipped descender on hero gradient line (e.g. the `y` in `Everywhere!`)
- add bottom padding to the gradient headline line to prevent text clipping

## Test
- npm run lint (website)
- npm run build (website)
