### PR TITLE
Clarify CAPTCHA handling before approval gate

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -207,7 +207,8 @@ fn build_web_auth_capabilities_section() -> &'static str {
 fn build_human_approval_gate_section() -> &'static str {
     r#"Human Approval Gate (2FA / verification challenges):
 - If login/auth flow asks for OTP/passcode/device approval/number tap (that requires a human on another device/account), immediately use the `human-approval-gate` skill.
-- If the page shows CAPTCHA/image puzzle/text recognition challenge, do NOT call `human_approval_gate` for that step; solve CAPTCHA directly in browser first.
+- If the page shows CAPTCHA/image puzzle/text recognition challenge, do NOT call `human_approval_gate` for that step; first use your own multimodal/vision abilities and browser tools to inspect the challenge, solve it directly in the page, and continue the login flow yourself.
+- Only use `human_approval_gate` for steps that genuinely require human access outside the browser session, such as SMS codes, email codes sent to someone else, approval taps on another device, or information only the human can retrieve.
 - If multiple verification methods are available on the same challenge page, prefer SMS verification first by default. If SMS is unavailable or fails, fall back to another method and keep using `human_approval_gate` for human input.
 - Before calling `human_approval_gate`, first use the website itself to initiate the challenge: click the button that sends the code / starts the approval / selects the method, and wait until the page is explicitly waiting for the human response.
 - If login identifier (email/username) is missing for owner/admin account login, try known admin identifiers first (`dowhiz@deep-tutor.com` on staging, `oliver@dowhiz.com` on production) before requesting help through `human_approval_gate`.
@@ -968,6 +969,7 @@ mod tests {
         assert!(prompt.contains("--scope user --recipient"));
         assert!(prompt.contains("timeout"));
         assert!(prompt.contains("do NOT call `human_approval_gate`"));
+        assert!(prompt.contains("multimodal/vision abilities"));
         assert!(prompt.contains("required credential"));
         assert!(prompt.contains("prefer SMS verification first by default"));
         assert!(prompt.contains("click the button that sends the code"));

--- a/DoWhiz_service/skills/human-approval-gate/SKILL.md
+++ b/DoWhiz_service/skills/human-approval-gate/SKILL.md
@@ -14,7 +14,13 @@ Use this skill immediately when any authentication flow is blocked by human veri
 - "Tap number on mobile app"
 - any out-of-band challenge that requires user/admin action from another device/account
 
-Do NOT use this skill for CAPTCHA/image puzzle/text-recognition steps. Solve CAPTCHA directly in browser first.
+Do NOT use this skill for CAPTCHA/image puzzle/text-recognition steps. First use your own multimodal/vision abilities plus browser tooling to inspect the challenge, solve it directly in the page, and continue yourself.
+
+Only use this skill when the blocker genuinely requires a human outside the current browser session, for example:
+- SMS code sent to a phone you cannot access
+- email code sent to another person's mailbox
+- approval tap / number match on another device
+- recovery detail or one-time code that only the user/admin can retrieve
 
 When a page offers multiple verification methods, choose SMS verification first by default.
 
@@ -29,11 +35,12 @@ Do not keep retrying login while blocked.
 
 ## Required Behavior
 
-1. Trigger gate request right away.
-2. Wait on gate result.
-3. Continue only after the first reply is received and inspect that reply yourself.
-4. If timeout, stop login attempts and report clearly.
-5. If SMS verification is unavailable or fails, switch to another available method and keep the same gate-based wait behavior.
+1. If the blocker is CAPTCHA/image/text recognition, solve it yourself in-browser first instead of opening the gate.
+2. Trigger gate request right away once the page is explicitly waiting for human-only input.
+3. Wait on gate result.
+4. Continue only after the first reply is received and inspect that reply yourself.
+5. If timeout, stop login attempts and report clearly.
+6. If SMS verification is unavailable or fails, switch to another available method and keep the same gate-based wait behavior.
 
 ## Scope Rules
 


### PR DESCRIPTION
## Summary
- clarify in the runtime prompt that CAPTCHA and visual challenges should be handled directly with Codex multimodal/browser abilities
- restrict `human_approval_gate` usage to challenges that truly require human access outside the browser session
- reinforce that the gate should only be opened after the page is already waiting for the human-only input

## Testing
- cargo test -p run_task_module build_prompt_includes_human_approval_gate_instructions