### PR TITLE
Add Notion OAuth button to auth page

### DIFF
--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1068,11 +1068,18 @@
                           </svg>
                           Connect GitHub
                         </button>
+                        <button id="notion-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L18.4 2.297c-.466-.373-.98-.56-2.055-.466L3.525 3.033c-.466.047-.56.28-.373.466l1.307.709zM5.252 7.27v14.083c0 .793.466 1.073 1.446.933l14.008-.793c.98-.14 1.073-.606 1.073-1.306V6.29c0-.7-.28-1.026-.933-.933l-14.615.84c-.653.094-.98.467-.98 1.073zm13.868.84c.14.653 0 1.306-.653 1.353l-.7.14v10.41c-.606.327-1.166.514-1.632.514-.746 0-.933-.234-1.493-.933l-4.666-7.334v7.1l1.446.327s0 1.306-1.819 1.306l-5.006.28c-.14-.28 0-.98.466-1.12l1.213-.327V9.476L4.679 9.29c-.14-.653.234-1.586 1.306-1.68l5.359-.327 4.852 7.428V8.083l-1.213-.14c-.14-.793.42-1.353 1.12-1.4l5.016-.326z"/>
+                          </svg>
+                          Connect Notion
+                        </button>
                       </div>
                       <div class="settings-status-stack">
                         <span id="discord-oauth-status"></span>
                         <span id="slack-oauth-status"></span>
                         <span id="github-connect-status"></span>
+                        <span id="notion-oauth-status"></span>
                       </div>
                     </div>
 
@@ -2284,6 +2291,56 @@
           const reason = urlParams.get('reason') || 'unknown error';
           githubStatus.textContent = `Failed to connect GitHub: ${reason}`;
           githubStatus.style.color = '#ef4444';
+        }
+        // Clean up URL
+        window.history.replaceState({}, document.title, window.location.pathname);
+      }
+
+      // Notion OAuth button
+      document.getElementById('notion-oauth-btn').addEventListener('click', async () => {
+        const notionStatus = document.getElementById('notion-oauth-status');
+        const { data: { session } } = await supabase.auth.getSession();
+
+        if (!session) {
+          notionStatus.textContent = 'Please sign in first';
+          notionStatus.style.color = '#ef4444';
+          return;
+        }
+
+        notionStatus.textContent = 'Redirecting to Notion...';
+        notionStatus.style.color = 'var(--text-muted, #888)';
+
+        try {
+          const res = await fetch(`${DOWHIZ_API_URL}/auth/notion`, {
+            headers: { 'Authorization': `Bearer ${session.access_token}` }
+          });
+
+          if (!res.ok) {
+            const err = await res.json();
+            throw new Error(err.error || 'Failed to start Notion OAuth');
+          }
+
+          const data = await res.json();
+          // Redirect to Notion OAuth page
+          window.location.href = data.redirect_url;
+        } catch (err) {
+          console.error('Notion OAuth error:', err);
+          notionStatus.textContent = `Error: ${err.message}`;
+          notionStatus.style.color = '#ef4444';
+        }
+      });
+
+      // Check for Notion OAuth callback result
+      const notionResult = urlParams.get('notion');
+      if (notionResult) {
+        const notionStatus = document.getElementById('notion-oauth-status');
+        if (notionResult === 'success') {
+          notionStatus.textContent = 'Notion connected successfully!';
+          notionStatus.style.color = '#22c55e';
+        } else if (notionResult === 'error') {
+          const reason = urlParams.get('reason') || 'unknown error';
+          notionStatus.textContent = `Failed to connect Notion: ${reason}`;
+          notionStatus.style.color = '#ef4444';
         }
         // Clean up URL
         window.history.replaceState({}, document.title, window.location.pathname);


### PR DESCRIPTION
## Summary
- Add "Connect Notion" button to the Channel Settings section on auth page
- Implement OAuth flow initiation via `/auth/notion` endpoint
- Handle callback results (success/error) with user feedback

## Changes
- `website/public/auth/index.html`: Added Notion OAuth button, status display, and JavaScript handlers

## Test plan
- [ ] Deploy to staging after merging
- [ ] Configure `NOTION_CLIENT_ID`, `NOTION_CLIENT_SECRET`, `NOTION_REDIRECT_URI` on staging VM
- [ ] Verify button appears in Channel Settings section
- [ ] Test OAuth flow: click button → redirect to Notion → authorize → callback
- [ ] Verify token is stored in MongoDB `notion_oauth_tokens` collection

## Notes
- Staging and production use different Notion integrations (separate client_id/secret)
- Staging redirect URI: `https://staging.dowhiz.com/auth/notion/callback`
- Production redirect URI: `https://dowhiz.com/auth/notion/callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)