### PR TITLE
Added account_id in ingestion envelope to search for linked email if …

### DIFF
--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
@@ -46,6 +46,7 @@ pub(super) struct CreateWorkspaceBriefRequest {
     pub goals: Vec<String>,
     pub current_assets: Option<Vec<String>>,
     pub plan_horizon_days: Option<i32>,
+    pub account_id: Option<Uuid>,
 }
 
 pub(super) async fn health() -> impl IntoResponse {
@@ -960,6 +961,7 @@ pub(super) async fn build_envelope(
         dedupe_key,
         payload: queue_payload,
         raw_payload_ref,
+        account_id: None,
     })
 }
 
@@ -1091,7 +1093,7 @@ Use the google-docs skill to create and share the document."#,
     };
 
     let external_message_id = message.message_id.clone();
-    let envelope = match build_envelope(
+    let mut envelope = match build_envelope(
         route,
         Channel::Email,
         external_message_id,
@@ -1109,6 +1111,8 @@ Use the google-docs skill to create and share the document."#,
             );
         }
     };
+
+    envelope.account_id = request.account_id;
 
     let task_id = envelope.envelope_id.to_string();
     let result = enqueue_envelope(state.queue.clone(), envelope).await;
@@ -1409,5 +1413,6 @@ pub(super) fn build_envelope_blocking(
         dedupe_key,
         payload: queue_payload,
         raw_payload_ref,
+        account_id: None,
     })
 }

--- a/DoWhiz_service/scheduler_module/src/bin/servicebus_enqueue_load.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/servicebus_enqueue_load.rs
@@ -82,6 +82,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 metadata: ChannelMetadata::default(),
             },
             raw_payload_ref: None,
+            account_id: None,
         };
 
         queue.enqueue(&envelope)?;

--- a/DoWhiz_service/scheduler_module/src/ingestion.rs
+++ b/DoWhiz_service/scheduler_module/src/ingestion.rs
@@ -18,6 +18,8 @@ pub struct IngestionEnvelope {
     pub payload: IngestionPayload,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_payload_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<Uuid>,
 }
 
 impl IngestionEnvelope {

--- a/DoWhiz_service/scheduler_module/src/ingestion_queue.rs
+++ b/DoWhiz_service/scheduler_module/src/ingestion_queue.rs
@@ -626,6 +626,7 @@ mod tests {
             dedupe_key: dedupe_key.to_string(),
             payload: IngestionPayload::from_inbound(&message),
             raw_payload_ref: None,
+            account_id: None,
         }
     }
 

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -7,6 +7,7 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 use chrono::Utc;
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 use crate::account_store::AccountStore;
 use crate::artifact_extractor::extract_artifacts_from_email;
@@ -41,6 +42,7 @@ pub fn process_inbound_payload(
     account_store: &AccountStore,
     payload: &PostmarkInbound,
     raw_payload: &[u8],
+    account_id: Option<Uuid>,
 ) -> Result<(), BoxError> {
     info!("processing inbound payload into workspace");
 
@@ -89,14 +91,58 @@ pub fn process_inbound_payload(
         "resolved inbound requester identifier_type={} identifier={}",
         requester.identifier_type, requester.identifier
     );
-    let user = user_store
-        .get_or_create_user(requester.identifier_type, &requester.identifier)
-        .map_err(|err| {
-            io::Error::other(format!(
-                "get_or_create_user failed identifier_type={} identifier={} error={}",
-                requester.identifier_type, requester.identifier, err
-            ))
-        })?;
+
+    let user = if let Some(acct_id) = account_id {
+        match account_store.list_identifiers(acct_id) {
+            Ok(identifiers) => {
+                let email_ident = identifiers.iter().find(|i| i.identifier_type == "email");
+                if let Some(ident) = email_ident {
+                    info!(
+                        "using account_id={} linked email={} for user lookup",
+                        acct_id, ident.identifier
+                    );
+                    user_store
+                        .get_or_create_user(&ident.identifier_type, &ident.identifier)
+                        .map_err(|err| {
+                            io::Error::other(format!(
+                                "get_or_create_user failed for account {} error={}",
+                                acct_id, err
+                            ))
+                        })?
+                } else {
+                    info!("account_id={} has no email identifier, using requester", acct_id);
+                    user_store
+                        .get_or_create_user(requester.identifier_type, &requester.identifier)
+                        .map_err(|err| {
+                            io::Error::other(format!(
+                                "get_or_create_user failed identifier_type={} identifier={} error={}",
+                                requester.identifier_type, requester.identifier, err
+                            ))
+                        })?
+                }
+            }
+            Err(err) => {
+                warn!("failed to list identifiers for account_id={}: {}, using requester", acct_id, err);
+                user_store
+                    .get_or_create_user(requester.identifier_type, &requester.identifier)
+                    .map_err(|err| {
+                        io::Error::other(format!(
+                            "get_or_create_user failed identifier_type={} identifier={} error={}",
+                            requester.identifier_type, requester.identifier, err
+                        ))
+                    })?
+            }
+        }
+    } else {
+        user_store
+            .get_or_create_user(requester.identifier_type, &requester.identifier)
+            .map_err(|err| {
+                io::Error::other(format!(
+                    "get_or_create_user failed identifier_type={} identifier={} error={}",
+                    requester.identifier_type, requester.identifier, err
+                ))
+            })?
+    };
     let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
     user_store.ensure_user_dirs(&user_paths).map_err(|err| {
         io::Error::other(format!(

--- a/DoWhiz_service/scheduler_module/src/service/ingestion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/ingestion.rs
@@ -149,6 +149,7 @@ fn process_ingestion_envelope(
                 account_store,
                 &payload,
                 &raw_payload,
+                envelope.account_id,
             )
         }
         Channel::Slack => {
@@ -412,6 +413,7 @@ mod tests {
                 },
             },
             raw_payload_ref: None,
+            account_id: None,
         };
 
         let (payload, raw) =
@@ -462,5 +464,62 @@ mod tests {
         ));
         assert!(!is_human_approval_gate_subject("Re: Project update"));
         assert!(!is_human_approval_gate_subject(""));
+    }
+
+    #[test]
+    fn ingestion_envelope_serializes_with_account_id() {
+        let account_id = Uuid::new_v4();
+        let envelope = IngestionEnvelope {
+            envelope_id: Uuid::new_v4(),
+            received_at: Utc::now(),
+            tenant_id: Some("test".to_string()),
+            employee_id: "little_bear".to_string(),
+            channel: Channel::Email,
+            external_message_id: None,
+            dedupe_key: "dedupe".to_string(),
+            payload: IngestionPayload {
+                sender: "sender@example.com".to_string(),
+                sender_name: None,
+                recipient: "oliver@dowhiz.com".to_string(),
+                subject: None,
+                text_body: Some("test".to_string()),
+                html_body: None,
+                thread_id: "thread".to_string(),
+                message_id: None,
+                attachments: vec![],
+                reply_to: vec![],
+                metadata: ChannelMetadata::default(),
+            },
+            raw_payload_ref: None,
+            account_id: Some(account_id),
+        };
+
+        let json = serde_json::to_string(&envelope).expect("serialize");
+        assert!(json.contains(&account_id.to_string()));
+
+        let deserialized: IngestionEnvelope = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deserialized.account_id, Some(account_id));
+    }
+
+    #[test]
+    fn ingestion_envelope_deserializes_without_account_id() {
+        let json = r#"{
+            "envelope_id": "00000000-0000-0000-0000-000000000001",
+            "received_at": "2026-03-17T00:00:00Z",
+            "tenant_id": "test",
+            "employee_id": "little_bear",
+            "channel": "email",
+            "external_message_id": null,
+            "dedupe_key": "dedupe",
+            "payload": {
+                "sender": "sender@example.com",
+                "recipient": "oliver@dowhiz.com",
+                "thread_id": "thread"
+            },
+            "raw_payload_ref": null
+        }"#;
+
+        let envelope: IngestionEnvelope = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(envelope.account_id, None);
     }
 }

--- a/DoWhiz_service/scheduler_module/tests/email_html_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/email_html_e2e.rs
@@ -175,6 +175,7 @@ fn inbound_email_html_is_sanitized() -> Result<(), Box<dyn std::error::Error + S
         &account_store,
         &payload,
         inbound_raw.as_bytes(),
+        None,
     )?;
 
     let user = user_store.get_or_create_user("email", "alice@example.com")?;

--- a/DoWhiz_service/scheduler_module/tests/email_html_e2e_2.rs
+++ b/DoWhiz_service/scheduler_module/tests/email_html_e2e_2.rs
@@ -208,6 +208,7 @@ fn process_payload_and_load_html(
         account_store,
         &payload,
         inbound_raw.as_bytes(),
+        None,
     )?;
 
     let user = user_store.get_or_create_user("email", requester_email)?;

--- a/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
@@ -390,6 +390,7 @@ fn email_flow_injects_github_env() {
         &account_store,
         &payload,
         inbound_raw.as_bytes(),
+        None,
     )
     .expect("process inbound");
 
@@ -531,6 +532,7 @@ fn email_flow_injects_employee_github_env() {
         &account_store,
         &payload,
         inbound_raw.as_bytes(),
+        None,
     )
     .expect("process inbound");
 
@@ -682,6 +684,7 @@ fn email_flow_injects_x402_env() {
         &account_store,
         &payload,
         inbound_raw.as_bytes(),
+        None,
     )
     .expect("process inbound");
 
@@ -844,6 +847,7 @@ fn email_flow_injects_employee_prefixed_x402_env() {
         &account_store,
         &payload,
         inbound_raw.as_bytes(),
+        None,
     )
     .expect("process inbound");
 

--- a/DoWhiz_service/scheduler_module/tests/secrets_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/secrets_e2e.rs
@@ -374,6 +374,7 @@ fn secrets_persist_across_workspaces_and_load(
         &account_store,
         &payload,
         inbound_raw.as_bytes(),
+        None,
     )?;
 
     let user = user_store.get_or_create_user("email", "alice@example.com")?;
@@ -406,6 +407,7 @@ fn secrets_persist_across_workspaces_and_load(
         &account_store,
         &follow_up,
         follow_up_raw.as_bytes(),
+        None,
     )?;
 
     let mut scheduler = Scheduler::load(&user_paths.tasks_db_path, ModuleExecutor::default())?;

--- a/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
@@ -274,6 +274,7 @@ fn thread_latest_epoch_end_to_end() {
         &account_store,
         &payload_1,
         inbound_raw_1.as_bytes(),
+        None,
     )
     .expect("process inbound 1");
 
@@ -312,6 +313,7 @@ fn thread_latest_epoch_end_to_end() {
         &account_store,
         &payload_2,
         inbound_raw_2.as_bytes(),
+        None,
     )
     .expect("process inbound 2");
 

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1936,7 +1936,8 @@
               stage: blueprint.venture?.stage || null,
               goals: blueprint.goals_30_90_days || [],
               current_assets: blueprint.current_assets || null,
-              plan_horizon_days: blueprint.plan_horizon_days || null
+              plan_horizon_days: blueprint.plan_horizon_days || null,
+              account_id: session?.user?.id || null
             })
           });
 


### PR DESCRIPTION
…available


* This change should also be helpful for future "next steps" tasks, as the real sender needs to be resolved to a linked email if available.
* Envelope creation in `build_envelope` and `build_envelope_blocking` in `handlers.rs` are now updated to take in `account_id` as a param.