### PR TITLE
Preserve release binaries during ACI context trim

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -252,9 +252,19 @@ jobs:
           }
 
           # Prior VM builds can leave a very large Rust target directory that bloats Docker context.
+          # Keep release binaries required by PM2 restarts, trim everything else.
           if [[ -d "$APP_DIR/target" ]]; then
-            echo "Removing $APP_DIR/target before az acr build to keep context small"
-            rm -rf "$APP_DIR/target"
+            echo "Trimming $APP_DIR/target before az acr build to keep context small"
+            if [[ -d "$APP_DIR/target/release" ]]; then
+              find "$APP_DIR/target/release" -mindepth 1 -maxdepth 1 \
+                ! -name rust_service \
+                ! -name inbound_gateway \
+                ! -name set_postmark_inbound_hook \
+                ! -name inbound_fanout \
+                ! -name google-docs \
+                -exec rm -rf {} +
+            fi
+            find "$APP_DIR/target" -mindepth 1 -maxdepth 1 ! -name release -exec rm -rf {} +
           fi
 
           echo "Building ACI image via az acr build: $run_task_image"

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -252,9 +252,19 @@ jobs:
           }
 
           # Prior VM builds can leave a very large Rust target directory that bloats Docker context.
+          # Keep release binaries required by PM2 restarts, trim everything else.
           if [[ -d "$APP_DIR/target" ]]; then
-            echo "Removing $APP_DIR/target before az acr build to keep context small"
-            rm -rf "$APP_DIR/target"
+            echo "Trimming $APP_DIR/target before az acr build to keep context small"
+            if [[ -d "$APP_DIR/target/release" ]]; then
+              find "$APP_DIR/target/release" -mindepth 1 -maxdepth 1 \
+                ! -name rust_service \
+                ! -name inbound_gateway \
+                ! -name set_postmark_inbound_hook \
+                ! -name inbound_fanout \
+                ! -name google-docs \
+                -exec rm -rf {} +
+            fi
+            find "$APP_DIR/target" -mindepth 1 -maxdepth 1 ! -name release -exec rm -rf {} +
           fi
 
           echo "Building ACI image via az acr build: $run_task_image"

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -82,7 +82,7 @@ Deployment workflows should:
 1. Write `.env` from `ENV_COMMON + ENV_STAGING/ENV_PROD`.
 2. Fail if `.env` contains keys matching `^(STAGING_|PROD_)`.
 3. Validate `GATEWAY_CONFIG_PATH` and `EMPLOYEE_CONFIG_PATH` exist and match expected target files.
-4. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), remove `DoWhiz_service/target` on the VM first, then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE` via `az acr build` before restarting services. This avoids sending stale Rust build artifacts in Docker context.
+4. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), trim `DoWhiz_service/target` on the VM before `az acr build` (drop debug/intermediate artifacts, keep required release binaries), then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE` before restarting services.
 5. Source `.env` before PM2 restarts and use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes.
 
 ## 5) Health Checks


### PR DESCRIPTION
## Summary
- fix deployment regression by trimming `DoWhiz_service/target` instead of deleting it entirely before `az acr build`
- preserve required release binaries (`rust_service`, `inbound_gateway`, `set_postmark_inbound_hook`, etc.) so PM2 restart can still launch services
- keep staging/production deploy doc aligned with the new behavior

## Why
Previous change removed the entire `target` tree to shrink Docker context. That also removed `target/release/rust_service`, and staging worker failed after restart with:
`/usr/bin/bash: line 1: target/release/rust_service: No such file or directory`.

## Validation
- YAML parse check passed for:
  - `.github/workflows/CICD-staging.yml`
  - `.github/workflows/CICD-production.yml`
- manual verification of target-trimming logic in both workflows
