### PR TITLE
Landing Hero: route existing briefs to questionnaire editor

### DIFF
--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import {
   getOrCreateSessionId,
   persistAttributionFromLocation,
@@ -19,6 +19,7 @@ import {
   getThemeForLocalTime,
   shouldEnableMouseField
 } from '../components/landing/mouseFieldUtils';
+import { loadWorkspaceBlueprint } from '../domain/workspaceBlueprint';
 
 const SITE_URL = 'https://dowhiz.com';
 const LOGO_URL = `${SITE_URL}/assets/DoWhiz.svg`;
@@ -1053,7 +1054,8 @@ function LandingPage() {
     }
   ];
 
-  const heroPrimaryCtaHref = '/start';
+  const hasSavedTeamBrief = useMemo(() => Boolean(loadWorkspaceBlueprint()), []);
+  const heroPrimaryCtaHref = hasSavedTeamBrief ? '/start?mode=edit' : '/start';
   const oliverContactHref = 'mailto:oliver@dowhiz.com';
 
   const handleHeroCtaClick = () => {


### PR DESCRIPTION
## Summary
- update landing page Hero primary CTA (`Create your agent team`) to route conditionally by local saved team brief state
- if a valid saved brief exists, CTA now points to `/start?mode=edit` (questionnaire)
- if no saved brief exists, CTA continues to point to `/start` (conversational intake)

## Test Evidence
- `cd website && npm run lint`

## Config / Env Changes
- none
