### PR TITLE
Close auth popup after success and resume Team Workspace in parent tab

### DIFF
--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1549,11 +1549,21 @@
       let recoverySession = null;
       let lastEmailActionAt = 0;
       const EMAIL_ACTION_COOLDOWN_MS = 30000;
+      const AUTH_POPUP_SUCCESS_EVENT = 'dowhiz-auth-popup-success';
 
       // Check if user came from logged-in state (expecting dashboard)
-      const expectingDashboard = new URLSearchParams(window.location.search).get('loggedIn') === 'true';
-      const authRedirectUrlWithIntent = expectingDashboard
-        ? `${authRedirectUrl}?loggedIn=true`
+      const authQueryParams = new URLSearchParams(window.location.search);
+      const expectingDashboard = authQueryParams.get('loggedIn') === 'true';
+      const popupAuthFlow = authQueryParams.get('popupAuth') === '1';
+      const authIntentParams = new URLSearchParams();
+      if (expectingDashboard) {
+        authIntentParams.set('loggedIn', 'true');
+      }
+      if (popupAuthFlow) {
+        authIntentParams.set('popupAuth', '1');
+      }
+      const authRedirectUrlWithIntent = authIntentParams.toString()
+        ? `${authRedirectUrl}?${authIntentParams.toString()}`
         : authRedirectUrl;
       // If expecting dashboard, keep everything hidden until ready
       // If not, show sign-in form immediately
@@ -1603,6 +1613,43 @@
 
       function setDashboardMode(enabled) {
         document.body.classList.toggle('dashboard-mode', enabled);
+      }
+
+      function completePopupAuthIfNeeded(session, accountData) {
+        if (!popupAuthFlow || !window.opener || window.opener.closed) {
+          return false;
+        }
+
+        try {
+          window.opener.postMessage(
+            {
+              type: AUTH_POPUP_SUCCESS_EVENT,
+              account_id: accountData?.account_id || null,
+              email: session?.user?.email || null
+            },
+            window.location.origin
+          );
+        } catch (err) {
+          console.warn('Failed to notify opener window after auth success:', err);
+        }
+
+        window.close();
+        if (window.closed) {
+          return true;
+        }
+
+        // Fallback: keep popup lightweight and ask the user to return to the parent tab.
+        setDashboardMode(false);
+        loadingContainer.classList.add('hidden');
+        signinFormContainer.classList.add('hidden');
+        signupFormContainer.classList.add('hidden');
+        passwordResetContainer.classList.add('hidden');
+        dashboardContainer.classList.add('hidden');
+        hideExistingAccountOptions();
+        pageTitle.textContent = 'Sign-in complete';
+        pageSubtitle.textContent = 'Return to the original tab to continue.';
+        showMessage('Signed in. You can close this popup and continue in the original tab.', 'success');
+        return true;
       }
 
       function updateSidebarNavigation() {
@@ -2470,6 +2517,11 @@
               eventKey: `first_authenticated_session:${accountData.account_id}`
             }
           );
+
+          if (completePopupAuthIfNeeded(session, accountData)) {
+            return;
+          }
+
           showDashboard(session, accountData);
         } catch (err) {
           // On error, show sign-in form with error message

--- a/website/src/pages/StartupIntakePage.jsx
+++ b/website/src/pages/StartupIntakePage.jsx
@@ -14,6 +14,8 @@ import {
 } from '../domain/workspaceBlueprint';
 
 const DASHBOARD_PATH = '/auth/index.html?loggedIn=true#section-workspace';
+const DASHBOARD_POPUP_AUTH_PATH = '/auth/index.html?loggedIn=true&popupAuth=1#section-workspace';
+const AUTH_POPUP_SUCCESS_EVENT = 'dowhiz-auth-popup-success';
 const INTAKE_CHAT_API_PATH = '/api/startup-workspace/intake-chat';
 const EDIT_MODE_QUERY_VALUE = 'edit';
 
@@ -271,7 +273,7 @@ function openDashboardAuthPopup() {
   const top = Math.max(0, window.screenY + Math.round((window.outerHeight - height) / 2));
 
   return window.open(
-    DASHBOARD_PATH,
+    DASHBOARD_POPUP_AUTH_PATH,
     'dowhiz_auth',
     `popup=yes,width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`
   );
@@ -347,6 +349,30 @@ function StartupIntakePage() {
     return () => {
       isMounted = false;
       authStateChange?.subscription?.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    const handlePopupAuthSuccess = (event) => {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+
+      if (event.data?.type !== AUTH_POPUP_SUCCESS_EVENT) {
+        return;
+      }
+
+      setHasActiveSession(true);
+      setMessages((prev) => [
+        ...prev,
+        createMessage('assistant', 'Signed in successfully. Opening Team Workspace now.')
+      ]);
+      window.location.assign(DASHBOARD_PATH);
+    };
+
+    window.addEventListener('message', handlePopupAuthSuccess);
+    return () => {
+      window.removeEventListener('message', handlePopupAuthSuccess);
     };
   }, []);
 
@@ -570,7 +596,7 @@ function StartupIntakePage() {
     if (authPopup) {
       authPopup.focus();
       addAssistantMessage(
-        'Blueprint saved. Sign in or sign up in the popup. After auth, Team Workspace will reflect your blueprint.'
+        'Blueprint saved. Sign in or sign up in the popup. It will close automatically after success.'
       );
       return;
     }


### PR DESCRIPTION
## Summary
- update startup intake auth popup flow so it uses `popupAuth=1` intent and no longer leaves users on a signed-in dashboard inside the popup
- on successful sign-in/sign-up in popup, post a success message back to the opener tab, close the popup, and continue from the original intake tab to Team Workspace
- preserve popup auth intent across redirect-based auth paths by carrying query params in `authRedirectUrlWithIntent`
- add a fallback confirmation view in popup if browser policy blocks `window.close()`

## Test evidence
- `cd website && npm run lint`
- `cd website && npm run build`

## Notes
- no backend or env changes
