### PR TITLE
Gate first blueprint creation behind auth and preserve Team Workspace handoff

### DIFF
--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1354,7 +1354,6 @@
         || window.location.pathname.startsWith(`${CN_PATH_PREFIX}/`);
       const localizePath = (path) => `${isCnPath ? CN_PATH_PREFIX : ''}${path === '/' ? '' : path}`;
       const authRedirectUrl = `${window.location.origin}${localizePath('/auth/index.html')}`;
-      const homeRedirectPath = localizePath('/');
 
       const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
         auth: {
@@ -1553,6 +1552,9 @@
 
       // Check if user came from logged-in state (expecting dashboard)
       const expectingDashboard = new URLSearchParams(window.location.search).get('loggedIn') === 'true';
+      const authRedirectUrlWithIntent = expectingDashboard
+        ? `${authRedirectUrl}?loggedIn=true`
+        : authRedirectUrl;
       // If expecting dashboard, keep everything hidden until ready
       // If not, show sign-in form immediately
       if (!expectingDashboard) {
@@ -2047,7 +2049,7 @@
           return;
         }
         const { error } = await supabase.auth.resetPasswordForEmail(email, {
-          redirectTo: authRedirectUrl
+          redirectTo: authRedirectUrlWithIntent
         });
         if (error) {
           showMessage(normalizeAuthError(error) || error.message);
@@ -2068,7 +2070,7 @@
         const { error } = await supabase.auth.signInWithOtp({
           email,
           options: {
-            emailRedirectTo: authRedirectUrl,
+            emailRedirectTo: authRedirectUrlWithIntent,
             shouldCreateUser: false
           }
         });
@@ -2199,7 +2201,7 @@
         const { data, error } = await supabase.auth.signUp({
           email,
           password,
-          options: { emailRedirectTo: authRedirectUrl }
+          options: { emailRedirectTo: authRedirectUrlWithIntent }
         });
         if (error) {
           trackAnalyticsEvent('auth_error', {
@@ -2237,7 +2239,7 @@
         });
         const { error } = await supabase.auth.signInWithOAuth({
           provider: 'google',
-          options: { redirectTo: authRedirectUrl }
+          options: { redirectTo: authRedirectUrlWithIntent }
         });
         if (error) {
           trackAnalyticsEvent('auth_error', {
@@ -3315,58 +3317,24 @@
               authMethod: flowType === 'magiclink' ? 'magic_link' : 'email_confirmation',
               flow: flowType
             });
-            window.history.replaceState({}, document.title, window.location.pathname);
+            window.history.replaceState(
+              {},
+              document.title,
+              `${window.location.pathname}${expectingDashboard ? '#section-workspace' : ''}`
+            );
             return true;
           }
 
           // Assume OAuth flow if no explicit type is provided
-          try {
-            const res = await fetch(`${DOWHIZ_API_URL}/auth/signup`, {
-              method: 'POST',
-              headers: {
-                'Authorization': `Bearer ${data.session.access_token}`,
-                'x-dowhiz-auth-method': 'oauth_google'
-              }
-            });
-            console.log('DoWhiz signup response:', res.status);
-            if (res.ok) {
-              const accountData = await res.json();
-              trackAnalyticsEvent(
-                'login_completed',
-                {
-                  auth_method: 'oauth_google',
-                  flow: 'oauth_callback',
-                  account_created: Boolean(accountData.created)
-                },
-                {
-                  accessToken: data.session.access_token
-                }
-              );
-              trackAnalyticsEvent(
-                'first_authenticated_session',
-                {
-                  auth_method: 'oauth_google',
-                  flow: 'oauth_callback',
-                  workspace_id: accountData.account_id
-                },
-                {
-                  accessToken: data.session.access_token,
-                  eventKey: `first_authenticated_session:${accountData.account_id}`
-                }
-              );
-            }
-          } catch (err) {
-            console.error('Failed to create DoWhiz account:', err);
-            trackAnalyticsEvent('auth_error', {
-              auth_method: 'oauth_google',
-              flow: 'oauth_callback',
-              error_type: 'post_auth_signup_failed',
-              error: err.message
-            });
-          }
-
-          // Redirect to home page after OAuth
-          window.location.href = homeRedirectPath;
+          await handleAuthSuccess(data.session, {
+            authMethod: 'oauth_google',
+            flow: expectingDashboard ? 'oauth_callback_dashboard' : 'oauth_callback'
+          });
+          window.history.replaceState(
+            {},
+            document.title,
+            `${window.location.pathname}${expectingDashboard ? '#section-workspace' : ''}`
+          );
           return true;
         }
 

--- a/website/src/pages/StartupIntakePage.jsx
+++ b/website/src/pages/StartupIntakePage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { supabase } from '../app/supabaseClient';
 import { getDoWhizApiBaseUrl } from '../analytics';
 import {
   CHANNEL_OPTIONS,
@@ -259,6 +260,23 @@ function serializeMessagesForApi(messages) {
   }));
 }
 
+function openDashboardAuthPopup() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const width = 540;
+  const height = 760;
+  const left = Math.max(0, window.screenX + Math.round((window.outerWidth - width) / 2));
+  const top = Math.max(0, window.screenY + Math.round((window.outerHeight - height) / 2));
+
+  return window.open(
+    DASHBOARD_PATH,
+    'dowhiz_auth',
+    `popup=yes,width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`
+  );
+}
+
 function StartupIntakePage() {
   const location = useLocation();
   const savedBlueprint = useMemo(() => loadWorkspaceBlueprint(), []);
@@ -282,6 +300,7 @@ function StartupIntakePage() {
   const [missingFields, setMissingFields] = useState([]);
   const [readyForBlueprint, setReadyForBlueprint] = useState(false);
   const [requestError, setRequestError] = useState('');
+  const [hasActiveSession, setHasActiveSession] = useState(false);
   const chatFeedRef = useRef(null);
 
   const blueprintJson = useMemo(
@@ -307,6 +326,29 @@ function StartupIntakePage() {
     }
     node.scrollTop = node.scrollHeight;
   }, [messages]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (!isMounted) {
+        return;
+      }
+      setHasActiveSession(Boolean(data?.session));
+    });
+
+    const { data: authStateChange } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMounted) {
+        return;
+      }
+      setHasActiveSession(Boolean(session));
+    });
+
+    return () => {
+      isMounted = false;
+      authStateChange?.subscription?.unsubscribe();
+    };
+  }, []);
 
   useEffect(() => {
     if (shouldShowQuestionnaire) {
@@ -501,11 +543,28 @@ function StartupIntakePage() {
     }
 
     saveWorkspaceBlueprint(result.blueprint);
-    setBlueprint(result.blueprint);
+    setBlueprint(null);
     setErrors([]);
+
+    if (hasActiveSession) {
+      addAssistantMessage('Blueprint saved. Opening Team Workspace now.');
+      window.location.assign(DASHBOARD_PATH);
+      return;
+    }
+
+    const authPopup = openDashboardAuthPopup();
+    if (authPopup) {
+      authPopup.focus();
+      addAssistantMessage(
+        'Blueprint saved. Sign in or sign up in the popup. After auth, Team Workspace will reflect your blueprint.'
+      );
+      return;
+    }
+
     addAssistantMessage(
-      'Blueprint saved. Open your dashboard workspace section to continue setup.'
+      'Blueprint saved. Popup was blocked, so redirecting to sign in. After auth, Team Workspace will reflect your blueprint.'
     );
+    window.location.assign(DASHBOARD_PATH);
   };
 
   if (shouldShowQuestionnaire) {


### PR DESCRIPTION
## Summary
- change startup intake `Create blueprint now` flow for first-time unauthenticated users to open sign-in/sign-up (popup with redirect fallback) instead of showing blueprint JSON
- keep signed-in users on a direct path to `#section-workspace` so Team Workspace reflects the newly saved blueprint immediately
- preserve dashboard intent (`loggedIn=true`) across email/password signup, magic link, reset, and Google OAuth callbacks in `public/auth/index.html`

## Test evidence
- `cd website && npm run lint`
- `cd website && npm run build`

## Notes
- no backend or env changes
