### PR TITLE
Sync documentation with workspace-first refactor

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -49,6 +49,16 @@ Inbound (email/slack/discord/sms/telegram/whatsapp/google workspace/bluebubbles)
 - Raw payload storage defaults to Supabase; Azure Blob backend is recommended for gateway production.
 - Scheduler/user/index state is Mongo-backed.
 
+### 1.4 Startup workspace product layer
+
+Startup workspace orchestration lives in `scheduler_module` (not `run_task_module`) and is split into:
+- `scheduler_module/src/domain/*`: canonical blueprint/resource/task/agent/artifact models
+- `scheduler_module/src/service/startup_workspace/*`: intake normalization, bootstrap planning, resource/provisioning mapping, provider runtime-state snapshots
+- `scheduler_module/src/service/workspace.rs`: bootstrap artifact persistence under each workspace (`startup_workspace/*.json`)
+
+Runtime provider visibility endpoint:
+- `GET /api/workspace/provider-state` (implemented in `scheduler_module/src/service/auth.rs`)
+
 ## 2) Components and Binaries
 
 Cargo workspace members:

--- a/DoWhiz_service/scheduler_module/README.md
+++ b/DoWhiz_service/scheduler_module/README.md
@@ -8,6 +8,7 @@ Responsibilities:
 - ingress path in `inbound_gateway`
 - outbound delivery (`SendReply`) across channels
 - user/task index integration with Mongo-backed stores
+- startup workspace product-layer bootstrap planning (blueprint validation, resource mapping, starter agents/tasks/artifacts, provisioning snapshot)
 
 ## Task Model
 
@@ -34,6 +35,33 @@ Supported channel enum values:
 - `src/service/*`
 - `src/scheduler/*`
 - `src/ingestion_queue.rs`
+- `src/domain/workspace_blueprint.rs`
+- `src/domain/resource_model.rs`
+- `src/domain/agent_roster.rs`
+- `src/domain/starter_tasks.rs`
+- `src/domain/artifact_queue.rs`
+- `src/service/startup_workspace/*`
+- `src/service/workspace.rs` (bootstrap artifact persistence under `startup_workspace/`)
+- `src/service/auth.rs` (`GET /api/workspace/provider-state`)
+
+## Startup Workspace Layer
+
+The startup workspace layer is intentionally separated from run-task runner concerns.
+
+Key boundaries:
+- Product modeling and bootstrap policy are in `scheduler_module`:
+  - `domain/*`: canonical blueprint/resource/task/roster/artifact schemas
+  - `service/startup_workspace/*`: intake normalization + bootstrap orchestration + runtime provider-state snapshots
+- Execution/runtime concerns remain in `run_task_module` (for example Codex/Claude execution and filesystem prep).
+
+Bootstrap output artifacts are persisted into each workspace under:
+- `startup_workspace/blueprint.json`
+- `startup_workspace/resources.json`
+- `startup_workspace/agent_roster.json`
+- `startup_workspace/starter_tasks.json`
+- `startup_workspace/artifact_queue.json`
+- `startup_workspace/provisioning.json`
+- `startup_workspace/workspace_home_snapshot.json`
 
 ## Test Commands
 
@@ -42,6 +70,7 @@ cd DoWhiz_service
 cargo test -p scheduler_module
 cargo test -p scheduler_module --test scheduler_basic
 cargo test -p scheduler_module --test send_reply_outbound_e2e
+cargo test -p scheduler_module startup_workspace::
 ```
 
 Live tests and manual scripts are listed in:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Current product model:
 - Workspace-first operating surface for resources, tasks, artifacts, approvals, and memory.
 - Multi-channel execution across email, Slack/Discord, GitHub, Google Docs, and related surfaces.
 
+Primary web routes:
+- `/`: public landing
+- `/start`: founder intake -> canonical startup workspace blueprint
+- `/workspace`: workspace home (brief/resources/agents/tasks/artifacts/approvals)
+- `/dashboard`: internal analytics/supporting page
+
+Startup workspace backend layer:
+- `DoWhiz_service/scheduler_module/src/domain/*`
+- `DoWhiz_service/scheduler_module/src/service/startup_workspace/*`
+- `DoWhiz_service/scheduler_module/src/service/workspace.rs` (persist bootstrap artifacts in workspace)
+
 Current production model:
 - `inbound_gateway` handles ingress (email/webhooks/chat events) and enqueue.
 - `rust_service` workers consume queue items and execute tasks.
@@ -95,6 +106,7 @@ Inbound message
 - Service docs: [`DoWhiz_service/README.md`](DoWhiz_service/README.md)
 - Operations runbook: [`DoWhiz_service/OPERATIONS.md`](DoWhiz_service/OPERATIONS.md)
 - Deployment policy: [`DoWhiz_service/docs/staging_production_deploy.md`](DoWhiz_service/docs/staging_production_deploy.md)
+- Product spec: [`docs/proactive-chief-of-staff-v1.md`](docs/proactive-chief-of-staff-v1.md)
 - Test checklist: [`reference_documentation/test_plans/DoWhiz_service_tests.md`](reference_documentation/test_plans/DoWhiz_service_tests.md)
 - Vision: [`reference_documentation/vision.md`](reference_documentation/vision.md)
 

--- a/reference_documentation/vision.md
+++ b/reference_documentation/vision.md
@@ -2,7 +2,7 @@
 
 ## 1) Current Baseline (What Exists Today)
 
-As of current `dev` codebase, DoWhiz already operates as a multi-channel digital employee system with:
+As of the current codebase, DoWhiz operates as a multi-channel digital employee runtime with a startup-workspace product shell:
 
 - ingress gateway (`inbound_gateway`) for webhook/event intake
 - worker service (`rust_service`) for queue consumption, scheduling, and task execution
@@ -11,17 +11,54 @@ As of current `dev` codebase, DoWhiz already operates as a multi-channel digital
 - Mongo-backed scheduler/user/index state
 - Supabase Postgres-backed account/auth/billing data
 - ingestion queue support for Postgres (legacy/optional) and Service Bus (required by gateway flow)
+- frontend product routes:
+  - `/` landing
+  - `/start` founder intake -> startup workspace blueprint
+  - `/workspace` workspace home
+  - `/dashboard` internal analytics/supporting view
+- canonical startup workspace modeling in both frontend and backend:
+  - blueprint
+  - resource model
+  - starter tasks
+  - agent roster
+  - artifact queue
+- provider runtime state endpoint for truthful connected/configured status overlays:
+  - `GET /api/workspace/provider-state`
 
 ## 2) Product North Star
 
-Give each user a dependable digital employee team that can:
-- accept work from normal communication channels
-- execute tasks with the right toolchain autonomously
-- keep context over time (memory + references)
-- follow up proactively and safely
-- escalate to humans when ambiguity/approval/risk requires it
+Help a founder spin up a one-person company workspace and digital founding team quickly, while keeping the same model extensible to small teams (2-5 people) without architectural rewrites.
 
-## 3) Platform Principles
+Core product truth:
+- primary object: workspace (not chat)
+- primary interaction model: humans + agents operating in one shared system
+- channel-native triggers remain first-class surfaces, but are not the product home
+
+## 3) Product Object Model
+
+DoWhiz models resources first, providers second.
+
+First-class workspace resource categories:
+- `workspace_home`
+- `knowledge_hub_structured`
+- `formal_docs`
+- `build_system`
+- `external_execution`
+- `coordination_layer`
+- `publish_presence`
+- `agent_roster`
+- `task_board`
+- `artifact_queue`
+- `approval_policy`
+
+Mapping rule:
+- tools are providers (GitHub, Google Docs, email, Slack/Discord, Notion)
+- resources are product objects
+
+This keeps automation truthful:
+- connected vs available-not-configured vs planned/manual vs blocked
+
+## 4) Platform Principles
 
 1. Isolation first
 - user-scoped workspace, memory, and task ownership must remain hard boundaries.
@@ -31,11 +68,16 @@ Give each user a dependable digital employee team that can:
 
 3. Channel-native UX
 - users interact from their existing channel; system handles tool complexity internally.
+- workspace remains the product operating home post-onboarding.
 
 4. Auditable behavior
 - task scheduling, outbound actions, and long-term memory updates should be inspectable.
+- artifact queues and approval policy should be visible, not implicit.
 
-## 4) Role Model
+5. Truthful automation
+- no fake “fully automated” claims where manual provisioning/approval is still required.
+
+## 5) Role Model
 
 Digital employees are role packages, not a single generic bot.
 
@@ -47,51 +89,55 @@ Each role combines:
 
 Current employee config model already supports this via `employee.toml` fields (`runner`, `model`, `addresses`, role-specific guide files, skills dirs).
 
-## 5) Target Architecture Evolution
+## 6) Target Architecture Evolution
 
-### 5.1 Ingress and routing
+### 6.1 Ingress and routing
 
 Continue to strengthen gateway-first ingress:
 - deterministic route resolution
 - richer dedupe and replay controls
 - stronger channel-level validation and anti-loop protection
 
-### 5.2 Orchestration
+### 6.2 Startup workspace product layer
 
-Continue evolving scheduler from task runner into policy engine:
-- better follow-up planning primitives
-- clearer cancellation/reschedule semantics
-- stronger concurrency and fairness controls
+Continue keeping startup workspace policy in dedicated scheduler modules:
+- `scheduler_module/src/domain/*` for canonical product objects
+- `scheduler_module/src/service/startup_workspace/*` for intake/bootstrap/provider-state policy
+- `scheduler_module/src/service/workspace.rs` for workspace artifact persistence seams
 
-### 5.3 Execution backends
+### 6.3 Execution backends
 
 Maintain dual-mode execution:
 - local/docker for development and constrained environments
 - Azure ACI backend for staging/production isolation and scalability
+- keep execution logic in `run_task_module`; avoid moving product policy into runner monoliths.
 
-### 5.4 Unified memory/account layer
+### 6.4 Unified memory/account layer
 
 Expand unified account-linked memory so cross-channel continuity improves while preserving per-user isolation and revocation controls.
 
-## 6) Near-Term Priorities
+## 7) Near-Term Priorities
 
-1. Harden queue and retry observability
+1. Harden startup workspace bootstrap observability
+- metrics/events for blueprint validation outcomes, resource-state generation, manual-step blockers, and provider-state resolution.
+
+2. Harden queue and retry observability
 - explicit metrics around enqueue/claim/ack/fail and channel-level error classes.
 
-2. Improve test ergonomics and confidence
+3. Improve test ergonomics and confidence
 - keep canonical suite mapping in `reference_documentation/test_plans/DoWhiz_service_tests.md`
-- close known gaps (queue race, ACI lifecycle, outbound failure injection).
+- expand startup workspace tests (domain + service layer) and keep runtime path tests green.
 
-3. Tighten deployment coherence
+4. Tighten deployment coherence
 - keep docs/scripts/workflows aligned to single runtime `.env` policy and explicit config-path selection.
 
-4. Reduce operator ambiguity
+5. Reduce operator ambiguity
 - make gateway vs worker responsibilities unambiguous across docs and runbooks.
 
-## 7) Long-Term Direction
+## 8) Long-Term Direction
 
-DoWhiz should evolve into a trustworthy, multi-tenant digital employee platform where:
+DoWhiz should evolve into a trustworthy, multi-tenant startup workspace platform where:
 - onboarding a new role is configuration-first
 - adding a new channel is adapter-first
 - scaling execution is backend-policy-first
-- governance and audit remain first-class, not afterthoughts
+- governance, artifact review, and human approvals remain first-class, not afterthoughts

--- a/website/README.md
+++ b/website/README.md
@@ -4,7 +4,8 @@
   <img src="public/assets/DoWhiz.svg" alt="Do icon" width="96" />
 </p>
 
-Product website for DoWhiz, built with Vite + React.
+Workspace-first product shell for DoWhiz, built with Vite + React.
+The web app handles founder onboarding (`/start`), workspace home (`/workspace`), and supporting internal analytics (`/dashboard`).
 
 ## Prerequisites
 - Node.js 18+ (20+ recommended).
@@ -24,6 +25,7 @@ Open the local URL shown in the terminal (defaults to http://localhost:5173).
 - Lint: `npm run lint`
 - Production build: `npm run build`
 - Preview production build: `npm run preview`
+- Responsive audit: `npm run test:responsive`
 - SEO crawl report: `npm run seo:crawl`
 
 Build output goes to `website/dist/`.
@@ -61,21 +63,30 @@ server {
 If you are using a dedicated API subdomain (example: `api.dowhiz.com`) for the Rust service, you can keep the website hosted on Vercel and only run the API on the VM.
 
 ## Project structure
-- `website/src/`: React components and app code.
-- `website/public/`: Static assets copied as-is.
-- `website/index.html`: App entry HTML.
-- `website/vite.config.js`: Vite configuration.
-- `website/eslint.config.js`: Lint rules (source of truth).
+- `website/src/app/`: app-level router and shared clients.
+- `website/src/pages/`: page-level route components (`LandingPage`, `StartupIntakePage`, `WorkspaceHomePage`, internal dashboard wrapper).
+- `website/src/domain/`: canonical startup workspace models (`workspaceBlueprint`, `resourceModel`, `workspaceHomeModel`, provider runtime overlay logic).
+- `website/src/components/`: reusable UI blocks for landing/workspace sections.
+- `website/src/styles/`: modular style layers (`tokens`, `base`, `landing`, `layout`, `responsive`).
+- `website/public/`: static pages and assets copied as-is.
+- `website/vercel.json`: hosting redirects/rewrites for Vercel deployment.
 
 ## Core route map
 - `/`: Landing page.
-- `/start`: GPT-5.4 conversational founder intake for first-time setup (or fallback when no saved brief exists).
-- `/start?mode=edit`: Questionnaire editor for updating an already-saved team brief.
-- `/workspace`: Lightweight handoff route to the unified dashboard workspace section.
+- `/start`: Founder intake form that produces a canonical startup workspace blueprint object.
+- `/workspace`: Workspace home showing startup brief, resources, agents, tasks, artifacts, approvals, and next actions.
+- `/dashboard`: Internal analytics dashboard (supporting page, not the primary product home).
 - `/auth/index.html`: Unified team + personal dashboard (channels, tasks, memo, settings).
+- `/cn`: Localized landing path.
+
+## Routing and hosting notes
+- SPA routing uses `BrowserRouter`, so direct deep links require host rewrites to `/index.html`.
+- On Vercel, rewrite coverage is defined in `website/vercel.json`, including `/start`, `/workspace`, and `/dashboard`.
+- On VM/Nginx hosting, `try_files $uri /index.html;` is required for SPA routes.
 
 ## Environment variables
-No `.env` file is required for local development at the moment.
+No website `.env` file is required for local development at the moment.
+Provider-runtime overlays gracefully degrade when the user is not authenticated.
 
 ## Troubleshooting
 - Port 5173 in use: run `npm run dev -- --port 5174` or stop the other process.


### PR DESCRIPTION
## Summary
Update documentation to align with the startup-workspace product refactor and current code structure.

### Updated docs
- `README.md`
  - Clarify primary web routes (`/`, `/start`, `/workspace`, `/dashboard`)
  - Document startup-workspace backend layer module locations
- `website/README.md`
  - Refresh route map and page behavior
  - Update project structure to reflect modular `src/app`, `src/pages`, `src/domain`, and style split
  - Add SPA hosting/rewrite notes for Vercel + VM/Nginx
- `DoWhiz_service/README.md`
  - Add startup-workspace product layer section and provider-state endpoint note
- `DoWhiz_service/scheduler_module/README.md`
  - Document startup-workspace domain/service boundaries
  - Add bootstrap artifact outputs and startup-workspace test command
- `reference_documentation/vision.md`
  - Reframe vision around workspace-first product object and resource-first model
  - Align architecture evolution and priorities with current implementation

## Notes
- Documentation-only PR (no runtime behavior changes).
- Left local untracked draft `docs/proactive-chief-of-staff-v1.md` out of this PR on purpose.
