### PR TITLE
Bypass agent and send fixed insufficient-balance notice

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -212,6 +212,16 @@ Azure ACI execution path (required vars):
   `PLAYWRIGHT_BROWSERS_PATH=/app/.cache/ms-playwright`,
   and `NPM_CONFIG_CACHE=/tmp/.npm` to avoid symlink failures from `npx`.
 
+### 4.6 Billing / insufficient-balance notices
+
+- Stripe billing routes are enabled only when both keys are present:
+  - `STRIPE_SECRET_KEY`
+  - `STRIPE_WEBHOOK_SECRET`
+- Optional fixed payment link for insufficient-balance auto notices:
+  - `INSUFFICIENT_BALANCE_PAYMENT_LINK` (preferred)
+  - fallback order: `BILLING_PAYMENT_LINK` -> `PAYMENT_LINK` -> `${FRONTEND_URL}/auth/index.html` -> `https://www.dowhiz.com/auth/index.html`
+- Insufficient-balance notices bypass agent execution and are sent directly by channel adapter (email HTML / other channels plain text).
+
 ## 5) Local Run Workflows
 
 ### 5.1 Fast path: one worker + one gateway

--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -283,7 +283,12 @@ impl<E: TaskExecutor> Scheduler<E> {
                         );
                     }
                     ingest_follow_up_tasks(self, task, &execution.follow_up_tasks);
-                    if let Err(err) = schedule_auto_reply(self, task) {
+                    if execution.skip_auto_reply {
+                        info!(
+                            "skip auto reply from {} (reply already handled in executor)",
+                            task.workspace_dir.display()
+                        );
+                    } else if let Err(err) = schedule_auto_reply(self, task) {
                         warn!(
                             "failed to schedule auto reply from {}: {}",
                             task.workspace_dir.display(),

--- a/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -247,6 +247,179 @@ fn write_github_sender_parse_failed_reply(
 </html>
 "#;
     std::fs::write(reply_path, html)?;
+    Ok(())
+}
+
+fn read_non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn configured_insufficient_balance_payment_link() -> Option<String> {
+    [
+        "INSUFFICIENT_BALANCE_PAYMENT_LINK",
+        "BILLING_PAYMENT_LINK",
+        "PAYMENT_LINK",
+    ]
+    .iter()
+    .find_map(|key| read_non_empty_env(key))
+}
+
+fn default_billing_link() -> String {
+    read_non_empty_env("FRONTEND_URL")
+        .map(|url| format!("{}/auth/index.html", url.trim_end_matches('/')))
+        .unwrap_or_else(|| "https://www.dowhiz.com/auth/index.html".to_string())
+}
+
+fn html_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn build_insufficient_balance_plain_text(payment_link: &str) -> String {
+    format!(
+        "Insufficient balance. I could not run this request.\n\
+Please add more employee hours, then resend your message.\n\
+Payment link: {payment_link}"
+    )
+}
+
+fn build_insufficient_balance_email_html(payment_link: &str) -> String {
+    let escaped_link = html_escape(payment_link);
+    format!(
+        r#"<!DOCTYPE html>
+<html>
+<body>
+  <p>Hi there,</p>
+  <p>Your account currently has insufficient balance, so I could not run this request.</p>
+  <p>Please add more employee hours, then resend your message.</p>
+  <p>Payment link: <a href="{link}">{link}</a></p>
+</body>
+</html>
+"#,
+        link = escaped_link
+    )
+}
+
+fn write_insufficient_balance_notice_body(
+    task: &super::types::RunTaskTask,
+    payment_link: &str,
+) -> Result<PathBuf, SchedulerError> {
+    let (filename, body) = match task.channel {
+        Channel::Email => (
+            ".insufficient_balance_notice.html",
+            build_insufficient_balance_email_html(payment_link),
+        ),
+        _ => (
+            ".insufficient_balance_notice.txt",
+            build_insufficient_balance_plain_text(payment_link),
+        ),
+    };
+    let path = task.workspace_dir.join(filename);
+    std::fs::write(&path, body)?;
+    Ok(path)
+}
+
+fn dispatch_send_reply_task(task: &SendReplyTask) -> Result<(), SchedulerError> {
+    if let Some(expected_epoch) = task.thread_epoch {
+        let state_path = task
+            .thread_state_path
+            .clone()
+            .or_else(|| task.html_path.parent().and_then(find_thread_state_path));
+        if let Some(state_path) = state_path {
+            if let Some(current_epoch) = current_thread_epoch(&state_path) {
+                if current_epoch != expected_epoch {
+                    info!(
+                        "skip stale send_email (expected epoch {}, current {}) for {}",
+                        expected_epoch,
+                        current_epoch,
+                        task.html_path.display()
+                    );
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    match task.channel {
+        Channel::Slack => {
+            delete_slack_working_placeholder_before_send(task);
+            execute_slack_send(task)?;
+        }
+        Channel::Discord => {
+            execute_discord_send(task)?;
+        }
+        Channel::GoogleDocs | Channel::GoogleSheets | Channel::GoogleSlides => {
+            execute_google_docs_send(task)?;
+        }
+        Channel::Sms => {
+            execute_sms_send(task)?;
+        }
+        Channel::BlueBubbles => {
+            execute_bluebubbles_send(task)?;
+        }
+        Channel::Telegram => {
+            execute_telegram_send(task)?;
+        }
+        Channel::WhatsApp => {
+            execute_whatsapp_send(task)?;
+        }
+        Channel::Email => {
+            execute_email_send(task)?;
+        }
+    }
+    Ok(())
+}
+
+fn send_insufficient_balance_notice(
+    task: &super::types::RunTaskTask,
+    account_id: Uuid,
+) -> Result<(), SchedulerError> {
+    if task.reply_to.is_empty() {
+        warn!(
+            "Account {} has insufficient balance but no reply recipients for workspace {}",
+            account_id,
+            task.workspace_dir.display()
+        );
+        return Ok(());
+    }
+
+    let payment_link =
+        configured_insufficient_balance_payment_link().unwrap_or_else(default_billing_link);
+    let body_path = write_insufficient_balance_notice_body(task, &payment_link)?;
+    let attachments_dir = task
+        .workspace_dir
+        .join(".insufficient_balance_notice_attachments");
+    std::fs::create_dir_all(&attachments_dir)?;
+    let reply_context = super::reply::load_reply_context(&task.workspace_dir);
+
+    let send_task = SendReplyTask {
+        channel: task.channel.clone(),
+        subject: reply_context.subject,
+        html_path: body_path,
+        attachments_dir,
+        from: task.reply_from.clone().or(reply_context.from),
+        to: task.reply_to.clone(),
+        cc: Vec::new(),
+        bcc: Vec::new(),
+        in_reply_to: reply_context.in_reply_to,
+        references: reply_context.references,
+        archive_root: task.archive_root.clone(),
+        thread_epoch: task.thread_epoch,
+        thread_state_path: task.thread_state_path.clone(),
+        employee_id: task.employee_id.clone(),
+    };
+
+    dispatch_send_reply_task(&send_task)?;
+    info!(
+        "sent insufficient-balance notice for account {} via {:?}",
+        account_id, task.channel
+    );
     Ok(())
 }
 
@@ -721,54 +894,7 @@ impl TaskExecutor for ModuleExecutor {
     fn execute(&self, task: &TaskKind) -> Result<TaskExecution, SchedulerError> {
         match task {
             TaskKind::SendReply(task) => {
-                if let Some(expected_epoch) = task.thread_epoch {
-                    let state_path = task
-                        .thread_state_path
-                        .clone()
-                        .or_else(|| task.html_path.parent().and_then(find_thread_state_path));
-                    if let Some(state_path) = state_path {
-                        if let Some(current_epoch) = current_thread_epoch(&state_path) {
-                            if current_epoch != expected_epoch {
-                                info!(
-                                    "skip stale send_email (expected epoch {}, current {}) for {}",
-                                    expected_epoch,
-                                    current_epoch,
-                                    task.html_path.display()
-                                );
-                                return Ok(TaskExecution::empty());
-                            }
-                        }
-                    }
-                }
-
-                // Dispatch to the appropriate adapter based on channel
-                match task.channel {
-                    Channel::Slack => {
-                        delete_slack_working_placeholder_before_send(task);
-                        execute_slack_send(task)?;
-                    }
-                    Channel::Discord => {
-                        execute_discord_send(task)?;
-                    }
-                    Channel::GoogleDocs | Channel::GoogleSheets | Channel::GoogleSlides => {
-                        execute_google_docs_send(task)?;
-                    }
-                    Channel::Sms => {
-                        execute_sms_send(task)?;
-                    }
-                    Channel::BlueBubbles => {
-                        execute_bluebubbles_send(task)?;
-                    }
-                    Channel::Telegram => {
-                        execute_telegram_send(task)?;
-                    }
-                    Channel::WhatsApp => {
-                        execute_whatsapp_send(task)?;
-                    }
-                    Channel::Email => {
-                        execute_email_send(task)?;
-                    }
-                }
+                dispatch_send_reply_task(task)?;
                 Ok(TaskExecution::empty())
             }
             TaskKind::RunTask(task) => {
@@ -793,6 +919,32 @@ impl TaskExecutor for ModuleExecutor {
                                 "skipping run_task for github notification: unable to extract sender login"
                             );
                             return Ok(TaskExecution::empty());
+                        }
+                    }
+                }
+
+                // Check balance before any run_task side effects.
+                if let Some(account_id) = account_id {
+                    if let Some(store) = get_global_account_store() {
+                        match store.has_sufficient_balance(account_id) {
+                            Ok(false) => {
+                                warn!(
+                                    "Account {} has insufficient balance, skipping task execution",
+                                    account_id
+                                );
+                                send_insufficient_balance_notice(task, account_id)?;
+                                let mut execution = TaskExecution::empty();
+                                execution.skip_auto_reply = true;
+                                return Ok(execution);
+                            }
+                            Ok(true) => {}
+                            Err(e) => {
+                                // Balance check failed - log but continue (fail open)
+                                warn!(
+                                    "Failed to check balance for account {}: {}, continuing anyway",
+                                    account_id, e
+                                );
+                            }
                         }
                     }
                 }
@@ -866,49 +1018,6 @@ impl TaskExecutor for ModuleExecutor {
                     );
                 }
                 crate::web_auth_bootstrap::bootstrap_workspace_web_auth(&task.workspace_dir);
-                // Check balance before running task (only for unified accounts)
-                if let Some(account_id) = account_id {
-                    if let Some(store) = get_global_account_store() {
-                        match store.has_sufficient_balance(account_id) {
-                            Ok(false) => {
-                                // Insufficient balance - write error reply and skip task
-                                warn!(
-                                    "Account {} has insufficient balance, skipping task execution",
-                                    account_id
-                                );
-                                let reply_message = "Insufficient balance. Please increase your balance for more employee hours.";
-
-                                // Write to appropriate reply file based on channel
-                                let reply_path = match task.channel {
-                                    Channel::Email
-                                    | Channel::GoogleDocs
-                                    | Channel::GoogleSheets
-                                    | Channel::GoogleSlides => {
-                                        task.workspace_dir.join("reply_email_draft.html")
-                                    }
-                                    _ => task.workspace_dir.join("reply_message.txt"),
-                                };
-
-                                if let Err(e) = std::fs::write(&reply_path, reply_message) {
-                                    warn!("Failed to write balance error reply: {}", e);
-                                }
-
-                                // Return empty execution (no token usage, task considered complete)
-                                return Ok(TaskExecution::empty());
-                            }
-                            Ok(true) => {
-                                // Sufficient balance, continue with task
-                            }
-                            Err(e) => {
-                                // Balance check failed - log but continue (fail open)
-                                warn!(
-                                    "Failed to check balance for account {}: {}, continuing anyway",
-                                    account_id, e
-                                );
-                            }
-                        }
-                    }
-                }
 
                 let user_identities = fetch_user_identities(account_id);
                 let params = run_task_module::RunTaskParams {
@@ -1016,6 +1125,7 @@ impl TaskExecutor for ModuleExecutor {
                     follow_up_error: output.scheduled_tasks_error,
                     scheduler_actions: output.scheduler_actions,
                     scheduler_actions_error: output.scheduler_actions_error,
+                    skip_auto_reply: false,
                 })
             }
             TaskKind::Noop => Ok(TaskExecution::empty()),

--- a/DoWhiz_service/scheduler_module/src/scheduler/types.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/types.rs
@@ -156,6 +156,7 @@ pub struct TaskExecution {
     pub follow_up_error: Option<String>,
     pub scheduler_actions: Vec<run_task_module::SchedulerActionRequest>,
     pub scheduler_actions_error: Option<String>,
+    pub skip_auto_reply: bool,
 }
 
 impl TaskExecution {

--- a/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
@@ -142,6 +142,7 @@ impl TaskExecutor for RecordingExecutor {
                     follow_up_error: output.scheduled_tasks_error,
                     scheduler_actions: output.scheduler_actions,
                     scheduler_actions_error: output.scheduler_actions_error,
+                    skip_auto_reply: false,
                 })
             }
             TaskKind::SendReply(_) => Ok(TaskExecution::default()),

--- a/DoWhiz_service/scheduler_module/tests/scheduler_agent_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_agent_e2e.rs
@@ -65,6 +65,7 @@ impl TaskExecutor for RecordingExecutor {
                     follow_up_error: output.scheduled_tasks_error,
                     scheduler_actions: output.scheduler_actions,
                     scheduler_actions_error: output.scheduler_actions_error,
+                    skip_auto_reply: false,
                 })
             }
             TaskKind::SendReply(send) => {

--- a/DoWhiz_service/scheduler_module/tests/scheduler_followups.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_followups.rs
@@ -30,6 +30,7 @@ impl TaskExecutor for FollowUpExecutor {
                     follow_up_error: None,
                     scheduler_actions: Vec::new(),
                     scheduler_actions_error: None,
+                    skip_auto_reply: false,
                 })
             }
             _ => Ok(TaskExecution::default()),

--- a/DoWhiz_service/scheduler_module/tests/scheduler_x402_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_x402_env_e2e.rs
@@ -93,6 +93,7 @@ impl TaskExecutor for RecordingExecutor {
                     follow_up_error: output.scheduled_tasks_error,
                     scheduler_actions: output.scheduler_actions,
                     scheduler_actions_error: output.scheduler_actions_error,
+                    skip_auto_reply: false,
                 })
             }
             TaskKind::SendReply(_) => Ok(TaskExecution::default()),

--- a/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
@@ -119,6 +119,7 @@ impl TaskExecutor for RecordingExecutor {
                     follow_up_error: output.scheduled_tasks_error,
                     scheduler_actions: output.scheduler_actions,
                     scheduler_actions_error: output.scheduler_actions_error,
+                    skip_auto_reply: false,
                 })
             }
             TaskKind::SendReply(send) => {


### PR DESCRIPTION
## Summary\n- bypass run_task when account balance is insufficient\n- send fixed template notice directly via channel adapter\n- add configurable payment link fallback ending at /auth/index.html\n- skip scheduler auto-reply when notice already sent\n\n## Validation\n- cargo fmt\n- cargo test -p scheduler_module --no-run