### PR TITLE
Convert /start onboarding from form to conversational UX

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -69,7 +69,7 @@ If you are using a dedicated API subdomain (example: `api.dowhiz.com`) for the R
 
 ## Core route map
 - `/`: Landing page.
-- `/start`: Founder intake for creating/updating your agent-team blueprint.
+- `/start`: Conversational founder intake for creating/updating your agent-team blueprint (default launch or custom tool-by-category setup).
 - `/workspace`: Lightweight handoff route to the unified dashboard workspace section.
 - `/auth/index.html`: Unified team + personal dashboard (channels, tasks, memo, settings).
 

--- a/website/src/pages/StartupIntakePage.jsx
+++ b/website/src/pages/StartupIntakePage.jsx
@@ -1,272 +1,506 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
-  CHANNEL_OPTIONS,
-  REPO_PROVIDER_OPTIONS,
   createFounderIntakeDefaults,
   createValidatedWorkspaceBlueprintFromIntake,
   saveWorkspaceBlueprint
 } from '../domain/workspaceBlueprint';
 
+const DASHBOARD_PATH = '/auth/index.html?loggedIn=true#section-workspace';
+
+const DEFAULT_RESOURCE_SELECTIONS = {
+  build_system: 'github',
+  formal_docs: 'google_docs',
+  coordination: 'slack',
+  external_execution: 'email'
+};
+
+const TOOL_LABELS = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  bitbucket: 'Bitbucket',
+  google_docs: 'Google Docs',
+  notion: 'Notion',
+  slack: 'Slack',
+  discord: 'Discord',
+  email: 'Email'
+};
+
+const CHAT_STEPS = {
+  PROJECT_DESCRIPTION: 'project_description',
+  FOUNDER_NAME: 'founder_name',
+  VENTURE_NAME: 'venture_name',
+  GOALS: 'goals',
+  LAUNCH_MODE: 'launch_mode',
+  RESOURCE_CATEGORY: 'resource_category',
+  CONFIRM: 'confirm',
+  COMPLETED: 'completed'
+};
+
+const LAUNCH_MODE_OPTIONS = [
+  {
+    value: 'default',
+    label: 'Use default resource launch',
+    description: 'Fastest path: GitHub + Google Docs + Slack + Email.'
+  },
+  {
+    value: 'custom',
+    label: 'Choose tools step by step',
+    description: 'Pick one tool in each resource category.'
+  }
+];
+
+const RESOURCE_CATEGORY_FLOW = [
+  {
+    id: 'build_system',
+    label: 'Build System',
+    options: [
+      { value: 'github', label: 'GitHub' },
+      { value: 'gitlab', label: 'GitLab' },
+      { value: 'bitbucket', label: 'Bitbucket' }
+    ]
+  },
+  {
+    id: 'formal_docs',
+    label: 'Formal Docs',
+    options: [
+      { value: 'google_docs', label: 'Google Docs' },
+      { value: 'notion', label: 'Notion' }
+    ]
+  },
+  {
+    id: 'coordination',
+    label: 'Coordination',
+    options: [
+      { value: 'slack', label: 'Slack' },
+      { value: 'discord', label: 'Discord' },
+      { value: 'email', label: 'Email' }
+    ]
+  },
+  {
+    id: 'external_execution',
+    label: 'External Execution',
+    options: [
+      { value: 'email', label: 'Email' },
+      { value: 'slack', label: 'Slack' },
+      { value: 'discord', label: 'Discord' }
+    ]
+  }
+];
+
+const CONFIRM_OPTIONS = [
+  {
+    value: 'create',
+    label: 'Create blueprint now',
+    description: 'Save team setup and continue to dashboard.'
+  },
+  {
+    value: 'restart',
+    label: 'Start over',
+    description: 'Clear this chat and restart intake.'
+  }
+];
+
+function createMessage(role, text) {
+  return {
+    id: `${role}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    role,
+    text
+  };
+}
+
+function createInitialMessages() {
+  return [
+    createMessage(
+      'assistant',
+      'Describe the project you want to start. I will build your agent-team workspace setup from that.'
+    )
+  ];
+}
+
+function applyResourceSelectionsToIntake(intake, selections) {
+  const next = {
+    ...intake
+  };
+
+  const channels = [];
+  const addChannel = (channel) => {
+    if (!channels.includes(channel)) {
+      channels.push(channel);
+    }
+  };
+
+  const buildSystem = selections.build_system || DEFAULT_RESOURCE_SELECTIONS.build_system;
+  if (buildSystem === 'github') {
+    addChannel('GitHub');
+  }
+
+  const formalDocs = selections.formal_docs || DEFAULT_RESOURCE_SELECTIONS.formal_docs;
+  if (formalDocs === 'google_docs') {
+    addChannel('Google Docs');
+  }
+
+  const coordination = selections.coordination || DEFAULT_RESOURCE_SELECTIONS.coordination;
+  if (coordination === 'slack') {
+    addChannel('Slack');
+  }
+  if (coordination === 'discord') {
+    addChannel('Discord');
+  }
+  if (coordination === 'email') {
+    addChannel('Email');
+  }
+
+  const externalExecution = selections.external_execution || DEFAULT_RESOURCE_SELECTIONS.external_execution;
+  if (externalExecution === 'email') {
+    addChannel('Email');
+  }
+  if (externalExecution === 'slack') {
+    addChannel('Slack');
+  }
+  if (externalExecution === 'discord') {
+    addChannel('Discord');
+  }
+
+  if (channels.length === 0) {
+    addChannel('Email');
+  }
+
+  const hasExistingRepo = buildSystem === 'github' || buildSystem === 'gitlab' || buildSystem === 'bitbucket';
+
+  next.preferred_channels = channels;
+  next.has_existing_repo = hasExistingRepo;
+  next.primary_repo_provider = hasExistingRepo ? buildSystem : 'github';
+  next.has_docs_workspace = formalDocs === 'google_docs' || formalDocs === 'notion';
+
+  return next;
+}
+
+function summarizeSelections(selections) {
+  return RESOURCE_CATEGORY_FLOW.map((category) => {
+    const tool = selections[category.id];
+    const label = TOOL_LABELS[tool] || tool || 'Not selected';
+    return `${category.label}: ${label}`;
+  }).join('\n');
+}
+
 function StartupIntakePage() {
   const [intake, setIntake] = useState(() => createFounderIntakeDefaults());
+  const [messages, setMessages] = useState(() => createInitialMessages());
+  const [inputValue, setInputValue] = useState('');
+  const [step, setStep] = useState(CHAT_STEPS.PROJECT_DESCRIPTION);
+  const [resourceIndex, setResourceIndex] = useState(0);
+  const [launchMode, setLaunchMode] = useState(null);
+  const [resourceSelections, setResourceSelections] = useState(() => ({ ...DEFAULT_RESOURCE_SELECTIONS }));
   const [errors, setErrors] = useState([]);
   const [blueprint, setBlueprint] = useState(null);
+  const chatFeedRef = useRef(null);
 
   const blueprintJson = useMemo(
     () => (blueprint ? JSON.stringify(blueprint, null, 2) : ''),
     [blueprint]
   );
 
-  const updateField = (field) => (event) => {
-    const value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
+  const activeResourceCategory = RESOURCE_CATEGORY_FLOW[resourceIndex] || null;
+  const isTextInputStep =
+    step === CHAT_STEPS.PROJECT_DESCRIPTION ||
+    step === CHAT_STEPS.FOUNDER_NAME ||
+    step === CHAT_STEPS.VENTURE_NAME ||
+    step === CHAT_STEPS.GOALS;
 
-    setIntake((prev) => {
-      if (field === 'has_existing_repo' && !value) {
-        return {
-          ...prev,
-          has_existing_repo: false,
-          primary_repo_provider: 'github'
-        };
-      }
+  const chatPlaceholder = (() => {
+    if (step === CHAT_STEPS.PROJECT_DESCRIPTION) {
+      return 'Example: AI onboarding copilot for B2B SaaS customer success teams...';
+    }
+    if (step === CHAT_STEPS.FOUNDER_NAME) {
+      return 'Your name';
+    }
+    if (step === CHAT_STEPS.VENTURE_NAME) {
+      return "Project name (or type 'skip')";
+    }
+    if (step === CHAT_STEPS.GOALS) {
+      return 'Ship MVP, close 3 pilots, launch onboarding analytics...';
+    }
+    return 'Type your answer...';
+  })();
 
-      return {
-        ...prev,
-        [field]: value
-      };
-    });
+  const activeChoiceOptions = useMemo(() => {
+    if (step === CHAT_STEPS.LAUNCH_MODE) {
+      return LAUNCH_MODE_OPTIONS;
+    }
+    if (step === CHAT_STEPS.RESOURCE_CATEGORY && activeResourceCategory) {
+      return activeResourceCategory.options;
+    }
+    if (step === CHAT_STEPS.CONFIRM) {
+      return CONFIRM_OPTIONS;
+    }
+    return [];
+  }, [activeResourceCategory, step]);
+
+  useEffect(() => {
+    const node = chatFeedRef.current;
+    if (!node) {
+      return;
+    }
+    node.scrollTop = node.scrollHeight;
+  }, [messages]);
+
+  const addAssistantMessage = (text) => {
+    setMessages((prev) => [...prev, createMessage('assistant', text)]);
   };
 
-  const toggleChannel = (channel) => {
-    setIntake((prev) => {
-      const hasChannel = prev.preferred_channels.includes(channel);
-      return {
-        ...prev,
-        preferred_channels: hasChannel
-          ? prev.preferred_channels.filter((item) => item !== channel)
-          : [...prev.preferred_channels, channel]
-      };
-    });
+  const addUserMessage = (text) => {
+    setMessages((prev) => [...prev, createMessage('user', text)]);
   };
 
-  const handleSubmit = (event) => {
-    event.preventDefault();
+  const resetConversation = () => {
+    setIntake(createFounderIntakeDefaults());
+    setMessages(createInitialMessages());
+    setInputValue('');
+    setStep(CHAT_STEPS.PROJECT_DESCRIPTION);
+    setResourceIndex(0);
+    setLaunchMode(null);
+    setResourceSelections({ ...DEFAULT_RESOURCE_SELECTIONS });
+    setErrors([]);
+    setBlueprint(null);
+  };
 
-    const result = createValidatedWorkspaceBlueprintFromIntake(intake);
+  const finalizeSelections = (mode, selections) => {
+    setLaunchMode(mode);
+    setResourceSelections(selections);
+    setIntake((prev) => applyResourceSelectionsToIntake(prev, selections));
+    addAssistantMessage(
+      `Great. I mapped your resource launch to:\n${summarizeSelections(selections)}\n\nReady to create your agent team blueprint?`
+    );
+    setStep(CHAT_STEPS.CONFIRM);
+    setErrors([]);
+  };
+
+  const askNextResourceCategory = (nextIndex) => {
+    const category = RESOURCE_CATEGORY_FLOW[nextIndex];
+    if (!category) {
+      return;
+    }
+    setResourceIndex(nextIndex);
+    addAssistantMessage(`Choose one tool for ${category.label}.`);
+    setStep(CHAT_STEPS.RESOURCE_CATEGORY);
+  };
+
+  const createBlueprintFromConversation = () => {
+    const finalIntake = applyResourceSelectionsToIntake(intake, resourceSelections);
+    setIntake(finalIntake);
+
+    const result = createValidatedWorkspaceBlueprintFromIntake(finalIntake);
     if (!result.is_valid) {
       setErrors(result.errors);
       setBlueprint(null);
+      addAssistantMessage(`I still need a few fields:\n- ${result.errors.join('\n- ')}`);
       return;
     }
 
     saveWorkspaceBlueprint(result.blueprint);
     setErrors([]);
     setBlueprint(result.blueprint);
+    addAssistantMessage(
+      'Blueprint saved. You can open your unified dashboard now, or restart this chat to adjust the setup.'
+    );
+    setStep(CHAT_STEPS.COMPLETED);
+  };
+
+  const handleTextSubmit = (event) => {
+    event.preventDefault();
+    if (!isTextInputStep) {
+      return;
+    }
+
+    const value = inputValue.trim();
+    if (!value) {
+      return;
+    }
+
+    setInputValue('');
+    addUserMessage(value);
+    setErrors([]);
+    setBlueprint(null);
+
+    if (step === CHAT_STEPS.PROJECT_DESCRIPTION) {
+      setIntake((prev) => ({
+        ...prev,
+        venture_thesis: value
+      }));
+      addAssistantMessage('Great context. What should I call you?');
+      setStep(CHAT_STEPS.FOUNDER_NAME);
+      return;
+    }
+
+    if (step === CHAT_STEPS.FOUNDER_NAME) {
+      if (value.toLowerCase() === 'skip') {
+        addAssistantMessage('I need your name to create the team blueprint. What should I call you?');
+        return;
+      }
+
+      setIntake((prev) => ({
+        ...prev,
+        founder_name: value
+      }));
+      addAssistantMessage("What is the project or company name? You can type 'skip' if undecided.");
+      setStep(CHAT_STEPS.VENTURE_NAME);
+      return;
+    }
+
+    if (step === CHAT_STEPS.VENTURE_NAME) {
+      if (value.toLowerCase() !== 'skip') {
+        setIntake((prev) => ({
+          ...prev,
+          venture_name: value
+        }));
+      }
+      addAssistantMessage(
+        'What are your top goals for the next 30-90 days? You can answer in one line or comma-separated.'
+      );
+      setStep(CHAT_STEPS.GOALS);
+      return;
+    }
+
+    if (step === CHAT_STEPS.GOALS) {
+      if (value.toLowerCase() === 'skip') {
+        addAssistantMessage('I need at least one goal before launch planning. Please share your top goal.');
+        return;
+      }
+
+      setIntake((prev) => ({
+        ...prev,
+        goals_text: value
+      }));
+      addAssistantMessage('How do you want to launch resources?');
+      setStep(CHAT_STEPS.LAUNCH_MODE);
+    }
+  };
+
+  const handleChoiceSelect = (option) => {
+    addUserMessage(option.label);
+    setErrors([]);
+    setBlueprint(null);
+
+    if (step === CHAT_STEPS.LAUNCH_MODE) {
+      if (option.value === 'default') {
+        finalizeSelections('default', { ...DEFAULT_RESOURCE_SELECTIONS });
+        return;
+      }
+
+      setLaunchMode('custom');
+      setResourceSelections({});
+      askNextResourceCategory(0);
+      return;
+    }
+
+    if (step === CHAT_STEPS.RESOURCE_CATEGORY && activeResourceCategory) {
+      const nextSelections = {
+        ...resourceSelections,
+        [activeResourceCategory.id]: option.value
+      };
+      const nextIndex = resourceIndex + 1;
+
+      if (nextIndex < RESOURCE_CATEGORY_FLOW.length) {
+        setResourceSelections(nextSelections);
+        addAssistantMessage(`Noted. ${activeResourceCategory.label}: ${option.label}.`);
+        askNextResourceCategory(nextIndex);
+        return;
+      }
+
+      finalizeSelections('custom', nextSelections);
+      return;
+    }
+
+    if (step === CHAT_STEPS.CONFIRM) {
+      if (option.value === 'restart') {
+        resetConversation();
+        return;
+      }
+      createBlueprintFromConversation();
+    }
   };
 
   return (
     <main className="route-shell route-shell-intake">
       <div className="route-card route-card-intake">
-        <p className="route-kicker">Founder Intake</p>
+        <p className="route-kicker">Conversational Intake</p>
         <h1>Create Your Agent Team</h1>
         <p>
-          Share the core brief once. We will generate your workspace blueprint and use it in your unified dashboard.
+          Start by describing your project in chat. Then pick default launch or configure each resource category one
+          step at a time.
         </p>
 
-        <form className="intake-form" onSubmit={handleSubmit} noValidate>
-          <section className="route-section intake-grid">
-            <div className="intake-field">
-              <label htmlFor="founder_name">Founder name</label>
+        <section className="route-section intake-chat-shell" aria-label="Conversational workspace intake">
+          <div className="intake-chat-feed" ref={chatFeedRef}>
+            {messages.map((message) => (
+              <article key={message.id} className={`intake-chat-message is-${message.role}`}>
+                <p>{message.text}</p>
+              </article>
+            ))}
+          </div>
+
+          {isTextInputStep ? (
+            <form className="intake-chat-composer" onSubmit={handleTextSubmit}>
               <input
-                id="founder_name"
                 type="text"
-                value={intake.founder_name}
-                onChange={updateField('founder_name')}
-                placeholder="Jane Founder"
-                required
+                className="intake-chat-input"
+                value={inputValue}
+                onChange={(event) => setInputValue(event.target.value)}
+                placeholder={chatPlaceholder}
               />
-            </div>
-
-            <div className="intake-field">
-              <label htmlFor="venture_name">Company / project name</label>
-              <input
-                id="venture_name"
-                type="text"
-                value={intake.venture_name}
-                onChange={updateField('venture_name')}
-                placeholder="Acme AI"
-              />
-            </div>
-
-            <div className="intake-field intake-field-full">
-              <label htmlFor="venture_thesis">Company or project thesis</label>
-              <textarea
-                id="venture_thesis"
-                value={intake.venture_thesis}
-                onChange={updateField('venture_thesis')}
-                placeholder="What company are you building and why now?"
-                required
-              />
-            </div>
-
-            <div className="intake-field intake-field-full">
-              <label htmlFor="goals_text">Top goals (one per line)</label>
-              <textarea
-                id="goals_text"
-                value={intake.goals_text}
-                onChange={updateField('goals_text')}
-                placeholder="Ship MVP\nClose 3 design partners"
-                required
-              />
-            </div>
-          </section>
-
-          <section className="route-section">
-            <h2>Preferred Channels</h2>
-            <p>Select where your team should receive and execute requests.</p>
-            <div className="intake-chip-grid">
-              {CHANNEL_OPTIONS.map((channel) => {
-                const checked = intake.preferred_channels.includes(channel);
-                return (
-                  <label key={channel} className={`intake-chip ${checked ? 'is-checked' : ''}`}>
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={() => toggleChannel(channel)}
-                    />
-                    <span>{channel}</span>
-                  </label>
-                );
-              })}
-            </div>
-          </section>
-
-          <section className="route-section intake-grid">
-            <div className="intake-field intake-field-full">
-              <label htmlFor="requested_agents_text">Agent roles (one per line, optional owner via role:owner)</label>
-              <textarea
-                id="requested_agents_text"
-                value={intake.requested_agents_text}
-                onChange={updateField('requested_agents_text')}
-                placeholder="Builder\nGTM Strategist\nChief of Staff:Founder"
-              />
-            </div>
-
-            <div className="intake-field intake-field-checkbox">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={intake.has_existing_repo}
-                  onChange={updateField('has_existing_repo')}
-                />
-                <span>Existing code repository</span>
-              </label>
-            </div>
-
-            <div className="intake-field intake-field-checkbox">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={intake.has_docs_workspace}
-                  onChange={updateField('has_docs_workspace')}
-                />
-                <span>Existing docs workspace (Google Docs / Sheets / Slides / Notion)</span>
-              </label>
-            </div>
-
-            {intake.has_existing_repo ? (
-              <div className="intake-field">
-                <label htmlFor="primary_repo_provider">Primary repo provider</label>
-                <select
-                  id="primary_repo_provider"
-                  value={intake.primary_repo_provider}
-                  onChange={updateField('primary_repo_provider')}
-                >
-                  {REPO_PROVIDER_OPTIONS.map((provider) => (
-                    <option key={provider} value={provider}>
-                      {provider}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            ) : null}
-          </section>
-
-          <section className="route-section">
-            <details className="intake-advanced">
-              <summary>Advanced details (optional)</summary>
-              <div className="intake-grid intake-advanced-grid">
-                <div className="intake-field">
-                  <label htmlFor="founder_email">Founder email</label>
-                  <input
-                    id="founder_email"
-                    type="email"
-                    value={intake.founder_email}
-                    onChange={updateField('founder_email')}
-                    placeholder="jane@startup.com"
-                  />
-                </div>
-
-                <div className="intake-field">
-                  <label htmlFor="venture_stage">Stage</label>
-                  <select id="venture_stage" value={intake.venture_stage} onChange={updateField('venture_stage')}>
-                    <option value="idea">Idea</option>
-                    <option value="prototype">Prototype</option>
-                    <option value="mvp">MVP</option>
-                    <option value="post_mvp">Post-MVP</option>
-                    <option value="growth">Growth</option>
-                  </select>
-                </div>
-
-                <div className="intake-field">
-                  <label htmlFor="plan_horizon_days">Planning horizon</label>
-                  <select
-                    id="plan_horizon_days"
-                    value={intake.plan_horizon_days}
-                    onChange={updateField('plan_horizon_days')}
-                  >
-                    <option value="30">30 days</option>
-                    <option value="60">60 days</option>
-                    <option value="90">90 days</option>
-                  </select>
-                </div>
-
-                <div className="intake-field intake-field-full">
-                  <label htmlFor="assets_text">Current assets (one per line)</label>
-                  <textarea
-                    id="assets_text"
-                    value={intake.assets_text}
-                    onChange={updateField('assets_text')}
-                    placeholder="Pitch deck\nCustomer interviews\nLanding page"
-                  />
-                </div>
-              </div>
-            </details>
-          </section>
-
-          {errors.length ? (
-            <section className="route-section intake-errors" aria-live="polite">
-              <h2>Blueprint validation issues</h2>
-              <ul>
-                {errors.map((error) => (
-                  <li key={error}>{error}</li>
-                ))}
-              </ul>
-            </section>
+              <button type="submit" className="btn btn-primary intake-chat-send-btn">
+                Send
+              </button>
+            </form>
           ) : null}
 
-          <div className="route-actions">
-            <button type="submit" className="btn btn-primary">
-              Save team blueprint
-            </button>
-            <a className="btn btn-secondary" href="/auth/index.html?loggedIn=true#section-workspace">
-              Open dashboard
-            </a>
-            <Link className="btn btn-secondary" to="/">
-              Back to landing
-            </Link>
-          </div>
-        </form>
+          {activeChoiceOptions.length ? (
+            <div className="intake-chat-options">
+              {activeChoiceOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  className="intake-chat-option"
+                  onClick={() => handleChoiceSelect(option)}
+                >
+                  <span>{option.label}</span>
+                  {option.description ? <small>{option.description}</small> : null}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </section>
+
+        {launchMode ? (
+          <section className="route-section">
+            <h2>Launch Plan</h2>
+            <pre className="intake-conversation-summary">{summarizeSelections(resourceSelections)}</pre>
+          </section>
+        ) : null}
+
+        {errors.length ? (
+          <section className="route-section intake-errors" aria-live="polite">
+            <h2>Blueprint validation issues</h2>
+            <ul>
+              {errors.map((error) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        <div className="route-actions">
+          <button type="button" className="btn btn-secondary" onClick={resetConversation}>
+            Restart chat
+          </button>
+          <a className="btn btn-secondary" href={DASHBOARD_PATH}>
+            Open dashboard
+          </a>
+          <Link className="btn btn-secondary" to="/">
+            Back to landing
+          </Link>
+        </div>
 
         {blueprint ? (
           <section className="route-section">

--- a/website/src/styles/layout.css
+++ b/website/src/styles/layout.css
@@ -213,6 +213,115 @@
   word-break: break-word;
 }
 
+.intake-chat-shell {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.intake-chat-feed {
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: #fbfdff;
+  padding: 0.75rem;
+  max-height: 430px;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.intake-chat-message {
+  max-width: min(88%, 680px);
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+}
+
+.intake-chat-message p {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.45;
+}
+
+.intake-chat-message.is-assistant {
+  justify-self: start;
+  background: #fff;
+  color: var(--text-primary);
+}
+
+.intake-chat-message.is-user {
+  justify-self: end;
+  background: #eaf3ff;
+  border-color: #c7dbfb;
+  color: #1b3f7d;
+}
+
+.intake-chat-composer {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.intake-chat-input {
+  flex: 1;
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--text-primary);
+  font: inherit;
+  padding: 0.62rem 0.85rem;
+}
+
+.intake-chat-input:focus {
+  outline: 2px solid color-mix(in srgb, var(--brand-primary) 40%, transparent);
+  outline-offset: 1px;
+}
+
+.intake-chat-send-btn {
+  white-space: nowrap;
+}
+
+.intake-chat-options {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.intake-chat-option {
+  text-align: left;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: #fff;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 0.68rem 0.75rem;
+  display: grid;
+  gap: 0.2rem;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.intake-chat-option span {
+  font-weight: 600;
+}
+
+.intake-chat-option small {
+  color: var(--text-secondary);
+}
+
+.intake-chat-option:hover {
+  border-color: color-mix(in srgb, var(--brand-primary) 45%, var(--color-border));
+  background: #f4f8ff;
+}
+
+.intake-conversation-summary {
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.75rem;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
 .workspace-inline-note {
   border: 1px solid var(--color-border);
   border-radius: 10px;
@@ -377,6 +486,18 @@
 
   .intake-field-full {
     grid-column: auto;
+  }
+
+  .intake-chat-message {
+    max-width: 94%;
+  }
+
+  .intake-chat-composer {
+    flex-direction: column;
+  }
+
+  .intake-chat-send-btn {
+    width: 100%;
   }
 
   .workspace-health-row,


### PR DESCRIPTION
## Summary
- Replace `/start` questionnaire form with a conversational chat-based onboarding flow
- Start from a freeform project description, then guide users through founder name, project name, and goals
- Add launch mode choice:
  - default resource launch
  - custom step-by-step tool selection
- For custom mode, enforce one tool selection per resource category:
  - Build System
  - Formal Docs
  - Coordination
  - External Execution
- Map chat selections into the existing startup workspace blueprint schema and persist locally
- Keep post-intake actions to open unified dashboard and review saved blueprint JSON

## UX Notes
- This keeps the existing data model compatible while shifting to conversational UX
- Default launch remains the fast path; custom launch provides explicit per-category tool control

## Test Evidence
- `cd website && npm run lint` ✅
- `cd website && npm run build` ✅
