### PR TITLE
Harden ACI playwright login fallback

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -198,6 +198,9 @@ Azure ACI execution path (required vars):
   `GOOGLE_ACCOUNT_PASSWORD`, `GOOGLE_EMPLOYEE_PASSWORD`, and prefixed forms like
   `<PREFIX>_GOOGLE_EMPLOYEE_EMAIL` via `EMPLOYEE_WEB_AUTH_ENV_PREFIX`/`WEB_AUTH_ENV_PREFIX`).
   Notion bootstrap tries Notion password login first, then falls back to Google login.
+  ACI run_task also sets Playwright/NPM runtime defaults for mounted workspaces:
+  `PLAYWRIGHT_MCP_EXECUTABLE_PATH` auto-discovery, `PLAYWRIGHT_BROWSERS_PATH=/app/.cache/ms-playwright`,
+  and `NPM_CONFIG_CACHE=/tmp/.npm` to avoid symlink failures from `npx`.
 
 ## 5) Local Run Workflows
 

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -1042,6 +1042,21 @@ fn run_azure_aci_execution(
     let script = format!(
         "set -euo pipefail\n\
 export PATH=/app/bin:$PATH\n\
+export PLAYWRIGHT_BROWSERS_PATH=\"${{PLAYWRIGHT_BROWSERS_PATH:-/app/.cache/ms-playwright}}\"\n\
+export XDG_CACHE_HOME=\"${{XDG_CACHE_HOME:-/tmp/.cache}}\"\n\
+export NPM_CONFIG_CACHE=\"${{NPM_CONFIG_CACHE:-/tmp/.npm}}\"\n\
+export npm_config_cache=\"$NPM_CONFIG_CACHE\"\n\
+mkdir -p \"$PLAYWRIGHT_BROWSERS_PATH\" \"$XDG_CACHE_HOME\" \"$NPM_CONFIG_CACHE\" /tmp/.local/share\n\
+if [ -z \"${{PLAYWRIGHT_MCP_EXECUTABLE_PATH:-}}\" ]; then\n\
+  if [ -x /opt/google/chrome/chrome ]; then\n\
+    export PLAYWRIGHT_MCP_EXECUTABLE_PATH=/opt/google/chrome/chrome\n\
+  else\n\
+    playwright_exec=\"$(find \"$PLAYWRIGHT_BROWSERS_PATH\" -path '*/chrome-linux/chrome' -type f 2>/dev/null | head -n1 || true)\"\n\
+    if [ -n \"$playwright_exec\" ]; then\n\
+      export PLAYWRIGHT_MCP_EXECUTABLE_PATH=\"$playwright_exec\"\n\
+    fi\n\
+  fi\n\
+fi\n\
 rm -f {output} {exit} {output_tmp} {exit_tmp}\n\
 if ! cd {workspace}; then\n\
   printf 'workspace path unavailable: %s\\n' {workspace} > {output_tmp}\n\

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -189,13 +189,20 @@ fn build_web_auth_capabilities_section() -> &'static str {
      - `playwright-cli state-load .auth/notion_state.json`
      - `playwright-cli state-load .auth/google_state.json`
   3. Open the target page and verify you are already authenticated.
-  4. If still redirected to sign-in, use env credentials with this order:
+  4. If browser launch fails before sign-in:
+     - If error says Chrome is missing, retry with:
+       - `export PLAYWRIGHT_MCP_EXECUTABLE_PATH=/opt/google/chrome/chrome`
+       - If that file does not exist, set it to the first hit under `/app/.cache/ms-playwright/*/chrome-linux/chrome`.
+     - Avoid `npx playwright install ...` on mounted workspaces (can fail with symlink errors).
+       Prefer `python3 -m playwright install chromium` or `playwright install chromium`.
+       If npm must be used, set `NPM_CONFIG_CACHE=/tmp/.npm` first.
+  5. If still redirected to sign-in, use env credentials with this order:
      - Notion email: `NOTION_ACCOUNT_EMAIL`, then `NOTION_EMAIL`
      - Notion password: `NOTION_PASSWORD`
      - Google email: `GOOGLE_ACCOUNT_EMAIL`, `GOOGLE_EMAIL`, `GOOGLE_EMPLOYEE_EMAIL`
      - Google password: `GOOGLE_PASSWORD`, `GOOGLE_ACCOUNT_PASSWORD`, `GOOGLE_EMPLOYEE_PASSWORD`
      - Also try prefixed keys (`<PREFIX>_<KEY>`) when `EMPLOYEE_WEB_AUTH_ENV_PREFIX` or `WEB_AUTH_ENV_PREFIX` is set.
-  5. After successful sign-in, refresh storage state in `.auth/` so retries are faster.
+  6. After successful sign-in, refresh storage state in `.auth/` so retries are faster.
 - Never include raw credentials in any user-facing reply, logs, or generated files.
 - Do not conclude "cannot access due to sign-in" until the sequence above has been attempted.
 


### PR DESCRIPTION
## Summary
- harden Azure ACI run_task runtime for browser auth fallback by pre-setting Playwright and npm cache env to local container disk
- auto-discover `PLAYWRIGHT_MCP_EXECUTABLE_PATH` from `/opt/google/chrome/chrome` or bundled Playwright Chromium path before launching Codex
- refine web auth prompt guidance to avoid `npx playwright install ...` on mounted workspace and prefer deterministic fallback commands
- document the ACI runtime defaults in `DoWhiz_service/README.md`

## Why
Staging logs showed fallback login path could fail with:
- `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`
- `npx playwright install chrome` failing with `ENOTSUP symlink` on Azure file-mounted workspace

This patch makes the runtime resilient without relying on agent trial-and-error.

## Test evidence
- `cargo test --manifest-path DoWhiz_service/Cargo.toml -p run_task_module test_collect_web_auth_env_overrides`
- `cargo test --manifest-path DoWhiz_service/Cargo.toml -p run_task_module run_task::prompt::tests::build_prompt_includes_cross_channel_capabilities`
