### PR TITLE
fix: Pass Service Account env vars to ACI containers

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -1849,6 +1849,17 @@ fn collect_google_workspace_cli_env_overrides(
             path.to_string_lossy().into_owned(),
         ));
     }
+
+    // Service Account + Domain-Wide Delegation support
+    // These env vars allow google-docs CLI to use Service Account authentication
+    // instead of OAuth refresh tokens (tokens never expire with Service Account)
+    if let Some(sa_json) = read_env_trimmed("GOOGLE_SERVICE_ACCOUNT_JSON") {
+        overrides.push(("GOOGLE_SERVICE_ACCOUNT_JSON".to_string(), sa_json));
+    }
+    if let Some(sa_subject) = read_env_trimmed("GOOGLE_SERVICE_ACCOUNT_SUBJECT") {
+        overrides.push(("GOOGLE_SERVICE_ACCOUNT_SUBJECT".to_string(), sa_subject));
+    }
+
     Ok(overrides)
 }
 


### PR DESCRIPTION
## Summary

- Pass `GOOGLE_SERVICE_ACCOUNT_JSON` and `GOOGLE_SERVICE_ACCOUNT_SUBJECT` env vars to Azure Container Instances
- Enables google-docs CLI in ACI to use Service Account + Domain-Wide Delegation authentication

## Problem

Previously, the ACI containers didn't receive Service Account configuration, causing the agent to fall back to browser-based OAuth login when trying to create/share Google Docs. This triggered CAPTCHA challenges and human approval gate requests.

## Solution

Add Service Account env vars to `collect_google_workspace_cli_env_overrides()` so they're passed to ACI containers along with other Google Workspace credentials.

## Test Plan

After merge and deploy to staging:
1. Send email to `dowhiz@deep-tutor.com`: "Create a Google Doc and share it with me"
2. Verify agent uses CLI (`google-docs create-document`) instead of browser
3. Verify no CAPTCHA/HAG requests are triggered
4. Verify document is created and shared successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)