### PR TITLE
Rebuild ACI image during deployment before service restart

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -198,6 +198,69 @@ jobs:
           chmod 600 "$APP_DIR/.env"
           EOF
 
+      - name: Build and push ACI image on Azure VM
+        run: |
+          ssh -F ~/.ssh/config azureproduction << 'EOF'
+          set -e
+          APP_ROOT=/home/${{ secrets.PROD_AZURE_VM_USER }}/server/DoWhiz
+          APP_DIR="$APP_ROOT/DoWhiz_service"
+          ENV_FILE="$APP_DIR/.env"
+          read_env_value() {
+            local key="$1"
+            local value
+            value="$(grep -E "^${key}=" "$ENV_FILE" | tail -n1 | cut -d= -f2- || true)"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            printf '%s' "$value"
+          }
+
+          run_task_backend="$(read_env_value RUN_TASK_EXECUTION_BACKEND)"
+          deploy_target="$(read_env_value DEPLOY_TARGET)"
+          should_build=0
+          case "$run_task_backend" in
+            azure_aci)
+              should_build=1
+              ;;
+            auto)
+              if [[ "$deploy_target" == "staging" || "$deploy_target" == "production" ]]; then
+                should_build=1
+              fi
+              ;;
+          esac
+          if [[ "$should_build" -eq 0 ]]; then
+            echo "Skipping ACI image build: RUN_TASK_EXECUTION_BACKEND=$run_task_backend DEPLOY_TARGET=$deploy_target"
+            exit 0
+          fi
+
+          run_task_image="$(read_env_value RUN_TASK_AZURE_ACI_IMAGE)"
+          [[ -n "$run_task_image" ]] || {
+            echo "RUN_TASK_AZURE_ACI_IMAGE is required when Azure ACI backend is enabled" >&2
+            exit 1
+          }
+          login_server="${run_task_image%%/*}"
+          image_name="${run_task_image#*/}"
+          if [[ "$login_server" == "$run_task_image" || -z "$image_name" ]]; then
+            echo "Invalid RUN_TASK_AZURE_ACI_IMAGE: $run_task_image" >&2
+            exit 1
+          fi
+          registry_name="${login_server%%.*}"
+          [[ -n "$registry_name" ]] || {
+            echo "Unable to parse ACR registry name from image: $run_task_image" >&2
+            exit 1
+          }
+
+          echo "Building ACI image via az acr build: $run_task_image"
+          cd "$APP_ROOT"
+          az acr build \
+            --registry "$registry_name" \
+            --image "$image_name" \
+            --file Dockerfile \
+            . \
+            --only-show-errors
+          EOF
+
       - name: Restart DoWhiz services
         run: |
           ssh -F ~/.ssh/config azureproduction << 'EOF'

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -198,6 +198,69 @@ jobs:
           chmod 600 "$APP_DIR/.env"
           EOF
 
+      - name: Build and push ACI image on Azure VM
+        run: |
+          ssh -F ~/.ssh/config azureproduction << 'EOF'
+          set -e
+          APP_ROOT=/home/${{ secrets.STAGING_AZURE_VM_USER }}/server/DoWhiz
+          APP_DIR="$APP_ROOT/DoWhiz_service"
+          ENV_FILE="$APP_DIR/.env"
+          read_env_value() {
+            local key="$1"
+            local value
+            value="$(grep -E "^${key}=" "$ENV_FILE" | tail -n1 | cut -d= -f2- || true)"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            printf '%s' "$value"
+          }
+
+          run_task_backend="$(read_env_value RUN_TASK_EXECUTION_BACKEND)"
+          deploy_target="$(read_env_value DEPLOY_TARGET)"
+          should_build=0
+          case "$run_task_backend" in
+            azure_aci)
+              should_build=1
+              ;;
+            auto)
+              if [[ "$deploy_target" == "staging" || "$deploy_target" == "production" ]]; then
+                should_build=1
+              fi
+              ;;
+          esac
+          if [[ "$should_build" -eq 0 ]]; then
+            echo "Skipping ACI image build: RUN_TASK_EXECUTION_BACKEND=$run_task_backend DEPLOY_TARGET=$deploy_target"
+            exit 0
+          fi
+
+          run_task_image="$(read_env_value RUN_TASK_AZURE_ACI_IMAGE)"
+          [[ -n "$run_task_image" ]] || {
+            echo "RUN_TASK_AZURE_ACI_IMAGE is required when Azure ACI backend is enabled" >&2
+            exit 1
+          }
+          login_server="${run_task_image%%/*}"
+          image_name="${run_task_image#*/}"
+          if [[ "$login_server" == "$run_task_image" || -z "$image_name" ]]; then
+            echo "Invalid RUN_TASK_AZURE_ACI_IMAGE: $run_task_image" >&2
+            exit 1
+          fi
+          registry_name="${login_server%%.*}"
+          [[ -n "$registry_name" ]] || {
+            echo "Unable to parse ACR registry name from image: $run_task_image" >&2
+            exit 1
+          }
+
+          echo "Building ACI image via az acr build: $run_task_image"
+          cd "$APP_ROOT"
+          az acr build \
+            --registry "$registry_name" \
+            --image "$image_name" \
+            --file Dockerfile \
+            . \
+            --only-show-errors
+          EOF
+
       - name: Restart DoWhiz services
         run: |
           ssh -F ~/.ssh/config azureproduction << 'EOF'

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -82,7 +82,8 @@ Deployment workflows should:
 1. Write `.env` from `ENV_COMMON + ENV_STAGING/ENV_PROD`.
 2. Fail if `.env` contains keys matching `^(STAGING_|PROD_)`.
 3. Validate `GATEWAY_CONFIG_PATH` and `EMPLOYEE_CONFIG_PATH` exist and match expected target files.
-4. Source `.env` before PM2 restarts and use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes.
+4. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), rebuild and push `RUN_TASK_AZURE_ACI_IMAGE` via `az acr build` before restarting services.
+5. Source `.env` before PM2 restarts and use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes.
 
 ## 5) Health Checks
 


### PR DESCRIPTION
## Why
Staging deploy succeeded after PR #793, but Azure ACI runtime still used an older image without `gws`.
Smoke check on staging VM ACI image execution showed:
- `/bin/bash: line 1: gws: command not found`

So Dockerfile updates alone are insufficient unless deployment also refreshes `RUN_TASK_AZURE_ACI_IMAGE`.

## Summary
- add a deployment step in staging workflow to rebuild/push `RUN_TASK_AZURE_ACI_IMAGE` via `az acr build` on the VM
- add the same step in production workflow for parity
- gate image build to Azure ACI backends only (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`)
- update deploy runbook doc accordingly

## Verification
| Item | Status | Evidence |
|---|---|---|
| YAML parse | PASS | `python3` + `yaml.safe_load` on both updated workflow files |
| Staging ACI smoke before fix | FAIL (expected) | `gws: command not found` from ACI container logs |
| Post-fix staging E2E | PENDING | Will run after this PR is merged + CICD finishes |

