### PR TITLE
Forward HAG env vars to MCP server

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -2020,10 +2020,16 @@ fn build_codex_config_block(azure_endpoint: &str) -> String {
 }
 
 fn build_human_approval_gate_mcp_block() -> String {
+    let env_vars = HUMAN_APPROVAL_GATE_ENV_KEYS
+        .iter()
+        .map(|key| format!(r#""{key}""#))
+        .collect::<Vec<_>>()
+        .join(", ");
     format!(
         r#"{HAG_MCP_CONFIG_START_MARKER}
 [mcp_servers.{HUMAN_APPROVAL_GATE_MCP_SERVER_NAME}]
 command = "human_approval_gate_mcp"
+env_vars = [{env_vars}]
 
 {HAG_MCP_CONFIG_END_MARKER}"#
     )

--- a/DoWhiz_service/run_task_module/tests/run_task_basic.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_basic.rs
@@ -32,6 +32,7 @@ fn expected_hag_mcp_block() -> &'static str {
     r#"# BEGIN DOWHIZ HUMAN APPROVAL GATE MCP
 [mcp_servers.human-approval-gate]
 command = "human_approval_gate_mcp"
+env_vars = ["POSTMARK_SERVER_TOKEN", "HUMAN_APPROVAL_FROM", "HUMAN_APPROVAL_REPLY_TO", "POSTMARK_API_BASE_URL"]
 
 # END DOWHIZ HUMAN APPROVAL GATE MCP"#
 }


### PR DESCRIPTION
## Summary
- forward the HAG Postmark and reply-address env vars into the  subprocess config
- keep the generated Codex config test fixture aligned with the new  line

## Testing
- cargo test -p run_task_module run_task_updates_existing_config_block -- --nocapture
- cargo test -p run_task_module run_task_writes_expected_codex_block -- --nocapture