### PR TITLE
Update hero CTA to email Oliver directly

### DIFF
--- a/website/public/cn-translations.json
+++ b/website/public/cn-translations.json
@@ -605,6 +605,7 @@
     "Jeffery 🐦": "杰弗里🐦",
     "Join the waitlist or contact us for a walkthrough of current workflows and integrations.": "加入候补名单或联系我们以了解当前工作流程和集成的演练。",
     "Join waitlist": "加入候补名单",
+    "try DoWhiz service today": "立即体验 DoWhiz 服务",
     "Jump to mobile Shorts": "跳转至手机 Shorts",
     "Keep Slack execution visible, structured, and reliable.": "保持 Slack 执行可见、结构化且可靠。",
     "Keep decisions and open questions in the same shared document where discussion happened. Each actionable comment should include owner, due date, and acceptance condition.": "将决策和未决问题保留在进行讨论的同一共享文档中。每个可操作的评论应包括所有者、截止日期和接受条件。",

--- a/website/scripts/generate_cn_translations.py
+++ b/website/scripts/generate_cn_translations.py
@@ -97,6 +97,7 @@ MANUAL_OVERRIDES = {
     "TBD": "待定",
     "TPM": "TPM",
     "Team": "团队",
+    "try DoWhiz service today": "立即体验 DoWhiz 服务",
     "Workflow Specialist": "工作流专家",
     "Workflows": "工作流",
 }

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -15,7 +15,6 @@ import struttonPigeonImg from './assets/Strutton-Pigeon.jpg';
 import fluffyElephantImg from './assets/Fluffy-Elephant.jpg';
 import plushAxolotlImg from './assets/Plush-Axolotl.jpg';
 
-const WAITLIST_FORM_URL = 'https://docs.google.com/forms/d/1UgZpFgYxq0uSjmVdai1mpjbfj2GxcWakFt3YKL8by34/viewform';
 const SITE_URL = 'https://dowhiz.com';
 const LOGO_URL = `${SITE_URL}/assets/DoWhiz.jpeg`;
 const SUPPORT_EMAIL = 'admin@dowhiz.com';
@@ -1296,6 +1295,11 @@ function App() {
     }
   ];
 
+  const oliverMember = teamMembers.find((member) => member.name === 'Oliver');
+  const heroPrimaryCtaHref = oliverMember
+    ? buildMailtoLink(oliverMember.email, oliverMember.subject, oliverMember.body)
+    : 'mailto:oliver@dowhiz.com';
+
   return (
     <div className="app-container">
       <script
@@ -1415,8 +1419,8 @@ function App() {
               Collaborate with specialized digital employees across operations, delivery, coding, docs, and GTM, all connected by shared memory.
             </p>
             <div className="hero-cta">
-              <a className="btn btn-primary" href={WAITLIST_FORM_URL} target="_blank" rel="noopener noreferrer">
-                Join waitlist
+              <a className="btn btn-primary" href={heroPrimaryCtaHref} target="_blank" rel="noopener noreferrer">
+                try DoWhiz service today
               </a>
               <a className="btn btn-secondary" href="/demo-videos/">
                 Watch demo videos


### PR DESCRIPTION
## Summary\n- change homepage primary CTA text from `Join waitlist` to `try DoWhiz service today`\n- make homepage primary CTA use the same mailto generation as Oliver card click\n- sync CN translation mapping for the new CTA text\n\n## Testing\n- not run: `npm run lint` (local environment missing `eslint`, command failed with `sh: eslint: command not found`)