### PR TITLE
Skip direct CAPTCHA solve before HAG

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -207,8 +207,7 @@ fn build_web_auth_capabilities_section() -> &'static str {
 fn build_human_approval_gate_section() -> &'static str {
     r#"Human Approval Gate (2FA / verification challenges):
 - If login/auth flow asks for OTP/passcode/device approval/number tap, or you are blocked on CAPTCHA/password after the required local checks below, use the `human-approval-gate` skill with an honest challenge type and browser screenshot.
-- If the page shows CAPTCHA/image puzzle/text recognition challenge, first use your own built-in multimodal/vision abilities and browser tools to inspect the challenge, attempt one direct solve in the page, and continue the login flow yourself.
-- If that first CAPTCHA solve attempt fails and the page is still blocked, use the MCP tool `dowhiz_human_approval_gate_request_and_wait` with `challenge_type="captcha"` and the current browser screenshot path(s).
+- If the page shows CAPTCHA/image puzzle/text recognition challenge, do NOT attempt to solve it yourself. Immediately take the current browser screenshot(s) and use the MCP tool `dowhiz_human_approval_gate_request_and_wait` with `challenge_type="captcha"`.
 - If login is waiting for a password, first check the workspace `.env` for the relevant secret (for Google login, check `GOOGLE_PASSWORD` first). Only if the needed password is still missing should you use `dowhiz_human_approval_gate_request_and_wait` with `challenge_type="password"` and the current browser screenshot path(s).
 - Only use `human_approval_gate` for steps that genuinely require human access outside the browser session, such as SMS codes, email codes sent to someone else, approval taps on another device, or information only the human can retrieve.
 - If multiple verification methods are available on the same challenge page, prefer SMS verification first by default. If SMS is unavailable or fails, fall back to another method and keep using `dowhiz_human_approval_gate_request_and_wait` for human input.
@@ -985,9 +984,7 @@ mod tests {
         assert!(prompt.contains("screenshot path(s)"));
         assert!(prompt.contains("GOOGLE_PASSWORD"));
         assert!(prompt.contains("timeout"));
-        assert!(prompt.contains("built-in multimodal/vision abilities"));
-        assert!(prompt.contains("attempt one direct solve"));
-        assert!(prompt.contains("multimodal/vision abilities"));
+        assert!(prompt.contains("do NOT attempt to solve it yourself"));
         assert!(prompt.contains("required credential"));
         assert!(prompt.contains("prefer SMS verification first by default"));
         assert!(prompt.contains("click the button that sends the code"));

--- a/DoWhiz_service/skills/human-approval-gate/SKILL.md
+++ b/DoWhiz_service/skills/human-approval-gate/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash(human_approval_gate:*), Bash(python3:*), Bash(cat:*), Bash(t
 ## When to Use
 
 Use this skill when any authentication flow is blocked by something the agent genuinely cannot finish alone, for example:
-- CAPTCHA after one failed built-in solve attempt
+- CAPTCHA shown in the browser
 - missing password after checking the workspace `.env`
 - OTP / verification code input
 - "Approve sign-in on your phone"
@@ -17,8 +17,8 @@ Use this skill when any authentication flow is blocked by something the agent ge
 - any out-of-band challenge that requires user/admin action from another device/account
 
 For CAPTCHA/image puzzle/text-recognition steps:
-- first use your own multimodal/vision abilities plus browser tooling to inspect the challenge and attempt one direct solve in the page
-- if that first attempt fails and you are still blocked on CAPTCHA, open the gate with challenge type `captcha`
+- do not attempt to solve the CAPTCHA yourself
+- immediately open the gate with challenge type `captcha`
 - always attach the current browser screenshot so the human can see exactly what blocked you
 
 Only use this skill when the blocker genuinely requires a human outside the current browser session, for example:
@@ -45,7 +45,7 @@ Do not keep retrying login while blocked.
 
 ## Required Behavior
 
-1. If the blocker is CAPTCHA/image/text recognition, attempt one built-in solve first. If still blocked, use `--challenge-type captcha`.
+1. If the blocker is CAPTCHA/image/text recognition, do not attempt to solve it yourself. Immediately use `--challenge-type captcha`.
 2. If the blocker is a missing password, check the workspace `.env` first. If still missing, use `--challenge-type password`.
 3. If the blocker is 2FA, trigger the website challenge first and only then use `--challenge-type two_factor`.
 4. In run_task/Codex environments, call the MCP tool `dowhiz_human_approval_gate_request_and_wait`. Do not use the shell CLI there.
@@ -119,14 +119,14 @@ $HAG_CMD request \
   --wait
 ```
 
-For CAPTCHA after one failed solve attempt:
+For CAPTCHA that is currently blocking the browser:
 
 ```bash
 $HAG_CMD request \
   --scope admin \
   --challenge-type captcha \
   --account-label "Oliver Google account" \
-  --context "I already tried one built-in CAPTCHA solve and the page still did not advance." \
+  --context "Google sign-in is blocked on a CAPTCHA and I need human help reading the current screenshot." \
   --screenshot work/google-captcha.png \
   --timeout-minutes 30 \
   --wait

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -469,7 +469,7 @@ def humanize_challenge_type(challenge_type: str) -> str:
 
 def humanize_page_state(page_state: str) -> str:
     return {
-        "captcha_blocked": "Still blocked on CAPTCHA after one built-in solve attempt",
+        "captcha_blocked": "Browser is currently blocked on a CAPTCHA challenge",
         "waiting_for_password": "Browser is waiting for the password field",
         "waiting_for_code_input": "Browser is waiting for a verification code to be typed",
         "waiting_for_device_approval": "Browser is waiting for an approval action on another device",
@@ -550,8 +550,6 @@ def build_text_body(state: Dict[str, Any]) -> str:
             lines.append(f"Password env key checked: {password_env_key}")
         if password_lookup_status:
             lines.append(f"Password lookup status: {password_lookup_status}")
-    if challenge_type == "captcha":
-        lines.append("Agent attempted one built-in visual solve before asking for help.")
     if screenshots:
         screenshot_names = ", ".join(
             str(item.get("name", "")).strip()

--- a/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
@@ -147,6 +147,25 @@ class HumanApprovalGateTests(unittest.TestCase):
             self.assertEqual(payload["attachments"][0]["name"], "screen.png")
             self.assertGreater(payload["attachments"][0]["size_bytes"], 0)
 
+    def test_captcha_body_reports_blocked_state_without_solve_attempt_claim(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            args = self.parse_request(
+                "--challenge-type",
+                "captcha",
+                "--scope",
+                "admin",
+                "--account-label",
+                "Oliver Google account",
+                "--screenshot",
+                screenshot,
+            )
+            state = MODULE.build_request_state(args)
+            rendered = state["_rendered_email"]
+
+            self.assertIn("Current browser state: Browser is currently blocked on a CAPTCHA challenge", rendered["text_body"])
+            self.assertNotIn("attempted one built-in visual solve", rendered["text_body"])
+
     def test_cli_rejects_shell_usage_when_mcp_required(self):
         previous = os.environ.get(MODULE.HAG_REQUIRE_MCP_ENV_KEY)
         os.environ[MODULE.HAG_REQUIRE_MCP_ENV_KEY] = "1"


### PR DESCRIPTION
## Summary
- stop asking the agent to attempt CAPTCHA solving before opening HAG
- update HAG wording to describe CAPTCHA as currently blocking the browser
- add regression coverage for the new CAPTCHA messaging

## Testing
- cd DoWhiz_service && cargo test -p run_task_module build_prompt_includes_human_approval_gate_instructions -- --nocapture
- cd DoWhiz_service && cargo test -p run_task_module run_task_updates_existing_config_block -- --nocapture
- cd DoWhiz_service && cargo test -p run_task_module run_task_writes_expected_codex_block -- --nocapture
- cd DoWhiz_service && cargo test -p run_task_module run_task_sets_human_approval_gate_mcp_env -- --nocapture
- cd DoWhiz_service && python3 -m unittest skills/human-approval-gate/scripts/test_human_approval_gate.py