### PR TITLE
Refine 2FA gate behavior for CAPTCHA and admin routing

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -206,7 +206,8 @@ fn build_web_auth_capabilities_section() -> &'static str {
 
 fn build_human_approval_gate_section() -> &'static str {
     r#"Human Approval Gate (2FA / verification challenges):
-- If login/auth flow asks for OTP/passcode/device approval/number tap/CAPTCHA/security challenge, immediately use the `human-approval-gate` skill.
+- If login/auth flow asks for OTP/passcode/device approval/number tap (that requires a human on another device/account), immediately use the `human-approval-gate` skill.
+- If the page shows CAPTCHA/image puzzle/text recognition challenge, do NOT call `human_approval_gate` for that step; solve CAPTCHA directly in browser first.
 - If multiple verification methods are available on the same challenge page, prefer SMS verification first by default. If SMS is unavailable or fails, fall back to another method and keep using `human_approval_gate` for human input.
 - If the requested login cannot proceed because required credential or challenge answer is missing (email/username/password/passcode), request it through `human_approval_gate` instead of guessing.
 - Use the `human_approval_gate` CLI and pause all unrelated work while waiting for result.
@@ -215,7 +216,7 @@ fn build_human_approval_gate_section() -> &'static str {
   2) Continue only if status is `approved`
   3) If status is `timeout` or `rejected`, stop login attempts and report clearly
 - Scope and recipient rules:
-  - Agent logging into owner/admin account (for example Oliver's own Google/Notion/X): `--scope admin` (sends to `admin@dowhiz.com`)
+  - Agent logging into owner/admin account (for example Oliver's own Google/Notion/X, `dowhiz@deep-tutor.com`, `oliver@dowhiz.com`): always use `--scope admin` (sends to `admin@dowhiz.com`)
   - Agent logging into user's account: `--scope user --recipient <that user email>`
 - Never keep retrying password/sign-in while waiting for verification.
 
@@ -961,7 +962,7 @@ mod tests {
         assert!(prompt.contains("--scope admin"));
         assert!(prompt.contains("--scope user --recipient"));
         assert!(prompt.contains("timeout"));
-        assert!(prompt.contains("CAPTCHA/security challenge"));
+        assert!(prompt.contains("do NOT call `human_approval_gate`"));
         assert!(prompt.contains("required credential"));
         assert!(prompt.contains("prefer SMS verification first by default"));
     }

--- a/DoWhiz_service/skills/human-approval-gate/SKILL.md
+++ b/DoWhiz_service/skills/human-approval-gate/SKILL.md
@@ -12,7 +12,9 @@ Use this skill immediately when any authentication flow is blocked by human veri
 - OTP / verification code input
 - "Approve sign-in on your phone"
 - "Tap number on mobile app"
-- security challenge that requires user/admin action
+- any out-of-band challenge that requires user/admin action from another device/account
+
+Do NOT use this skill for CAPTCHA/image puzzle/text-recognition steps. Solve CAPTCHA directly in browser first.
 
 When a page offers multiple verification methods, choose SMS verification first by default.
 
@@ -30,6 +32,7 @@ Do not keep retrying login while blocked.
 
 - `scope=admin`: when agent logs in an owner/admin account (for example Oliver's own Google/Notion/X account). Send to `admin@dowhiz.com`.
 - `scope=user`: when agent logs in an end user's account. Send to that specific user email.
+- For `scope=admin`, do not pass a user recipient address.
 
 ## CLI Quick Start
 

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -27,6 +27,7 @@ STATE_DIR_DEFAULT = ".human_approval_gate/challenges"
 DEFAULT_TIMEOUT_MINUTES = 30
 DEFAULT_POLL_SECONDS = 15
 DEFAULT_ADMIN_RECIPIENT = "admin@dowhiz.com"
+ADMIN_RECIPIENT_ENV_KEY = "HUMAN_APPROVAL_ADMIN_RECIPIENT"
 SUBJECT_TOKEN_PREFIX = "HAG"
 MAX_REPLY_SNIPPET_CHARS = 2000
 # Postmark limits metadata key names to at most 20 characters.
@@ -140,11 +141,31 @@ def normalize_scope(scope: str) -> str:
     return normalized
 
 
+def canonical_email(value: str) -> str:
+    email = extract_email(value)
+    if email:
+        return email
+    return value.strip().lower()
+
+
+def resolve_admin_recipient() -> str:
+    return get_env_first(ADMIN_RECIPIENT_ENV_KEY) or DEFAULT_ADMIN_RECIPIENT
+
+
 def resolve_recipient(scope: str, recipient_arg: Optional[str], user_email_arg: Optional[str]) -> str:
+    if scope == "admin":
+        admin_recipient = resolve_admin_recipient()
+        if recipient_arg and recipient_arg.strip():
+            recipient = recipient_arg.strip()
+            if canonical_email(recipient) != canonical_email(admin_recipient):
+                raise CliError(
+                    "scope=admin cannot send to non-admin recipient; remove --recipient "
+                    f"or set {ADMIN_RECIPIENT_ENV_KEY} if admin address changed"
+                )
+            return recipient
+        return admin_recipient
     if recipient_arg and recipient_arg.strip():
         return recipient_arg.strip()
-    if scope == "admin":
-        return DEFAULT_ADMIN_RECIPIENT
     if user_email_arg and user_email_arg.strip():
         return user_email_arg.strip()
     raise CliError("user scope requires --recipient or --user-email")


### PR DESCRIPTION
## Summary
- stop treating CAPTCHA/image puzzle steps as human-approval-gate triggers; require agent to solve CAPTCHA in-browser first
- keep HAG only for out-of-band human verification (OTP/passcode/device approval), while still preferring SMS first
- enforce admin routing safety in human_approval_gate: --scope admin cannot send to non-admin recipient; allow override via HUMAN_APPROVAL_ADMIN_RECIPIENT

## Why
Recent staging E2E showed two regressions:
1. CAPTCHA was incorrectly escalated to human approval gate
2. admin-scope approval request could end up sent to requester mailbox

## Validation
- cargo fmt -p run_task_module
- cargo test -p run_task_module
- python3 -m py_compile DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
- dry-run CLI checks:
  - admin default recipient resolves to admin@dowhiz.com
  - admin + non-admin --recipient returns explicit error
  - admin recipient can be customized with HUMAN_APPROVAL_ADMIN_RECIPIENT
