### PR TITLE
Prefer SMS as default 2FA method in agent guidance

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -207,6 +207,7 @@ fn build_web_auth_capabilities_section() -> &'static str {
 fn build_human_approval_gate_section() -> &'static str {
     r#"Human Approval Gate (2FA / verification challenges):
 - If login/auth flow asks for OTP/passcode/device approval/number tap/CAPTCHA/security challenge, immediately use the `human-approval-gate` skill.
+- If multiple verification methods are available on the same challenge page, prefer SMS verification first by default. If SMS is unavailable or fails, fall back to another method and keep using `human_approval_gate` for human input.
 - If the requested login cannot proceed because required credential or challenge answer is missing (email/username/password/passcode), request it through `human_approval_gate` instead of guessing.
 - Use the `human_approval_gate` CLI and pause all unrelated work while waiting for result.
 - Primary flow:
@@ -962,6 +963,7 @@ mod tests {
         assert!(prompt.contains("timeout"));
         assert!(prompt.contains("CAPTCHA/security challenge"));
         assert!(prompt.contains("required credential"));
+        assert!(prompt.contains("prefer SMS verification first by default"));
     }
 
     #[test]

--- a/DoWhiz_service/skills/human-approval-gate/SKILL.md
+++ b/DoWhiz_service/skills/human-approval-gate/SKILL.md
@@ -14,6 +14,8 @@ Use this skill immediately when any authentication flow is blocked by human veri
 - "Tap number on mobile app"
 - security challenge that requires user/admin action
 
+When a page offers multiple verification methods, choose SMS verification first by default.
+
 Do not keep retrying login while blocked.
 
 ## Required Behavior
@@ -22,6 +24,7 @@ Do not keep retrying login while blocked.
 2. Wait on gate result.
 3. Continue only if approved.
 4. If timeout/rejected, stop login attempts and report clearly.
+5. If SMS verification is unavailable or fails, switch to another available method and keep the same gate-based wait behavior.
 
 ## Scope Rules
 


### PR DESCRIPTION
## Summary
- update run-task prompt guidance to prefer SMS as the default 2FA method when multiple verification options are available
- keep fallback behavior explicit: if SMS is unavailable/fails, continue with other available methods while still using `human_approval_gate`
- update `human-approval-gate` skill doc with the same default SMS preference guidance

## Validation
- `cargo fmt -p run_task_module`
- `cargo test -p run_task_module`
