### PR TITLE
Conversational UX: support Cmd+Enter newline in intake chat

### DIFF
--- a/website/src/pages/StartupIntakePage.jsx
+++ b/website/src/pages/StartupIntakePage.jsx
@@ -514,6 +514,20 @@ function StartupIntakePage() {
     }
   };
 
+  const handleChatComposerKeyDown = (event) => {
+    if (event.key !== 'Enter' || event.isComposing) {
+      return;
+    }
+
+    // Keep multiline authoring available with modifier+Enter (Cmd on macOS, Ctrl on Windows/Linux).
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    event.preventDefault();
+    event.currentTarget.form?.requestSubmit();
+  };
+
   const handleCreateBlueprint = () => {
     setErrors([]);
     setRequestError('');
@@ -834,13 +848,14 @@ function StartupIntakePage() {
           </div>
 
           <form className="intake-chat-composer" onSubmit={handleTextSubmit}>
-            <input
-              type="text"
+            <textarea
               className="intake-chat-input"
               value={inputValue}
               onChange={(event) => setInputValue(event.target.value)}
-              placeholder="Share project details or answer the latest question..."
+              onKeyDown={handleChatComposerKeyDown}
+              placeholder="Share project details or answer the latest question... (Enter to send, Cmd+Enter for new line)"
               disabled={isSending}
+              rows={2}
             />
             <button type="submit" className="btn btn-primary intake-chat-send-btn" disabled={isSending}>
               {isSending ? 'Thinking...' : 'Send'}

--- a/website/src/styles/layout.css
+++ b/website/src/styles/layout.css
@@ -264,11 +264,15 @@
   flex: 1;
   width: 100%;
   border: 1px solid var(--color-border);
-  border-radius: 999px;
+  border-radius: 14px;
   background: #fff;
   color: var(--text-primary);
   font: inherit;
+  line-height: 1.45;
+  min-height: 44px;
+  max-height: 180px;
   padding: 0.62rem 0.85rem;
+  resize: vertical;
 }
 
 .intake-chat-input:focus {


### PR DESCRIPTION
## Summary
- update the conversational intake composer to use a multiline textarea
- keep `Enter` as send in the chat composer
- support newline authoring with modifier keys (`Cmd+Enter` on macOS, `Ctrl+Enter` on Windows/Linux)
- update chat input styling for multiline readability

## Test Evidence
- `cd website && npm run lint`
- `cd website && npm run build`

## Config / Env Changes
- none
