### PR TITLE
Avoid mutating VM target before ACR build

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -284,24 +284,22 @@ jobs:
             exit 1
           }
 
-          # Prior VM builds can leave a very large Rust target directory that bloats Docker context.
-          # Keep release binaries required by PM2 restarts, trim everything else.
-          if [[ -d "$APP_DIR/target" ]]; then
-            echo "Trimming $APP_DIR/target before az acr build to keep context small"
-            if [[ -d "$APP_DIR/target/release" ]]; then
-              find "$APP_DIR/target/release" -mindepth 1 -maxdepth 1 \
-                ! -name rust_service \
-                ! -name inbound_gateway \
-                ! -name set_postmark_inbound_hook \
-                ! -name inbound_fanout \
-                ! -name google-docs \
-                -exec rm -rf {} +
-            fi
-            find "$APP_DIR/target" -mindepth 1 -maxdepth 1 ! -name release -exec rm -rf {} +
-          fi
+          build_context_root="$(mktemp -d)"
+          cleanup_build_context() {
+            rm -rf "$build_context_root"
+          }
+          trap cleanup_build_context EXIT
+
+          echo "Preparing clean ACR build context at $build_context_root"
+          tar -C "$APP_ROOT" \
+            --exclude='DoWhiz_service/target' \
+            --exclude='DoWhiz_service/.workspace' \
+            --exclude='DoWhiz_service/.env' \
+            --exclude='DoWhiz_service/.env.*' \
+            -cf - Dockerfile .dockerignore DoWhiz_service | tar -C "$build_context_root" -xf -
 
           echo "Building ACI image via az acr build: $run_task_image"
-          cd "$APP_ROOT"
+          cd "$build_context_root"
           az acr build \
             --registry "$registry_name" \
             --image "$image_name" \

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -284,24 +284,22 @@ jobs:
             exit 1
           }
 
-          # Prior VM builds can leave a very large Rust target directory that bloats Docker context.
-          # Keep release binaries required by PM2 restarts, trim everything else.
-          if [[ -d "$APP_DIR/target" ]]; then
-            echo "Trimming $APP_DIR/target before az acr build to keep context small"
-            if [[ -d "$APP_DIR/target/release" ]]; then
-              find "$APP_DIR/target/release" -mindepth 1 -maxdepth 1 \
-                ! -name rust_service \
-                ! -name inbound_gateway \
-                ! -name set_postmark_inbound_hook \
-                ! -name inbound_fanout \
-                ! -name google-docs \
-                -exec rm -rf {} +
-            fi
-            find "$APP_DIR/target" -mindepth 1 -maxdepth 1 ! -name release -exec rm -rf {} +
-          fi
+          build_context_root="$(mktemp -d)"
+          cleanup_build_context() {
+            rm -rf "$build_context_root"
+          }
+          trap cleanup_build_context EXIT
+
+          echo "Preparing clean ACR build context at $build_context_root"
+          tar -C "$APP_ROOT" \
+            --exclude='DoWhiz_service/target' \
+            --exclude='DoWhiz_service/.workspace' \
+            --exclude='DoWhiz_service/.env' \
+            --exclude='DoWhiz_service/.env.*' \
+            -cf - Dockerfile .dockerignore DoWhiz_service | tar -C "$build_context_root" -xf -
 
           echo "Building ACI image via az acr build: $run_task_image"
-          cd "$APP_ROOT"
+          cd "$build_context_root"
           az acr build \
             --registry "$registry_name" \
             --image "$image_name" \

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -97,7 +97,7 @@ Deployment workflows should:
 3. Validate `GATEWAY_CONFIG_PATH` and `EMPLOYEE_CONFIG_PATH` exist and match expected target files.
 4. After release binaries and `.env` are installed, source `.env` and restart PM2-managed services immediately so live traffic moves onto the new worker/gateway before any long-running follow-up work.
 5. Disable any legacy `systemd` worker unit (for example `dowhiz-oliver.service`) so PM2 remains the only supervisor.
-6. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), trim `DoWhiz_service/target` on the VM before `az acr build` (drop debug/intermediate artifacts, keep required release binaries), then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE`.
+6. If Azure ACI backend is enabled (`RUN_TASK_EXECUTION_BACKEND=azure_aci` or `auto` with `DEPLOY_TARGET in {staging,production}`), stage a temporary VM build context that contains only `Dockerfile`, `.dockerignore`, and `DoWhiz_service/` without runtime `.env`, `.workspace`, or `target`, then rebuild and push `RUN_TASK_AZURE_ACI_IMAGE`. This keeps the upload small without mutating the live PM2 binaries.
 7. Use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes, and finish with local health checks that allow a short retry window while worker/gateway bind their ports.
 
 ## 5) Health Checks


### PR DESCRIPTION
## Summary
- stop deleting the live VM `DoWhiz_service/target` tree before `az acr build`
- build ACR images from a temporary clean context that excludes `target`, `.workspace`, and runtime env files
- update staging/production deploy docs to match the new flow

## Testing
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/CICD-production.yml"); YAML.load_file(".github/workflows/CICD-staging.yml"); puts "workflow yaml ok"'