### PR TITLE
Ignore mailer-daemon email loops

### DIFF
--- a/DoWhiz_service/scheduler_module/src/adapters/postmark.rs
+++ b/DoWhiz_service/scheduler_module/src/adapters/postmark.rs
@@ -450,7 +450,13 @@ fn contains_replyable_address(value: &str) -> bool {
     emails.iter().any(|address| !is_no_reply_address(address))
 }
 
-const NO_REPLY_LOCAL_PARTS: [&str; 3] = ["noreply", "no-reply", "do-not-reply"];
+const NO_REPLY_LOCAL_PARTS: [&str; 5] = [
+    "noreply",
+    "no-reply",
+    "do-not-reply",
+    "mailer-daemon",
+    "postmaster",
+];
 
 fn is_no_reply_address(address: &str) -> bool {
     let normalized = address.trim().to_ascii_lowercase();
@@ -507,6 +513,12 @@ mod tests {
     #[test]
     fn replyable_recipients_filters_noreply() {
         let result = replyable_recipients("noreply@example.com, user@example.com");
+        assert_eq!(result, vec!["user@example.com"]);
+    }
+
+    #[test]
+    fn replyable_recipients_filters_mailer_daemon() {
+        let result = replyable_recipients("mailer-daemon@googlemail.com, user@example.com");
         assert_eq!(result, vec!["user@example.com"]);
     }
 }

--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
@@ -598,24 +598,17 @@ pub(super) async fn ingest_wechat(
     };
 
     let external_message_id = message.message_id.clone();
-    let envelope = match build_envelope(
-        route,
-        Channel::WeChat,
-        external_message_id,
-        &message,
-        &body,
-    )
-    .await
-    {
-        Ok(envelope) => envelope,
-        Err(err) => {
-            error!("gateway failed to store raw payload: {}", err);
-            return (
-                StatusCode::BAD_GATEWAY,
-                Json(json!({"status": "payload_store_failed"})),
-            );
-        }
-    };
+    let envelope =
+        match build_envelope(route, Channel::WeChat, external_message_id, &message, &body).await {
+            Ok(envelope) => envelope,
+            Err(err) => {
+                error!("gateway failed to store raw payload: {}", err);
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({"status": "payload_store_failed"})),
+                );
+            }
+        };
     enqueue_envelope(state.queue.clone(), envelope).await
 }
 
@@ -649,7 +642,13 @@ pub(super) async fn enqueue_envelope(
     }
 }
 
-const NO_REPLY_MARKERS: [&str; 3] = ["noreply", "no-reply", "do-not-reply"];
+const NO_REPLY_MARKERS: [&str; 5] = [
+    "noreply",
+    "no-reply",
+    "do-not-reply",
+    "mailer-daemon",
+    "postmaster",
+];
 
 fn payload_contains_no_reply_marker(payload: &PostmarkInboundPayload) -> bool {
     let candidates = [payload.from.as_deref(), payload.reply_to.as_deref()];
@@ -950,6 +949,13 @@ mod tests {
         let payload: PostmarkInboundPayload =
             serde_json::from_str(r#"{"From":"user@example.com"}"#).expect("payload");
         assert!(!payload_contains_no_reply_marker(&payload));
+    }
+
+    #[test]
+    fn payload_contains_no_reply_marker_detects_mailer_daemon() {
+        let payload: PostmarkInboundPayload =
+            serde_json::from_str(r#"{"From":"mailer-daemon@googlemail.com"}"#).expect("payload");
+        assert!(payload_contains_no_reply_marker(&payload));
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -367,7 +367,16 @@ pub(super) fn is_blacklisted_sender(sender: &str, service_addresses: &HashSet<St
 }
 
 fn is_blacklisted_address(address: &str, service_addresses: &HashSet<String>) -> bool {
-    mailbox::is_service_address(address, service_addresses)
+    mailbox::is_service_address(address, service_addresses) || is_auto_reply_address(address)
+}
+
+fn is_auto_reply_address(address: &str) -> bool {
+    let normalized = address.trim().to_ascii_lowercase();
+    let local = normalized.split('@').next().unwrap_or("");
+    matches!(
+        local,
+        "noreply" | "no-reply" | "do-not-reply" | "mailer-daemon" | "postmaster"
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -878,5 +887,18 @@ mod tests {
         )
         .expect("payload");
         assert!(is_human_approval_gate_reply(&payload));
+    }
+
+    #[test]
+    fn blacklisted_sender_detects_mailer_daemon() {
+        let service_addresses = HashSet::new();
+        assert!(is_blacklisted_sender(
+            "Mail Delivery Subsystem <mailer-daemon@googlemail.com>",
+            &service_addresses
+        ));
+        assert!(is_blacklisted_sender(
+            "postmaster@example.com",
+            &service_addresses
+        ));
     }
 }

--- a/DoWhiz_service/scheduler_module/src/service/recipients.rs
+++ b/DoWhiz_service/scheduler_module/src/service/recipients.rs
@@ -57,7 +57,13 @@ fn contains_replyable_address(value: &str) -> bool {
 }
 
 // Only local-part markers; avoid domain-based filtering.
-const NO_REPLY_LOCAL_PARTS: [&str; 3] = ["noreply", "no-reply", "do-not-reply"];
+const NO_REPLY_LOCAL_PARTS: [&str; 5] = [
+    "noreply",
+    "no-reply",
+    "do-not-reply",
+    "mailer-daemon",
+    "postmaster",
+];
 
 fn is_no_reply_address(address: &str) -> bool {
     let normalized = address.trim().to_ascii_lowercase();
@@ -105,6 +111,8 @@ mod tests {
         assert!(is_no_reply_address("noreply@example.com"));
         assert!(is_no_reply_address("no-reply@example.com"));
         assert!(is_no_reply_address("do-not-reply@example.com"));
+        assert!(is_no_reply_address("mailer-daemon@googlemail.com"));
+        assert!(is_no_reply_address("postmaster@example.com"));
         assert!(!is_no_reply_address("reply@example.com"));
     }
 


### PR DESCRIPTION
## Summary
- ignore  /  senders in inbound no-reply detection
- stop treating delivery failure notices as normal actionable email tasks
- stop selecting  /  as replyable recipients

## Why
While validating a real staging email task for Google login + 2FA, staging was repeatedly consuming Google delivery-failure notices as normal tasks and sending replies back to , which created more bounce tasks and clogged the email ingestion queue. This blocked the real HAG browser-login validation path.

## Testing
- 
- 
- 
- 
- 

## Notes
- broader  is currently blocked by unrelated untracked  files already present in the workspace, so validation used targeted test invocations that avoid compiling those accidental bin names.
