### PR TITLE
Fix runtime panic when recording auth analytics

### DIFF
--- a/DoWhiz_service/scheduler_module/src/account_store.rs
+++ b/DoWhiz_service/scheduler_module/src/account_store.rs
@@ -176,6 +176,21 @@ pub struct AccountStore {
     prefer_fallback: Arc<AtomicBool>,
 }
 
+fn log_record_analytics_event_error(
+    context: &str,
+    event: &AnalyticsEventInsert,
+    err: &AccountStoreError,
+) {
+    let account_suffix = event
+        .account_id
+        .map(|id| format!(" for account {}", id))
+        .unwrap_or_default();
+    warn!(
+        "{}: failed to record analytics event {}{}: {}",
+        context, event.event_name, account_suffix, err
+    );
+}
+
 impl AccountStore {
     pub fn from_env() -> Result<Self, AccountStoreError> {
         let primary_db_url = env::var("SUPABASE_DB_URL")
@@ -779,6 +794,29 @@ impl AccountStore {
         Ok(inserted > 0)
     }
 
+    pub fn record_analytics_event_detached(
+        self: &Arc<Self>,
+        event: AnalyticsEventInsert,
+        context: &'static str,
+    ) {
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let store = Arc::clone(self);
+            std::mem::drop(handle.spawn_blocking(move || {
+                if let Err(err) = store.record_analytics_event(&event) {
+                    log_record_analytics_event_error(context, &event, &err);
+                }
+            }));
+            return;
+        }
+
+        let store = Arc::clone(self);
+        std::mem::drop(std::thread::spawn(move || {
+            if let Err(err) = store.record_analytics_event(&event) {
+                log_record_analytics_event_error(context, &event, &err);
+            }
+        }));
+    }
+
     pub fn count_analytics_events(
         &self,
         event_name: &str,
@@ -1128,9 +1166,12 @@ pub fn lookup_account_by_channel(
 
 #[cfg(test)]
 mod tests {
-    use super::account_store_allow_invalid_certs;
+    use super::{account_store_allow_invalid_certs, AccountStore, AnalyticsEventInsert};
+    use chrono::Utc;
+    use serde_json::json;
     use std::env;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, Mutex, OnceLock};
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -1173,5 +1214,47 @@ mod tests {
         env::set_var("ACCOUNT_STORE_TLS_ALLOW_INVALID_CERTS", "1");
         assert!(account_store_allow_invalid_certs());
         reset_tls_env();
+    }
+
+    #[test]
+    fn detached_analytics_recording_can_be_called_inside_tokio_runtime() {
+        let store = Arc::new(AccountStore {
+            primary_pool: None,
+            fallback_pool: None,
+            prefer_fallback: Arc::new(AtomicBool::new(false)),
+        });
+        let event = AnalyticsEventInsert {
+            event_name: "auth_smoke".to_string(),
+            source: "server".to_string(),
+            event_timestamp: Utc::now(),
+            account_id: None,
+            auth_user_id: None,
+            anonymous_id: None,
+            session_id: None,
+            workspace_id: None,
+            org_id: None,
+            plan_type: None,
+            environment: Some("test".to_string()),
+            app_version: None,
+            page_path: None,
+            route_path: Some("/auth/signup".to_string()),
+            referrer: None,
+            utm_source: None,
+            utm_medium: None,
+            utm_campaign: None,
+            utm_term: None,
+            utm_content: None,
+            device_type: None,
+            browser: None,
+            os: None,
+            event_key: Some("auth_smoke".to_string()),
+            properties: json!({}),
+        };
+
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime.block_on(async move {
+            store.record_analytics_event_detached(event, "test");
+            tokio::task::yield_now().await;
+        });
     }
 }

--- a/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
@@ -194,12 +194,7 @@ fn track_scheduler_event(
         event_key,
         properties,
     };
-    if let Err(err) = store.record_analytics_event(&event) {
-        warn!(
-            "failed to record scheduler analytics event {} for account {}: {}",
-            event_name, account_id, err
-        );
-    }
+    store.record_analytics_event_detached(event, "scheduler");
 }
 
 fn track_task_start_markers(account_id: Uuid, task: &super::types::RunTaskTask, dedupe_key: &str) {

--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -150,7 +150,7 @@ pub fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
 }
 
 fn track_auth_event(
-    store: &AccountStore,
+    store: &Arc<AccountStore>,
     event_name: &str,
     account_id: Option<Uuid>,
     auth_user_id: Option<Uuid>,
@@ -189,12 +189,7 @@ fn track_auth_event(
         event_key,
         properties,
     };
-    if let Err(err) = store.record_analytics_event(&insert) {
-        warn!(
-            "failed to record auth analytics event {}: {}",
-            event_name, err
-        );
-    }
+    store.record_analytics_event_detached(insert, "auth");
 }
 
 // ============================================================================

--- a/DoWhiz_service/scheduler_module/src/service/billing.rs
+++ b/DoWhiz_service/scheduler_module/src/service/billing.rs
@@ -92,12 +92,9 @@ fn track_billing_event(
         event_key,
         properties,
     };
-    if let Err(err) = state.account_store.record_analytics_event(&event) {
-        warn!(
-            "failed to record billing analytics event {}: {}",
-            event_name, err
-        );
-    }
+    state
+        .account_store
+        .record_analytics_event_detached(event, "billing");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- move server-side analytics writes off Tokio runtime threads
- fix the prod login flow path that hit `/auth/signup` and crashed the worker
- apply the same detached analytics recording path to auth, billing, and scheduler tracking

## Testing
- `cargo test -p scheduler_module detached_analytics_recording_can_be_called_inside_tokio_runtime -- --nocapture`
- `cargo test -p scheduler_module service::auth::tests:: -- --nocapture`
- `cargo test -p scheduler_module` (`SKIP` for full pass: local env lacks `MONGODB_URI`, causing existing storage-backed tests to fail)
- `cargo test -p scheduler_module --test scheduler_basic` (`SKIP` for full pass: local env lacks `MONGODB_URI`)

## Prod note
- confirmed the prod failure was caused by `record_analytics_event` being called directly from async request paths, which triggered `Cannot start a runtime from within a runtime` in Postgres client drop handling