### PR TITLE
Fix prod auth API startup panic under mongo backend

### DIFF
--- a/DoWhiz_service/scheduler_module/src/service/server.rs
+++ b/DoWhiz_service/scheduler_module/src/service/server.rs
@@ -42,8 +42,12 @@ pub async fn run_server(
 ) -> Result<(), BoxError> {
     let storage_backend = StorageBackend::from_env();
     if storage_backend.uses_mongo() {
-        health_check_from_env()?;
-        bootstrap_indexes_from_env()?;
+        task::spawn_blocking(health_check_from_env)
+            .await
+            .map_err(|err| -> BoxError { err.into() })??;
+        task::spawn_blocking(bootstrap_indexes_from_env)
+            .await
+            .map_err(|err| -> BoxError { err.into() })??;
         info!(
             "mongo backend enabled backend={:?} database={}",
             storage_backend,
@@ -228,7 +232,10 @@ pub async fn run_server(
     // Clean up any active ACI containers to prevent orphans
     let cleaned = run_task_module::cleanup_all_aci_containers();
     if cleaned > 0 {
-        info!("cleaned up {} orphaned ACI container(s) on shutdown", cleaned);
+        info!(
+            "cleaned up {} orphaned ACI container(s) on shutdown",
+            cleaned
+        );
     }
 
     serve_result?;


### PR DESCRIPTION
## Summary
- run Mongo health check and index bootstrap in blocking tasks during service startup
- avoid calling mongodb sync client parse/run directly inside tokio async context

## Root Cause
rust_service startup called Mongo sync initialization in async context, which triggered a nested runtime panic (Cannot start a runtime from within a runtime) and kept port 9001 down, causing https://api.production1.dowhiz.com/service/* to return 502.

## Validation
- cargo check -p scheduler_module --bin rust_service
