### PR TITLE
Improve human approval gate logging

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -205,12 +205,19 @@ Azure ACI execution path (required vars):
 - Browser-based web auth for private Notion/Google pages is agent-driven at task runtime
   (no service-side bootstrap step).
 - `human_approval_gate` (via skill `human-approval-gate`) provides a blocking
-  approval flow for login OTP/device-approval steps. It sends an email request
-  and waits for the first same-thread reply, typically with a 30-minute timeout.
-  The CLI returns the full reply payload to the agent for interpretation. Sender
-  resolution priority is `--from` > `HUMAN_APPROVAL_FROM` > employee mailbox from
-  employee config. HAG-thread replies (`[HAG:...]`) are ignored by normal inbound
-  task routing to prevent recursive Email->task loops.
+  approval flow for login CAPTCHA/password/OTP/device-approval steps. It sends an
+  email request with the current browser screenshot(s), models the blocker as
+  `captcha`, `password`, or `two_factor`, and waits for the first same-thread
+  reply, typically with a 30-minute timeout. For `two_factor`, callers should
+  only invoke it after the site is explicitly waiting for a code or device
+  approval, and they should include the concrete method details (SMS/email/auth
+  app/device tap). The CLI returns the full reply payload to the agent for
+  interpretation. Each send also writes `.human_approval_gate/events.jsonl` and
+  emits a `HAG_EVENT ...` stderr line containing challenge type plus attachment
+  filenames and sizes, so prod/staging task logs can prove exactly what was
+  sent. Sender resolution priority is `--from` > `HUMAN_APPROVAL_FROM` >
+  employee mailbox from employee config. HAG-thread replies (`[HAG:...]`) are
+  ignored by normal inbound task routing to prevent recursive Email->task loops.
 - ACI run_task sets Playwright/NPM runtime defaults for mounted workspaces:
   `PLAYWRIGHT_MCP_EXECUTABLE_PATH` auto-discovery (`chrome-linux` / `chrome-linux64`),
   `PLAYWRIGHT_BROWSERS_PATH=/app/.cache/ms-playwright`,

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -206,16 +206,22 @@ fn build_web_auth_capabilities_section() -> &'static str {
 
 fn build_human_approval_gate_section() -> &'static str {
     r#"Human Approval Gate (2FA / verification challenges):
-- If login/auth flow asks for OTP/passcode/device approval/number tap (that requires a human on another device/account), immediately use the `human-approval-gate` skill.
-- If the page shows CAPTCHA/image puzzle/text recognition challenge, do NOT call `human_approval_gate` for that step; first use your own multimodal/vision abilities and browser tools to inspect the challenge, solve it directly in the page, and continue the login flow yourself.
+- If login/auth flow asks for OTP/passcode/device approval/number tap, or you are blocked on CAPTCHA/password after the required local checks below, use the `human-approval-gate` skill with an honest challenge type and browser screenshot.
+- If the page shows CAPTCHA/image puzzle/text recognition challenge, first use your own built-in multimodal/vision abilities and browser tools to inspect the challenge, attempt one direct solve in the page, and continue the login flow yourself.
+- If that first CAPTCHA solve attempt fails and the page is still blocked, call `human_approval_gate request --challenge-type captcha ... --screenshot <current-browser-shot>`.
+- If login is waiting for a password, first check the workspace `.env` for the relevant secret (for Google login, check `GOOGLE_PASSWORD` first). Only if the needed password is still missing should you call `human_approval_gate request --challenge-type password ... --screenshot <current-browser-shot>`.
 - Only use `human_approval_gate` for steps that genuinely require human access outside the browser session, such as SMS codes, email codes sent to someone else, approval taps on another device, or information only the human can retrieve.
 - If multiple verification methods are available on the same challenge page, prefer SMS verification first by default. If SMS is unavailable or fails, fall back to another method and keep using `human_approval_gate` for human input.
-- Before calling `human_approval_gate`, first use the website itself to initiate the challenge: click the button that sends the code / starts the approval / selects the method, and wait until the page is explicitly waiting for the human response.
+- Before calling `human_approval_gate` for 2FA, first use the website itself to initiate the challenge: click the button that sends the code / starts the approval / selects the method, and wait until the page is explicitly waiting for the human response.
+- For `--challenge-type two_factor`, do not send the email unless you can truthfully identify the current page state as either `waiting_for_code_input` or `waiting_for_device_approval`.
+- For `--challenge-type two_factor`, always describe the exact method in use: SMS, email, authenticator app, or device tap / number match, plus the masked destination if visible.
 - If login identifier (email/username) is missing for owner/admin account login, try known admin identifiers first (`dowhiz@deep-tutor.com` on staging, `oliver@dowhiz.com` on production) before requesting help through `human_approval_gate`.
 - For owner/admin account login, do NOT trigger `human_approval_gate` only to ask for account email/username when a known identifier is already available.
 - If the requested login still cannot proceed because required credential/challenge input is missing after trying known safe identifiers, request it through `human_approval_gate` instead of guessing.
 - Use the `human_approval_gate` CLI and pause all unrelated work while waiting for result.
 - If `human_approval_gate` is not found on PATH, retry using `/app/bin/human_approval_gate` or `python3 .agents/skills/human-approval-gate/scripts/human_approval_gate.py`.
+- Every `human_approval_gate` request must attach the current browser screenshot with `--screenshot ...` and must describe the current state honestly. Never claim a code was sent unless the page actually shows that it was sent and is waiting.
+- `human_approval_gate` now writes a structured send record to `.human_approval_gate/events.jsonl` and emits a `HAG_EVENT ...` stderr line that includes challenge type plus attachment filenames and sizes. Use those records for debugging instead of guessing.
 - Primary flow:
   1) Run `human_approval_gate request ... --wait --timeout-minutes 30`
   2) Continue only if status is `replied`
@@ -967,12 +973,23 @@ mod tests {
         assert!(prompt.contains("human_approval_gate request"));
         assert!(prompt.contains("--scope admin"));
         assert!(prompt.contains("--scope user --recipient"));
+        assert!(prompt.contains("--challenge-type captcha"));
+        assert!(prompt.contains("--challenge-type password"));
+        assert!(prompt.contains("--challenge-type two_factor"));
+        assert!(prompt.contains("--screenshot"));
+        assert!(prompt.contains("GOOGLE_PASSWORD"));
         assert!(prompt.contains("timeout"));
-        assert!(prompt.contains("do NOT call `human_approval_gate`"));
+        assert!(prompt.contains("built-in multimodal/vision abilities"));
+        assert!(prompt.contains("attempt one direct solve"));
         assert!(prompt.contains("multimodal/vision abilities"));
         assert!(prompt.contains("required credential"));
         assert!(prompt.contains("prefer SMS verification first by default"));
         assert!(prompt.contains("click the button that sends the code"));
+        assert!(prompt.contains("waiting_for_code_input"));
+        assert!(prompt.contains("waiting_for_device_approval"));
+        assert!(prompt.contains("Never claim a code was sent"));
+        assert!(prompt.contains(".human_approval_gate/events.jsonl"));
+        assert!(prompt.contains("HAG_EVENT"));
         assert!(prompt.contains("status is `replied`"));
         assert!(prompt.contains("returned `reply` payload"));
         assert!(prompt.contains("dowhiz@deep-tutor.com"));

--- a/DoWhiz_service/skills/human-approval-gate/SKILL.md
+++ b/DoWhiz_service/skills/human-approval-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: human-approval-gate
-description: Use when browser/login flow asks for OTP, passcode, approval tap, or any user/admin verification step. Sends a request email and blocks until the first reply or timeout using the human_approval_gate CLI.
+description: Use when browser/login flow is blocked by CAPTCHA, missing password, OTP, passcode, approval tap, or another user/admin verification step. Sends a request email with browser screenshots and blocks until the first reply or timeout using the human_approval_gate CLI.
 allowed-tools: Bash(human_approval_gate:*), Bash(python3:*), Bash(cat:*), Bash(test:*), Bash(date:*)
 ---
 
@@ -8,19 +8,25 @@ allowed-tools: Bash(human_approval_gate:*), Bash(python3:*), Bash(cat:*), Bash(t
 
 ## When to Use
 
-Use this skill immediately when any authentication flow is blocked by human verification, for example:
+Use this skill when any authentication flow is blocked by something the agent genuinely cannot finish alone, for example:
+- CAPTCHA after one failed built-in solve attempt
+- missing password after checking the workspace `.env`
 - OTP / verification code input
 - "Approve sign-in on your phone"
 - "Tap number on mobile app"
 - any out-of-band challenge that requires user/admin action from another device/account
 
-Do NOT use this skill for CAPTCHA/image puzzle/text-recognition steps. First use your own multimodal/vision abilities plus browser tooling to inspect the challenge, solve it directly in the page, and continue yourself.
+For CAPTCHA/image puzzle/text-recognition steps:
+- first use your own multimodal/vision abilities plus browser tooling to inspect the challenge and attempt one direct solve in the page
+- if that first attempt fails and you are still blocked on CAPTCHA, open the gate with `--challenge-type captcha`
+- always attach the current browser screenshot so the human can see exactly what blocked you
 
 Only use this skill when the blocker genuinely requires a human outside the current browser session, for example:
 - SMS code sent to a phone you cannot access
 - email code sent to another person's mailbox
 - approval tap / number match on another device
 - recovery detail or one-time code that only the user/admin can retrieve
+- password not present in the workspace `.env`
 
 When a page offers multiple verification methods, choose SMS verification first by default.
 
@@ -28,19 +34,25 @@ Trigger this skill only after the website has already initiated the challenge. F
 - click "send code", "text me a code", "email me a code", or similar first
 - choose the verification method first if the site asks
 - wait until the page is explicitly waiting for the code / tap / approval, then send the human approval email
+- for 2FA requests, describe exactly which method is active: SMS, email, authenticator app, or device tap / number match
+- for every request type, attach the current browser screenshot(s)
 
 For owner/admin login flows, if account email/username is missing, try known admin identifiers first (`dowhiz@deep-tutor.com` on staging, `oliver@dowhiz.com` on production). Do not use the approval gate only to ask for identifier when these known values are available.
+
+For password requests, check the workspace `.env` first. For Google login, prefer checking `GOOGLE_PASSWORD` before asking a human.
 
 Do not keep retrying login while blocked.
 
 ## Required Behavior
 
-1. If the blocker is CAPTCHA/image/text recognition, solve it yourself in-browser first instead of opening the gate.
-2. Trigger gate request right away once the page is explicitly waiting for human-only input.
-3. Wait on gate result.
-4. Continue only after the first reply is received and inspect that reply yourself.
-5. If timeout, stop login attempts and report clearly.
-6. If SMS verification is unavailable or fails, switch to another available method and keep the same gate-based wait behavior.
+1. If the blocker is CAPTCHA/image/text recognition, attempt one built-in solve first. If still blocked, use `--challenge-type captcha`.
+2. If the blocker is a missing password, check the workspace `.env` first. If still missing, use `--challenge-type password`.
+3. If the blocker is 2FA, trigger the website challenge first and only then use `--challenge-type two_factor`.
+4. Always attach the current browser screenshot(s) with `--screenshot ...`.
+5. Wait on gate result.
+6. Continue only after the first reply is received and inspect that reply yourself.
+7. If timeout, stop login attempts and report clearly.
+8. If SMS verification is unavailable or fails, switch to another available method and keep the same gate-based wait behavior.
 
 ## Scope Rules
 
@@ -67,9 +79,41 @@ fi
 ```bash
 $HAG_CMD request \
   --scope admin \
+  --challenge-type two_factor \
+  --page-state waiting_for_code_input \
+  --two-factor-method sms \
+  --verification-destination "phone ending in 9315" \
   --account-label "Oliver Google account" \
-  --action-text "Please reply in this thread with the verification code or approval result shown by Google" \
-  --context "Agent is on Google verification page" \
+  --context "Google has already sent the code and the page is waiting for it." \
+  --screenshot work/google-verify.png \
+  --timeout-minutes 30 \
+  --wait
+```
+
+For CAPTCHA after one failed solve attempt:
+
+```bash
+$HAG_CMD request \
+  --scope admin \
+  --challenge-type captcha \
+  --account-label "Oliver Google account" \
+  --context "I already tried one built-in CAPTCHA solve and the page still did not advance." \
+  --screenshot work/google-captcha.png \
+  --timeout-minutes 30 \
+  --wait
+```
+
+For password help:
+
+```bash
+$HAG_CMD request \
+  --scope admin \
+  --challenge-type password \
+  --page-state waiting_for_password \
+  --account-label "Oliver Google account" \
+  --password-env-key GOOGLE_PASSWORD \
+  --password-lookup-status "Checked workspace .env for GOOGLE_PASSWORD; no value was present." \
+  --screenshot work/google-password.png \
   --timeout-minutes 30 \
   --wait
 ```
@@ -80,8 +124,12 @@ For user-owned account:
 $HAG_CMD request \
   --scope user \
   --recipient "user@example.com" \
+  --challenge-type two_factor \
+  --page-state waiting_for_code_input \
+  --two-factor-method email \
+  --verification-destination "user@example.com" \
   --account-label "User X account" \
-  --action-text "Please reply in this thread with the code or any instructions shown during login" \
+  --screenshot work/user-login.png \
   --timeout-minutes 30 \
   --wait
 ```
@@ -116,5 +164,7 @@ No rigid reply format is required. Ask the recipient to reply in the same thread
 - Keep waiting in this command; do not run unrelated steps while waiting.
 - Reuse the same challenge thread; do not spam multiple requests unless previous one timed out.
 - Never include raw credentials in outbound messages.
+- Every outbound request should honestly describe the current browser state and include at least one screenshot attachment.
+- Every outbound request now also writes a structured send record to `.human_approval_gate/events.jsonl` and emits a `HAG_EVENT ...` line to stderr so prod/staging task logs show attachment filenames and sizes.
 - Sender identity priority is: `--from` > `HUMAN_APPROVAL_FROM` > employee mailbox from `employee.toml`/`employee.staging.toml`.
 - HAG reply emails (`[HAG:...]` threads) are consumed by the gate flow and are not routed into normal Email->task execution.

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Human approval gate for 2FA flows.
+"""Human approval gate for auth blockers that need a human.
 
 This CLI sends an approval email and optionally blocks while polling Postmark inbound
 messages for the first reply in the same challenge thread.
@@ -8,7 +8,9 @@ messages for the first reply in the same challenge thread.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
+import mimetypes
 import os
 import re
 import sys
@@ -18,6 +20,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from html import escape
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
@@ -37,6 +40,17 @@ SUBJECT_TOKEN_PREFIX = "HAG"
 # Postmark limits metadata key names to at most 20 characters.
 POSTMARK_METADATA_CHALLENGE_ID_KEY = "hag_challenge_id"
 POSTMARK_METADATA_SCOPE_KEY = "hag_scope"
+POSTMARK_METADATA_TYPE_KEY = "hag_type"
+MAX_TOTAL_ATTACHMENT_BYTES = 10 * 1024 * 1024
+DEFAULT_PASSWORD_ENV_KEY = "GOOGLE_PASSWORD"
+CHALLENGE_TYPES = ("captcha", "password", "two_factor")
+TWO_FACTOR_METHODS = ("sms", "email", "auth_app", "device_tap", "other")
+EVENTS_LOG_FILENAME = "events.jsonl"
+PAGE_STATES_BY_TYPE = {
+    "captcha": {"captcha_blocked"},
+    "password": {"waiting_for_password"},
+    "two_factor": {"waiting_for_code_input", "waiting_for_device_approval"},
+}
 
 EMAIL_PATTERN = re.compile(r"([A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,})")
 
@@ -90,6 +104,13 @@ def write_json(path: Path, payload: Dict[str, Any]) -> None:
     temp_path = path.with_suffix(".tmp")
     temp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     temp_path.replace(path)
+
+
+def append_jsonl(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+        handle.write("\n")
 
 
 def get_env_first(*keys: str) -> Optional[str]:
@@ -230,6 +251,40 @@ def normalize_scope(scope: str) -> str:
     return normalized
 
 
+def normalize_challenge_type(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in CHALLENGE_TYPES:
+        raise CliError(f"challenge type must be one of: {', '.join(CHALLENGE_TYPES)}")
+    return normalized
+
+
+def normalize_two_factor_method(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in TWO_FACTOR_METHODS:
+        raise CliError(f"two-factor method must be one of: {', '.join(TWO_FACTOR_METHODS)}")
+    return normalized
+
+
+def normalize_page_state(challenge_type: str, value: str) -> str:
+    normalized = value.strip().lower()
+    allowed_states = PAGE_STATES_BY_TYPE[challenge_type]
+    if not normalized:
+        if challenge_type == "captcha":
+            return "captcha_blocked"
+        if challenge_type == "password":
+            return "waiting_for_password"
+        raise CliError(
+            "--page-state is required for two_factor challenges "
+            f"({', '.join(sorted(allowed_states))})"
+        )
+    if normalized not in allowed_states:
+        raise CliError(
+            f"page state {normalized!r} is invalid for {challenge_type}; "
+            f"expected one of: {', '.join(sorted(allowed_states))}"
+        )
+    return normalized
+
+
 def canonical_email(value: str) -> str:
     email = extract_email(value)
     if email:
@@ -264,6 +319,10 @@ def get_state_path(state_dir: Path, challenge_id: str) -> Path:
     return state_dir / f"{challenge_id}.json"
 
 
+def get_events_log_path(state_dir: Path) -> Path:
+    return state_dir.parent / EVENTS_LOG_FILENAME
+
+
 def load_state(state_dir: Path, challenge_id: str) -> Dict[str, Any]:
     path = get_state_path(state_dir, challenge_id)
     if not path.exists():
@@ -288,6 +347,57 @@ def ensure_token(token_arg: Optional[str], dry_run: bool) -> str:
     if not token:
         raise CliError("missing Postmark token: provide --token or set POSTMARK_SERVER_TOKEN")
     return token
+
+
+def ensure_file_paths(paths: List[str]) -> List[Path]:
+    resolved: List[Path] = []
+    for raw_path in paths:
+        path_text = raw_path.strip()
+        if not path_text:
+            continue
+        path = Path(path_text).expanduser()
+        if not path.is_absolute():
+            path = (Path.cwd() / path).resolve()
+        else:
+            path = path.resolve()
+        if not path.exists():
+            raise CliError(f"screenshot file not found: {path}")
+        if not path.is_file():
+            raise CliError(f"screenshot path is not a file: {path}")
+        resolved.append(path)
+    if not resolved:
+        raise CliError("at least one --screenshot file is required")
+    return resolved
+
+
+def build_postmark_attachments(paths: List[Path]) -> Tuple[List[Dict[str, str]], List[Dict[str, Any]]]:
+    total_bytes = 0
+    postmark_attachments: List[Dict[str, str]] = []
+    attachment_summaries: List[Dict[str, Any]] = []
+
+    for path in paths:
+        raw = path.read_bytes()
+        total_bytes += len(raw)
+        if total_bytes > MAX_TOTAL_ATTACHMENT_BYTES:
+            raise CliError("total attachment size exceeds Postmark 10 MB limit")
+        content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        postmark_attachments.append(
+            {
+                "Name": path.name,
+                "Content": base64.b64encode(raw).decode("ascii"),
+                "ContentType": content_type,
+            }
+        )
+        attachment_summaries.append(
+            {
+                "name": path.name,
+                "path": str(path),
+                "content_type": content_type,
+                "size_bytes": len(raw),
+            }
+        )
+
+    return postmark_attachments, attachment_summaries
 
 
 def http_json_request(
@@ -335,29 +445,120 @@ def http_json_request(
     return parsed
 
 
-def build_subject(challenge_id: str, account_label: str) -> str:
+def build_subject(challenge_id: str, account_label: str, challenge_type: str) -> str:
     token = f"[{SUBJECT_TOKEN_PREFIX}:{challenge_id}]"
+    subject_prefix = {
+        "captcha": "CAPTCHA help needed",
+        "password": "Password needed",
+        "two_factor": "2FA approval needed",
+    }[challenge_type]
     if account_label.strip():
-        return f"{token} 2FA approval needed for {account_label.strip()}"
-    return f"{token} 2FA approval needed"
+        return f"{token} {subject_prefix} for {account_label.strip()}"
+    return f"{token} {subject_prefix}"
 
 
-def build_text_body(
-    challenge_id: str,
+def humanize_challenge_type(challenge_type: str) -> str:
+    return {
+        "captcha": "CAPTCHA",
+        "password": "Password",
+        "two_factor": "2FA",
+    }[challenge_type]
+
+
+def humanize_page_state(page_state: str) -> str:
+    return {
+        "captcha_blocked": "Still blocked on CAPTCHA after one built-in solve attempt",
+        "waiting_for_password": "Browser is waiting for the password field",
+        "waiting_for_code_input": "Browser is waiting for a verification code to be typed",
+        "waiting_for_device_approval": "Browser is waiting for an approval action on another device",
+    }[page_state]
+
+
+def describe_two_factor_method(method: str, destination: str) -> str:
+    destination = destination.strip()
+    if method == "sms":
+        return f"SMS code to {destination}" if destination else "SMS code"
+    if method == "email":
+        return f"Email code sent to {destination}" if destination else "Email code"
+    if method == "auth_app":
+        return "Authenticator app code"
+    if method == "device_tap":
+        return f"Device approval / number tap on {destination}" if destination else "Device approval / number tap"
+    return destination or "Other verification method"
+
+
+def build_default_action_text(
+    challenge_type: str,
     account_label: str,
-    timeout_minutes: int,
-    action_text: str,
-    context: str,
-    scope: str,
+    two_factor_method: str,
+    verification_destination: str,
+    page_state: str,
 ) -> str:
+    label = account_label.strip() or "the target account"
+    if challenge_type == "captcha":
+        return (
+            f"Please inspect the attached browser screenshot for {label} and reply "
+            "with the CAPTCHA text or instructions I should enter."
+        )
+    if challenge_type == "password":
+        return (
+            f"Please reply with the password for {label}, or tell me if I should use another account."
+        )
+    method_description = describe_two_factor_method(two_factor_method, verification_destination)
+    if page_state == "waiting_for_device_approval":
+        return (
+            f"Please complete the pending {method_description} and reply with the approval result "
+            "or any number shown on the approval screen."
+        )
+    return f"Please reply with the {method_description} that is currently required on the attached screen."
+
+
+def build_text_body(state: Dict[str, Any]) -> str:
+    challenge_id = str(state["challenge_id"])
+    account_label = str(state.get("account_label", ""))
+    timeout_minutes = int(state.get("timeout_minutes", DEFAULT_TIMEOUT_MINUTES))
+    action_text = str(state.get("action_text", ""))
+    context = str(state.get("context", ""))
+    scope = str(state.get("scope", ""))
+    challenge_type = str(state.get("challenge_type", ""))
+    page_state = str(state.get("page_state", ""))
+    two_factor_method = str(state.get("two_factor_method", ""))
+    verification_destination = str(state.get("verification_destination", ""))
+    password_env_key = str(state.get("password_env_key", ""))
+    password_lookup_status = str(state.get("password_lookup_status", ""))
+    screenshots = state.get("request_attachments") or []
+
     lines = [
         "DoWhiz agent needs your help to continue a blocked authentication step.",
         "",
         f"Challenge ID: {challenge_id}",
+        f"Challenge type: {humanize_challenge_type(challenge_type)}",
         f"Scope: {scope}",
     ]
     if account_label.strip():
         lines.append(f"Account context: {account_label.strip()}")
+    if page_state:
+        lines.append(f"Current browser state: {humanize_page_state(page_state)}")
+    if challenge_type == "two_factor":
+        lines.append(
+            f"Verification method: {describe_two_factor_method(two_factor_method, verification_destination)}"
+        )
+    if challenge_type == "password":
+        if password_env_key:
+            lines.append(f"Password env key checked: {password_env_key}")
+        if password_lookup_status:
+            lines.append(f"Password lookup status: {password_lookup_status}")
+    if challenge_type == "captcha":
+        lines.append("Agent attempted one built-in visual solve before asking for help.")
+    if screenshots:
+        screenshot_names = ", ".join(
+            str(item.get("name", "")).strip()
+            for item in screenshots
+            if str(item.get("name", "")).strip()
+        )
+        lines.append(
+            f"Attached screenshot(s): {screenshot_names or f'{len(screenshots)} file(s)'}"
+        )
     if action_text.strip():
         lines.append(f"Action needed: {action_text.strip()}")
     if context.strip():
@@ -365,8 +566,8 @@ def build_text_body(
     lines.extend(
         [
             "",
-            "Please reply in this same email thread with the verification code,",
-            "approval result, or any information the agent needs to continue.",
+            "Please reply in this same email thread with the exact information",
+            "the current browser screen needs so the agent can continue.",
             "",
             f"The agent will wait for up to {timeout_minutes} minutes.",
             "It will not continue until a reply is received.",
@@ -376,12 +577,7 @@ def build_text_body(
 
 
 def build_html_body(text_body: str) -> str:
-    escaped = (
-        text_body.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace("\n", "<br>")
-    )
+    escaped = escape(text_body).replace("\n", "<br>")
     return f"<html><body><p>{escaped}</p></body></html>"
 
 
@@ -396,6 +592,7 @@ def send_approval_email(
     text_body: str,
     html_body: str,
     metadata: Dict[str, str],
+    attachments: List[Dict[str, str]],
 ) -> str:
     payload: Dict[str, Any] = {
         "From": from_address,
@@ -406,6 +603,7 @@ def send_approval_email(
         "MessageStream": "outbound",
         "Tag": "human-approval-gate",
         "Metadata": metadata,
+        "Attachments": attachments,
     }
     if reply_to:
         payload["ReplyTo"] = reply_to
@@ -422,10 +620,11 @@ def send_approval_email(
     return message_id
 
 
-def build_postmark_metadata(challenge_id: str, scope: str) -> Dict[str, str]:
+def build_postmark_metadata(challenge_id: str, scope: str, challenge_type: str) -> Dict[str, str]:
     metadata = {
         POSTMARK_METADATA_CHALLENGE_ID_KEY: challenge_id,
         POSTMARK_METADATA_SCOPE_KEY: scope,
+        POSTMARK_METADATA_TYPE_KEY: challenge_type,
     }
     for key in metadata:
         if len(key) > 20:
@@ -629,6 +828,39 @@ def emit_json(payload: Dict[str, Any]) -> None:
     print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
 
 
+def build_send_event_payload(state: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "event": "hag_request_sent",
+        "challenge_id": state.get("challenge_id"),
+        "challenge_type": state.get("challenge_type"),
+        "scope": state.get("scope"),
+        "page_state": state.get("page_state"),
+        "account_label": state.get("account_label"),
+        "recipient": state.get("recipient"),
+        "expected_reply_from": state.get("expected_reply_from"),
+        "two_factor_method": state.get("two_factor_method"),
+        "verification_destination": state.get("verification_destination"),
+        "password_env_key": state.get("password_env_key"),
+        "password_lookup_status": state.get("password_lookup_status"),
+        "attachment_count": len(state.get("request_attachments") or []),
+        "attachments": state.get("request_attachments") or [],
+        "outbound_message_id": state.get("outbound_message_id"),
+        "outbound_dry_run": state.get("outbound_dry_run"),
+        "created_at": state.get("created_at"),
+        "expires_at": state.get("expires_at"),
+    }
+
+
+def record_send_event(state_dir: Path, state: Dict[str, Any]) -> None:
+    event_payload = build_send_event_payload(state)
+    append_jsonl(get_events_log_path(state_dir), event_payload)
+    print(
+        f"HAG_EVENT {json.dumps(event_payload, ensure_ascii=True, sort_keys=True)}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 def build_request_state(args: argparse.Namespace) -> Dict[str, Any]:
     if args.timeout_minutes <= 0:
         raise CliError("--timeout-minutes must be greater than zero")
@@ -638,6 +870,8 @@ def build_request_state(args: argparse.Namespace) -> Dict[str, Any]:
         raise CliError("--poll-interval-seconds must be greater than zero")
 
     scope = normalize_scope(args.scope)
+    challenge_type = normalize_challenge_type(args.challenge_type)
+    page_state = normalize_page_state(challenge_type, args.page_state)
     recipient = resolve_recipient(scope, args.recipient, args.user_email)
     challenge_id = (args.challenge_id or "").strip() or str(uuid4())
     sender = resolve_sender(args.from_address)
@@ -646,34 +880,58 @@ def build_request_state(args: argparse.Namespace) -> Dict[str, Any]:
     timeout_minutes = args.timeout_minutes
 
     account_label = (args.account_label or "").strip()
-    action_text = (args.action_text or "").strip()
     context = (args.context or "").strip()
+    two_factor_method = ""
+    verification_destination = (args.verification_destination or "").strip()
+    if challenge_type == "two_factor":
+        two_factor_method = normalize_two_factor_method(args.two_factor_method)
+        if two_factor_method in {"sms", "email"} and not verification_destination:
+            raise CliError(
+                f"--verification-destination is required for {two_factor_method} two_factor challenges"
+            )
+    elif args.two_factor_method.strip():
+        raise CliError("--two-factor-method is only valid for two_factor challenges")
+    elif verification_destination:
+        raise CliError("--verification-destination is only valid for two_factor challenges")
 
-    subject = build_subject(challenge_id, account_label)
-    text_body = build_text_body(
-        challenge_id=challenge_id,
+    password_env_key = (args.password_env_key or "").strip() or DEFAULT_PASSWORD_ENV_KEY
+    password_lookup_status = (args.password_lookup_status or "").strip()
+    if challenge_type != "password":
+        password_env_key = ""
+        password_lookup_status = ""
+
+    screenshot_paths = ensure_file_paths(args.screenshot)
+    postmark_attachments, attachment_summaries = build_postmark_attachments(screenshot_paths)
+
+    action_text = (args.action_text or "").strip() or build_default_action_text(
+        challenge_type=challenge_type,
         account_label=account_label,
-        timeout_minutes=timeout_minutes,
-        action_text=action_text,
-        context=context,
-        scope=scope,
+        two_factor_method=two_factor_method,
+        verification_destination=verification_destination,
+        page_state=page_state,
     )
-    html_body = build_html_body(text_body)
 
     created_at = utc_now()
     state: Dict[str, Any] = {
         "challenge_id": challenge_id,
         "status": "pending",
         "scope": scope,
+        "challenge_type": challenge_type,
+        "page_state": page_state,
         "recipient": recipient,
         "expected_reply_from": expected_reply_from,
         "from_address": sender,
         "reply_to": reply_to,
-        "subject": subject,
+        "subject": build_subject(challenge_id, account_label, challenge_type),
         "subject_token": f"[{SUBJECT_TOKEN_PREFIX}:{challenge_id}]",
         "account_label": account_label,
         "action_text": action_text,
         "context": context,
+        "two_factor_method": two_factor_method,
+        "verification_destination": verification_destination,
+        "password_env_key": password_env_key,
+        "password_lookup_status": password_lookup_status,
+        "request_attachments": attachment_summaries,
         "timeout_minutes": timeout_minutes,
         "created_at": isoformat_utc(created_at),
         "expires_at": isoformat_utc(created_at + timedelta(minutes=timeout_minutes)),
@@ -683,10 +941,12 @@ def build_request_state(args: argparse.Namespace) -> Dict[str, Any]:
         "outbound_dry_run": bool(args.dry_run),
         "message_stream": "outbound",
     }
+    text_body = build_text_body(state)
     state["_rendered_email"] = {
-        "subject": subject,
+        "subject": state["subject"],
         "text_body": text_body,
-        "html_body": html_body,
+        "html_body": build_html_body(text_body),
+        "attachments": postmark_attachments,
     }
     return state
 
@@ -702,7 +962,11 @@ def cmd_request(args: argparse.Namespace) -> int:
     if args.dry_run:
         state["outbound_message_id"] = "DRY_RUN"
     else:
-        metadata = build_postmark_metadata(str(state["challenge_id"]), str(state["scope"]))
+        metadata = build_postmark_metadata(
+            str(state["challenge_id"]),
+            str(state["scope"]),
+            str(state["challenge_type"]),
+        )
         message_id = send_approval_email(
             api_base=api_base,
             token=token,
@@ -713,10 +977,12 @@ def cmd_request(args: argparse.Namespace) -> int:
             text_body=rendered["text_body"],
             html_body=rendered["html_body"],
             metadata=metadata,
+            attachments=rendered["attachments"],
         )
         state["outbound_message_id"] = message_id
 
     save_state(state_dir, state)
+    record_send_event(state_dir, state)
 
     if args.wait:
         result = wait_for_resolution(
@@ -796,6 +1062,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     request_parser = subparsers.add_parser("request", help="create a challenge and send email")
     request_parser.add_argument("--scope", default="user", choices=["admin", "user"])
+    request_parser.add_argument(
+        "--challenge-type",
+        default="two_factor",
+        choices=list(CHALLENGE_TYPES),
+        help="auth blocker type being escalated",
+    )
     request_parser.add_argument("--challenge-id", default="")
     request_parser.add_argument("--recipient", default="")
     request_parser.add_argument("--user-email", default="")
@@ -805,6 +1077,38 @@ def build_parser() -> argparse.ArgumentParser:
     request_parser.add_argument("--account-label", default="")
     request_parser.add_argument("--action-text", default="")
     request_parser.add_argument("--context", default="")
+    request_parser.add_argument(
+        "--page-state",
+        default="",
+        help="explicit browser state, required for two_factor challenges",
+    )
+    request_parser.add_argument(
+        "--two-factor-method",
+        default="",
+        metavar="{sms,email,auth_app,device_tap,other}",
+        help="specific 2FA method in use",
+    )
+    request_parser.add_argument(
+        "--verification-destination",
+        default="",
+        help="where the code/approval was sent (masked phone/email/device label)",
+    )
+    request_parser.add_argument(
+        "--password-env-key",
+        default=DEFAULT_PASSWORD_ENV_KEY,
+        help="workspace env key checked before asking for password help",
+    )
+    request_parser.add_argument(
+        "--password-lookup-status",
+        default="",
+        help="honest note about what password sources were already checked",
+    )
+    request_parser.add_argument(
+        "--screenshot",
+        action="append",
+        default=[],
+        help="current browser screenshot to attach; repeatable and required",
+    )
     request_parser.add_argument(
         "--timeout-minutes",
         type=int,

--- a/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
@@ -1,0 +1,142 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("human_approval_gate.py")
+SPEC = importlib.util.spec_from_file_location("human_approval_gate", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class HumanApprovalGateTests(unittest.TestCase):
+    def create_screenshot(self, directory: str, name: str = "screen.png") -> str:
+        path = Path(directory) / name
+        path.write_bytes(
+            b"\x89PNG\r\n\x1a\n"
+            b"\x00\x00\x00\rIHDR"
+            b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00"
+            b"\x90wS\xde"
+            b"\x00\x00\x00\x0cIDATx\x9cc```\x00\x00\x00\x04\x00\x01"
+            b"\x0b\xe7\x02\x9d"
+            b"\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        return str(path)
+
+    def parse_request(self, *extra_args: str):
+        parser = MODULE.build_parser()
+        return parser.parse_args(["request", *extra_args])
+
+    def test_request_requires_screenshot(self):
+        args = self.parse_request("--challenge-type", "captcha")
+        with self.assertRaises(MODULE.CliError):
+            MODULE.build_request_state(args)
+
+    def test_two_factor_requires_explicit_page_state(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            args = self.parse_request(
+                "--challenge-type",
+                "two_factor",
+                "--scope",
+                "admin",
+                "--two-factor-method",
+                "sms",
+                "--verification-destination",
+                "phone ending in 9315",
+                "--screenshot",
+                screenshot,
+            )
+            with self.assertRaises(MODULE.CliError):
+                MODULE.build_request_state(args)
+
+    def test_two_factor_body_reports_method_and_destination(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            args = self.parse_request(
+                "--challenge-type",
+                "two_factor",
+                "--scope",
+                "admin",
+                "--page-state",
+                "waiting_for_code_input",
+                "--two-factor-method",
+                "sms",
+                "--verification-destination",
+                "phone ending in 9315",
+                "--account-label",
+                "Oliver Google account",
+                "--screenshot",
+                screenshot,
+            )
+            state = MODULE.build_request_state(args)
+            rendered = state["_rendered_email"]
+
+            self.assertEqual(state["challenge_type"], "two_factor")
+            self.assertEqual(state["page_state"], "waiting_for_code_input")
+            self.assertIn("Verification method: SMS code to phone ending in 9315", rendered["text_body"])
+            self.assertIn("waiting for a verification code to be typed", rendered["text_body"])
+            self.assertIn("screen.png", rendered["text_body"])
+            self.assertEqual(rendered["attachments"][0]["Name"], "screen.png")
+            self.assertEqual(state["request_attachments"][0]["content_type"], "image/png")
+
+    def test_password_body_reports_env_lookup(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            args = self.parse_request(
+                "--challenge-type",
+                "password",
+                "--scope",
+                "admin",
+                "--password-env-key",
+                "GOOGLE_PASSWORD",
+                "--password-lookup-status",
+                "Checked workspace .env for GOOGLE_PASSWORD; no value was present.",
+                "--account-label",
+                "Oliver Google account",
+                "--screenshot",
+                screenshot,
+            )
+            state = MODULE.build_request_state(args)
+            rendered = state["_rendered_email"]
+
+            self.assertIn("Password env key checked: GOOGLE_PASSWORD", rendered["text_body"])
+            self.assertIn("Checked workspace .env for GOOGLE_PASSWORD; no value was present.", rendered["text_body"])
+            self.assertIn("Password needed", state["subject"])
+
+    def test_record_send_event_writes_attachment_details(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            args = self.parse_request(
+                "--challenge-type",
+                "captcha",
+                "--scope",
+                "admin",
+                "--account-label",
+                "Oliver Google account",
+                "--screenshot",
+                screenshot,
+            )
+            state = MODULE.build_request_state(args)
+            state["outbound_message_id"] = "msg-123"
+            state_dir = Path(temp_dir) / ".human_approval_gate" / "challenges"
+
+            MODULE.record_send_event(state_dir, state)
+
+            events_path = state_dir.parent / "events.jsonl"
+            lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+            payload = json.loads(lines[-1])
+            self.assertEqual(payload["event"], "hag_request_sent")
+            self.assertEqual(payload["challenge_type"], "captcha")
+            self.assertEqual(payload["attachment_count"], 1)
+            self.assertEqual(payload["attachments"][0]["name"], "screen.png")
+            self.assertGreater(payload["attachments"][0]["size_bytes"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand `human_approval_gate` into explicit `captcha`, `password`, and `two_factor` challenge types
- require screenshot attachments and honest state/method reporting for all auth escalation emails
- record each HAG send as both `.human_approval_gate/events.jsonl` and `HAG_EVENT ...` stderr output for prod/staging debugging

## Testing
- `python3 -m unittest DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py`
- `python3 -m py_compile DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py`
- `cargo test -p run_task_module`
