### PR TITLE
Prevent duplicate scheduler repairs

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -192,6 +192,10 @@ jobs:
           source "$ENV_FILE"
           set +a
 
+          if systemctl list-unit-files 'dowhiz-oliver.service' --no-legend 2>/dev/null | grep -q '^dowhiz-oliver\.service'; then
+            sudo systemctl disable --now dowhiz-oliver.service || true
+          fi
+
           if pm2 describe dw_worker >/dev/null 2>&1; then
             pm2 restart dw_worker --update-env
           else

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -192,6 +192,10 @@ jobs:
           source "$ENV_FILE"
           set +a
 
+          if systemctl list-unit-files 'dowhiz-oliver.service' --no-legend 2>/dev/null | grep -q '^dowhiz-oliver\.service'; then
+            sudo systemctl disable --now dowhiz-oliver.service || true
+          fi
+
           if pm2 describe dw_worker >/dev/null 2>&1; then
             pm2 restart dw_worker --update-env
           else

--- a/DoWhiz_service/OPERATIONS.md
+++ b/DoWhiz_service/OPERATIONS.md
@@ -52,6 +52,10 @@ PM2 logs (if PM2-managed):
 
 ## 4) Start / Restart Patterns
 
+On staging/production VMs, PM2 is the canonical runtime manager. Treat any leftover `systemd`
+unit such as `dowhiz-oliver.service` as legacy and disable it so it cannot compete with PM2 or
+confuse incident response.
+
 ### 4.1 Script-based (foreground/local style)
 
 ```bash
@@ -80,6 +84,12 @@ pm2 restart dw_gateway --update-env || \
 
 pm2 save
 pm2 list
+```
+
+If a legacy worker unit exists on a VM, disable it once:
+
+```bash
+sudo systemctl disable --now dowhiz-oliver.service || true
 ```
 
 ## 5) Health Checks

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -52,26 +52,39 @@ Staging ingest isolation policy:
 
 ## 3) VM Deployment
 
+PM2 is the canonical process manager on staging/production VMs. Do not use the foreground
+`run_gateway_local.sh` / `run_employee.sh` pair as the steady-state VM runtime; those are for
+local debugging and manual foreground sessions only.
+
+If a legacy `systemd` worker unit such as `dowhiz-oliver.service` exists on a VM, disable it so
+PM2 is the only process supervisor for DoWhiz.
+
 ### Staging (`dev`)
 ```bash
 ssh dowhizstaging
-cd /home/azureuser/server/.dowhiz/DoWhiz
-git fetch origin
-git checkout dev
-git pull --ff-only origin dev
-./DoWhiz_service/scripts/run_gateway_local.sh
-./DoWhiz_service/scripts/run_employee.sh boiled_egg 9001 --skip-hook --skip-ngrok
+cd /home/azureuser/server/.dowhiz/DoWhiz/DoWhiz_service
+set -a
+source .env
+set +a
+sudo systemctl disable --now dowhiz-oliver.service || true
+pm2 restart dw_gateway --update-env || pm2 start ./target/release/inbound_gateway --name dw_gateway --cwd "$PWD"
+pm2 restart dw_worker --update-env || pm2 start ./target/release/rust_service --name dw_worker --cwd "$PWD" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
+pm2 save
+pm2 list
 ```
 
 ### Production (`main`)
 ```bash
 ssh dowhizprod1
-cd /home/azureuser/server/.dowhiz/DoWhiz
-git fetch origin
-git checkout main
-git pull --ff-only origin main
-./DoWhiz_service/scripts/run_gateway_local.sh
-./DoWhiz_service/scripts/run_employee.sh little_bear 9001 --skip-hook --skip-ngrok
+cd /home/azureuser/server/.dowhiz/DoWhiz/DoWhiz_service
+set -a
+source .env
+set +a
+sudo systemctl disable --now dowhiz-oliver.service || true
+pm2 restart dw_gateway --update-env || pm2 start ./target/release/inbound_gateway --name dw_gateway --cwd "$PWD"
+pm2 restart dw_worker --update-env || pm2 start ./target/release/rust_service --name dw_worker --cwd "$PWD" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
+pm2 save
+pm2 list
 ```
 
 Do not use `scripts/start_all.sh` on staging/production VMs; it is local-only and will start ngrok plus rewrite Postmark inbound hook.
@@ -83,8 +96,9 @@ Deployment workflows should:
 2. Fail if `.env` contains keys matching `^(STAGING_|PROD_)`.
 3. Validate `GATEWAY_CONFIG_PATH` and `EMPLOYEE_CONFIG_PATH` exist and match expected target files.
 4. After release binaries and `.env` are installed, source `.env` and restart PM2-managed services immediately so live traffic moves onto the new worker/gateway before any long-running follow-up work.
-5. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), trim `DoWhiz_service/target` on the VM before `az acr build` (drop debug/intermediate artifacts, keep required release binaries), then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE`.
-6. Use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes, and finish with local health checks that allow a short retry window while worker/gateway bind their ports.
+5. Disable any legacy `systemd` worker unit (for example `dowhiz-oliver.service`) so PM2 remains the only supervisor.
+6. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), trim `DoWhiz_service/target` on the VM before `az acr build` (drop debug/intermediate artifacts, keep required release binaries), then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE`.
+7. Use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes, and finish with local health checks that allow a short retry window while worker/gateway bind their ports.
 
 ## 5) Health Checks
 

--- a/DoWhiz_service/scheduler_module/src/scheduler/snapshot.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/snapshot.rs
@@ -50,6 +50,7 @@ pub(crate) struct SchedulerSnapshot {
     pub(crate) window_start: DateTime<Utc>,
     pub(crate) window_end: DateTime<Utc>,
     pub(crate) total_enabled: usize,
+    pub(crate) due: Vec<SchedulerSnapshotTask>,
     pub(crate) upcoming: Vec<SchedulerSnapshotTask>,
     pub(crate) omitted_past_due: usize,
     pub(crate) omitted_after_window: usize,
@@ -96,8 +97,9 @@ pub(crate) fn build_scheduler_snapshot(
     now: DateTime<Utc>,
 ) -> SchedulerSnapshot {
     let window_end = now + chrono::Duration::days(SCHEDULER_SNAPSHOT_WINDOW_DAYS);
+    let mut due = Vec::new();
     let mut upcoming = Vec::new();
-    let mut omitted_past_due = 0usize;
+    let omitted_past_due = 0usize;
     let mut omitted_after_window = 0usize;
     let mut total_enabled = 0usize;
 
@@ -107,8 +109,16 @@ pub(crate) fn build_scheduler_snapshot(
         }
         total_enabled += 1;
         let next_run = schedule_next_run_at(&task.schedule);
-        if next_run < now {
-            omitted_past_due += 1;
+        if task.is_due(now) {
+            due.push(SchedulerSnapshotTask {
+                id: task.id.to_string(),
+                kind: task_kind_label(&task.kind).to_string(),
+                schedule: snapshot_schedule(&task.schedule),
+                next_run,
+                last_run: task.last_run,
+                status: task_status_label(task, now),
+                label: task_label(&task.kind),
+            });
             continue;
         }
         if next_run > window_end {
@@ -126,6 +136,7 @@ pub(crate) fn build_scheduler_snapshot(
         });
     }
 
+    due.sort_by_key(|task| task.next_run);
     upcoming.sort_by_key(|task| task.next_run);
 
     SchedulerSnapshot {
@@ -133,6 +144,7 @@ pub(crate) fn build_scheduler_snapshot(
         window_start: now,
         window_end,
         total_enabled,
+        due,
         upcoming,
         omitted_past_due,
         omitted_after_window,

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -173,9 +173,44 @@ fn build_scheduler_snapshot_limits_to_window() {
     };
 
     let snapshot = build_scheduler_snapshot(&[in_window, out_window], now);
+    assert!(snapshot.due.is_empty());
     assert_eq!(snapshot.upcoming.len(), 1);
     assert_eq!(snapshot.omitted_after_window, 1);
     assert_eq!(snapshot.total_enabled, 2);
+}
+
+#[test]
+fn build_scheduler_snapshot_surfaces_due_tasks_with_ids() {
+    let now = Utc::now();
+    let due_cron = ScheduledTask {
+        id: Uuid::new_v4(),
+        kind: TaskKind::Noop,
+        schedule: Schedule::Cron {
+            expression: "0 0 16 * * *".to_string(),
+            next_run: now - chrono::Duration::minutes(3),
+        },
+        enabled: true,
+        created_at: now,
+        last_run: Some(now - chrono::Duration::days(1)),
+    };
+    let future_one_shot = ScheduledTask {
+        id: Uuid::new_v4(),
+        kind: TaskKind::Noop,
+        schedule: Schedule::OneShot {
+            run_at: now + chrono::Duration::hours(2),
+        },
+        enabled: true,
+        created_at: now,
+        last_run: None,
+    };
+
+    let snapshot = build_scheduler_snapshot(&[due_cron.clone(), future_one_shot], now);
+    assert_eq!(snapshot.total_enabled, 2);
+    assert_eq!(snapshot.due.len(), 1);
+    assert_eq!(snapshot.due[0].id, due_cron.id.to_string());
+    assert_eq!(snapshot.due[0].status, "due");
+    assert_eq!(snapshot.omitted_past_due, 0);
+    assert_eq!(snapshot.upcoming.len(), 1);
 }
 
 #[test]

--- a/DoWhiz_service/skills/scheduler_maintain/SKILL.md
+++ b/DoWhiz_service/skills/scheduler_maintain/SKILL.md
@@ -8,10 +8,10 @@ allowed-tools: None
 
 ## Context
 - Scheduler snapshot (if available): `scheduler_snapshot.json` in workspace root.
-- Snapshot includes enabled tasks scheduled between `window_start` and `window_end` (UTC, 7-day window), plus counts outside the window.
+- Snapshot includes enabled tasks that are already `due`, enabled tasks still `upcoming` between `window_start` and `window_end` (UTC, 7-day window), plus counts outside the visible window.
 
 ## Listing tasks
-- Read and summarize `upcoming` tasks (id, kind, next_run/run_at, status, label).
+- Read and summarize `due` tasks first, then `upcoming` tasks (id, kind, next_run/run_at, status, label).
 - If the snapshot is missing, state that scheduler state is unavailable.
 
 ## Scheduling outputs
@@ -47,4 +47,7 @@ SCHEDULER_ACTIONS_JSON_END
 - Cron uses 6 fields: `sec min hour day month weekday`.
 - Do not include workspace paths; `create_run_task` always targets the current workspace.
 - Output only JSON inside blocks; no commentary inside blocks.
+- Treat any enabled task shown under `due` as an existing active schedule/task, not as evidence that scheduling is missing.
+- Never create a duplicate recurring `run_task` solely because `upcoming` is empty while `due` is non-empty or `total_enabled` is already positive.
+- If scheduler repair is needed, prefer cancelling or rescheduling the existing task IDs from the snapshot over blindly creating a fresh cron.
 - If no changes are requested, omit the relevant block.


### PR DESCRIPTION
## Summary
- surface enabled due scheduler tasks separately from upcoming tasks so agent runs do not treat a due cron as a missing schedule
- update the scheduler maintenance guidance to prefer existing task IDs over blind recurring task recreation
- align staging/production VM docs and CI/CD around PM2 as the canonical runtime manager, including disabling the legacy `dowhiz-oliver.service` unit if it exists

## Testing
- `cargo test -p scheduler_module build_scheduler_snapshot -- --nocapture`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/CICD-staging.yml"); YAML.load_file(".github/workflows/CICD-production.yml"); puts "workflow yaml ok"'`
