### PR TITLE
Prevent huge ACI context uploads in staging/prod deploys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,9 @@
 !DoWhiz_service/
 !DoWhiz_service/**
 
-DoWhiz_service/.workspace/
-DoWhiz_service/target/
+DoWhiz_service/.workspace
+DoWhiz_service/.workspace/**
+DoWhiz_service/target
+DoWhiz_service/target/**
 DoWhiz_service/**/.env
 DoWhiz_service/**/.env.*

--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -251,6 +251,12 @@ jobs:
             exit 1
           }
 
+          # Prior VM builds can leave a very large Rust target directory that bloats Docker context.
+          if [[ -d "$APP_DIR/target" ]]; then
+            echo "Removing $APP_DIR/target before az acr build to keep context small"
+            rm -rf "$APP_DIR/target"
+          fi
+
           echo "Building ACI image via az acr build: $run_task_image"
           cd "$APP_ROOT"
           az acr build \

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -251,6 +251,12 @@ jobs:
             exit 1
           }
 
+          # Prior VM builds can leave a very large Rust target directory that bloats Docker context.
+          if [[ -d "$APP_DIR/target" ]]; then
+            echo "Removing $APP_DIR/target before az acr build to keep context small"
+            rm -rf "$APP_DIR/target"
+          fi
+
           echo "Building ACI image via az acr build: $run_task_image"
           cd "$APP_ROOT"
           az acr build \

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -82,7 +82,7 @@ Deployment workflows should:
 1. Write `.env` from `ENV_COMMON + ENV_STAGING/ENV_PROD`.
 2. Fail if `.env` contains keys matching `^(STAGING_|PROD_)`.
 3. Validate `GATEWAY_CONFIG_PATH` and `EMPLOYEE_CONFIG_PATH` exist and match expected target files.
-4. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), rebuild and push `RUN_TASK_AZURE_ACI_IMAGE` via `az acr build` before restarting services.
+4. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), remove `DoWhiz_service/target` on the VM first, then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE` via `az acr build` before restarting services. This avoids sending stale Rust build artifacts in Docker context.
 5. Source `.env` before PM2 restarts and use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes.
 
 ## 5) Health Checks


### PR DESCRIPTION
## Summary
- remove `DoWhiz_service/target` on the VM right before `az acr build` in both staging and production deploy workflows
- tighten `.dockerignore` patterns for `DoWhiz_service/target` and `.workspace`
- document the target cleanup requirement in staging/prod deploy runbook

## Why
Recent staging deploy spent a long time in ACI image build because VM-local Rust artifacts were being read from `DoWhiz_service/target` (27G observed on staging VM). Cleaning target before build keeps Docker context small and makes ACI rebuild practical during CICD.

## Validation
- YAML parse check passed for:
  - `.github/workflows/CICD-staging.yml`
  - `.github/workflows/CICD-production.yml`
- manual verification that updated workflow/docs lines are present
