### PR TITLE
GPT-5.4 conversational intake for Create your agent team

### DIFF
--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -20,8 +20,9 @@ use crate::user_store::UserStore;
 use crate::{load_tasks_with_status, TaskStatusSummary};
 
 use super::startup_workspace::{
-    derive_provider_capabilities, derive_provider_connections, LinkedIdentifierSnapshot,
-    ProviderCapabilityInputs, WorkspaceProviderRuntimeState,
+    derive_provider_capabilities, derive_provider_connections,
+    generate_startup_intake_chat_response, LinkedIdentifierSnapshot, ProviderCapabilityInputs,
+    StartupIntakeChatRequest, WorkspaceProviderRuntimeState,
 };
 
 /// State for auth routes
@@ -709,6 +710,43 @@ pub async fn get_workspace_provider_state(
         }),
     )
         .into_response()
+}
+
+/// POST /api/startup-workspace/intake-chat
+/// LLM-driven conversational intake that returns a structured draft JSON.
+pub async fn startup_workspace_intake_chat(
+    Json(request): Json<StartupIntakeChatRequest>,
+) -> impl IntoResponse {
+    if request.messages.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "messages must include at least one conversation message"
+            })),
+        )
+            .into_response();
+    }
+
+    match generate_startup_intake_chat_response(request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error_message) => {
+            let status = if error_message.contains("No conversation messages")
+                || error_message.contains("messages")
+            {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::BAD_GATEWAY
+            };
+
+            (
+                status,
+                Json(serde_json::json!({
+                    "error": error_message
+                })),
+            )
+                .into_response()
+        }
+    }
 }
 
 fn oauth_ready(
@@ -2866,7 +2904,9 @@ pub async fn notion_oauth_callback(
 
     info!(
         "Notion OAuth successful for user {} (Notion workspace: {} / user: {:?})",
-        auth_user_id, notion_token.workspace_name.as_deref().unwrap_or("unknown"), notion_user_id
+        auth_user_id,
+        notion_token.workspace_name.as_deref().unwrap_or("unknown"),
+        notion_user_id
     );
 
     // Get user's account
@@ -2891,13 +2931,18 @@ pub async fn notion_oauth_callback(
 
     // Create a unique identifier for this Notion connection
     // We use workspace_id to allow users to connect multiple workspaces
-    let notion_identifier = format!("{}:{}", notion_token.workspace_id, notion_user_id.as_deref().unwrap_or("bot"));
+    let notion_identifier = format!(
+        "{}:{}",
+        notion_token.workspace_id,
+        notion_user_id.as_deref().unwrap_or("bot")
+    );
 
     // Link Notion to account
     let store = state.account_store.clone();
-    let link_result =
-        task::spawn_blocking(move || store.create_identifier(account.id, "notion", &notion_identifier))
-            .await;
+    let link_result = task::spawn_blocking(move || {
+        store.create_identifier(account.id, "notion", &notion_identifier)
+    })
+    .await;
 
     match link_result {
         Ok(Ok(_identifier)) => {
@@ -2918,13 +2963,11 @@ pub async fn notion_oauth_callback(
                 updated_at: chrono::Utc::now(),
             };
 
-            let store_result = task::spawn_blocking(move || {
-                match NotionStore::new() {
-                    Ok(store) => store.upsert_credential(&credential),
-                    Err(e) => {
-                        error!("Failed to create NotionStore: {}", e);
-                        Err(e)
-                    }
+            let store_result = task::spawn_blocking(move || match NotionStore::new() {
+                Ok(store) => store.upsert_credential(&credential),
+                Err(e) => {
+                    error!("Failed to create NotionStore: {}", e);
+                    Err(e)
                 }
             })
             .await;
@@ -2942,7 +2985,10 @@ pub async fn notion_oauth_callback(
                     // Continue anyway - the identifier is already linked
                 }
                 Err(e) => {
-                    error!("spawn_blocking panicked while storing Notion credential: {}", e);
+                    error!(
+                        "spawn_blocking panicked while storing Notion credential: {}",
+                        e
+                    );
                 }
             }
 
@@ -3380,8 +3426,12 @@ pub fn auth_router(state: AuthState) -> Router {
         .route("/auth/slack/callback", get(slack_oauth_callback))
         .route("/auth/github", get(github_oauth_start))
         .route("/auth/github/callback", get(github_oauth_callback))
-.route("/auth/notion", get(notion_oauth_start))
+        .route("/auth/notion", get(notion_oauth_start))
         .route("/auth/notion/callback", get(notion_oauth_callback))
+        .route(
+            "/api/startup-workspace/intake-chat",
+            post(startup_workspace_intake_chat),
+        )
         .route(
             "/api/workspace/provider-state",
             get(get_workspace_provider_state),

--- a/DoWhiz_service/scheduler_module/src/service/startup_workspace/intake_chat.rs
+++ b/DoWhiz_service/scheduler_module/src/service/startup_workspace/intake_chat.rs
@@ -1,0 +1,688 @@
+use std::collections::HashSet;
+use std::env;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_OPENAI_URL: &str = "https://api.openai.com/v1";
+const DEFAULT_MODEL: &str = "gpt-5.4";
+const LLM_TIMEOUT: Duration = Duration::from_secs(30);
+
+const DEFAULT_BUILD_SYSTEM: &str = "github";
+const DEFAULT_FORMAL_DOCS: &str = "google_docs";
+const DEFAULT_COORDINATION: &str = "slack";
+const DEFAULT_EXTERNAL_EXECUTION: &str = "email";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StartupIntakeChatMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StartupResourceToolDraft {
+    pub build_system: Option<String>,
+    pub formal_docs: Option<String>,
+    pub coordination: Option<String>,
+    pub external_execution: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StartupRequestedAgentDraft {
+    pub role: String,
+    pub owner: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StartupIntakeDraft {
+    pub founder_name: Option<String>,
+    pub founder_email: Option<String>,
+    pub venture_name: Option<String>,
+    pub venture_thesis: Option<String>,
+    pub venture_stage: Option<String>,
+    pub plan_horizon_days: Option<u16>,
+    #[serde(default)]
+    pub goals_30_90_days: Vec<String>,
+    #[serde(default)]
+    pub current_assets: Vec<String>,
+    #[serde(default)]
+    pub requested_agents: Vec<StartupRequestedAgentDraft>,
+    pub resource_launch_mode: Option<String>,
+    #[serde(default)]
+    pub resource_tools: StartupResourceToolDraft,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StartupIntakeChatRequest {
+    #[serde(default)]
+    pub messages: Vec<StartupIntakeChatMessage>,
+    #[serde(default)]
+    pub current_draft: Option<StartupIntakeDraft>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StartupIntakeChatResponse {
+    pub assistant_message: String,
+    pub intake_draft: StartupIntakeDraft,
+    pub missing_fields: Vec<String>,
+    pub ready_for_blueprint: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LlmIntakeOutput {
+    #[serde(default, alias = "assistant_reply", alias = "message")]
+    assistant_message: String,
+    #[serde(default, alias = "draft")]
+    intake_draft: StartupIntakeDraft,
+}
+
+#[derive(Debug, Clone)]
+struct StartupIntakeLlmConfig {
+    api_key: String,
+    api_url: String,
+    model: String,
+    use_azure_auth: bool,
+}
+
+impl StartupIntakeLlmConfig {
+    fn from_env() -> Result<Self, String> {
+        let azure_api_key = env::var("AZURE_OPENAI_API_KEY_BACKUP")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let azure_endpoint = env::var("AZURE_OPENAI_ENDPOINT_BACKUP")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        if let (Some(api_key), Some(endpoint)) = (azure_api_key, azure_endpoint) {
+            let api_url = normalize_azure_endpoint(&endpoint);
+            let model = env::var("STARTUP_INTAKE_MODEL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+            return Ok(Self {
+                api_key,
+                api_url,
+                model,
+                use_azure_auth: true,
+            });
+        }
+
+        let api_key = env::var("OPENAI_API_KEY")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                "Startup intake LLM is not configured (set AZURE_OPENAI_API_KEY_BACKUP + AZURE_OPENAI_ENDPOINT_BACKUP, or OPENAI_API_KEY).".to_string()
+            })?;
+
+        let api_url = env::var("OPENAI_API_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_OPENAI_URL.to_string());
+        let model = env::var("STARTUP_INTAKE_MODEL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+        Ok(Self {
+            api_key,
+            api_url: api_url.trim_end_matches('/').to_string(),
+            model,
+            use_azure_auth: false,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ChatRequestBody {
+    model: String,
+    messages: Vec<ChatMessage>,
+    max_completion_tokens: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ChatResponseBody {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+
+pub async fn generate_startup_intake_chat_response(
+    request: StartupIntakeChatRequest,
+) -> Result<StartupIntakeChatResponse, String> {
+    let messages = normalize_messages(request.messages);
+    if messages.is_empty() {
+        return Err("No conversation messages were provided.".to_string());
+    }
+
+    let config = StartupIntakeLlmConfig::from_env()?;
+    let system_prompt = startup_intake_system_prompt();
+    let user_prompt = startup_intake_user_prompt(&messages, request.current_draft.as_ref())?;
+    let raw = call_chat_completion(&config, &system_prompt, &user_prompt).await?;
+    let parsed = parse_llm_output(&raw)?;
+
+    let mut draft = normalize_intake_draft(parsed.intake_draft);
+    if draft.resource_launch_mode.as_deref() == Some("default") {
+        draft = apply_default_tool_selection(draft);
+    }
+
+    let missing_fields = derive_missing_fields(&draft);
+    let ready_for_blueprint = missing_fields.is_empty();
+    let assistant_message = normalize_assistant_message(
+        parsed.assistant_message,
+        &missing_fields,
+        ready_for_blueprint,
+    );
+
+    Ok(StartupIntakeChatResponse {
+        assistant_message,
+        intake_draft: draft,
+        missing_fields,
+        ready_for_blueprint,
+    })
+}
+
+fn normalize_messages(messages: Vec<StartupIntakeChatMessage>) -> Vec<StartupIntakeChatMessage> {
+    messages
+        .into_iter()
+        .filter_map(|message| {
+            let role = message.role.trim().to_lowercase();
+            let normalized_role = if role == "assistant" {
+                "assistant"
+            } else if role == "system" {
+                "system"
+            } else {
+                "user"
+            };
+            let content = message.content.trim();
+            if content.is_empty() {
+                return None;
+            }
+            Some(StartupIntakeChatMessage {
+                role: normalized_role.to_string(),
+                content: content.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn startup_intake_system_prompt() -> String {
+    r#"You are DoWhiz intake assistant.
+
+Your job is to collect enough information to create a startup workspace blueprint.
+You must drive the conversation naturally and ask only the next most important question.
+
+Required fields before ready_for_blueprint can be true:
+- founder_name
+- venture_thesis
+- at least one goals_30_90_days item
+- resource_launch_mode chosen: "default" or "custom"
+- if mode is "custom", exactly one tool chosen for each category:
+  - build_system: github | gitlab | bitbucket
+  - formal_docs: google_docs | notion
+  - coordination: slack | discord | email
+  - external_execution: email | slack | discord
+
+Output requirements:
+- Return ONLY a valid JSON object (no markdown, no code fences, no extra text).
+- JSON shape:
+{
+  "assistant_message": "string",
+  "intake_draft": {
+    "founder_name": "string|null",
+    "founder_email": "string|null",
+    "venture_name": "string|null",
+    "venture_thesis": "string|null",
+    "venture_stage": "idea|prototype|mvp|post_mvp|growth|null",
+    "plan_horizon_days": 30|60|90|null,
+    "goals_30_90_days": ["..."],
+    "current_assets": ["..."],
+    "requested_agents": [{"role":"string","owner":"string|null"}],
+    "resource_launch_mode": "default|custom|null",
+    "resource_tools": {
+      "build_system": "github|gitlab|bitbucket|null",
+      "formal_docs": "google_docs|notion|null",
+      "coordination": "slack|discord|email|null",
+      "external_execution": "email|slack|discord|null"
+    }
+  }
+}
+
+Behavior rules:
+- Never hallucinate user details. Only fill values grounded in conversation.
+- Keep assistant_message concise and actionable.
+- If missing key data, ask one focused follow-up question.
+- If enough data is present, ask user to click "Create blueprint now".
+"#
+    .to_string()
+}
+
+fn startup_intake_user_prompt(
+    messages: &[StartupIntakeChatMessage],
+    current_draft: Option<&StartupIntakeDraft>,
+) -> Result<String, String> {
+    let transcript = messages
+        .iter()
+        .map(|message| {
+            let role = match message.role.as_str() {
+                "assistant" => "Assistant",
+                "system" => "System",
+                _ => "User",
+            };
+            format!("{}: {}", role, message.content)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let draft_json = serde_json::to_string_pretty(&current_draft.cloned().unwrap_or_default())
+        .map_err(|err| format!("failed to serialize current draft: {}", err))?;
+
+    Ok(format!(
+        "Current intake draft (may be partial):\n{}\n\nConversation transcript:\n{}",
+        draft_json, transcript
+    ))
+}
+
+async fn call_chat_completion(
+    config: &StartupIntakeLlmConfig,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Result<String, String> {
+    let client = Client::builder()
+        .timeout(LLM_TIMEOUT)
+        .build()
+        .map_err(|err| format!("failed to build HTTP client: {}", err))?;
+
+    let url = format!("{}/chat/completions", config.api_url.trim_end_matches('/'));
+    let payload = ChatRequestBody {
+        model: config.model.clone(),
+        messages: vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: system_prompt.to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: user_prompt.to_string(),
+            },
+        ],
+        max_completion_tokens: 1600,
+    };
+
+    let mut request_builder = client.post(url).header("Content-Type", "application/json");
+
+    if config.use_azure_auth {
+        request_builder = request_builder.header("api-key", &config.api_key);
+    } else {
+        request_builder =
+            request_builder.header("Authorization", format!("Bearer {}", config.api_key));
+    }
+
+    let response = request_builder
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|err| format!("startup intake LLM request failed: {}", err))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("startup intake LLM returned {}: {}", status, body));
+    }
+
+    let parsed: ChatResponseBody = response
+        .json()
+        .await
+        .map_err(|err| format!("failed to parse startup intake LLM response: {}", err))?;
+
+    let content = parsed
+        .choices
+        .first()
+        .map(|choice| choice.message.content.clone())
+        .unwrap_or_default();
+
+    if content.trim().is_empty() {
+        return Err("startup intake LLM returned an empty response".to_string());
+    }
+
+    Ok(content)
+}
+
+fn parse_llm_output(raw: &str) -> Result<LlmIntakeOutput, String> {
+    if let Ok(parsed) = serde_json::from_str::<LlmIntakeOutput>(raw) {
+        return Ok(parsed);
+    }
+
+    if let Some(extracted) = extract_json_object(raw) {
+        if let Ok(parsed) = serde_json::from_str::<LlmIntakeOutput>(&extracted) {
+            return Ok(parsed);
+        }
+    }
+
+    Err(format!(
+        "startup intake LLM response was not valid JSON. raw={}",
+        raw
+    ))
+}
+
+fn extract_json_object(input: &str) -> Option<String> {
+    let mut start_index = None;
+    let mut brace_depth: i32 = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (index, ch) in input.char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            continue;
+        }
+
+        if ch == '{' {
+            if start_index.is_none() {
+                start_index = Some(index);
+            }
+            brace_depth += 1;
+            continue;
+        }
+
+        if ch == '}' && brace_depth > 0 {
+            brace_depth -= 1;
+            if brace_depth == 0 {
+                if let Some(start) = start_index {
+                    return Some(input[start..=index].to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn normalize_intake_draft(mut draft: StartupIntakeDraft) -> StartupIntakeDraft {
+    draft.founder_name = normalize_optional_string(draft.founder_name);
+    draft.founder_email = normalize_optional_string(draft.founder_email);
+    draft.venture_name = normalize_optional_string(draft.venture_name);
+    draft.venture_thesis = normalize_optional_string(draft.venture_thesis);
+    draft.venture_stage = normalize_stage(draft.venture_stage);
+    draft.plan_horizon_days = draft.plan_horizon_days.map(normalize_horizon);
+    draft.goals_30_90_days = normalize_string_list(draft.goals_30_90_days);
+    draft.current_assets = normalize_string_list(draft.current_assets);
+    draft.requested_agents = normalize_agents(draft.requested_agents);
+    draft.resource_launch_mode = normalize_launch_mode(draft.resource_launch_mode);
+    draft.resource_tools = normalize_resource_tools(draft.resource_tools);
+    draft
+}
+
+fn apply_default_tool_selection(mut draft: StartupIntakeDraft) -> StartupIntakeDraft {
+    draft.resource_tools.build_system = Some(DEFAULT_BUILD_SYSTEM.to_string());
+    draft.resource_tools.formal_docs = Some(DEFAULT_FORMAL_DOCS.to_string());
+    draft.resource_tools.coordination = Some(DEFAULT_COORDINATION.to_string());
+    draft.resource_tools.external_execution = Some(DEFAULT_EXTERNAL_EXECUTION.to_string());
+    draft
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|item| item.trim().to_string())
+        .filter(|item| !item.is_empty())
+}
+
+fn normalize_horizon(value: u16) -> u16 {
+    if value <= 30 {
+        30
+    } else if value <= 60 {
+        60
+    } else {
+        90
+    }
+}
+
+fn normalize_stage(value: Option<String>) -> Option<String> {
+    let normalized = normalize_optional_string(value)?;
+    let lower = normalized.to_lowercase();
+    match lower.as_str() {
+        "idea" => Some("idea".to_string()),
+        "prototype" => Some("prototype".to_string()),
+        "mvp" => Some("mvp".to_string()),
+        "post_mvp" | "post-mvp" | "post mvp" => Some("post_mvp".to_string()),
+        "growth" => Some("growth".to_string()),
+        _ => None,
+    }
+}
+
+fn normalize_launch_mode(value: Option<String>) -> Option<String> {
+    let normalized = normalize_optional_string(value)?;
+    let lower = normalized.to_lowercase();
+
+    if lower == "default" || lower.contains("default") || lower == "auto" {
+        return Some("default".to_string());
+    }
+    if lower == "custom" || lower.contains("custom") || lower == "manual" {
+        return Some("custom".to_string());
+    }
+
+    None
+}
+
+fn normalize_string_list(values: Vec<String>) -> Vec<String> {
+    let mut output = Vec::new();
+    let mut seen = HashSet::new();
+
+    for value in values {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let key = trimmed.to_lowercase();
+        if seen.insert(key) {
+            output.push(trimmed.to_string());
+        }
+    }
+
+    output
+}
+
+fn normalize_agents(values: Vec<StartupRequestedAgentDraft>) -> Vec<StartupRequestedAgentDraft> {
+    let mut output = Vec::new();
+    let mut seen = HashSet::new();
+
+    for mut agent in values {
+        agent.role = agent.role.trim().to_string();
+        agent.owner = normalize_optional_string(agent.owner);
+        if agent.role.is_empty() {
+            continue;
+        }
+
+        let key = agent.role.to_lowercase();
+        if seen.insert(key) {
+            output.push(agent);
+        }
+    }
+
+    output
+}
+
+fn normalize_resource_tools(mut tools: StartupResourceToolDraft) -> StartupResourceToolDraft {
+    tools.build_system =
+        normalize_allowed_value(tools.build_system, &["github", "gitlab", "bitbucket"]);
+    tools.formal_docs = normalize_allowed_value(tools.formal_docs, &["google_docs", "notion"]);
+    tools.coordination =
+        normalize_allowed_value(tools.coordination, &["slack", "discord", "email"]);
+    tools.external_execution =
+        normalize_allowed_value(tools.external_execution, &["email", "slack", "discord"]);
+    tools
+}
+
+fn normalize_allowed_value(value: Option<String>, allowed: &[&str]) -> Option<String> {
+    let normalized = normalize_optional_string(value)?.to_lowercase();
+    allowed
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == normalized)
+        .map(|candidate| candidate.to_string())
+}
+
+fn derive_missing_fields(draft: &StartupIntakeDraft) -> Vec<String> {
+    let mut missing = Vec::new();
+
+    if draft.founder_name.is_none() {
+        missing.push("founder_name".to_string());
+    }
+    if draft.venture_thesis.is_none() {
+        missing.push("venture_thesis".to_string());
+    }
+    if draft.goals_30_90_days.is_empty() {
+        missing.push("goals_30_90_days".to_string());
+    }
+
+    match draft.resource_launch_mode.as_deref() {
+        Some("default") => {}
+        Some("custom") => {
+            if draft.resource_tools.build_system.is_none() {
+                missing.push("resource_tools.build_system".to_string());
+            }
+            if draft.resource_tools.formal_docs.is_none() {
+                missing.push("resource_tools.formal_docs".to_string());
+            }
+            if draft.resource_tools.coordination.is_none() {
+                missing.push("resource_tools.coordination".to_string());
+            }
+            if draft.resource_tools.external_execution.is_none() {
+                missing.push("resource_tools.external_execution".to_string());
+            }
+        }
+        _ => {
+            missing.push("resource_launch_mode".to_string());
+        }
+    }
+
+    missing
+}
+
+fn normalize_assistant_message(
+    assistant_message: String,
+    missing_fields: &[String],
+    ready_for_blueprint: bool,
+) -> String {
+    let trimmed = assistant_message.trim();
+    if !trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+
+    if ready_for_blueprint {
+        return "I have enough information. Click \"Create blueprint now\" to continue."
+            .to_string();
+    }
+
+    match missing_fields.first().map(|value| value.as_str()) {
+        Some("founder_name") => "What should I call you as the founder?".to_string(),
+        Some("venture_thesis") => {
+            "Can you describe the project you want to start in one or two sentences?".to_string()
+        }
+        Some("goals_30_90_days") => "What are your top goals for the next 30-90 days?".to_string(),
+        Some("resource_launch_mode") => {
+            "Do you want default resource launch, or custom tool selection by category?".to_string()
+        }
+        Some("resource_tools.build_system") => {
+            "Choose one Build System tool: GitHub, GitLab, or Bitbucket.".to_string()
+        }
+        Some("resource_tools.formal_docs") => {
+            "Choose one Formal Docs tool: Google Docs or Notion.".to_string()
+        }
+        Some("resource_tools.coordination") => {
+            "Choose one Coordination tool: Slack, Discord, or Email.".to_string()
+        }
+        Some("resource_tools.external_execution") => {
+            "Choose one External Execution tool: Email, Slack, or Discord.".to_string()
+        }
+        _ => "Tell me a bit more about your startup goals and preferred setup.".to_string(),
+    }
+}
+
+fn normalize_azure_endpoint(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.ends_with("/openai/v1") {
+        trimmed.to_string()
+    } else {
+        format!("{}/openai/v1", trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_json_object_finds_first_valid_object() {
+        let raw = "noise {\"assistant_message\":\"hi\",\"intake_draft\":{}} trailing";
+        let extracted = extract_json_object(raw).expect("json object should be extracted");
+        assert!(extracted.contains("\"assistant_message\":\"hi\""));
+    }
+
+    #[test]
+    fn normalize_draft_clamps_horizon_and_mode() {
+        let draft = StartupIntakeDraft {
+            founder_name: Some("  Found  ".to_string()),
+            venture_thesis: Some("  Build it ".to_string()),
+            goals_30_90_days: vec![" Goal ".to_string()],
+            plan_horizon_days: Some(42),
+            resource_launch_mode: Some("Manual".to_string()),
+            ..StartupIntakeDraft::default()
+        };
+
+        let normalized = normalize_intake_draft(draft);
+        assert_eq!(normalized.founder_name.as_deref(), Some("Found"));
+        assert_eq!(normalized.venture_thesis.as_deref(), Some("Build it"));
+        assert_eq!(normalized.plan_horizon_days, Some(60));
+        assert_eq!(normalized.resource_launch_mode.as_deref(), Some("custom"));
+    }
+
+    #[test]
+    fn derive_missing_fields_requires_custom_tools() {
+        let draft = StartupIntakeDraft {
+            founder_name: Some("Founder".to_string()),
+            venture_thesis: Some("Build".to_string()),
+            goals_30_90_days: vec!["Ship MVP".to_string()],
+            resource_launch_mode: Some("custom".to_string()),
+            resource_tools: StartupResourceToolDraft {
+                build_system: Some("github".to_string()),
+                ..StartupResourceToolDraft::default()
+            },
+            ..StartupIntakeDraft::default()
+        };
+
+        let missing = derive_missing_fields(&draft);
+        assert!(missing.contains(&"resource_tools.formal_docs".to_string()));
+        assert!(missing.contains(&"resource_tools.coordination".to_string()));
+        assert!(missing.contains(&"resource_tools.external_execution".to_string()));
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/service/startup_workspace/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/service/startup_workspace/mod.rs
@@ -1,5 +1,6 @@
 pub mod bootstrap;
 pub mod intake;
+pub mod intake_chat;
 pub mod provider_state;
 pub mod provisioning;
 pub mod resource_mapping;
@@ -7,6 +8,9 @@ pub mod workspace_home;
 
 pub use bootstrap::{bootstrap_workspace_plan, StartupWorkspaceBootstrapPlan};
 pub use intake::normalize_and_validate_blueprint;
+pub use intake_chat::{
+    generate_startup_intake_chat_response, StartupIntakeChatRequest, StartupIntakeChatResponse,
+};
 pub use provider_state::{
     derive_provider_capabilities, derive_provider_connections, LinkedIdentifierSnapshot,
     ProviderCapabilityInputs, ProviderCapabilitySnapshot, ProviderConnectionSnapshot,

--- a/website/README.md
+++ b/website/README.md
@@ -69,7 +69,7 @@ If you are using a dedicated API subdomain (example: `api.dowhiz.com`) for the R
 
 ## Core route map
 - `/`: Landing page.
-- `/start`: Conversational founder intake for creating/updating your agent-team blueprint (default launch or custom tool-by-category setup).
+- `/start`: GPT-5.4 conversational founder intake for creating/updating your agent-team blueprint (default launch or custom tool-by-category setup, JSON draft driven).
 - `/workspace`: Lightweight handoff route to the unified dashboard workspace section.
 - `/auth/index.html`: Unified team + personal dashboard (channels, tasks, memo, settings).
 

--- a/website/src/pages/StartupIntakePage.jsx
+++ b/website/src/pages/StartupIntakePage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { getDoWhizApiBaseUrl } from '../analytics';
 import {
   createFounderIntakeDefaults,
   createValidatedWorkspaceBlueprintFromIntake,
@@ -7,6 +8,7 @@ import {
 } from '../domain/workspaceBlueprint';
 
 const DASHBOARD_PATH = '/auth/index.html?loggedIn=true#section-workspace';
+const INTAKE_CHAT_API_PATH = '/api/startup-workspace/intake-chat';
 
 const DEFAULT_RESOURCE_SELECTIONS = {
   build_system: 'github',
@@ -15,91 +17,8 @@ const DEFAULT_RESOURCE_SELECTIONS = {
   external_execution: 'email'
 };
 
-const TOOL_LABELS = {
-  github: 'GitHub',
-  gitlab: 'GitLab',
-  bitbucket: 'Bitbucket',
-  google_docs: 'Google Docs',
-  notion: 'Notion',
-  slack: 'Slack',
-  discord: 'Discord',
-  email: 'Email'
-};
-
-const CHAT_STEPS = {
-  PROJECT_DESCRIPTION: 'project_description',
-  FOUNDER_NAME: 'founder_name',
-  VENTURE_NAME: 'venture_name',
-  GOALS: 'goals',
-  LAUNCH_MODE: 'launch_mode',
-  RESOURCE_CATEGORY: 'resource_category',
-  CONFIRM: 'confirm',
-  COMPLETED: 'completed'
-};
-
-const LAUNCH_MODE_OPTIONS = [
-  {
-    value: 'default',
-    label: 'Use default resource launch',
-    description: 'Fastest path: GitHub + Google Docs + Slack + Email.'
-  },
-  {
-    value: 'custom',
-    label: 'Choose tools step by step',
-    description: 'Pick one tool in each resource category.'
-  }
-];
-
-const RESOURCE_CATEGORY_FLOW = [
-  {
-    id: 'build_system',
-    label: 'Build System',
-    options: [
-      { value: 'github', label: 'GitHub' },
-      { value: 'gitlab', label: 'GitLab' },
-      { value: 'bitbucket', label: 'Bitbucket' }
-    ]
-  },
-  {
-    id: 'formal_docs',
-    label: 'Formal Docs',
-    options: [
-      { value: 'google_docs', label: 'Google Docs' },
-      { value: 'notion', label: 'Notion' }
-    ]
-  },
-  {
-    id: 'coordination',
-    label: 'Coordination',
-    options: [
-      { value: 'slack', label: 'Slack' },
-      { value: 'discord', label: 'Discord' },
-      { value: 'email', label: 'Email' }
-    ]
-  },
-  {
-    id: 'external_execution',
-    label: 'External Execution',
-    options: [
-      { value: 'email', label: 'Email' },
-      { value: 'slack', label: 'Slack' },
-      { value: 'discord', label: 'Discord' }
-    ]
-  }
-];
-
-const CONFIRM_OPTIONS = [
-  {
-    value: 'create',
-    label: 'Create blueprint now',
-    description: 'Save team setup and continue to dashboard.'
-  },
-  {
-    value: 'restart',
-    label: 'Start over',
-    description: 'Clear this chat and restart intake.'
-  }
-];
+const INITIAL_ASSISTANT_PROMPT =
+  'Describe the project you want to start. I will ask follow-ups and build the JSON blueprint draft with you.';
 
 function createMessage(role, text) {
   return {
@@ -110,12 +29,91 @@ function createMessage(role, text) {
 }
 
 function createInitialMessages() {
-  return [
-    createMessage(
-      'assistant',
-      'Describe the project you want to start. I will build your agent-team workspace setup from that.'
-    )
-  ];
+  return [createMessage('assistant', INITIAL_ASSISTANT_PROMPT)];
+}
+
+function normalizeLaunchMode(mode) {
+  const value = String(mode || '').trim().toLowerCase();
+  if (!value) return null;
+  if (value.includes('default') || value === 'auto') return 'default';
+  if (value.includes('custom') || value === 'manual') return 'custom';
+  return null;
+}
+
+function normalizeToolValue(value, allowed) {
+  const normalized = String(value || '').trim().toLowerCase();
+  return allowed.includes(normalized) ? normalized : null;
+}
+
+function normalizeToolSelections(mode, resourceTools = {}) {
+  if (mode === 'default') {
+    return { ...DEFAULT_RESOURCE_SELECTIONS };
+  }
+
+  return {
+    build_system:
+      normalizeToolValue(resourceTools.build_system, ['github', 'gitlab', 'bitbucket']) || 'github',
+    formal_docs: normalizeToolValue(resourceTools.formal_docs, ['google_docs', 'notion']) || 'google_docs',
+    coordination: normalizeToolValue(resourceTools.coordination, ['slack', 'discord', 'email']) || 'slack',
+    external_execution:
+      normalizeToolValue(resourceTools.external_execution, ['email', 'slack', 'discord']) || 'email'
+  };
+}
+
+function clampPlanHorizon(value) {
+  const numeric = Number.parseInt(value, 10);
+  if (!Number.isFinite(numeric) || Number.isNaN(numeric) || numeric <= 30) {
+    return '30';
+  }
+  if (numeric <= 60) {
+    return '60';
+  }
+  return '90';
+}
+
+function normalizeStringList(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  const seen = new Set();
+  const result = [];
+  for (const value of values) {
+    const normalized = String(value || '').trim();
+    if (!normalized) {
+      continue;
+    }
+    const key = normalized.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(normalized);
+    }
+  }
+  return result;
+}
+
+function normalizeRequestedAgents(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  const seen = new Set();
+  const result = [];
+  for (const value of values) {
+    const role = String(value?.role || '').trim();
+    const owner = String(value?.owner || '').trim();
+    if (!role) {
+      continue;
+    }
+    const key = role.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push({
+      role,
+      owner
+    });
+  }
+  return result;
 }
 
 function applyResourceSelectionsToIntake(intake, selections) {
@@ -130,35 +128,31 @@ function applyResourceSelectionsToIntake(intake, selections) {
     }
   };
 
-  const buildSystem = selections.build_system || DEFAULT_RESOURCE_SELECTIONS.build_system;
-  if (buildSystem === 'github') {
+  if (selections.build_system === 'github') {
     addChannel('GitHub');
   }
 
-  const formalDocs = selections.formal_docs || DEFAULT_RESOURCE_SELECTIONS.formal_docs;
-  if (formalDocs === 'google_docs') {
+  if (selections.formal_docs === 'google_docs') {
     addChannel('Google Docs');
   }
 
-  const coordination = selections.coordination || DEFAULT_RESOURCE_SELECTIONS.coordination;
-  if (coordination === 'slack') {
+  if (selections.coordination === 'slack') {
     addChannel('Slack');
   }
-  if (coordination === 'discord') {
+  if (selections.coordination === 'discord') {
     addChannel('Discord');
   }
-  if (coordination === 'email') {
+  if (selections.coordination === 'email') {
     addChannel('Email');
   }
 
-  const externalExecution = selections.external_execution || DEFAULT_RESOURCE_SELECTIONS.external_execution;
-  if (externalExecution === 'email') {
+  if (selections.external_execution === 'email') {
     addChannel('Email');
   }
-  if (externalExecution === 'slack') {
+  if (selections.external_execution === 'slack') {
     addChannel('Slack');
   }
-  if (externalExecution === 'discord') {
+  if (selections.external_execution === 'discord') {
     addChannel('Discord');
   }
 
@@ -166,34 +160,75 @@ function applyResourceSelectionsToIntake(intake, selections) {
     addChannel('Email');
   }
 
-  const hasExistingRepo = buildSystem === 'github' || buildSystem === 'gitlab' || buildSystem === 'bitbucket';
+  const hasExistingRepo =
+    selections.build_system === 'github' ||
+    selections.build_system === 'gitlab' ||
+    selections.build_system === 'bitbucket';
 
   next.preferred_channels = channels;
   next.has_existing_repo = hasExistingRepo;
-  next.primary_repo_provider = hasExistingRepo ? buildSystem : 'github';
-  next.has_docs_workspace = formalDocs === 'google_docs' || formalDocs === 'notion';
+  next.primary_repo_provider = hasExistingRepo ? selections.build_system : 'github';
+  next.has_docs_workspace = selections.formal_docs === 'google_docs' || selections.formal_docs === 'notion';
 
   return next;
 }
 
-function summarizeSelections(selections) {
-  return RESOURCE_CATEGORY_FLOW.map((category) => {
-    const tool = selections[category.id];
-    const label = TOOL_LABELS[tool] || tool || 'Not selected';
-    return `${category.label}: ${label}`;
-  }).join('\n');
+function mapDraftToIntake(draft) {
+  const base = createFounderIntakeDefaults();
+  const launchMode = normalizeLaunchMode(draft?.resource_launch_mode);
+  const normalizedTools = normalizeToolSelections(launchMode, draft?.resource_tools || {});
+  const withResources = applyResourceSelectionsToIntake(base, normalizedTools);
+
+  const goals = normalizeStringList(draft?.goals_30_90_days);
+  const assets = normalizeStringList(draft?.current_assets);
+  const requestedAgents = normalizeRequestedAgents(draft?.requested_agents);
+  const requestedAgentsText = requestedAgents
+    .map((agent) => (agent.owner ? `${agent.role}:${agent.owner}` : agent.role))
+    .join('\n');
+
+  return {
+    ...withResources,
+    founder_name: String(draft?.founder_name || '').trim(),
+    founder_email: String(draft?.founder_email || '').trim(),
+    venture_name: String(draft?.venture_name || '').trim(),
+    venture_thesis: String(draft?.venture_thesis || '').trim(),
+    venture_stage: String(draft?.venture_stage || '').trim() || 'idea',
+    plan_horizon_days: clampPlanHorizon(draft?.plan_horizon_days),
+    goals_text: goals.join('\n'),
+    assets_text: assets.join('\n'),
+    requested_agents_text: requestedAgentsText
+  };
+}
+
+function summarizeToolSelections(draft) {
+  const mode = normalizeLaunchMode(draft?.resource_launch_mode);
+  const tools = normalizeToolSelections(mode, draft?.resource_tools || {});
+  return [
+    `Mode: ${mode || 'not selected'}`,
+    `Build System: ${tools.build_system}`,
+    `Formal Docs: ${tools.formal_docs}`,
+    `Coordination: ${tools.coordination}`,
+    `External Execution: ${tools.external_execution}`
+  ].join('\n');
+}
+
+function serializeMessagesForApi(messages) {
+  return messages.map((message) => ({
+    role: message.role,
+    content: message.text
+  }));
 }
 
 function StartupIntakePage() {
-  const [intake, setIntake] = useState(() => createFounderIntakeDefaults());
   const [messages, setMessages] = useState(() => createInitialMessages());
   const [inputValue, setInputValue] = useState('');
-  const [step, setStep] = useState(CHAT_STEPS.PROJECT_DESCRIPTION);
-  const [resourceIndex, setResourceIndex] = useState(0);
-  const [launchMode, setLaunchMode] = useState(null);
-  const [resourceSelections, setResourceSelections] = useState(() => ({ ...DEFAULT_RESOURCE_SELECTIONS }));
+  const [isSending, setIsSending] = useState(false);
   const [errors, setErrors] = useState([]);
   const [blueprint, setBlueprint] = useState(null);
+  const [intakeDraft, setIntakeDraft] = useState(null);
+  const [missingFields, setMissingFields] = useState([]);
+  const [readyForBlueprint, setReadyForBlueprint] = useState(false);
+  const [requestError, setRequestError] = useState('');
   const chatFeedRef = useRef(null);
 
   const blueprintJson = useMemo(
@@ -201,41 +236,10 @@ function StartupIntakePage() {
     [blueprint]
   );
 
-  const activeResourceCategory = RESOURCE_CATEGORY_FLOW[resourceIndex] || null;
-  const isTextInputStep =
-    step === CHAT_STEPS.PROJECT_DESCRIPTION ||
-    step === CHAT_STEPS.FOUNDER_NAME ||
-    step === CHAT_STEPS.VENTURE_NAME ||
-    step === CHAT_STEPS.GOALS;
-
-  const chatPlaceholder = (() => {
-    if (step === CHAT_STEPS.PROJECT_DESCRIPTION) {
-      return 'Example: AI onboarding copilot for B2B SaaS customer success teams...';
-    }
-    if (step === CHAT_STEPS.FOUNDER_NAME) {
-      return 'Your name';
-    }
-    if (step === CHAT_STEPS.VENTURE_NAME) {
-      return "Project name (or type 'skip')";
-    }
-    if (step === CHAT_STEPS.GOALS) {
-      return 'Ship MVP, close 3 pilots, launch onboarding analytics...';
-    }
-    return 'Type your answer...';
-  })();
-
-  const activeChoiceOptions = useMemo(() => {
-    if (step === CHAT_STEPS.LAUNCH_MODE) {
-      return LAUNCH_MODE_OPTIONS;
-    }
-    if (step === CHAT_STEPS.RESOURCE_CATEGORY && activeResourceCategory) {
-      return activeResourceCategory.options;
-    }
-    if (step === CHAT_STEPS.CONFIRM) {
-      return CONFIRM_OPTIONS;
-    }
-    return [];
-  }, [activeResourceCategory, step]);
+  const draftJson = useMemo(
+    () => (intakeDraft ? JSON.stringify(intakeDraft, null, 2) : ''),
+    [intakeDraft]
+  );
 
   useEffect(() => {
     const node = chatFeedRef.current;
@@ -249,67 +253,21 @@ function StartupIntakePage() {
     setMessages((prev) => [...prev, createMessage('assistant', text)]);
   };
 
-  const addUserMessage = (text) => {
-    setMessages((prev) => [...prev, createMessage('user', text)]);
-  };
-
   const resetConversation = () => {
-    setIntake(createFounderIntakeDefaults());
     setMessages(createInitialMessages());
     setInputValue('');
-    setStep(CHAT_STEPS.PROJECT_DESCRIPTION);
-    setResourceIndex(0);
-    setLaunchMode(null);
-    setResourceSelections({ ...DEFAULT_RESOURCE_SELECTIONS });
+    setIsSending(false);
     setErrors([]);
     setBlueprint(null);
+    setIntakeDraft(null);
+    setMissingFields([]);
+    setReadyForBlueprint(false);
+    setRequestError('');
   };
 
-  const finalizeSelections = (mode, selections) => {
-    setLaunchMode(mode);
-    setResourceSelections(selections);
-    setIntake((prev) => applyResourceSelectionsToIntake(prev, selections));
-    addAssistantMessage(
-      `Great. I mapped your resource launch to:\n${summarizeSelections(selections)}\n\nReady to create your agent team blueprint?`
-    );
-    setStep(CHAT_STEPS.CONFIRM);
-    setErrors([]);
-  };
-
-  const askNextResourceCategory = (nextIndex) => {
-    const category = RESOURCE_CATEGORY_FLOW[nextIndex];
-    if (!category) {
-      return;
-    }
-    setResourceIndex(nextIndex);
-    addAssistantMessage(`Choose one tool for ${category.label}.`);
-    setStep(CHAT_STEPS.RESOURCE_CATEGORY);
-  };
-
-  const createBlueprintFromConversation = () => {
-    const finalIntake = applyResourceSelectionsToIntake(intake, resourceSelections);
-    setIntake(finalIntake);
-
-    const result = createValidatedWorkspaceBlueprintFromIntake(finalIntake);
-    if (!result.is_valid) {
-      setErrors(result.errors);
-      setBlueprint(null);
-      addAssistantMessage(`I still need a few fields:\n- ${result.errors.join('\n- ')}`);
-      return;
-    }
-
-    saveWorkspaceBlueprint(result.blueprint);
-    setErrors([]);
-    setBlueprint(result.blueprint);
-    addAssistantMessage(
-      'Blueprint saved. You can open your unified dashboard now, or restart this chat to adjust the setup.'
-    );
-    setStep(CHAT_STEPS.COMPLETED);
-  };
-
-  const handleTextSubmit = (event) => {
+  const handleTextSubmit = async (event) => {
     event.preventDefault();
-    if (!isTextInputStep) {
+    if (isSending) {
       return;
     }
 
@@ -318,107 +276,91 @@ function StartupIntakePage() {
       return;
     }
 
+    const userMessage = createMessage('user', value);
+    const nextMessages = [...messages, userMessage];
+    setMessages(nextMessages);
     setInputValue('');
-    addUserMessage(value);
     setErrors([]);
     setBlueprint(null);
+    setRequestError('');
+    setIsSending(true);
 
-    if (step === CHAT_STEPS.PROJECT_DESCRIPTION) {
-      setIntake((prev) => ({
-        ...prev,
-        venture_thesis: value
-      }));
-      addAssistantMessage('Great context. What should I call you?');
-      setStep(CHAT_STEPS.FOUNDER_NAME);
-      return;
-    }
+    try {
+      const response = await fetch(`${getDoWhizApiBaseUrl()}${INTAKE_CHAT_API_PATH}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          messages: serializeMessagesForApi(nextMessages),
+          current_draft: intakeDraft
+        })
+      });
 
-    if (step === CHAT_STEPS.FOUNDER_NAME) {
-      if (value.toLowerCase() === 'skip') {
-        addAssistantMessage('I need your name to create the team blueprint. What should I call you?');
-        return;
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => ({}));
+        throw new Error(errorPayload.error || 'Failed to get a model response for startup intake.');
       }
 
-      setIntake((prev) => ({
-        ...prev,
-        founder_name: value
-      }));
-      addAssistantMessage("What is the project or company name? You can type 'skip' if undecided.");
-      setStep(CHAT_STEPS.VENTURE_NAME);
-      return;
-    }
+      const payload = await response.json();
+      const assistantMessage = String(payload.assistant_message || '').trim();
+      setIntakeDraft(payload.intake_draft || null);
+      setMissingFields(Array.isArray(payload.missing_fields) ? payload.missing_fields : []);
+      setReadyForBlueprint(Boolean(payload.ready_for_blueprint));
 
-    if (step === CHAT_STEPS.VENTURE_NAME) {
-      if (value.toLowerCase() !== 'skip') {
-        setIntake((prev) => ({
-          ...prev,
-          venture_name: value
-        }));
+      if (assistantMessage) {
+        addAssistantMessage(assistantMessage);
+      } else {
+        addAssistantMessage('I updated the intake JSON. Please continue with any missing details.');
       }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Startup intake conversation request failed.';
+      setRequestError(message);
       addAssistantMessage(
-        'What are your top goals for the next 30-90 days? You can answer in one line or comma-separated.'
+        'I could not reach the startup intake model right now. Please try again in a few seconds.'
       );
-      setStep(CHAT_STEPS.GOALS);
-      return;
-    }
-
-    if (step === CHAT_STEPS.GOALS) {
-      if (value.toLowerCase() === 'skip') {
-        addAssistantMessage('I need at least one goal before launch planning. Please share your top goal.');
-        return;
-      }
-
-      setIntake((prev) => ({
-        ...prev,
-        goals_text: value
-      }));
-      addAssistantMessage('How do you want to launch resources?');
-      setStep(CHAT_STEPS.LAUNCH_MODE);
+    } finally {
+      setIsSending(false);
     }
   };
 
-  const handleChoiceSelect = (option) => {
-    addUserMessage(option.label);
+  const handleCreateBlueprint = () => {
     setErrors([]);
-    setBlueprint(null);
+    setRequestError('');
 
-    if (step === CHAT_STEPS.LAUNCH_MODE) {
-      if (option.value === 'default') {
-        finalizeSelections('default', { ...DEFAULT_RESOURCE_SELECTIONS });
-        return;
-      }
-
-      setLaunchMode('custom');
-      setResourceSelections({});
-      askNextResourceCategory(0);
+    if (!intakeDraft) {
+      addAssistantMessage('I need more intake context first. Please describe your project to continue.');
       return;
     }
 
-    if (step === CHAT_STEPS.RESOURCE_CATEGORY && activeResourceCategory) {
-      const nextSelections = {
-        ...resourceSelections,
-        [activeResourceCategory.id]: option.value
-      };
-      const nextIndex = resourceIndex + 1;
-
-      if (nextIndex < RESOURCE_CATEGORY_FLOW.length) {
-        setResourceSelections(nextSelections);
-        addAssistantMessage(`Noted. ${activeResourceCategory.label}: ${option.label}.`);
-        askNextResourceCategory(nextIndex);
-        return;
-      }
-
-      finalizeSelections('custom', nextSelections);
+    if (!readyForBlueprint) {
+      addAssistantMessage(
+        `I still need a few fields before creating the blueprint:\n- ${
+          missingFields.length ? missingFields.join('\n- ') : 'additional details'
+        }`
+      );
       return;
     }
 
-    if (step === CHAT_STEPS.CONFIRM) {
-      if (option.value === 'restart') {
-        resetConversation();
-        return;
-      }
-      createBlueprintFromConversation();
+    const intake = mapDraftToIntake(intakeDraft);
+    const result = createValidatedWorkspaceBlueprintFromIntake(intake);
+
+    if (!result.is_valid) {
+      setErrors(result.errors);
+      setBlueprint(null);
+      addAssistantMessage(`Validation still failed:\n- ${result.errors.join('\n- ')}`);
+      return;
     }
+
+    saveWorkspaceBlueprint(result.blueprint);
+    setBlueprint(result.blueprint);
+    setErrors([]);
+    addAssistantMessage(
+      'Blueprint saved. Open your dashboard workspace section to continue setup.'
+    );
   };
 
   return (
@@ -427,8 +369,7 @@ function StartupIntakePage() {
         <p className="route-kicker">Conversational Intake</p>
         <h1>Create Your Agent Team</h1>
         <p>
-          Start by describing your project in chat. Then pick default launch or configure each resource category one
-          step at a time.
+          This chat is powered by GPT-5.4. Describe your project and I will gather what is needed for blueprint JSON.
         </p>
 
         <section className="route-section intake-chat-shell" aria-label="Conversational workspace intake">
@@ -440,42 +381,44 @@ function StartupIntakePage() {
             ))}
           </div>
 
-          {isTextInputStep ? (
-            <form className="intake-chat-composer" onSubmit={handleTextSubmit}>
-              <input
-                type="text"
-                className="intake-chat-input"
-                value={inputValue}
-                onChange={(event) => setInputValue(event.target.value)}
-                placeholder={chatPlaceholder}
-              />
-              <button type="submit" className="btn btn-primary intake-chat-send-btn">
-                Send
-              </button>
-            </form>
-          ) : null}
-
-          {activeChoiceOptions.length ? (
-            <div className="intake-chat-options">
-              {activeChoiceOptions.map((option) => (
-                <button
-                  key={option.value}
-                  type="button"
-                  className="intake-chat-option"
-                  onClick={() => handleChoiceSelect(option)}
-                >
-                  <span>{option.label}</span>
-                  {option.description ? <small>{option.description}</small> : null}
-                </button>
-              ))}
-            </div>
-          ) : null}
+          <form className="intake-chat-composer" onSubmit={handleTextSubmit}>
+            <input
+              type="text"
+              className="intake-chat-input"
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              placeholder="Share project details or answer the latest question..."
+              disabled={isSending}
+            />
+            <button type="submit" className="btn btn-primary intake-chat-send-btn" disabled={isSending}>
+              {isSending ? 'Thinking...' : 'Send'}
+            </button>
+          </form>
         </section>
 
-        {launchMode ? (
+        {requestError ? (
+          <section className="route-section intake-errors" aria-live="polite">
+            <h2>Conversation API error</h2>
+            <ul>
+              <li>{requestError}</li>
+            </ul>
+          </section>
+        ) : null}
+
+        {intakeDraft ? (
           <section className="route-section">
-            <h2>Launch Plan</h2>
-            <pre className="intake-conversation-summary">{summarizeSelections(resourceSelections)}</pre>
+            <h2>Current JSON Draft</h2>
+            <p>The model updates this draft every turn.</p>
+            <pre className="intake-conversation-summary">{summarizeToolSelections(intakeDraft)}</pre>
+            <details className="intake-advanced">
+              <summary>View full draft JSON</summary>
+              <pre className="intake-blueprint-preview">{draftJson}</pre>
+            </details>
+            <p className="workspace-inline-note">
+              {readyForBlueprint
+                ? 'Ready to create blueprint.'
+                : `Missing fields: ${missingFields.length ? missingFields.join(', ') : 'waiting for more details'}`}
+            </p>
           </section>
         ) : null}
 
@@ -491,6 +434,9 @@ function StartupIntakePage() {
         ) : null}
 
         <div className="route-actions">
+          <button type="button" className="btn btn-primary" onClick={handleCreateBlueprint}>
+            Create blueprint now
+          </button>
           <button type="button" className="btn btn-secondary" onClick={resetConversation}>
             Restart chat
           </button>


### PR DESCRIPTION
## Summary
- replace `/start` predefined questionnaire flow with GPT-5.4 conversational intake
- add backend endpoint `POST /api/startup-workspace/intake-chat` that returns structured intake JSON draft + readiness state
- normalize and validate draft values server-side, then derive missing required fields for follow-up turns
- keep the existing blueprint pipeline by mapping model draft into the current intake schema before blueprint creation
- update website route docs for the GPT-5.4 JSON-draft intake flow

## API
`POST /api/startup-workspace/intake-chat`

Request:
```json
{
  "messages": [{ "role": "user", "content": "..." }],
  "current_draft": {}
}
```

Response:
```json
{
  "assistant_message": "...",
  "intake_draft": {},
  "missing_fields": ["..."],
  "ready_for_blueprint": true
}
```

## Config / Env
- default model: `gpt-5.4`
- optional override: `STARTUP_INTAKE_MODEL`
- credential resolution order:
  1. `AZURE_OPENAI_API_KEY_BACKUP` + `AZURE_OPENAI_ENDPOINT_BACKUP`
  2. `OPENAI_API_KEY` (+ optional `OPENAI_API_URL`)

## Test Evidence
- `cd DoWhiz_service && cargo check -p scheduler_module`
- `cd DoWhiz_service && cargo test -p scheduler_module intake_chat -- --nocapture`
- `cd website && npm run lint`
- `cd website && npm run build`

## Screenshots
- UI updated in `/start` (chat-driven intake + live draft JSON view).
