### PR TITLE
Fix Vercel routing for /start and /workspace

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,22 @@
 {
   "rewrites": [
     {
+      "source": "/start",
+      "destination": "/"
+    },
+    {
+      "source": "/start/",
+      "destination": "/"
+    },
+    {
+      "source": "/workspace",
+      "destination": "/"
+    },
+    {
+      "source": "/workspace/",
+      "destination": "/"
+    },
+    {
       "source": "/dashboard",
       "destination": "/"
     },


### PR DESCRIPTION
## Summary
Fix production 404s when loading SPA routes directly:
- `/start`
- `/workspace`

## Root cause
`website/vercel.json` only rewrote `/dashboard` to `/`, so direct deep links to the new React routes were handled by Vercel as missing static paths.

## Change
Add rewrites (with trailing slash variants):
- `/start` -> `/`
- `/start/` -> `/`
- `/workspace` -> `/`
- `/workspace/` -> `/`

This keeps existing static/public pages intact while enabling direct route loads for SPA pages.

## Verification
- `jq` parse of `website/vercel.json` ✅
- `cd website && npm run build` ✅
