### PR TITLE
Make human approval gate a blocking Codex MCP tool

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -65,7 +65,7 @@ Key binaries (from `scheduler_module/src/bin`):
 | `set_postmark_inbound_hook` | Utility to update Postmark inbound webhook |
 | `inbound_fanout` | Legacy fanout ingress helper |
 | `google-docs` / `google-sheets` / `google-slides` | Workspace integration CLI tools |
-| `human_approval_gate` | CLI for OTP/2FA approval requests (email + wait for reply) |
+| `human_approval_gate` / `human_approval_gate_mcp` | Human approval gate for CAPTCHA/password/2FA blockers; CLI for manual use and MCP server for blocking Codex runs |
 
 Key scripts:
 
@@ -205,19 +205,24 @@ Azure ACI execution path (required vars):
 - Browser-based web auth for private Notion/Google pages is agent-driven at task runtime
   (no service-side bootstrap step).
 - `human_approval_gate` (via skill `human-approval-gate`) provides a blocking
-  approval flow for login CAPTCHA/password/OTP/device-approval steps. It sends an
-  email request with the current browser screenshot(s), models the blocker as
-  `captcha`, `password`, or `two_factor`, and waits for the first same-thread
-  reply, typically with a 30-minute timeout. For `two_factor`, callers should
-  only invoke it after the site is explicitly waiting for a code or device
-  approval, and they should include the concrete method details (SMS/email/auth
-  app/device tap). The CLI returns the full reply payload to the agent for
-  interpretation. Each send also writes `.human_approval_gate/events.jsonl` and
-  emits a `HAG_EVENT ...` stderr line containing challenge type plus attachment
-  filenames and sizes, so prod/staging task logs can prove exactly what was
-  sent. Sender resolution priority is `--from` > `HUMAN_APPROVAL_FROM` >
-  employee mailbox from employee config. HAG-thread replies (`[HAG:...]`) are
-  ignored by normal inbound task routing to prevent recursive Email->task loops.
+  approval flow for login CAPTCHA/password/OTP/device-approval steps. In
+  run_task/Codex environments, the preferred path is the injected MCP tool
+  `dowhiz_human_approval_gate_request_and_wait`, which sends the email with the
+  current browser screenshot(s) and blocks the same Codex turn until the first
+  same-thread reply or timeout, preserving the current browser session while it
+  waits. The blocker must be modeled as `captcha`, `password`, or
+  `two_factor`. For `two_factor`, callers should only invoke it after the site
+  is explicitly waiting for a code or device approval, and they should include
+  the concrete method details (SMS/email/auth app/device tap). The manual CLI
+  remains available outside Codex runtime, but run_task sets
+  `HUMAN_APPROVAL_GATE_REQUIRE_MCP=1` so shell-side HAG calls are rejected and
+  the blocking MCP path is enforced. Each send also writes
+  `.human_approval_gate/events.jsonl` and emits a `HAG_EVENT ...` stderr line
+  containing challenge type plus attachment filenames and sizes, so
+  prod/staging task logs can prove exactly what was sent. Sender resolution
+  priority is `--from` > `HUMAN_APPROVAL_FROM` > employee mailbox from employee
+  config. HAG-thread replies (`[HAG:...]`) are ignored by normal inbound task
+  routing to prevent recursive Email->task loops.
 - ACI run_task sets Playwright/NPM runtime defaults for mounted workspaces:
   `PLAYWRIGHT_MCP_EXECUTABLE_PATH` auto-discovery (`chrome-linux` / `chrome-linux64`),
   `PLAYWRIGHT_BROWSERS_PATH=/app/.cache/ms-playwright`,

--- a/DoWhiz_service/bin/human_approval_gate_mcp
+++ b/DoWhiz_service/bin/human_approval_gate_mcp
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  echo "python interpreter not found for human_approval_gate_mcp" >&2
+  exit 1
+fi
+
+candidates=(
+  "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../skills/human-approval-gate/scripts/human_approval_gate_mcp.py"
+  "${PWD}/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate_mcp.py"
+  "./.agents/skills/human-approval-gate/scripts/human_approval_gate_mcp.py"
+  "${PWD}/.agents/skills/human-approval-gate/scripts/human_approval_gate_mcp.py"
+  "/app/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate_mcp.py"
+  "${HOME:-}/.dowhiz/DoWhiz/skills/human-approval-gate/scripts/human_approval_gate_mcp.py"
+)
+
+for script_path in "${candidates[@]}"; do
+  if [[ -n "${script_path}" && -f "${script_path}" ]]; then
+    exec "${PYTHON_BIN}" "${script_path}" "$@"
+  fi
+done
+
+echo "human_approval_gate_mcp.py not found in expected locations" >&2
+exit 1

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -55,6 +55,8 @@ const HUMAN_APPROVAL_GATE_ENV_KEYS: &[&str] = &[
     "HUMAN_APPROVAL_REPLY_TO",
     "POSTMARK_API_BASE_URL",
 ];
+const HUMAN_APPROVAL_GATE_REQUIRE_MCP_ENV_KEY: &str = "HUMAN_APPROVAL_GATE_REQUIRE_MCP";
+const HUMAN_APPROVAL_GATE_MCP_SERVER_NAME: &str = "human-approval-gate";
 const HUMAN_APPROVAL_FROM_ENV_KEY: &str = "HUMAN_APPROVAL_FROM";
 const HUMAN_APPROVAL_REPLY_TO_ENV_KEY: &str = "HUMAN_APPROVAL_REPLY_TO";
 const EMPLOYEE_CONFIG_PATH_ENV_KEY: &str = "EMPLOYEE_CONFIG_PATH";
@@ -73,6 +75,8 @@ const GOOGLE_WORKSPACE_CLI_CREDENTIALS_REL_PATH: &str =
 
 const REMOTE_OUTPUT_FILENAME: &str = ".codex_remote_output.log";
 const REMOTE_EXIT_CODE_FILENAME: &str = ".codex_remote_exit_code";
+const HAG_MCP_CONFIG_START_MARKER: &str = "# BEGIN DOWHIZ HUMAN APPROVAL GATE MCP";
+const HAG_MCP_CONFIG_END_MARKER: &str = "# END DOWHIZ HUMAN APPROVAL GATE MCP";
 static ACI_CONTAINER_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Deserialize)]
@@ -418,6 +422,8 @@ pub(super) fn run_codex_task(
         for (key, value) in &human_approval_gate_env_overrides {
             cmd.arg("-e").arg(format!("{}={}", key, value));
         }
+        cmd.arg("-e")
+            .arg(format!("{}=1", HUMAN_APPROVAL_GATE_REQUIRE_MCP_ENV_KEY));
         for (key, value) in &github_auth.env_overrides {
             cmd.arg("-e").arg(format!("{}={}", key, value));
         }
@@ -529,6 +535,7 @@ pub(super) fn run_codex_task(
         for (key, value) in &human_approval_gate_env_overrides {
             cmd.env(key, value);
         }
+        cmd.env(HUMAN_APPROVAL_GATE_REQUIRE_MCP_ENV_KEY, "1");
         for (key, value) in github_auth.env_overrides {
             cmd.env(key, value);
         }
@@ -802,6 +809,10 @@ fn run_codex_task_azure_aci(
     for (key, value) in human_approval_gate_env_overrides {
         env_overrides.push((key, value));
     }
+    env_overrides.push((
+        HUMAN_APPROVAL_GATE_REQUIRE_MCP_ENV_KEY.to_string(),
+        "1".to_string(),
+    ));
     for (key, value) in github_auth.env_overrides {
         env_overrides.push((key, value));
     }
@@ -1613,6 +1624,7 @@ fn ensure_codex_config_at(
     fs::create_dir_all(config_dir)?;
 
     let block = build_codex_config_block(azure_endpoint);
+    let hag_mcp_block = build_human_approval_gate_mcp_block();
 
     let existing = if config_path.exists() {
         fs::read_to_string(&config_path)?
@@ -1621,6 +1633,12 @@ fn ensure_codex_config_at(
     };
 
     let updated = update_config_block(&existing, &block);
+    let updated = update_managed_config_block(
+        &updated,
+        HAG_MCP_CONFIG_START_MARKER,
+        HAG_MCP_CONFIG_END_MARKER,
+        &hag_mcp_block,
+    );
     let updated = ensure_project_trust(&updated, trust_workspace_dir);
     fs::write(config_path, updated)?;
     Ok(())
@@ -2001,6 +2019,16 @@ fn build_codex_config_block(azure_endpoint: &str) -> String {
     CODEX_CONFIG_BLOCK_TEMPLATE.replace(CODEX_CONFIG_BASE_URL_PLACEHOLDER, azure_endpoint)
 }
 
+fn build_human_approval_gate_mcp_block() -> String {
+    format!(
+        r#"{HAG_MCP_CONFIG_START_MARKER}
+[mcp_servers.{HUMAN_APPROVAL_GATE_MCP_SERVER_NAME}]
+command = "human_approval_gate_mcp"
+
+{HAG_MCP_CONFIG_END_MARKER}"#
+    )
+}
+
 fn normalize_azure_endpoint(endpoint: &str) -> String {
     let trimmed = endpoint.trim();
     if trimmed.ends_with("/openai/v1") {
@@ -2026,6 +2054,40 @@ fn update_config_block(existing: &str, block: &str) -> String {
             updated.push_str(block.trim_end());
             updated.push('\n');
             updated.push_str(existing[end_line_index..].trim_start());
+            return updated;
+        }
+    }
+
+    let mut updated = existing.trim_end().to_string();
+    if !updated.is_empty() {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(block.trim_end());
+    updated.push('\n');
+    updated
+}
+
+fn update_managed_config_block(
+    existing: &str,
+    start_marker: &str,
+    end_marker: &str,
+    block: &str,
+) -> String {
+    if let Some(start_index) = existing.find(start_marker) {
+        if let Some(end_relative_index) = existing[start_index..].find(end_marker) {
+            let end_marker_index = start_index + end_relative_index + end_marker.len();
+            let trailing_newline_index = existing[end_marker_index..]
+                .find('\n')
+                .map(|idx| end_marker_index + idx + 1)
+                .unwrap_or(existing.len());
+            let mut updated = String::new();
+            updated.push_str(existing[..start_index].trim_end());
+            if !updated.is_empty() {
+                updated.push_str("\n\n");
+            }
+            updated.push_str(block.trim_end());
+            updated.push('\n');
+            updated.push_str(existing[trailing_newline_index..].trim_start());
             return updated;
         }
     }

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -208,28 +208,28 @@ fn build_human_approval_gate_section() -> &'static str {
     r#"Human Approval Gate (2FA / verification challenges):
 - If login/auth flow asks for OTP/passcode/device approval/number tap, or you are blocked on CAPTCHA/password after the required local checks below, use the `human-approval-gate` skill with an honest challenge type and browser screenshot.
 - If the page shows CAPTCHA/image puzzle/text recognition challenge, first use your own built-in multimodal/vision abilities and browser tools to inspect the challenge, attempt one direct solve in the page, and continue the login flow yourself.
-- If that first CAPTCHA solve attempt fails and the page is still blocked, call `human_approval_gate request --challenge-type captcha ... --screenshot <current-browser-shot>`.
-- If login is waiting for a password, first check the workspace `.env` for the relevant secret (for Google login, check `GOOGLE_PASSWORD` first). Only if the needed password is still missing should you call `human_approval_gate request --challenge-type password ... --screenshot <current-browser-shot>`.
+- If that first CAPTCHA solve attempt fails and the page is still blocked, use the MCP tool `dowhiz_human_approval_gate_request_and_wait` with `challenge_type="captcha"` and the current browser screenshot path(s).
+- If login is waiting for a password, first check the workspace `.env` for the relevant secret (for Google login, check `GOOGLE_PASSWORD` first). Only if the needed password is still missing should you use `dowhiz_human_approval_gate_request_and_wait` with `challenge_type="password"` and the current browser screenshot path(s).
 - Only use `human_approval_gate` for steps that genuinely require human access outside the browser session, such as SMS codes, email codes sent to someone else, approval taps on another device, or information only the human can retrieve.
-- If multiple verification methods are available on the same challenge page, prefer SMS verification first by default. If SMS is unavailable or fails, fall back to another method and keep using `human_approval_gate` for human input.
-- Before calling `human_approval_gate` for 2FA, first use the website itself to initiate the challenge: click the button that sends the code / starts the approval / selects the method, and wait until the page is explicitly waiting for the human response.
-- For `--challenge-type two_factor`, do not send the email unless you can truthfully identify the current page state as either `waiting_for_code_input` or `waiting_for_device_approval`.
-- For `--challenge-type two_factor`, always describe the exact method in use: SMS, email, authenticator app, or device tap / number match, plus the masked destination if visible.
+- If multiple verification methods are available on the same challenge page, prefer SMS verification first by default. If SMS is unavailable or fails, fall back to another method and keep using `dowhiz_human_approval_gate_request_and_wait` for human input.
+- Before calling `dowhiz_human_approval_gate_request_and_wait` for 2FA, first use the website itself to initiate the challenge: click the button that sends the code / starts the approval / selects the method, and wait until the page is explicitly waiting for the human response.
+- For `challenge_type="two_factor"`, do not send the email unless you can truthfully identify the current page state as either `waiting_for_code_input` or `waiting_for_device_approval`.
+- For `challenge_type="two_factor"`, always describe the exact method in use: SMS, email, authenticator app, or device tap / number match, plus the masked destination if visible.
 - If login identifier (email/username) is missing for owner/admin account login, try known admin identifiers first (`dowhiz@deep-tutor.com` on staging, `oliver@dowhiz.com` on production) before requesting help through `human_approval_gate`.
 - For owner/admin account login, do NOT trigger `human_approval_gate` only to ask for account email/username when a known identifier is already available.
 - If the requested login still cannot proceed because required credential/challenge input is missing after trying known safe identifiers, request it through `human_approval_gate` instead of guessing.
-- Use the `human_approval_gate` CLI and pause all unrelated work while waiting for result.
-- If `human_approval_gate` is not found on PATH, retry using `/app/bin/human_approval_gate` or `python3 .agents/skills/human-approval-gate/scripts/human_approval_gate.py`.
-- Every `human_approval_gate` request must attach the current browser screenshot with `--screenshot ...` and must describe the current state honestly. Never claim a code was sent unless the page actually shows that it was sent and is waiting.
-- `human_approval_gate` now writes a structured send record to `.human_approval_gate/events.jsonl` and emits a `HAG_EVENT ...` stderr line that includes challenge type plus attachment filenames and sizes. Use those records for debugging instead of guessing.
+- Inside run_task/Codex environments, do NOT use the shell CLI `human_approval_gate` or split request/wait steps yourself. Use only the MCP tool `dowhiz_human_approval_gate_request_and_wait`, which blocks this Codex turn until reply or timeout.
+- Every `dowhiz_human_approval_gate_request_and_wait` call must attach the current browser screenshot path(s) and must describe the current state honestly. Never claim a code was sent unless the page actually shows that it was sent and is waiting.
+- HAG sends still write `.human_approval_gate/events.jsonl` and emit a `HAG_EVENT ...` stderr line that includes challenge type plus attachment filenames and sizes. Use those records for debugging instead of guessing.
 - Primary flow:
-  1) Run `human_approval_gate request ... --wait --timeout-minutes 30`
-  2) Continue only if status is `replied`
-  3) Inspect the returned `reply` payload yourself and decide what to type/click next
-  4) If status is `timeout`, stop login attempts and report clearly
+  1) Take the current browser screenshot(s)
+  2) Call `dowhiz_human_approval_gate_request_and_wait`
+  3) Continue only if the returned status is `replied`
+  4) Inspect the returned `reply` payload yourself and decide what to type/click next
+  5) If status is `timeout`, stop login attempts and report clearly
 - Scope and recipient rules:
-  - Agent logging into owner/admin account (for example Oliver's own Google/Notion/X, `dowhiz@deep-tutor.com`, `oliver@dowhiz.com`): always use `--scope admin` (sends to `admin@dowhiz.com`)
-  - Agent logging into user's account: `--scope user --recipient <that user email>`
+  - Agent logging into owner/admin account (for example Oliver's own Google/Notion/X, `dowhiz@deep-tutor.com`, `oliver@dowhiz.com`): use `scope="admin"` (sends to `admin@dowhiz.com`)
+  - Agent logging into user's account: use `scope="user"` plus that user's recipient email
 - Never keep retrying password/sign-in while waiting for verification.
 
 "#
@@ -970,13 +970,13 @@ mod tests {
         );
 
         assert!(prompt.contains("Human Approval Gate"));
-        assert!(prompt.contains("human_approval_gate request"));
-        assert!(prompt.contains("--scope admin"));
-        assert!(prompt.contains("--scope user --recipient"));
-        assert!(prompt.contains("--challenge-type captcha"));
-        assert!(prompt.contains("--challenge-type password"));
-        assert!(prompt.contains("--challenge-type two_factor"));
-        assert!(prompt.contains("--screenshot"));
+        assert!(prompt.contains("dowhiz_human_approval_gate_request_and_wait"));
+        assert!(prompt.contains("scope=\"admin\""));
+        assert!(prompt.contains("scope=\"user\""));
+        assert!(prompt.contains("challenge_type=\"captcha\""));
+        assert!(prompt.contains("challenge_type=\"password\""));
+        assert!(prompt.contains("challenge_type=\"two_factor\""));
+        assert!(prompt.contains("screenshot path(s)"));
         assert!(prompt.contains("GOOGLE_PASSWORD"));
         assert!(prompt.contains("timeout"));
         assert!(prompt.contains("built-in multimodal/vision abilities"));
@@ -994,7 +994,7 @@ mod tests {
         assert!(prompt.contains("returned `reply` payload"));
         assert!(prompt.contains("dowhiz@deep-tutor.com"));
         assert!(prompt.contains("oliver@dowhiz.com"));
-        assert!(prompt.contains("/app/bin/human_approval_gate"));
+        assert!(prompt.contains("do NOT use the shell CLI `human_approval_gate`"));
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/tests/run_task_basic.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_basic.rs
@@ -28,6 +28,14 @@ wire_api = "responses""#
     )
 }
 
+fn expected_hag_mcp_block() -> &'static str {
+    r#"# BEGIN DOWHIZ HUMAN APPROVAL GATE MCP
+[mcp_servers.human-approval-gate]
+command = "human_approval_gate_mcp"
+
+# END DOWHIZ HUMAN APPROVAL GATE MCP"#
+}
+
 #[test]
 #[cfg(unix)]
 fn run_task_updates_existing_config_block() {
@@ -87,6 +95,7 @@ value = "still"
     assert!(!updated.contains("model = \"override-model\""));
     assert!(updated.contains("https://example.azure.com/openai/v1"));
     assert!(!updated.contains("https://old.azure.com/openai/v1"));
+    assert!(updated.contains(expected_hag_mcp_block()));
 }
 
 #[test]
@@ -122,4 +131,5 @@ fn run_task_writes_expected_codex_block() {
         config.contains(&expected),
         "codex config block should match the expected canonical content"
     );
+    assert!(config.contains(expected_hag_mcp_block()));
 }

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -149,6 +149,35 @@ fn run_task_uses_danger_sandbox_with_bypass() {
 
 #[test]
 #[cfg(unix)]
+fn run_task_sets_human_approval_gate_mcp_env() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_hag_mcp_env").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_codex(&bin_dir, FakeCodexMode::EnsureHumanApprovalGateMcpEnv).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let params = build_params(&workspace);
+    let result = run_task(&params).unwrap();
+    assert!(result.reply_html_path.exists());
+    assert!(result.reply_attachments_dir.is_dir());
+}
+
+#[test]
+#[cfg(unix)]
 fn run_task_passes_add_dir_for_gh_config() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_add_dir").unwrap();

--- a/DoWhiz_service/run_task_module/tests/support/mod.rs
+++ b/DoWhiz_service/run_task_module/tests/support/mod.rs
@@ -130,6 +130,7 @@ pub enum FakeCodexMode {
     EnsureYolo,
     EnsureDangerSandbox,
     EnsureAddDir,
+    EnsureHumanApprovalGateMcpEnv,
     Sleep,
 }
 
@@ -296,6 +297,18 @@ for arg in "$@"; do
 done
 if [ "$found" != "1" ]; then
   echo "missing --add-dir ${expected}" >&2
+  exit 3
+fi
+echo "<html><body>Test reply</body></html>" > reply_email_draft.html
+mkdir -p reply_email_attachments
+echo "attachment" > reply_email_attachments/attachment.txt
+"#
+        }
+        FakeCodexMode::EnsureHumanApprovalGateMcpEnv => {
+            r#"#!/bin/sh
+set -e
+if [ "${HUMAN_APPROVAL_GATE_REQUIRE_MCP:-}" != "1" ]; then
+  echo "missing HUMAN_APPROVAL_GATE_REQUIRE_MCP=1" >&2
   exit 3
 fi
 echo "<html><body>Test reply</body></html>" > reply_email_draft.html

--- a/DoWhiz_service/skills/human-approval-gate/SKILL.md
+++ b/DoWhiz_service/skills/human-approval-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: human-approval-gate
-description: Use when browser/login flow is blocked by CAPTCHA, missing password, OTP, passcode, approval tap, or another user/admin verification step. Sends a request email with browser screenshots and blocks until the first reply or timeout using the human_approval_gate CLI.
+description: Use when browser/login flow is blocked by CAPTCHA, missing password, OTP, passcode, approval tap, or another user/admin verification step. In run_task/Codex environments, use the blocking MCP tool so the current browser session stays paused on the same page until the human replies.
 allowed-tools: Bash(human_approval_gate:*), Bash(python3:*), Bash(cat:*), Bash(test:*), Bash(date:*)
 ---
 
@@ -18,7 +18,7 @@ Use this skill when any authentication flow is blocked by something the agent ge
 
 For CAPTCHA/image puzzle/text-recognition steps:
 - first use your own multimodal/vision abilities plus browser tooling to inspect the challenge and attempt one direct solve in the page
-- if that first attempt fails and you are still blocked on CAPTCHA, open the gate with `--challenge-type captcha`
+- if that first attempt fails and you are still blocked on CAPTCHA, open the gate with challenge type `captcha`
 - always attach the current browser screenshot so the human can see exactly what blocked you
 
 Only use this skill when the blocker genuinely requires a human outside the current browser session, for example:
@@ -48,11 +48,12 @@ Do not keep retrying login while blocked.
 1. If the blocker is CAPTCHA/image/text recognition, attempt one built-in solve first. If still blocked, use `--challenge-type captcha`.
 2. If the blocker is a missing password, check the workspace `.env` first. If still missing, use `--challenge-type password`.
 3. If the blocker is 2FA, trigger the website challenge first and only then use `--challenge-type two_factor`.
-4. Always attach the current browser screenshot(s) with `--screenshot ...`.
-5. Wait on gate result.
-6. Continue only after the first reply is received and inspect that reply yourself.
-7. If timeout, stop login attempts and report clearly.
-8. If SMS verification is unavailable or fails, switch to another available method and keep the same gate-based wait behavior.
+4. In run_task/Codex environments, call the MCP tool `dowhiz_human_approval_gate_request_and_wait`. Do not use the shell CLI there.
+5. Always attach the current browser screenshot(s).
+6. Wait on gate result.
+7. Continue only after the first reply is received and inspect that reply yourself.
+8. If timeout, stop login attempts and report clearly.
+9. If SMS verification is unavailable or fails, switch to another available method and keep the same gate-based wait behavior.
 
 ## Scope Rules
 
@@ -60,7 +61,34 @@ Do not keep retrying login while blocked.
 - `scope=user`: when agent logs in an end user's account. Send to that specific user email.
 - For `scope=admin`, do not pass a user recipient address.
 
+## Blocking MCP Tool
+
+Preferred in run_task/Codex environments:
+
+- Take the current browser screenshot(s) first.
+- Call `dowhiz_human_approval_gate_request_and_wait`.
+- That single tool call sends the email, waits for the first same-thread reply or timeout, and returns the full challenge state.
+- While that tool call is pending, do not do any other browser or shell actions.
+
+Example parameter shape:
+
+```json
+{
+  "scope": "admin",
+  "challenge_type": "two_factor",
+  "page_state": "waiting_for_code_input",
+  "two_factor_method": "sms",
+  "verification_destination": "phone ending in 9315",
+  "account_label": "Oliver Google account",
+  "context": "Google has already sent the code and the page is waiting for it.",
+  "screenshot": ["work/google-verify.png"],
+  "timeout_minutes": 30
+}
+```
+
 ## CLI Quick Start
+
+Manual fallback only. Do not use this shell CLI inside run_task/Codex environments because it bypasses the enforced blocking MCP path.
 
 CLI fallback (if command not found on PATH):
 
@@ -161,6 +189,7 @@ No rigid reply format is required. Ask the recipient to reply in the same thread
 
 ## Important Notes
 
+- In run_task/Codex environments, the shell CLI is intentionally disabled and the MCP tool is the only supported path.
 - Keep waiting in this command; do not run unrelated steps while waiting.
 - Reuse the same challenge thread; do not spam multiple requests unless previous one timed out.
 - Never include raw credentials in outbound messages.

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -41,6 +41,8 @@ SUBJECT_TOKEN_PREFIX = "HAG"
 POSTMARK_METADATA_CHALLENGE_ID_KEY = "hag_challenge_id"
 POSTMARK_METADATA_SCOPE_KEY = "hag_scope"
 POSTMARK_METADATA_TYPE_KEY = "hag_type"
+HAG_REQUIRE_MCP_ENV_KEY = "HUMAN_APPROVAL_GATE_REQUIRE_MCP"
+HAG_BLOCKING_MCP_TOOL_NAME = "dowhiz_human_approval_gate_request_and_wait"
 MAX_TOTAL_ATTACHMENT_BYTES = 10 * 1024 * 1024
 DEFAULT_PASSWORD_ENV_KEY = "GOOGLE_PASSWORD"
 CHALLENGE_TYPES = ("captcha", "password", "two_factor")
@@ -951,7 +953,7 @@ def build_request_state(args: argparse.Namespace) -> Dict[str, Any]:
     return state
 
 
-def cmd_request(args: argparse.Namespace) -> int:
+def submit_request(args: argparse.Namespace) -> Tuple[Path, str, str, Dict[str, Any]]:
     state_dir = Path(args.state_dir)
     api_base = args.api_base
     token = ensure_token(args.token, args.dry_run)
@@ -983,6 +985,14 @@ def cmd_request(args: argparse.Namespace) -> int:
 
     save_state(state_dir, state)
     record_send_event(state_dir, state)
+    return state_dir, api_base, token, state
+
+
+def execute_request(args: argparse.Namespace) -> Tuple[Dict[str, Any], int]:
+    state_dir, api_base, token, state = submit_request(args)
+
+    if args.wait and args.dry_run:
+        return state, 0
 
     if args.wait:
         result = wait_for_resolution(
@@ -993,11 +1003,27 @@ def cmd_request(args: argparse.Namespace) -> int:
             timeout_minutes=args.wait_timeout_minutes,
             poll_interval_seconds=args.poll_interval_seconds,
         )
-        emit_json(result.state)
-        return 0 if result.replied else 4
+        return result.state, 0 if result.replied else 4
 
+    return state, 0
+
+
+def cmd_request(args: argparse.Namespace) -> int:
+    state, exit_code = execute_request(args)
     emit_json(state)
-    return 0
+    return exit_code
+
+
+def shell_cli_requires_mcp_tool() -> bool:
+    return get_env_first(HAG_REQUIRE_MCP_ENV_KEY, "RUN_TASK_HUMAN_APPROVAL_GATE_REQUIRE_MCP") in {
+        "1",
+        "true",
+        "TRUE",
+        "yes",
+        "YES",
+        "on",
+        "ON",
+    }
 
 
 def cmd_status(args: argparse.Namespace) -> int:
@@ -1155,6 +1181,18 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: List[str]) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if shell_cli_requires_mcp_tool():
+        emit_json(
+            {
+                "status": "error",
+                "error": (
+                    "human_approval_gate shell CLI is disabled in Codex runtime; "
+                    f"use the MCP tool {HAG_BLOCKING_MCP_TOOL_NAME} instead"
+                ),
+            }
+        )
+        return 2
 
     try:
         result = args.func(args)

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate_mcp.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate_mcp.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Blocking MCP wrapper for the human approval gate."""
+
+import argparse
+from typing import Any, Dict, List, Literal, Optional
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, ConfigDict, Field
+
+import human_approval_gate as hag
+
+
+mcp = FastMCP("human_approval_gate_mcp")
+
+
+class BlockingHumanApprovalGateInput(BaseModel):
+    """Input payload for the blocking human approval gate tool."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    scope: Literal["admin", "user"] = Field(
+        default="user",
+        description="Who should receive the HAG email.",
+    )
+    challenge_type: Literal["captcha", "password", "two_factor"] = Field(
+        default="two_factor",
+        description="Type of blocker currently shown in the browser.",
+    )
+    screenshot: List[str] = Field(
+        ...,
+        min_length=1,
+        description="Absolute or workspace-relative browser screenshot paths to attach.",
+    )
+    page_state: str = Field(
+        default="",
+        description="Explicit page state. Required for two_factor challenges.",
+    )
+    account_label: str = Field(
+        default="",
+        description="Human-readable account context, for example 'Oliver Google account'.",
+    )
+    context: str = Field(
+        default="",
+        description="Additional honest context about the current blocker.",
+    )
+    action_text: str = Field(
+        default="",
+        description="Optional custom ask shown in the HAG email.",
+    )
+    challenge_id: str = Field(
+        default="",
+        description="Optional existing challenge id. Leave blank to generate one.",
+    )
+    recipient: str = Field(
+        default="",
+        description="Explicit recipient for user scope. Leave blank for admin scope.",
+    )
+    user_email: str = Field(
+        default="",
+        description="Fallback user email for user scope when recipient is omitted.",
+    )
+    from_address: str = Field(
+        default="",
+        description="Optional sender override.",
+    )
+    reply_to: str = Field(
+        default="",
+        description="Optional reply-to override.",
+    )
+    expected_reply_from: str = Field(
+        default="",
+        description="Optional email address expected to reply in-thread.",
+    )
+    two_factor_method: str = Field(
+        default="",
+        description="For two_factor only: sms, email, auth_app, device_tap, or other.",
+    )
+    verification_destination: str = Field(
+        default="",
+        description="Masked phone/email/device label shown by the site.",
+    )
+    password_env_key: str = Field(
+        default=hag.DEFAULT_PASSWORD_ENV_KEY,
+        description="Env key that was checked before asking a human for password help.",
+    )
+    password_lookup_status: str = Field(
+        default="",
+        description="Honest description of what password lookup was already attempted.",
+    )
+    timeout_minutes: int = Field(
+        default=hag.DEFAULT_TIMEOUT_MINUTES,
+        ge=1,
+        description="Max wait window communicated to the human recipient.",
+    )
+    wait_timeout_minutes: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Optional shorter local timeout for this tool call.",
+    )
+    poll_interval_seconds: int = Field(
+        default=hag.DEFAULT_POLL_SECONDS,
+        ge=1,
+        description="Polling interval while waiting for the reply.",
+    )
+    state_dir: str = Field(
+        default=hag.STATE_DIR_DEFAULT,
+        description="Challenge state directory inside the current workspace.",
+    )
+    api_base: str = Field(
+        default_factory=lambda: hag.get_env_first("POSTMARK_API_BASE_URL") or hag.API_BASE_DEFAULT,
+        description="Postmark API base URL override.",
+    )
+    dry_run: bool = Field(
+        default=False,
+        description="If true, writes challenge state without sending email or waiting.",
+    )
+
+
+def build_request_namespace(params: BlockingHumanApprovalGateInput) -> argparse.Namespace:
+    return argparse.Namespace(
+        api_base=params.api_base,
+        state_dir=params.state_dir,
+        token="",
+        scope=params.scope,
+        challenge_type=params.challenge_type,
+        challenge_id=params.challenge_id,
+        recipient=params.recipient,
+        user_email=params.user_email,
+        from_address=params.from_address,
+        reply_to=params.reply_to,
+        expected_reply_from=params.expected_reply_from,
+        account_label=params.account_label,
+        action_text=params.action_text,
+        context=params.context,
+        page_state=params.page_state,
+        two_factor_method=params.two_factor_method,
+        verification_destination=params.verification_destination,
+        password_env_key=params.password_env_key,
+        password_lookup_status=params.password_lookup_status,
+        screenshot=list(params.screenshot),
+        timeout_minutes=params.timeout_minutes,
+        wait=not params.dry_run,
+        wait_timeout_minutes=params.wait_timeout_minutes,
+        poll_interval_seconds=params.poll_interval_seconds,
+        dry_run=params.dry_run,
+    )
+
+
+def execute_blocking_hag_request(params: BlockingHumanApprovalGateInput) -> Dict[str, Any]:
+    state, _exit_code = hag.execute_request(build_request_namespace(params))
+    return state
+
+
+@mcp.tool(
+    name=hag.HAG_BLOCKING_MCP_TOOL_NAME,
+    annotations={
+        "title": "DoWhiz Human Approval Gate",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+def dowhiz_human_approval_gate_request_and_wait(
+    params: BlockingHumanApprovalGateInput,
+) -> Dict[str, Any]:
+    """Send a HAG email with screenshots and block until reply or timeout.
+
+    Use this only after the website has already reached the exact blocker screen.
+    The call is synchronous: while it is waiting, Codex should not continue with
+    other browser or shell actions.
+    """
+
+    return execute_blocking_hag_request(params)
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
@@ -1,5 +1,8 @@
+import contextlib
 import importlib.util
+import io
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -12,6 +15,13 @@ MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
+
+MCP_SCRIPT_PATH = Path(__file__).with_name("human_approval_gate_mcp.py")
+MCP_SPEC = importlib.util.spec_from_file_location("human_approval_gate_mcp", MCP_SCRIPT_PATH)
+MCP_MODULE = importlib.util.module_from_spec(MCP_SPEC)
+assert MCP_SPEC.loader is not None
+sys.modules[MCP_SPEC.name] = MCP_MODULE
+MCP_SPEC.loader.exec_module(MCP_MODULE)
 
 
 class HumanApprovalGateTests(unittest.TestCase):
@@ -136,6 +146,43 @@ class HumanApprovalGateTests(unittest.TestCase):
             self.assertEqual(payload["attachment_count"], 1)
             self.assertEqual(payload["attachments"][0]["name"], "screen.png")
             self.assertGreater(payload["attachments"][0]["size_bytes"], 0)
+
+    def test_cli_rejects_shell_usage_when_mcp_required(self):
+        previous = os.environ.get(MODULE.HAG_REQUIRE_MCP_ENV_KEY)
+        os.environ[MODULE.HAG_REQUIRE_MCP_ENV_KEY] = "1"
+        stdout = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout):
+                exit_code = MODULE.main(["status", "--challenge-id", "missing"])
+        finally:
+            if previous is None:
+                os.environ.pop(MODULE.HAG_REQUIRE_MCP_ENV_KEY, None)
+            else:
+                os.environ[MODULE.HAG_REQUIRE_MCP_ENV_KEY] = previous
+
+        self.assertEqual(exit_code, 2)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["status"], "error")
+        self.assertIn(MODULE.HAG_BLOCKING_MCP_TOOL_NAME, payload["error"])
+
+    def test_mcp_wrapper_reuses_blocking_request_flow(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            params = MCP_MODULE.BlockingHumanApprovalGateInput(
+                scope="admin",
+                challenge_type="captcha",
+                screenshot=[screenshot],
+                account_label="Oliver Google account",
+                state_dir=str(Path(temp_dir) / ".human_approval_gate" / "challenges"),
+                dry_run=True,
+            )
+
+            state = MCP_MODULE.execute_blocking_hag_request(params)
+
+            self.assertEqual(state["status"], "pending")
+            self.assertEqual(state["challenge_type"], "captcha")
+            self.assertEqual(state["outbound_message_id"], "DRY_RUN")
+            self.assertEqual(state["request_attachments"][0]["name"], "screen.png")
 
 
 if __name__ == "__main__":

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,8 +126,9 @@ COPY DoWhiz_service/employees/ /app/DoWhiz_service/employees/
 # Copy skills directory for Codex
 COPY DoWhiz_service/skills/ /app/DoWhiz_service/skills/
 
-RUN chmod +x /app/bin/human_approval_gate || true
+RUN chmod +x /app/bin/human_approval_gate /app/bin/human_approval_gate_mcp || true
 RUN ln -sf /app/bin/human_approval_gate /usr/local/bin/human_approval_gate
+RUN ln -sf /app/bin/human_approval_gate_mcp /usr/local/bin/human_approval_gate_mcp
 RUN chown -R app:nogroup /app/DoWhiz_service /app/bin
 
 USER app


### PR DESCRIPTION
## Summary
- inject a blocking `human_approval_gate_mcp` server into Codex config so HAG runs as a synchronous MCP tool inside the same Codex/ACI/browser session
- enforce `HUMAN_APPROVAL_GATE_REQUIRE_MCP=1` in run_task runtimes so shell CLI HAG calls are rejected and the model cannot split request/wait or continue unrelated work
- add MCP wrapper/tests/docs for the new blocking path while keeping the manual CLI available outside Codex runtime

## Testing
- `python3 -m unittest DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py`
- `cargo test -p run_task_module run_task_ -- --nocapture`
- `cargo test -p run_task_module build_prompt_includes_human_approval_gate_instructions -- --nocapture`
- `python3 -m py_compile DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate_mcp.py`
