### PR TITLE
Extend HAG MCP tool timeout

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -210,7 +210,9 @@ Azure ACI execution path (required vars):
   `dowhiz_human_approval_gate_request_and_wait`, which sends the email with the
   current browser screenshot(s) and blocks the same Codex turn until the first
   same-thread reply or timeout, preserving the current browser session while it
-  waits. The blocker must be modeled as `captcha`, `password`, or
+  waits. run_task injects `tool_timeout_sec = 1860` for that MCP server so the
+  Codex-side tool call can remain blocked for the default 30-minute HAG wait
+  window plus a small buffer. The blocker must be modeled as `captcha`, `password`, or
   `two_factor`. For `two_factor`, callers should only invoke it after the site
   is explicitly waiting for a code or device approval, and they should include
   the concrete method details (SMS/email/auth app/device tap). The manual CLI

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -57,6 +57,7 @@ const HUMAN_APPROVAL_GATE_ENV_KEYS: &[&str] = &[
 ];
 const HUMAN_APPROVAL_GATE_REQUIRE_MCP_ENV_KEY: &str = "HUMAN_APPROVAL_GATE_REQUIRE_MCP";
 const HUMAN_APPROVAL_GATE_MCP_SERVER_NAME: &str = "human-approval-gate";
+const HUMAN_APPROVAL_GATE_MCP_TOOL_TIMEOUT_SECONDS: u32 = 31 * 60;
 const HUMAN_APPROVAL_FROM_ENV_KEY: &str = "HUMAN_APPROVAL_FROM";
 const HUMAN_APPROVAL_REPLY_TO_ENV_KEY: &str = "HUMAN_APPROVAL_REPLY_TO";
 const EMPLOYEE_CONFIG_PATH_ENV_KEY: &str = "EMPLOYEE_CONFIG_PATH";
@@ -2030,6 +2031,7 @@ fn build_human_approval_gate_mcp_block() -> String {
 [mcp_servers.{HUMAN_APPROVAL_GATE_MCP_SERVER_NAME}]
 command = "human_approval_gate_mcp"
 env_vars = [{env_vars}]
+tool_timeout_sec = {HUMAN_APPROVAL_GATE_MCP_TOOL_TIMEOUT_SECONDS}
 
 {HAG_MCP_CONFIG_END_MARKER}"#
     )

--- a/DoWhiz_service/run_task_module/tests/run_task_basic.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_basic.rs
@@ -33,6 +33,7 @@ fn expected_hag_mcp_block() -> &'static str {
 [mcp_servers.human-approval-gate]
 command = "human_approval_gate_mcp"
 env_vars = ["POSTMARK_SERVER_TOKEN", "HUMAN_APPROVAL_FROM", "HUMAN_APPROVAL_REPLY_TO", "POSTMARK_API_BASE_URL"]
+tool_timeout_sec = 1860
 
 # END DOWHIZ HUMAN APPROVAL GATE MCP"#
 }

--- a/DoWhiz_service/skills/human-approval-gate/SKILL.md
+++ b/DoWhiz_service/skills/human-approval-gate/SKILL.md
@@ -68,6 +68,7 @@ Preferred in run_task/Codex environments:
 - Take the current browser screenshot(s) first.
 - Call `dowhiz_human_approval_gate_request_and_wait`.
 - That single tool call sends the email, waits for the first same-thread reply or timeout, and returns the full challenge state.
+- In run_task/Codex environments, the injected MCP server config sets `tool_timeout_sec = 1860`, so the tool can stay blocked for the default 30-minute wait window plus a small buffer.
 - While that tool call is pending, do not do any other browser or shell actions.
 
 Example parameter shape:


### PR DESCRIPTION
## Summary
- set the injected human approval gate MCP server tool timeout to 1860 seconds so blocking waits can span the default 30-minute approval window
- keep the generated Codex config test fixture aligned with the timeout line
- document the longer blocking timeout in the HAG docs

## Testing
- cargo test -p run_task_module run_task_updates_existing_config_block -- --nocapture
- cargo test -p run_task_module run_task_writes_expected_codex_block -- --nocapture