### PR TITLE
Fix Google access token for agent sandbox: use OAuth dynamic refresh

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/utils.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/utils.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use std::path::Path;
 
 use crate::channel::Channel;
+use crate::google_auth::{GoogleAuth, GoogleAuthConfig};
 
 use super::types::{SchedulerError, TaskKind};
 
@@ -25,21 +26,78 @@ pub(crate) fn parse_datetime(value: &str) -> Result<DateTime<Utc>, SchedulerErro
     Ok(DateTime::parse_from_rfc3339(value)?.with_timezone(&Utc))
 }
 
+/// Load or dynamically generate a Google access token for agent sandbox use.
+///
+/// This function first checks for a pre-generated `GOOGLE_ACCESS_TOKEN` in the environment.
+/// If not found, it attempts to use OAuth credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`,
+/// and `GOOGLE_REFRESH_TOKEN` or employee-specific `GOOGLE_REFRESH_TOKEN_{EMPLOYEE_ID}`) to
+/// dynamically obtain a fresh access token.
+///
+/// This ensures that agents running in sandboxed environments (like Codex) can use the
+/// `google-docs` CLI without requiring browser-based authentication.
 pub fn load_google_access_token_from_service_env() -> Option<String> {
+    // First, try to load a pre-generated access token from .env file
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let service_root = manifest_dir.parent().unwrap_or(manifest_dir);
     let env_path = service_root.join(".env");
-    let iter = dotenvy::from_path_iter(&env_path).ok()?;
-    for item in iter {
-        if let Ok((key, value)) = item {
-            if key == "GOOGLE_ACCESS_TOKEN" {
-                let value = value.trim();
-                if value.is_empty() {
-                    return None;
+    if let Ok(iter) = dotenvy::from_path_iter(&env_path) {
+        for item in iter {
+            if let Ok((key, value)) = item {
+                if key == "GOOGLE_ACCESS_TOKEN" {
+                    let value = value.trim();
+                    if !value.is_empty() {
+                        tracing::debug!("Using pre-generated GOOGLE_ACCESS_TOKEN from .env");
+                        return Some(value.to_string());
+                    }
                 }
-                return Some(value.to_string());
             }
         }
     }
-    None
+
+    // Also check environment variable directly (may be set by container/process)
+    if let Ok(token) = std::env::var("GOOGLE_ACCESS_TOKEN") {
+        let token = token.trim();
+        if !token.is_empty() {
+            tracing::debug!("Using GOOGLE_ACCESS_TOKEN from environment variable");
+            return Some(token.to_string());
+        }
+    }
+
+    // No pre-generated token found, try to dynamically obtain one using OAuth credentials
+    tracing::debug!("No GOOGLE_ACCESS_TOKEN found, attempting dynamic refresh via OAuth");
+
+    // Get employee ID if available for employee-specific refresh tokens
+    let employee_id = std::env::var("EMPLOYEE_ID").ok();
+    let config = GoogleAuthConfig::from_env_for_employee(employee_id.as_deref());
+
+    if !config.is_valid() {
+        tracing::debug!(
+            "Google OAuth credentials not configured (need GOOGLE_CLIENT_ID + \
+             GOOGLE_CLIENT_SECRET + GOOGLE_REFRESH_TOKEN)"
+        );
+        return None;
+    }
+
+    match GoogleAuth::new(config) {
+        Ok(auth) => match auth.get_access_token() {
+            Ok(token) => {
+                tracing::info!(
+                    "Successfully obtained Google access token via OAuth refresh{}",
+                    employee_id
+                        .as_ref()
+                        .map(|id| format!(" for employee {}", id))
+                        .unwrap_or_default()
+                );
+                Some(token)
+            }
+            Err(e) => {
+                tracing::warn!("Failed to refresh Google access token: {}", e);
+                None
+            }
+        },
+        Err(e) => {
+            tracing::warn!("Failed to initialize Google auth: {}", e);
+            None
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Fix production issue where Oliver couldn't create/share Google Docs, falling back to browser-use which was blocked by Google CAPTCHA
- Enhance `load_google_access_token_from_service_env()` to dynamically obtain Google access tokens using OAuth credentials when no pre-generated token is available

## Problem

When agents (like Oliver) tried to use the `google-docs` CLI in sandboxed environments, the CLI couldn't authenticate because:

1. The function only looked for `GOOGLE_ACCESS_TOKEN` (pre-generated)
2. Production `.env` has `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_REFRESH_TOKEN`, but no pre-generated `GOOGLE_ACCESS_TOKEN`
3. Without a token, agents fell back to `browser-use` for authentication
4. Google blocked automated logins with CAPTCHA

## Solution

The `load_google_access_token_from_service_env()` function now:

1. First checks for pre-generated `GOOGLE_ACCESS_TOKEN` (unchanged behavior)
2. If not found, dynamically refreshes using OAuth credentials:
   - `GOOGLE_CLIENT_ID`
   - `GOOGLE_CLIENT_SECRET`
   - `GOOGLE_REFRESH_TOKEN` (or `GOOGLE_REFRESH_TOKEN_{EMPLOYEE_ID}`)

This ensures agents can use the `google-docs` CLI via OAuth API without browser-based login.

## Test plan

- [x] Code compiles without errors
- [x] `google-docs` binary builds successfully
- [ ] Manual test: Verify agent can create Google Docs in staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)