### PR TITLE
Harden admin login gate behavior and CLI fallback

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -209,8 +209,11 @@ fn build_human_approval_gate_section() -> &'static str {
 - If login/auth flow asks for OTP/passcode/device approval/number tap (that requires a human on another device/account), immediately use the `human-approval-gate` skill.
 - If the page shows CAPTCHA/image puzzle/text recognition challenge, do NOT call `human_approval_gate` for that step; solve CAPTCHA directly in browser first.
 - If multiple verification methods are available on the same challenge page, prefer SMS verification first by default. If SMS is unavailable or fails, fall back to another method and keep using `human_approval_gate` for human input.
-- If the requested login cannot proceed because required credential or challenge answer is missing (email/username/password/passcode), request it through `human_approval_gate` instead of guessing.
+- If login identifier (email/username) is missing for owner/admin account login, try known admin identifiers first (`dowhiz@deep-tutor.com` on staging, `oliver@dowhiz.com` on production) before requesting help through `human_approval_gate`.
+- For owner/admin account login, do NOT trigger `human_approval_gate` only to ask for account email/username when a known identifier is already available.
+- If the requested login still cannot proceed because required credential/challenge input is missing after trying known safe identifiers, request it through `human_approval_gate` instead of guessing.
 - Use the `human_approval_gate` CLI and pause all unrelated work while waiting for result.
+- If `human_approval_gate` is not found on PATH, retry using `/app/bin/human_approval_gate` or `python3 .agents/skills/human-approval-gate/scripts/human_approval_gate.py`.
 - Primary flow:
   1) Run `human_approval_gate request ... --wait --timeout-minutes 30`
   2) Continue only if status is `approved`
@@ -965,6 +968,9 @@ mod tests {
         assert!(prompt.contains("do NOT call `human_approval_gate`"));
         assert!(prompt.contains("required credential"));
         assert!(prompt.contains("prefer SMS verification first by default"));
+        assert!(prompt.contains("dowhiz@deep-tutor.com"));
+        assert!(prompt.contains("oliver@dowhiz.com"));
+        assert!(prompt.contains("/app/bin/human_approval_gate"));
     }
 
     #[test]

--- a/DoWhiz_service/skills/human-approval-gate/SKILL.md
+++ b/DoWhiz_service/skills/human-approval-gate/SKILL.md
@@ -18,6 +18,8 @@ Do NOT use this skill for CAPTCHA/image puzzle/text-recognition steps. Solve CAP
 
 When a page offers multiple verification methods, choose SMS verification first by default.
 
+For owner/admin login flows, if account email/username is missing, try known admin identifiers first (`dowhiz@deep-tutor.com` on staging, `oliver@dowhiz.com` on production). Do not use the approval gate only to ask for identifier when these known values are available.
+
 Do not keep retrying login while blocked.
 
 ## Required Behavior
@@ -36,10 +38,22 @@ Do not keep retrying login while blocked.
 
 ## CLI Quick Start
 
+CLI fallback (if command not found on PATH):
+
+```bash
+if command -v human_approval_gate >/dev/null 2>&1; then
+  HAG_CMD="human_approval_gate"
+elif [ -x /app/bin/human_approval_gate ]; then
+  HAG_CMD="/app/bin/human_approval_gate"
+else
+  HAG_CMD="python3 .agents/skills/human-approval-gate/scripts/human_approval_gate.py"
+fi
+```
+
 ### A) Create request and wait (preferred)
 
 ```bash
-human_approval_gate request \
+$HAG_CMD request \
   --scope admin \
   --account-label "Oliver Google account" \
   --action-text "Please approve Google sign-in and send the OTP code if shown" \
@@ -51,7 +65,7 @@ human_approval_gate request \
 For user-owned account:
 
 ```bash
-human_approval_gate request \
+$HAG_CMD request \
   --scope user \
   --recipient "user@example.com" \
   --account-label "User X account" \
@@ -63,14 +77,14 @@ human_approval_gate request \
 ### B) Split mode (request then wait later)
 
 ```bash
-human_approval_gate request --scope admin --wait-timeout-minutes 30
-human_approval_gate wait --challenge-id "<challenge_id>" --timeout-minutes 30
+$HAG_CMD request --scope admin --wait-timeout-minutes 30
+$HAG_CMD wait --challenge-id "<challenge_id>" --timeout-minutes 30
 ```
 
 ### C) Check status
 
 ```bash
-human_approval_gate status --challenge-id "<challenge_id>" --refresh
+$HAG_CMD status --challenge-id "<challenge_id>" --refresh
 ```
 
 ## Return States

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ COPY DoWhiz_service/employees/ /app/DoWhiz_service/employees/
 COPY DoWhiz_service/skills/ /app/DoWhiz_service/skills/
 
 RUN chmod +x /app/bin/human_approval_gate || true
+RUN ln -sf /app/bin/human_approval_gate /usr/local/bin/human_approval_gate
 RUN chown -R app:nogroup /app/DoWhiz_service /app/bin
 
 USER app


### PR DESCRIPTION
## Summary
- tighten HAG prompt rules so admin login uses known owner identifiers (`dowhiz@deep-tutor.com` on staging, `oliver@dowhiz.com` on prod) before requesting human help
- explicitly forbid triggering HAG just to ask for admin account identifier when known identifiers are available
- add explicit HAG CLI fallback guidance (`/app/bin/human_approval_gate` and skill script path)
- add `/usr/local/bin/human_approval_gate` symlink in runtime image to reduce PATH-dependent command-not-found failures

## Test
- `cargo test -p run_task_module build_prompt_includes_human_approval_gate_instructions -- --nocapture`
