### PR TITLE
Resolve relative employee config path in human approval gate

### DIFF
--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -137,7 +137,24 @@ def discover_do_whiz_service_root() -> Optional[Path]:
 def resolve_employee_config_candidates() -> List[Path]:
     explicit = get_env_first("EMPLOYEE_CONFIG_PATH")
     if explicit:
-        return [Path(explicit).expanduser()]
+        raw = Path(explicit).expanduser()
+        if raw.is_absolute():
+            return [raw]
+        cwd = Path.cwd()
+        candidates: List[Path] = [cwd / raw, cwd / "DoWhiz_service" / raw]
+        script_root = discover_do_whiz_service_root()
+        if script_root is not None:
+            candidates.append(script_root / raw)
+        deduped: List[Path] = []
+        seen: set[str] = set()
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            key = str(resolved)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(resolved)
+        return deduped
 
     deploy_target = (get_env_first("DEPLOY_TARGET") or "").strip().lower()
     if deploy_target == "staging":


### PR DESCRIPTION
## Summary
- fix `human_approval_gate` sender fallback when `EMPLOYEE_CONFIG_PATH` is relative (for example `employee.staging.toml` in staging `.env`)
- resolve relative config path candidates against cwd, `cwd/DoWhiz_service`, and discovered `DoWhiz_service` script root
- keep existing sender precedence unchanged

## Validation
- `python3 -m py_compile DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py`
- `DEPLOY_TARGET=staging EMPLOYEE_ID=boiled_egg EMPLOYEE_CONFIG_PATH=employee.staging.toml POSTMARK_TEST_FROM=mini-mouse@deep-tutor.com DoWhiz_service/bin/human_approval_gate request --scope admin --account-label verify --action-text reply --context ctx --timeout-minutes 5 --dry-run`
  - expected/observed: `from_address=dowhiz@deep-tutor.com`
