### PR TITLE
Refactor website onboarding into unified team/personal dashboard

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -67,6 +67,12 @@ If you are using a dedicated API subdomain (example: `api.dowhiz.com`) for the R
 - `website/vite.config.js`: Vite configuration.
 - `website/eslint.config.js`: Lint rules (source of truth).
 
+## Core route map
+- `/`: Landing page.
+- `/start`: Founder intake for creating/updating your agent-team blueprint.
+- `/workspace`: Lightweight handoff route to the unified dashboard workspace section.
+- `/auth/index.html`: Unified team + personal dashboard (channels, tasks, memo, settings).
+
 ## Environment variables
 No `.env` file is required for local development at the moment.
 

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -760,6 +760,53 @@
         color: var(--text-muted, #888);
       }
 
+      .workspace-summary-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.75rem;
+      }
+
+      .workspace-summary-card {
+        padding: 0.75rem;
+        border-radius: 0.7rem;
+        border: 1px solid var(--border, #333);
+        background: color-mix(in srgb, var(--surface, #1a1a1a) 82%, transparent);
+      }
+
+      .workspace-summary-card h3 {
+        margin: 0 0 0.45rem;
+        font-size: 0.92rem;
+      }
+
+      .workspace-summary-meta {
+        margin: 0.3rem 0 0;
+        font-size: 0.88rem;
+        color: var(--text-muted, #888);
+      }
+
+      .workspace-summary-meta strong {
+        color: var(--text, #fff);
+        font-weight: 600;
+      }
+
+      .workspace-summary-list {
+        margin: 0;
+        padding-left: 1rem;
+        list-style: disc;
+        display: grid;
+        gap: 0.3rem;
+        color: var(--text-muted, #888);
+        font-size: 0.9rem;
+      }
+
+      .workspace-summary-empty {
+        grid-column: 1 / -1;
+        padding: 0.8rem;
+        border-radius: 0.7rem;
+        border: 1px dashed var(--border, #333);
+        color: var(--text-muted, #888);
+      }
+
       .settings-grid {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -821,6 +868,7 @@
 
       @media (max-width: 780px) {
         .account-grid,
+        .workspace-summary-grid,
         .settings-grid {
           grid-template-columns: 1fr;
         }
@@ -853,7 +901,7 @@
           <div class="eyebrow">Account</div>
           <h1 id="page-title">Sign in to DoWhiz</h1>
           <p class="lead" id="page-subtitle">
-            Open your account dashboard to manage channels, tasks, and settings in one place.
+            Open one unified dashboard for team workspace context and personal account controls.
           </p>
         </section>
 
@@ -945,11 +993,12 @@
           <div id="dashboard-container" class="hidden">
             <div class="dashboard-shell">
               <aside class="dashboard-sidebar">
-                <p class="sidebar-eyebrow">Dashboard</p>
-                <h2 class="sidebar-title">Workspace Settings</h2>
-                <p class="sidebar-description">Navigate quickly to channels, tasks, memo, and account controls.</p>
+                <p class="sidebar-eyebrow">Unified Dashboard</p>
+                <h2 class="sidebar-title">Team + Personal</h2>
+                <p class="sidebar-description">One page for workspace context, channels, tasks, memo, and account controls.</p>
                 <nav class="sidebar-nav" aria-label="Dashboard Sections">
                   <a class="sidebar-link is-active" href="#section-overview">Overview</a>
+                  <a class="sidebar-link" href="#section-workspace">Team Workspace</a>
                   <a class="sidebar-link" href="#section-channels">Channels</a>
                   <a class="sidebar-link" href="#section-tasks">Tasks</a>
                   <a class="sidebar-link" href="#section-memo">Memo</a>
@@ -967,12 +1016,12 @@
               <div class="dashboard-main">
                 <section id="section-overview" class="legal-card dashboard-section">
                   <div class="dashboard-header">
-                    <h2>Account Overview</h2>
+                    <h2>Personal Overview</h2>
                     <button id="info-btn" class="auth-btn auth-btn-primary" style="padding: 0.5rem 1rem; font-size: 0.85rem;">
                       Add Employee Hours
                     </button>
                   </div>
-                  <p class="dashboard-overview-copy">Your core dashboard identity and billing controls.</p>
+                  <p class="dashboard-overview-copy">Your personal identity and billing controls.</p>
                   <div class="account-grid">
                     <div class="account-meta-item">
                       <p class="account-meta-label">Account ID</p>
@@ -982,6 +1031,19 @@
                       <p class="account-meta-label">Primary Email</p>
                       <code id="user-email">Loading...</code>
                     </div>
+                  </div>
+                </section>
+
+                <section id="section-workspace" class="legal-card dashboard-section">
+                  <div class="dashboard-header">
+                    <h2>Team Workspace</h2>
+                    <a class="auth-btn auth-btn-oauth" href="/start">Update Team Brief</a>
+                  </div>
+                  <p class="dashboard-overview-copy">
+                    Concise team context shared across your channels and task runtime.
+                  </p>
+                  <div id="workspace-summary-content" class="workspace-summary-grid">
+                    <div class="workspace-summary-empty">Loading workspace summary...</div>
                   </div>
                 </section>
 
@@ -1180,6 +1242,7 @@
       const ANALYTICS_ANON_KEY = 'dowhiz_analytics_anonymous_id';
       const ANALYTICS_SESSION_KEY = 'dowhiz_analytics_session_id';
       const ANALYTICS_ATTRIBUTION_KEY = 'dowhiz_analytics_attribution';
+      const STARTUP_BLUEPRINT_STORAGE_KEY = 'dowhiz_startup_workspace_blueprint_v1';
 
       function analyticsGenerateId(prefix) {
         if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -1490,6 +1553,114 @@
           return 'Password must be at least 6 characters.';
         }
         return message;
+      }
+
+      function normalizeWorkspaceText(value, fallback = 'Not set') {
+        const normalized = String(value || '').trim();
+        return normalized || fallback;
+      }
+
+      function normalizeWorkspaceList(value) {
+        if (!Array.isArray(value)) {
+          return [];
+        }
+        return value
+          .map((item) => String(item || '').trim())
+          .filter(Boolean);
+      }
+
+      function normalizeWorkspaceAgents(value) {
+        if (!Array.isArray(value)) {
+          return [];
+        }
+        return value
+          .map((agent) => ({
+            role: String(agent?.role || '').trim(),
+            owner: String(agent?.owner || '').trim()
+          }))
+          .filter((agent) => agent.role.length > 0);
+      }
+
+      function loadWorkspaceSummaryFromStorage() {
+        const container = document.getElementById('workspace-summary-content');
+        if (!container) {
+          return;
+        }
+
+        let workspaceBlueprint = null;
+        const raw = window.localStorage.getItem(STARTUP_BLUEPRINT_STORAGE_KEY);
+        if (raw) {
+          try {
+            workspaceBlueprint = JSON.parse(raw);
+          } catch {
+            workspaceBlueprint = null;
+          }
+        }
+
+        const workspaceName = normalizeWorkspaceText(
+          workspaceBlueprint?.venture?.name,
+          'Personal Workspace'
+        );
+        const founderName = normalizeWorkspaceText(
+          workspaceBlueprint?.founder?.name,
+          'Add your founder name'
+        );
+        const stage = normalizeWorkspaceText(workspaceBlueprint?.venture?.stage, 'Not set');
+        const thesis = normalizeWorkspaceText(
+          workspaceBlueprint?.venture?.thesis,
+          'Add a short founder thesis to personalize your team context.'
+        );
+
+        const goals = normalizeWorkspaceList(workspaceBlueprint?.goals_30_90_days).slice(0, 3);
+        const channels = normalizeWorkspaceList(workspaceBlueprint?.preferred_channels).slice(0, 5);
+        const agents = normalizeWorkspaceAgents(workspaceBlueprint?.requested_agents).slice(0, 4);
+
+        const goalItems = goals.length
+          ? goals.map((goal) => `<li>${escapeHtml(goal)}</li>`).join('')
+          : '<li>Add your top goals in founder intake.</li>';
+
+        const channelItems = channels.length
+          ? channels.map((channel) => `<li>${escapeHtml(channel)}</li>`).join('')
+          : '<li>No channels selected yet.</li>';
+
+        const agentItems = agents.length
+          ? agents.map((agent) => {
+            const owner = agent.owner ? ` (${escapeHtml(agent.owner)})` : '';
+            return `<li>${escapeHtml(agent.role)}${owner}</li>`;
+          }).join('')
+          : '<li>No agent roles defined yet.</li>';
+
+        container.innerHTML = `
+          <article class="workspace-summary-card">
+            <h3>Snapshot</h3>
+            <p class="workspace-summary-meta"><strong>${escapeHtml(workspaceName)}</strong></p>
+            <p class="workspace-summary-meta">Founder: <strong>${escapeHtml(founderName)}</strong></p>
+            <p class="workspace-summary-meta">Stage: <strong>${escapeHtml(stage)}</strong></p>
+            <p class="workspace-summary-meta">${escapeHtml(thesis)}</p>
+          </article>
+          <article class="workspace-summary-card">
+            <h3>Top Goals</h3>
+            <ul class="workspace-summary-list">${goalItems}</ul>
+          </article>
+          <article class="workspace-summary-card">
+            <h3>Team + Channels</h3>
+            <p class="workspace-summary-meta">Agents</p>
+            <ul class="workspace-summary-list">${agentItems}</ul>
+            <p class="workspace-summary-meta">Channels</p>
+            <ul class="workspace-summary-list">${channelItems}</ul>
+          </article>
+        `;
+      }
+
+      function scrollToDashboardHashTarget() {
+        const hash = window.location.hash;
+        if (!hash || !hash.startsWith('#section-')) {
+          return;
+        }
+        const target = document.querySelector(hash);
+        if (target) {
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
       }
 
       async function sendPasswordReset(email) {
@@ -1948,10 +2119,11 @@
         hideExistingAccountOptions();
         dashboardContainer.classList.remove('hidden');
         pageTitle.textContent = 'Your Dashboard';
-        pageSubtitle.textContent = 'Manage channels, tasks, memo, and settings from one unified dashboard.';
+        pageSubtitle.textContent = 'Manage team workspace context and personal account operations from one dashboard.';
 
         document.getElementById('account-id').textContent = accountData.account_id;
         document.getElementById('user-email').textContent = session.user.email;
+        loadWorkspaceSummaryFromStorage();
 
         // Load identifiers, memo, and tasks in parallel
         await Promise.all([
@@ -1963,6 +2135,7 @@
         // Start polling for task updates
         startTaskPolling();
         updateSidebarNavigation();
+        window.setTimeout(scrollToDashboardHashTarget, 80);
       }
 
       // Load linked identifiers
@@ -2785,7 +2958,11 @@
 
         // Clean up loggedIn parameter from URL
         if (expectingDashboard) {
-          window.history.replaceState({}, document.title, window.location.pathname);
+          window.history.replaceState(
+            {},
+            document.title,
+            `${window.location.pathname}${window.location.hash || ''}`
+          );
         }
 
         if (session) {

--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -1054,12 +1054,11 @@ function LandingPage() {
   ];
 
   const heroPrimaryCtaHref = '/start';
-  const heroSecondaryCtaHref = '/workspace';
 
   const handleHeroCtaClick = () => {
     trackAnalyticsEvent('secondary_cta_click', {
       cta_location: 'hero_primary',
-      cta_text: 'Start workspace',
+      cta_text: 'Create your agent team',
       cta_text_legacy: 'Try DoWhiz service today'
     });
   };
@@ -1199,10 +1198,7 @@ function LandingPage() {
                 href={heroPrimaryCtaHref}
                 onClick={handleHeroCtaClick}
               >
-                Start your workspace
-              </a>
-              <a className="btn btn-secondary" href={heroSecondaryCtaHref}>
-                Preview workspace home
+                Create your agent team
               </a>
             </div>
           </div>

--- a/website/src/pages/StartupIntakePage.jsx
+++ b/website/src/pages/StartupIntakePage.jsx
@@ -2,9 +2,7 @@ import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   CHANNEL_OPTIONS,
-  PLAN_HORIZON_OPTIONS,
   REPO_PROVIDER_OPTIONS,
-  STAGE_OPTIONS,
   createFounderIntakeDefaults,
   createValidatedWorkspaceBlueprintFromIntake,
   saveWorkspaceBlueprint
@@ -70,10 +68,9 @@ function StartupIntakePage() {
     <main className="route-shell route-shell-intake">
       <div className="route-card route-card-intake">
         <p className="route-kicker">Founder Intake</p>
-        <h1>Create Your Startup Workspace Blueprint</h1>
+        <h1>Create Your Agent Team</h1>
         <p>
-          Define your startup objective, channels, stack status, and desired digital founding team. This generates a
-          canonical workspace blueprint object.
+          Share the core brief once. We will generate your workspace blueprint and use it in your unified dashboard.
         </p>
 
         <form className="intake-form" onSubmit={handleSubmit} noValidate>
@@ -91,17 +88,6 @@ function StartupIntakePage() {
             </div>
 
             <div className="intake-field">
-              <label htmlFor="founder_email">Founder email (optional)</label>
-              <input
-                id="founder_email"
-                type="email"
-                value={intake.founder_email}
-                onChange={updateField('founder_email')}
-                placeholder="jane@startup.com"
-              />
-            </div>
-
-            <div className="intake-field">
               <label htmlFor="venture_name">Company / project name</label>
               <input
                 id="venture_name"
@@ -110,17 +96,6 @@ function StartupIntakePage() {
                 onChange={updateField('venture_name')}
                 placeholder="Acme AI"
               />
-            </div>
-
-            <div className="intake-field">
-              <label htmlFor="venture_stage">Stage</label>
-              <select id="venture_stage" value={intake.venture_stage} onChange={updateField('venture_stage')}>
-                {STAGE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
             </div>
 
             <div className="intake-field intake-field-full">
@@ -134,23 +109,8 @@ function StartupIntakePage() {
               />
             </div>
 
-            <div className="intake-field">
-              <label htmlFor="plan_horizon_days">Planning horizon</label>
-              <select
-                id="plan_horizon_days"
-                value={intake.plan_horizon_days}
-                onChange={updateField('plan_horizon_days')}
-              >
-                {PLAN_HORIZON_OPTIONS.map((days) => (
-                  <option key={days} value={String(days)}>
-                    {days} days
-                  </option>
-                ))}
-              </select>
-            </div>
-
             <div className="intake-field intake-field-full">
-              <label htmlFor="goals_text">Goals for the next 30-90 days (one per line)</label>
+              <label htmlFor="goals_text">Top goals (one per line)</label>
               <textarea
                 id="goals_text"
                 value={intake.goals_text}
@@ -159,21 +119,11 @@ function StartupIntakePage() {
                 required
               />
             </div>
-
-            <div className="intake-field intake-field-full">
-              <label htmlFor="assets_text">Current assets (one per line)</label>
-              <textarea
-                id="assets_text"
-                value={intake.assets_text}
-                onChange={updateField('assets_text')}
-                placeholder="Pitch deck\nCustomer interviews\nLanding page"
-              />
-            </div>
           </section>
 
           <section className="route-section">
             <h2>Preferred Channels</h2>
-            <p>Select where your agents should trigger and coordinate work.</p>
+            <p>Select where your team should receive and execute requests.</p>
             <div className="intake-chip-grid">
               {CHANNEL_OPTIONS.map((channel) => {
                 const checked = intake.preferred_channels.includes(channel);
@@ -192,6 +142,16 @@ function StartupIntakePage() {
           </section>
 
           <section className="route-section intake-grid">
+            <div className="intake-field intake-field-full">
+              <label htmlFor="requested_agents_text">Agent roles (one per line, optional owner via role:owner)</label>
+              <textarea
+                id="requested_agents_text"
+                value={intake.requested_agents_text}
+                onChange={updateField('requested_agents_text')}
+                placeholder="Builder\nGTM Strategist\nChief of Staff:Founder"
+              />
+            </div>
+
             <div className="intake-field intake-field-checkbox">
               <label>
                 <input
@@ -201,22 +161,6 @@ function StartupIntakePage() {
                 />
                 <span>Existing code repository</span>
               </label>
-            </div>
-
-            <div className="intake-field">
-              <label htmlFor="primary_repo_provider">Primary repo provider</label>
-              <select
-                id="primary_repo_provider"
-                value={intake.primary_repo_provider}
-                onChange={updateField('primary_repo_provider')}
-                disabled={!intake.has_existing_repo}
-              >
-                {REPO_PROVIDER_OPTIONS.map((provider) => (
-                  <option key={provider} value={provider}>
-                    {provider}
-                  </option>
-                ))}
-              </select>
             </div>
 
             <div className="intake-field intake-field-checkbox">
@@ -230,15 +174,74 @@ function StartupIntakePage() {
               </label>
             </div>
 
-            <div className="intake-field intake-field-full">
-              <label htmlFor="requested_agents_text">Desired founding-team agents (one per line, optional owner via role:owner)</label>
-              <textarea
-                id="requested_agents_text"
-                value={intake.requested_agents_text}
-                onChange={updateField('requested_agents_text')}
-                placeholder="Builder\nGTM Strategist\nChief of Staff:Founder"
-              />
-            </div>
+            {intake.has_existing_repo ? (
+              <div className="intake-field">
+                <label htmlFor="primary_repo_provider">Primary repo provider</label>
+                <select
+                  id="primary_repo_provider"
+                  value={intake.primary_repo_provider}
+                  onChange={updateField('primary_repo_provider')}
+                >
+                  {REPO_PROVIDER_OPTIONS.map((provider) => (
+                    <option key={provider} value={provider}>
+                      {provider}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : null}
+          </section>
+
+          <section className="route-section">
+            <details className="intake-advanced">
+              <summary>Advanced details (optional)</summary>
+              <div className="intake-grid intake-advanced-grid">
+                <div className="intake-field">
+                  <label htmlFor="founder_email">Founder email</label>
+                  <input
+                    id="founder_email"
+                    type="email"
+                    value={intake.founder_email}
+                    onChange={updateField('founder_email')}
+                    placeholder="jane@startup.com"
+                  />
+                </div>
+
+                <div className="intake-field">
+                  <label htmlFor="venture_stage">Stage</label>
+                  <select id="venture_stage" value={intake.venture_stage} onChange={updateField('venture_stage')}>
+                    <option value="idea">Idea</option>
+                    <option value="prototype">Prototype</option>
+                    <option value="mvp">MVP</option>
+                    <option value="post_mvp">Post-MVP</option>
+                    <option value="growth">Growth</option>
+                  </select>
+                </div>
+
+                <div className="intake-field">
+                  <label htmlFor="plan_horizon_days">Planning horizon</label>
+                  <select
+                    id="plan_horizon_days"
+                    value={intake.plan_horizon_days}
+                    onChange={updateField('plan_horizon_days')}
+                  >
+                    <option value="30">30 days</option>
+                    <option value="60">60 days</option>
+                    <option value="90">90 days</option>
+                  </select>
+                </div>
+
+                <div className="intake-field intake-field-full">
+                  <label htmlFor="assets_text">Current assets (one per line)</label>
+                  <textarea
+                    id="assets_text"
+                    value={intake.assets_text}
+                    onChange={updateField('assets_text')}
+                    placeholder="Pitch deck\nCustomer interviews\nLanding page"
+                  />
+                </div>
+              </div>
+            </details>
           </section>
 
           {errors.length ? (
@@ -254,11 +257,11 @@ function StartupIntakePage() {
 
           <div className="route-actions">
             <button type="submit" className="btn btn-primary">
-              Generate workspace blueprint
+              Save team blueprint
             </button>
-            <Link className="btn btn-secondary" to="/workspace">
-              Open workspace home
-            </Link>
+            <a className="btn btn-secondary" href="/auth/index.html?loggedIn=true#section-workspace">
+              Open dashboard
+            </a>
             <Link className="btn btn-secondary" to="/">
               Back to landing
             </Link>
@@ -267,11 +270,14 @@ function StartupIntakePage() {
 
         {blueprint ? (
           <section className="route-section">
-            <h2>Generated Canonical Blueprint</h2>
+            <h2>Blueprint saved</h2>
             <p>
-              This object is saved locally and mirrored to backend schema fields for validation and bootstrap planning.
+              Your team blueprint is saved locally and now appears in your dashboard workspace section.
             </p>
-            <pre className="intake-blueprint-preview">{blueprintJson}</pre>
+            <details className="intake-advanced">
+              <summary>View blueprint JSON</summary>
+              <pre className="intake-blueprint-preview">{blueprintJson}</pre>
+            </details>
           </section>
         ) : null}
       </div>

--- a/website/src/pages/WorkspaceHomePage.jsx
+++ b/website/src/pages/WorkspaceHomePage.jsx
@@ -1,82 +1,56 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import WorkspaceSectionCard from '../components/workspace/WorkspaceSectionCard';
-import WorkspaceStatusPill from '../components/workspace/WorkspaceStatusPill';
 import { demoWorkspace } from '../data/demoWorkspace';
-import { getProvisioningLabel } from '../domain/resourceModel';
-import { loadProviderRuntimeState } from '../domain/providerRuntimeState';
 import { loadWorkspaceBlueprint } from '../domain/workspaceBlueprint';
 import { createWorkspaceHomeModel } from '../domain/workspaceHomeModel';
 
-function WorkspaceHomePage() {
-  const [providerRuntimeState, setProviderRuntimeState] = useState(null);
-  const [providerRuntimeStatus, setProviderRuntimeStatus] = useState('loading');
+const DASHBOARD_WORKSPACE_ANCHOR = '/auth/index.html?loggedIn=true#section-workspace';
 
+function WorkspaceHomePage() {
   const savedBlueprint = loadWorkspaceBlueprint();
   const isUsingDemo = !savedBlueprint;
   const blueprint = savedBlueprint || demoWorkspace.blueprint;
-  const model = createWorkspaceHomeModel(blueprint, {
-    demoMode: isUsingDemo,
-    providerRuntimeState
-  });
+  const model = createWorkspaceHomeModel(blueprint, { demoMode: isUsingDemo });
 
   useEffect(() => {
-    let cancelled = false;
-
-    async function hydrateProviderState() {
-      try {
-        const result = await loadProviderRuntimeState();
-        if (cancelled) {
-          return;
-        }
-        setProviderRuntimeState(result.runtimeState);
-        setProviderRuntimeStatus(result.reason || 'unavailable');
-      } catch {
-        if (!cancelled) {
-          setProviderRuntimeState(null);
-          setProviderRuntimeStatus('unavailable');
-        }
-      }
+    if (typeof window === 'undefined') {
+      return undefined;
     }
 
-    hydrateProviderState();
+    const timeoutId = window.setTimeout(() => {
+      window.location.replace(DASHBOARD_WORKSPACE_ANCHOR);
+    }, 250);
 
-    return () => {
-      cancelled = true;
-    };
+    return () => window.clearTimeout(timeoutId);
   }, []);
 
   return (
     <main className="route-shell route-shell-workspace">
-      <div className="route-card route-card-workspace">
-        <p className="route-kicker">Workspace Home</p>
-        <h1>{model.title}</h1>
-        <p>{model.subtitle}</p>
+      <div className="route-card route-card-workspace-compact">
+        <p className="route-kicker">Workspace</p>
+        <h1>Redirecting To Your Unified Dashboard</h1>
+        <p>
+          Workspace preview is now merged into your dashboard. You will be redirected automatically.
+        </p>
 
         {isUsingDemo ? (
           <p className="workspace-inline-note">
-            Showing demo workspace data. Complete founder intake to generate your own canonical workspace blueprint.
+            Showing demo values because you have not saved a founder intake yet.
           </p>
-        ) : null}
-        {providerRuntimeStatus === 'ok' ? (
+        ) : (
           <p className="workspace-inline-note">
-            Live provider status loaded from linked account integrations and runtime capability checks.
+            Blueprint loaded from your latest saved founder intake.
           </p>
-        ) : null}
-        {providerRuntimeStatus === 'not_authenticated' ? (
-          <p className="workspace-inline-note">
-            Sign in to load live GitHub, Google Docs, email, Slack, and Discord connection status.
-          </p>
-        ) : null}
+        )}
 
         <section className="workspace-health-row" aria-label="Workspace readiness">
           <article className="workspace-health-item">
-            <span>Connected resources</span>
-            <strong>{model.workspaceHealth.connected}</strong>
+            <span>Workspace</span>
+            <strong>{model.title}</strong>
           </article>
           <article className="workspace-health-item">
-            <span>Pending setup</span>
-            <strong>{model.workspaceHealth.nonConnected}</strong>
+            <span>Connected resources</span>
+            <strong>{model.workspaceHealth.connected}</strong>
           </article>
           <article className="workspace-health-item">
             <span>Readiness</span>
@@ -84,164 +58,47 @@ function WorkspaceHomePage() {
           </article>
         </section>
 
-        <section className="workspace-grid" aria-label="Workspace sections">
-          <WorkspaceSectionCard
-            title="Startup Brief"
-            subtitle="Founder context and execution window"
-          >
+        <section className="workspace-quick-grid" aria-label="Workspace summary">
+          <article className="workspace-quick-card">
+            <h2>Team</h2>
             <ul className="workspace-list">
-              <li>
-                <strong>Founder:</strong> {model.founderName}
-              </li>
-              <li>
-                <strong>Stage:</strong> {model.stage}
-              </li>
-              <li>
-                <strong>Planning horizon:</strong> {model.planHorizonDays} days
-              </li>
+              <li>Founder: {model.founderName}</li>
+              {model.agentRoster.slice(0, 3).map((agent) => (
+                <li key={`${agent.role}-${agent.name}`}>
+                  {agent.role}: {agent.name}
+                </li>
+              ))}
             </ul>
-            <h3>Goals (30-90 days)</h3>
+          </article>
+
+          <article className="workspace-quick-card">
+            <h2>Goals</h2>
             <ul className="workspace-list">
-              {model.goals.map((goal) => (
+              {model.goals.slice(0, 3).map((goal) => (
                 <li key={goal}>{goal}</li>
               ))}
             </ul>
-          </WorkspaceSectionCard>
+          </article>
 
-          <WorkspaceSectionCard title="Agent Roster" subtitle="Digital founding team ownership">
+          <article className="workspace-quick-card">
+            <h2>Channels</h2>
             <ul className="workspace-list">
-              {model.agentRoster.map((agent) => (
-                <li key={`${agent.role}-${agent.name}`} className="workspace-list-row">
-                  <div>
-                    <strong>{agent.role}</strong>
-                    <p>{agent.focus}</p>
-                  </div>
-                  <div className="workspace-row-right">
-                    <span>{agent.name}</span>
-                    <WorkspaceStatusPill status={agent.status} label={agent.status} />
-                  </div>
-                </li>
+              {model.preferredChannels.map((channel) => (
+                <li key={channel}>{channel}</li>
               ))}
             </ul>
-          </WorkspaceSectionCard>
-
-          <WorkspaceSectionCard title="Resource Status" subtitle="Product objects mapped to providers">
-            <ul className="workspace-list">
-              {model.resources.map((resource) => (
-                <li
-                  key={`${resource.category}-${resource.provider.key}`}
-                  className="workspace-list-row"
-                >
-                  <div>
-                    <strong>{resource.object_name}</strong>
-                    <p>
-                      {resource.object_purpose}
-                    </p>
-                    <p>
-                      Provider: {resource.provider.display_name}
-                      {resource.note ? ` | ${resource.note}` : ''}
-                    </p>
-                    {resource.manual_next_step ? (
-                      <p>Manual next step: {resource.manual_next_step}</p>
-                    ) : null}
-                  </div>
-                  <WorkspaceStatusPill
-                    status={resource.state}
-                    label={getProvisioningLabel(resource.state)}
-                  />
-                </li>
-              ))}
-            </ul>
-          </WorkspaceSectionCard>
-
-          <WorkspaceSectionCard title="Starter Task Board" subtitle="Blueprint-derived execution graph">
-            <ul className="workspace-list">
-              {model.starterTasks.map((task) => (
-                <li key={task.id} className="workspace-list-row">
-                  <div>
-                    <strong>{task.title}</strong>
-                    <p>
-                      Owner: {task.ownerRole}
-                      {task.dependsOn.length ? ` | Depends on: ${task.dependsOn.join(', ')}` : ''}
-                    </p>
-                    <p>{task.rationale}</p>
-                  </div>
-                  <WorkspaceStatusPill status={task.status} label={task.status.replace('_', ' ')} />
-                </li>
-              ))}
-            </ul>
-          </WorkspaceSectionCard>
-
-          <WorkspaceSectionCard title="Recent Artifacts" subtitle="Reviewable outputs">
-            <ul className="workspace-list">
-              {model.recentArtifacts.map((artifact) => (
-                <li key={artifact.id} className="workspace-list-row">
-                  <div>
-                    <strong>{artifact.title}</strong>
-                    <p>
-                      Surface: {artifact.surface} | Updated: {artifact.updatedAtLabel}
-                    </p>
-                  </div>
-                  <WorkspaceStatusPill status={artifact.status} label={artifact.status} />
-                </li>
-              ))}
-            </ul>
-          </WorkspaceSectionCard>
-
-          <WorkspaceSectionCard title="Approval Queue" subtitle="Human decisions required before sensitive actions">
-            {model.approvalPolicy ? (
-              <p className="workspace-inline-note">
-                Approval policy: {model.approvalPolicy.provider.display_name} (
-                {getProvisioningLabel(model.approvalPolicy.state)}).
-                {model.approvalPolicy.manual_next_step
-                  ? ` ${model.approvalPolicy.manual_next_step}`
-                  : ' Human review stays explicit before outbound actions.'}
-              </p>
-            ) : null}
-            <ul className="workspace-list">
-              {model.approvalQueue.map((approval) => (
-                <li key={approval.id} className="workspace-list-row">
-                  <div>
-                    <strong>{approval.title}</strong>
-                    <p>
-                      Owner: {approval.owner} | {approval.reason}
-                    </p>
-                  </div>
-                  <WorkspaceStatusPill
-                    status={approval.status}
-                    label={approval.status.replace('_', ' ')}
-                  />
-                </li>
-              ))}
-            </ul>
-          </WorkspaceSectionCard>
-
-          <WorkspaceSectionCard title="Next Recommended Actions" subtitle="What to do next">
-            <ol className="workspace-list workspace-list-ordered">
-              {model.nextActions.map((action) => (
-                <li key={action}>{action}</li>
-              ))}
-            </ol>
-            <h3>Current assets</h3>
-            <ul className="workspace-list">
-              {model.currentAssets.length ? (
-                model.currentAssets.map((asset) => <li key={asset}>{asset}</li>)
-              ) : (
-                <li>No assets listed yet.</li>
-              )}
-            </ul>
-          </WorkspaceSectionCard>
+          </article>
         </section>
 
         <div className="route-actions">
-          <Link className="btn btn-primary" to="/start">
-            {isUsingDemo ? 'Create your blueprint' : 'Edit founder intake'}
+          <a className="btn btn-primary" href={DASHBOARD_WORKSPACE_ANCHOR}>
+            Open unified dashboard
+          </a>
+          <Link className="btn btn-secondary" to="/start">
+            Edit team brief
           </Link>
           <Link className="btn btn-secondary" to="/">
             Back to landing
-          </Link>
-          <Link className="btn btn-secondary" to="/dashboard">
-            Internal analytics dashboard
           </Link>
         </div>
       </div>

--- a/website/src/styles/layout.css
+++ b/website/src/styles/layout.css
@@ -70,6 +70,10 @@
   width: min(1200px, 100%);
 }
 
+.route-card-workspace-compact {
+  width: min(940px, 100%);
+}
+
 .route-card-intake {
   width: min(980px, 100%);
 }
@@ -160,6 +164,29 @@
   margin: 0;
 }
 
+.intake-advanced {
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.7rem 0.8rem;
+}
+
+.intake-advanced summary {
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.intake-advanced[open] summary {
+  margin-bottom: 0.7rem;
+}
+
+.intake-advanced-grid {
+  margin-top: 0.2rem;
+}
+
 .intake-errors h2 {
   margin-bottom: 0.5rem;
 }
@@ -223,6 +250,24 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.85rem;
+}
+
+.workspace-quick-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.workspace-quick-card {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.8rem;
+}
+
+.workspace-quick-card h2 {
+  margin: 0 0 0.6rem;
+  font-size: 0.98rem;
 }
 
 .workspace-card {
@@ -335,7 +380,8 @@
   }
 
   .workspace-health-row,
-  .workspace-grid {
+  .workspace-grid,
+  .workspace-quick-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- Keep a single hero action on landing: **Create your agent team** (remove secondary workspace preview CTA)
- Simplify the `/start` founder intake by surfacing core fields first and moving optional fields into an **Advanced details** block
- Merge workspace preview into `/auth/index.html` by adding a concise **Team Workspace** section in the unified dashboard
- Keep `/workspace` as a lightweight handoff route that redirects users into `#section-workspace` on the unified dashboard
- Update route map docs in `website/README.md`

## UX Impact
- One primary user path from landing: `/start`
- One dashboard surface for both personal controls and team workspace context
- Reduced form complexity on startup intake

## Test Evidence
- `cd website && npm run lint` ✅
- `cd website && npm run build` ✅
