### PR TITLE
Fix CICD deploy failure: scope BASE_IMAGE arg for Docker runtime FROM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.6
 
+ARG BASE_IMAGE
+
 FROM rust:1.93-bookworm AS builder
 WORKDIR /app
 
@@ -14,7 +16,6 @@ COPY DoWhiz_service/ DoWhiz_service/
 RUN cargo build --locked -p scheduler_module --bin rust_service --bin inbound_fanout --bin inbound_gateway --bin google-docs --release \
   --manifest-path DoWhiz_service/Cargo.toml
 
-ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS runtime
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
Fix CI/CD deploy workflow failure where Docker build errored with:
- `FROM ${BASE_IMAGE} AS runtime`
- `base name (${BASE_IMAGE}) should not be blank`

### Root cause
`BASE_IMAGE` was declared after the first stage in `Dockerfile`, so it was not correctly scoped for `FROM ${BASE_IMAGE}` resolution.

### Change
- Move `ARG BASE_IMAGE` to top-level before the first `FROM`.
- Keep `FROM ${BASE_IMAGE} AS runtime` unchanged.

## Files changed
- `Dockerfile`

## Validation
- Verified Dockerfile now declares `ARG BASE_IMAGE` at line 3 before any `FROM`.
- Patch is minimal and directly addresses the failing step in Actions run `23082580978`.
