### PR TITLE
Restart PM2 services before ACI build

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -202,6 +202,37 @@ jobs:
           chmod 600 "$APP_DIR/.env"
           EOF
 
+      - name: Restart DoWhiz services before ACI build
+        run: |
+          ssh -F ~/.ssh/config azureproduction << 'EOF'
+          set -e
+          if [ -s /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh ]; then
+            source /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh
+          fi
+          APP_DIR=/home/${{ secrets.PROD_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
+          ENV_FILE="$APP_DIR/.env"
+          set -a
+          source "$ENV_FILE"
+          set +a
+
+          if pm2 describe dw_worker >/dev/null 2>&1; then
+            pm2 restart dw_worker --update-env
+          else
+            pm2 start "$APP_DIR/target/release/rust_service" --name dw_worker --cwd "$APP_DIR" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
+          fi
+
+          if pm2 describe dw_gateway >/dev/null 2>&1; then
+            pm2 restart dw_gateway --update-env
+          else
+            pm2 start "$APP_DIR/target/release/inbound_gateway" --name dw_gateway --cwd "$APP_DIR"
+          fi
+
+          worker_health="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health" || true)"
+          gateway_health="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "http://127.0.0.1:${GATEWAY_PORT:-9100}/health" || true)"
+          [[ "$worker_health" == "200" ]] || { echo "Early worker health check failed (HTTP $worker_health)" >&2; exit 1; }
+          [[ "$gateway_health" == "200" ]] || { echo "Early gateway health check failed (HTTP $gateway_health)" >&2; exit 1; }
+          EOF
+
       - name: Build and push ACI image on Azure VM
         run: |
           ssh -F ~/.ssh/config azureproduction << 'EOF'

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -202,6 +202,37 @@ jobs:
           chmod 600 "$APP_DIR/.env"
           EOF
 
+      - name: Restart DoWhiz services before ACI build
+        run: |
+          ssh -F ~/.ssh/config azureproduction << 'EOF'
+          set -e
+          if [ -s /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh ]; then
+            source /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh
+          fi
+          APP_DIR=/home/${{ secrets.STAGING_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
+          ENV_FILE="$APP_DIR/.env"
+          set -a
+          source "$ENV_FILE"
+          set +a
+
+          if pm2 describe dw_worker >/dev/null 2>&1; then
+            pm2 restart dw_worker --update-env
+          else
+            pm2 start "$APP_DIR/target/release/rust_service" --name dw_worker --cwd "$APP_DIR" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
+          fi
+
+          if pm2 describe dw_gateway >/dev/null 2>&1; then
+            pm2 restart dw_gateway --update-env
+          else
+            pm2 start "$APP_DIR/target/release/inbound_gateway" --name dw_gateway --cwd "$APP_DIR"
+          fi
+
+          worker_health="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health" || true)"
+          gateway_health="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "http://127.0.0.1:${GATEWAY_PORT:-9100}/health" || true)"
+          [[ "$worker_health" == "200" ]] || { echo "Early worker health check failed (HTTP $worker_health)" >&2; exit 1; }
+          [[ "$gateway_health" == "200" ]] || { echo "Early gateway health check failed (HTTP $gateway_health)" >&2; exit 1; }
+          EOF
+
       - name: Build and push ACI image on Azure VM
         run: |
           ssh -F ~/.ssh/config azureproduction << 'EOF'

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -82,8 +82,9 @@ Deployment workflows should:
 1. Write `.env` from `ENV_COMMON + ENV_STAGING/ENV_PROD`.
 2. Fail if `.env` contains keys matching `^(STAGING_|PROD_)`.
 3. Validate `GATEWAY_CONFIG_PATH` and `EMPLOYEE_CONFIG_PATH` exist and match expected target files.
-4. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), trim `DoWhiz_service/target` on the VM before `az acr build` (drop debug/intermediate artifacts, keep required release binaries), then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE` before restarting services.
-5. Source `.env` before PM2 restarts and use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes.
+4. After release binaries and `.env` are installed, source `.env` and restart PM2-managed services immediately so live traffic moves onto the new worker/gateway before any long-running follow-up work.
+5. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), trim `DoWhiz_service/target` on the VM before `az acr build` (drop debug/intermediate artifacts, keep required release binaries), then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE`.
+6. Use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes, and finish with local health checks.
 
 ## 5) Health Checks
 


### PR DESCRIPTION
## Summary
- restart PM2-managed worker and gateway immediately after installing release binaries and writing `.env`
- keep the later full restart/health-check step, but remove the long window where live traffic can still hit an old worker while `az acr build` is running
- document the updated staging/production deployment expectation in the service deploy guide

## Test Evidence
- `git diff --check`
- YAML parse check for `.github/workflows/CICD-production.yml`
- YAML parse check for `.github/workflows/CICD-staging.yml`

## Config / Env Changes
- no runtime key changes
- deployment order now switches PM2 processes onto the new release binary before the ACI image build starts
