### PR TITLE
Harden HAG reply guard in ingestion email path

### DIFF
--- a/DoWhiz_service/scheduler_module/src/service/ingestion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/ingestion.rs
@@ -133,7 +133,22 @@ fn process_ingestion_envelope(
                 return Ok(());
             }
             let (payload, raw_payload) = resolve_email_payload(envelope)?;
-            process_inbound_payload(config, user_store, index_store, account_store, &payload, &raw_payload)
+            let subject = payload.subject.as_deref().unwrap_or("");
+            if is_human_approval_gate_subject(subject) {
+                info!(
+                    "skipping human approval gate reply from ingestion workflow: subject={}",
+                    subject
+                );
+                return Ok(());
+            }
+            process_inbound_payload(
+                config,
+                user_store,
+                index_store,
+                account_store,
+                &payload,
+                &raw_payload,
+            )
         }
         Channel::Slack => {
             info!("processing slack envelope, trying quick response first");
@@ -250,6 +265,24 @@ fn is_blacklisted_email_sender(
     super::email::is_blacklisted_sender(sender, service_addresses)
 }
 
+fn is_human_approval_gate_subject(subject: &str) -> bool {
+    let normalized = subject.trim();
+    if normalized.is_empty() {
+        return false;
+    }
+
+    let lowered = normalized.to_ascii_lowercase();
+    if lowered.starts_with("[hag:") {
+        return true;
+    }
+    if let Some(rest) = lowered.strip_prefix("re:") {
+        if rest.trim_start().starts_with("[hag:") {
+            return true;
+        }
+    }
+    false
+}
+
 fn resolve_email_payload(
     envelope: &IngestionEnvelope,
 ) -> Result<(PostmarkInbound, Vec<u8>), BoxError> {
@@ -312,7 +345,9 @@ fn resolve_email_payload(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_blacklisted_email_sender, resolve_email_payload};
+    use super::{
+        is_blacklisted_email_sender, is_human_approval_gate_subject, resolve_email_payload,
+    };
     use crate::channel::{Attachment, Channel, ChannelMetadata};
     use crate::ingestion::{IngestionEnvelope, IngestionPayload};
     use chrono::Utc;
@@ -386,5 +421,20 @@ mod tests {
             "user@example.com",
             &service_addresses
         ));
+    }
+
+    #[test]
+    fn human_approval_gate_subject_detection_matches_hag_threads() {
+        assert!(is_human_approval_gate_subject(
+            "[HAG:49d7368d-95a6-4c6c-91cc-8c30a4583c35] 2FA approval needed"
+        ));
+        assert!(is_human_approval_gate_subject(
+            "Re: [HAG:49d7368d-95a6-4c6c-91cc-8c30a4583c35] 2FA approval needed"
+        ));
+        assert!(is_human_approval_gate_subject(
+            "re:    [hag:49d7368d-95a6-4c6c-91cc-8c30a4583c35] 2fa approval needed"
+        ));
+        assert!(!is_human_approval_gate_subject("Re: Project update"));
+        assert!(!is_human_approval_gate_subject(""));
     }
 }


### PR DESCRIPTION
## Summary
- add a defensive HAG subject guard in `DoWhiz_service/scheduler_module/src/service/ingestion.rs` before handing email payloads to the normal inbound flow
- skip `[HAG:...]` and `Re: [HAG:...]` subjects in the ingestion path as well
- add unit tests for HAG subject detection in the ingestion module

## Why
Staging showed a real `Re: [HAG:...]` reply still entering normal run_task flow and producing an auto-reply draft. This patch hardens the primary ingestion path to prevent that loop even if later stages regress.

## Validation
- `cargo test -p scheduler_module human_approval_gate_subject_detection_matches_hag_threads -- --nocapture`
- `cargo test -p scheduler_module blacklisted_email_sender_allows_external_sender -- --nocapture`
