### PR TITLE
Retry deploy health checks after PM2 restart

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -455,9 +455,24 @@ jobs:
           [[ -n "$worker_pid" ]] || { echo "No running worker PID found after restart" >&2; exit 1; }
           [[ -n "$gateway_pid" ]] || { echo "No running gateway PID found after restart" >&2; exit 1; }
 
-          worker_health="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health" || true)"
-          gateway_health="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "http://127.0.0.1:${GATEWAY_PORT:-9100}/health" || true)"
-          [[ "$worker_health" == "200" ]] || { echo "Worker health check failed (HTTP $worker_health)" >&2; exit 1; }
-          [[ "$gateway_health" == "200" ]] || { echo "Gateway health check failed (HTTP $gateway_health)" >&2; exit 1; }
+          wait_for_health() {
+            local label="$1"
+            local url="$2"
+            local http_code=""
+            local attempt
+            for attempt in $(seq 1 12); do
+              http_code="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "$url" || true)"
+              if [[ "$http_code" == "200" ]]; then
+                printf '%s' "$http_code"
+                return 0
+              fi
+              sleep 5
+            done
+            echo "$label health check failed after retries (HTTP ${http_code:-000})" >&2
+            return 1
+          }
+
+          worker_health="$(wait_for_health worker "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health")"
+          gateway_health="$(wait_for_health gateway "http://127.0.0.1:${GATEWAY_PORT:-9100}/health")"
           echo "Post-restart health check passed: worker=$worker_health gateway=$gateway_health"
           EOF

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -455,9 +455,24 @@ jobs:
           [[ -n "$worker_pid" ]] || { echo "No running worker PID found after restart" >&2; exit 1; }
           [[ -n "$gateway_pid" ]] || { echo "No running gateway PID found after restart" >&2; exit 1; }
 
-          worker_health="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health" || true)"
-          gateway_health="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "http://127.0.0.1:${GATEWAY_PORT:-9100}/health" || true)"
-          [[ "$worker_health" == "200" ]] || { echo "Worker health check failed (HTTP $worker_health)" >&2; exit 1; }
-          [[ "$gateway_health" == "200" ]] || { echo "Gateway health check failed (HTTP $gateway_health)" >&2; exit 1; }
+          wait_for_health() {
+            local label="$1"
+            local url="$2"
+            local http_code=""
+            local attempt
+            for attempt in $(seq 1 12); do
+              http_code="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "$url" || true)"
+              if [[ "$http_code" == "200" ]]; then
+                printf '%s' "$http_code"
+                return 0
+              fi
+              sleep 5
+            done
+            echo "$label health check failed after retries (HTTP ${http_code:-000})" >&2
+            return 1
+          }
+
+          worker_health="$(wait_for_health worker "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health")"
+          gateway_health="$(wait_for_health gateway "http://127.0.0.1:${GATEWAY_PORT:-9100}/health")"
           echo "Post-restart health check passed: worker=$worker_health gateway=$gateway_health"
           EOF

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -84,7 +84,7 @@ Deployment workflows should:
 3. Validate `GATEWAY_CONFIG_PATH` and `EMPLOYEE_CONFIG_PATH` exist and match expected target files.
 4. After release binaries and `.env` are installed, source `.env` and restart PM2-managed services immediately so live traffic moves onto the new worker/gateway before any long-running follow-up work.
 5. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), trim `DoWhiz_service/target` on the VM before `az acr build` (drop debug/intermediate artifacts, keep required release binaries), then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE`.
-6. Use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes, and finish with local health checks.
+6. Use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes, and finish with local health checks that allow a short retry window while worker/gateway bind their ports.
 
 ## 5) Health Checks
 


### PR DESCRIPTION
## Summary
- add a short retry window for post-restart worker and gateway health checks in staging/production deploy workflows
- avoid false deploy failures when PM2 restarts succeed but the services need a few extra seconds to bind their ports
- sync the deploy guide with the new health-check expectation

## Testing
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/CICD-staging.yml"); YAML.load_file(".github/workflows/CICD-production.yml"); puts "yaml ok"'