### PR TITLE
Dashboard: open questionnaire for existing Team Brief updates

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -69,7 +69,8 @@ If you are using a dedicated API subdomain (example: `api.dowhiz.com`) for the R
 
 ## Core route map
 - `/`: Landing page.
-- `/start`: GPT-5.4 conversational founder intake for creating/updating your agent-team blueprint (default launch or custom tool-by-category setup, JSON draft driven).
+- `/start`: GPT-5.4 conversational founder intake for first-time setup (or fallback when no saved brief exists).
+- `/start?mode=edit`: Questionnaire editor for updating an already-saved team brief.
 - `/workspace`: Lightweight handoff route to the unified dashboard workspace section.
 - `/auth/index.html`: Unified team + personal dashboard (channels, tasks, memo, settings).
 

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1037,7 +1037,7 @@
                 <section id="section-workspace" class="legal-card dashboard-section">
                   <div class="dashboard-header">
                     <h2>Team Workspace</h2>
-                    <a class="auth-btn auth-btn-oauth" href="/start">Update Team Brief</a>
+                    <a id="update-team-brief-btn" class="auth-btn auth-btn-oauth" href="/start">Update Team Brief</a>
                   </div>
                   <p class="dashboard-overview-copy">
                     Concise team context shared across your channels and task runtime.
@@ -1423,6 +1423,7 @@
       const backToSigninLink = document.getElementById('back-to-signin');
       const forgotPasswordLink = document.getElementById('forgot-password-link');
       const setPasswordLink = document.getElementById('set-password-link');
+      const updateTeamBriefBtn = document.getElementById('update-team-brief-btn');
       const dashboardSidebarLinks = Array.from(document.querySelectorAll('.sidebar-link'));
       const dashboardSidebarTargets = dashboardSidebarLinks
         .map((link) => document.querySelector(link.getAttribute('href')))
@@ -1588,21 +1589,46 @@
           .filter((agent) => agent.role.length > 0);
       }
 
+      function loadWorkspaceBlueprintFromStorage() {
+        const raw = window.localStorage.getItem(STARTUP_BLUEPRINT_STORAGE_KEY);
+        if (!raw) {
+          return null;
+        }
+
+        try {
+          return JSON.parse(raw);
+        } catch {
+          return null;
+        }
+      }
+
+      function hasSavedTeamBrief(blueprint) {
+        if (!blueprint || typeof blueprint !== 'object') {
+          return false;
+        }
+
+        const founderName = normalizeWorkspaceText(blueprint?.founder?.name, '');
+        const thesis = normalizeWorkspaceText(blueprint?.venture?.thesis, '');
+        const goals = normalizeWorkspaceList(blueprint?.goals_30_90_days);
+        return Boolean(founderName) && Boolean(thesis) && goals.length > 0;
+      }
+
+      function updateTeamBriefLinkFromStorage() {
+        if (!updateTeamBriefBtn) {
+          return;
+        }
+        const workspaceBlueprint = loadWorkspaceBlueprintFromStorage();
+        const href = hasSavedTeamBrief(workspaceBlueprint) ? '/start?mode=edit' : '/start';
+        updateTeamBriefBtn.setAttribute('href', href);
+      }
+
       function loadWorkspaceSummaryFromStorage() {
         const container = document.getElementById('workspace-summary-content');
         if (!container) {
           return;
         }
-
-        let workspaceBlueprint = null;
-        const raw = window.localStorage.getItem(STARTUP_BLUEPRINT_STORAGE_KEY);
-        if (raw) {
-          try {
-            workspaceBlueprint = JSON.parse(raw);
-          } catch {
-            workspaceBlueprint = null;
-          }
-        }
+        const workspaceBlueprint = loadWorkspaceBlueprintFromStorage();
+        updateTeamBriefLinkFromStorage();
 
         const workspaceName = normalizeWorkspaceText(
           workspaceBlueprint?.venture?.name,

--- a/website/src/pages/StartupIntakePage.jsx
+++ b/website/src/pages/StartupIntakePage.jsx
@@ -1,14 +1,20 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { getDoWhizApiBaseUrl } from '../analytics';
 import {
+  CHANNEL_OPTIONS,
+  PLAN_HORIZON_OPTIONS,
+  REPO_PROVIDER_OPTIONS,
+  STAGE_OPTIONS,
   createFounderIntakeDefaults,
   createValidatedWorkspaceBlueprintFromIntake,
+  loadWorkspaceBlueprint,
   saveWorkspaceBlueprint
 } from '../domain/workspaceBlueprint';
 
 const DASHBOARD_PATH = '/auth/index.html?loggedIn=true#section-workspace';
 const INTAKE_CHAT_API_PATH = '/api/startup-workspace/intake-chat';
+const EDIT_MODE_QUERY_VALUE = 'edit';
 
 const DEFAULT_RESOURCE_SELECTIONS = {
   build_system: 'github',
@@ -200,6 +206,40 @@ function mapDraftToIntake(draft) {
   };
 }
 
+function mapBlueprintToIntake(blueprint) {
+  const base = createFounderIntakeDefaults();
+  if (!blueprint) {
+    return base;
+  }
+
+  const goals = normalizeStringList(blueprint.goals_30_90_days);
+  const assets = normalizeStringList(blueprint.current_assets);
+  const channels = normalizeStringList(blueprint.preferred_channels);
+  const requestedAgents = normalizeRequestedAgents(blueprint.requested_agents);
+  const requestedAgentsText = requestedAgents
+    .map((agent) => (agent.owner ? `${agent.role}:${agent.owner}` : agent.role))
+    .join('\n');
+
+  return {
+    ...base,
+    founder_name: String(blueprint.founder?.name || '').trim(),
+    founder_email: String(blueprint.founder?.email || '').trim(),
+    venture_name: String(blueprint.venture?.name || '').trim(),
+    venture_thesis: String(blueprint.venture?.thesis || '').trim(),
+    venture_stage: String(blueprint.venture?.stage || '').trim() || base.venture_stage,
+    plan_horizon_days: clampPlanHorizon(blueprint.plan_horizon_days),
+    goals_text: goals.join('\n'),
+    assets_text: assets.join('\n'),
+    preferred_channels: channels.length ? channels : base.preferred_channels,
+    has_existing_repo: Boolean(blueprint.stack?.has_existing_repo),
+    primary_repo_provider:
+      normalizeToolValue(blueprint.stack?.primary_repo_provider, REPO_PROVIDER_OPTIONS) ||
+      base.primary_repo_provider,
+    has_docs_workspace: Boolean(blueprint.stack?.has_docs_workspace),
+    requested_agents_text: requestedAgentsText
+  };
+}
+
 function summarizeToolSelections(draft) {
   const mode = normalizeLaunchMode(draft?.resource_launch_mode);
   const tools = normalizeToolSelections(mode, draft?.resource_tools || {});
@@ -220,12 +260,25 @@ function serializeMessagesForApi(messages) {
 }
 
 function StartupIntakePage() {
+  const location = useLocation();
+  const savedBlueprint = useMemo(() => loadWorkspaceBlueprint(), []);
+  const hasSavedBlueprint = Boolean(savedBlueprint);
+  const isEditModeRequested = useMemo(() => {
+    const searchParams = new URLSearchParams(location.search);
+    return searchParams.get('mode') === EDIT_MODE_QUERY_VALUE;
+  }, [location.search]);
+  const shouldShowQuestionnaire = isEditModeRequested && hasSavedBlueprint;
+
   const [messages, setMessages] = useState(() => createInitialMessages());
   const [inputValue, setInputValue] = useState('');
   const [isSending, setIsSending] = useState(false);
   const [errors, setErrors] = useState([]);
   const [blueprint, setBlueprint] = useState(null);
   const [intakeDraft, setIntakeDraft] = useState(null);
+  const [questionnaireIntake, setQuestionnaireIntake] = useState(() =>
+    mapBlueprintToIntake(savedBlueprint)
+  );
+  const [questionnaireNotice, setQuestionnaireNotice] = useState('');
   const [missingFields, setMissingFields] = useState([]);
   const [readyForBlueprint, setReadyForBlueprint] = useState(false);
   const [requestError, setRequestError] = useState('');
@@ -241,6 +294,12 @@ function StartupIntakePage() {
     [intakeDraft]
   );
 
+  const selectedChannels = useMemo(() => {
+    return new Set(
+      normalizeStringList(questionnaireIntake.preferred_channels).map((channel) => channel.toLowerCase())
+    );
+  }, [questionnaireIntake.preferred_channels]);
+
   useEffect(() => {
     const node = chatFeedRef.current;
     if (!node) {
@@ -248,6 +307,16 @@ function StartupIntakePage() {
     }
     node.scrollTop = node.scrollHeight;
   }, [messages]);
+
+  useEffect(() => {
+    if (shouldShowQuestionnaire) {
+      setQuestionnaireIntake(mapBlueprintToIntake(savedBlueprint));
+      setQuestionnaireNotice('');
+      setErrors([]);
+      setBlueprint(null);
+      setRequestError('');
+    }
+  }, [savedBlueprint, shouldShowQuestionnaire]);
 
   const addAssistantMessage = (text) => {
     setMessages((prev) => [...prev, createMessage('assistant', text)]);
@@ -263,6 +332,82 @@ function StartupIntakePage() {
     setMissingFields([]);
     setReadyForBlueprint(false);
     setRequestError('');
+  };
+
+  const updateQuestionnaireIntake = (updater) => {
+    setQuestionnaireIntake((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      return {
+        ...prev,
+        ...next
+      };
+    });
+    setErrors([]);
+    setBlueprint(null);
+    setQuestionnaireNotice('');
+    setRequestError('');
+  };
+
+  const handleQuestionnaireFieldChange = (event) => {
+    const { name, type, checked, value } = event.target;
+    updateQuestionnaireIntake({
+      [name]: type === 'checkbox' ? checked : value
+    });
+  };
+
+  const handlePreferredChannelToggle = (channel) => {
+    updateQuestionnaireIntake((prev) => {
+      const channels = normalizeStringList(prev.preferred_channels);
+      const existingIndex = channels.findIndex(
+        (item) => item.toLowerCase() === channel.toLowerCase()
+      );
+
+      if (existingIndex >= 0) {
+        channels.splice(existingIndex, 1);
+      } else {
+        channels.push(channel);
+      }
+
+      return {
+        preferred_channels: channels
+      };
+    });
+  };
+
+  const handleQuestionnaireSubmit = (event) => {
+    event.preventDefault();
+    setErrors([]);
+    setRequestError('');
+    setBlueprint(null);
+    setQuestionnaireNotice('');
+
+    const normalizedIntake = {
+      ...questionnaireIntake,
+      founder_name: String(questionnaireIntake.founder_name || '').trim(),
+      founder_email: String(questionnaireIntake.founder_email || '').trim(),
+      venture_name: String(questionnaireIntake.venture_name || '').trim(),
+      venture_thesis: String(questionnaireIntake.venture_thesis || '').trim(),
+      venture_stage: String(questionnaireIntake.venture_stage || '').trim() || 'idea',
+      plan_horizon_days: clampPlanHorizon(questionnaireIntake.plan_horizon_days),
+      goals_text: String(questionnaireIntake.goals_text || '').trim(),
+      assets_text: String(questionnaireIntake.assets_text || '').trim(),
+      preferred_channels: normalizeStringList(questionnaireIntake.preferred_channels),
+      has_existing_repo: Boolean(questionnaireIntake.has_existing_repo),
+      primary_repo_provider:
+        normalizeToolValue(questionnaireIntake.primary_repo_provider, REPO_PROVIDER_OPTIONS) || 'github',
+      has_docs_workspace: Boolean(questionnaireIntake.has_docs_workspace),
+      requested_agents_text: String(questionnaireIntake.requested_agents_text || '').trim()
+    };
+
+    const result = createValidatedWorkspaceBlueprintFromIntake(normalizedIntake);
+    if (!result.is_valid) {
+      setErrors(result.errors);
+      return;
+    }
+
+    saveWorkspaceBlueprint(result.blueprint);
+    setBlueprint(result.blueprint);
+    setQuestionnaireNotice('Team brief saved. Open your dashboard workspace section to continue setup.');
   };
 
   const handleTextSubmit = async (event) => {
@@ -363,6 +508,248 @@ function StartupIntakePage() {
     );
   };
 
+  if (shouldShowQuestionnaire) {
+    return (
+      <main className="route-shell route-shell-intake">
+        <div className="route-card route-card-intake">
+          <p className="route-kicker">Team Brief Questionnaire</p>
+          <h1>Update Your Team Brief</h1>
+          <p>
+            Review and edit your saved team context. Changes are validated and saved to your workspace blueprint.
+          </p>
+
+          <section className="route-section" aria-label="Team brief questionnaire">
+            <form className="intake-form" onSubmit={handleQuestionnaireSubmit}>
+              <div className="intake-grid">
+                <div className="intake-field">
+                  <label htmlFor="founder_name">Founder name</label>
+                  <input
+                    id="founder_name"
+                    name="founder_name"
+                    type="text"
+                    value={questionnaireIntake.founder_name}
+                    onChange={handleQuestionnaireFieldChange}
+                    placeholder="Your name"
+                  />
+                </div>
+
+                <div className="intake-field">
+                  <label htmlFor="founder_email">Founder email</label>
+                  <input
+                    id="founder_email"
+                    name="founder_email"
+                    type="email"
+                    value={questionnaireIntake.founder_email}
+                    onChange={handleQuestionnaireFieldChange}
+                    placeholder="you@example.com"
+                  />
+                </div>
+
+                <div className="intake-field">
+                  <label htmlFor="venture_name">Project / startup name</label>
+                  <input
+                    id="venture_name"
+                    name="venture_name"
+                    type="text"
+                    value={questionnaireIntake.venture_name}
+                    onChange={handleQuestionnaireFieldChange}
+                    placeholder="Project name"
+                  />
+                </div>
+
+                <div className="intake-field">
+                  <label htmlFor="venture_stage">Stage</label>
+                  <select
+                    id="venture_stage"
+                    name="venture_stage"
+                    value={questionnaireIntake.venture_stage}
+                    onChange={handleQuestionnaireFieldChange}
+                  >
+                    {STAGE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="intake-field intake-field-full">
+                  <label htmlFor="venture_thesis">Venture thesis</label>
+                  <textarea
+                    id="venture_thesis"
+                    name="venture_thesis"
+                    value={questionnaireIntake.venture_thesis}
+                    onChange={handleQuestionnaireFieldChange}
+                    placeholder="What are you building and why now?"
+                  />
+                </div>
+
+                <div className="intake-field">
+                  <label htmlFor="plan_horizon_days">Planning horizon</label>
+                  <select
+                    id="plan_horizon_days"
+                    name="plan_horizon_days"
+                    value={questionnaireIntake.plan_horizon_days}
+                    onChange={handleQuestionnaireFieldChange}
+                  >
+                    {PLAN_HORIZON_OPTIONS.map((days) => (
+                      <option key={days} value={String(days)}>
+                        {days} days
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="intake-field intake-field-checkbox">
+                  <label htmlFor="has_docs_workspace">
+                    <input
+                      id="has_docs_workspace"
+                      name="has_docs_workspace"
+                      type="checkbox"
+                      checked={Boolean(questionnaireIntake.has_docs_workspace)}
+                      onChange={handleQuestionnaireFieldChange}
+                    />
+                    Docs workspace is available
+                  </label>
+                </div>
+
+                <div className="intake-field intake-field-full">
+                  <label htmlFor="goals_text">30-90 day goals</label>
+                  <textarea
+                    id="goals_text"
+                    name="goals_text"
+                    value={questionnaireIntake.goals_text}
+                    onChange={handleQuestionnaireFieldChange}
+                    placeholder="One goal per line"
+                  />
+                </div>
+
+                <div className="intake-field intake-field-full">
+                  <label htmlFor="assets_text">Current assets</label>
+                  <textarea
+                    id="assets_text"
+                    name="assets_text"
+                    value={questionnaireIntake.assets_text}
+                    onChange={handleQuestionnaireFieldChange}
+                    placeholder="Team, code, channels, docs, data sources..."
+                  />
+                </div>
+
+                <div className="intake-field intake-field-full">
+                  <label>Preferred channels</label>
+                  <div className="intake-chip-grid" role="group" aria-label="Preferred channels">
+                    {CHANNEL_OPTIONS.map((channel) => {
+                      const isChecked = selectedChannels.has(channel.toLowerCase());
+                      return (
+                        <label
+                          key={channel}
+                          className={`intake-chip${isChecked ? ' is-checked' : ''}`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isChecked}
+                            onChange={() => handlePreferredChannelToggle(channel)}
+                          />
+                          <span>{channel}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="intake-field intake-field-checkbox">
+                  <label htmlFor="has_existing_repo">
+                    <input
+                      id="has_existing_repo"
+                      name="has_existing_repo"
+                      type="checkbox"
+                      checked={Boolean(questionnaireIntake.has_existing_repo)}
+                      onChange={handleQuestionnaireFieldChange}
+                    />
+                    Existing repository available
+                  </label>
+                </div>
+
+                <div className="intake-field">
+                  <label htmlFor="primary_repo_provider">Repository provider</label>
+                  <select
+                    id="primary_repo_provider"
+                    name="primary_repo_provider"
+                    value={questionnaireIntake.primary_repo_provider}
+                    onChange={handleQuestionnaireFieldChange}
+                    disabled={!questionnaireIntake.has_existing_repo}
+                  >
+                    {REPO_PROVIDER_OPTIONS.map((provider) => (
+                      <option key={provider} value={provider}>
+                        {provider}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="intake-field intake-field-full">
+                  <label htmlFor="requested_agents_text">Requested agents</label>
+                  <textarea
+                    id="requested_agents_text"
+                    name="requested_agents_text"
+                    value={questionnaireIntake.requested_agents_text}
+                    onChange={handleQuestionnaireFieldChange}
+                    placeholder="Role:Owner (one per line), for example: Builder:Alice"
+                  />
+                </div>
+              </div>
+
+              <div className="route-actions">
+                <button type="submit" className="btn btn-primary">
+                  Save team brief
+                </button>
+                <Link className="btn btn-secondary" to="/start">
+                  Use conversational intake
+                </Link>
+                <a className="btn btn-secondary" href={DASHBOARD_PATH}>
+                  Open dashboard
+                </a>
+                <Link className="btn btn-secondary" to="/">
+                  Back to landing
+                </Link>
+              </div>
+            </form>
+          </section>
+
+          {questionnaireNotice ? (
+            <section className="route-section" aria-live="polite">
+              <p className="workspace-inline-note">{questionnaireNotice}</p>
+            </section>
+          ) : null}
+
+          {errors.length ? (
+            <section className="route-section intake-errors" aria-live="polite">
+              <h2>Blueprint validation issues</h2>
+              <ul>
+                {errors.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          {blueprint ? (
+            <section className="route-section">
+              <h2>Blueprint saved</h2>
+              <p>
+                Your team blueprint is saved locally and now appears in your dashboard workspace section.
+              </p>
+              <details className="intake-advanced">
+                <summary>View blueprint JSON</summary>
+                <pre className="intake-blueprint-preview">{blueprintJson}</pre>
+              </details>
+            </section>
+          ) : null}
+        </div>
+      </main>
+    );
+  }
+
   return (
     <main className="route-shell route-shell-intake">
       <div className="route-card route-card-intake">
@@ -371,6 +758,12 @@ function StartupIntakePage() {
         <p>
           This chat is powered by GPT-5.4. Describe your project and I will gather what is needed for blueprint JSON.
         </p>
+
+        {isEditModeRequested && !hasSavedBlueprint ? (
+          <p className="workspace-inline-note">
+            No saved team brief was found, so you are in first-time conversational setup.
+          </p>
+        ) : null}
 
         <section className="route-section intake-chat-shell" aria-label="Conversational workspace intake">
           <div className="intake-chat-feed" ref={chatFeedRef}>


### PR DESCRIPTION
## Summary
- make `Update Team Brief` on `/auth/index.html` dynamic based on saved workspace blueprint presence
- route users with an existing saved team brief to `/start?mode=edit`
- keep first-time users on conversational `/start` flow
- add `/start?mode=edit` questionnaire mode in `StartupIntakePage` with prefilled values and blueprint validation/save
- keep docs in sync by documenting the new route behavior in `website/README.md`

## Test Evidence
- `cd website && npm run lint`
- `cd website && npm run build`

## Config / Env Changes
- none
