### PR TITLE
Sanitize outbound attachment names

### DIFF
--- a/DoWhiz_service/send_emails_module/src/lib.rs
+++ b/DoWhiz_service/send_emails_module/src/lib.rs
@@ -2,6 +2,7 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 use mime_guess::MimeGuess;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -264,12 +265,93 @@ fn strip_html_tags(input: &str) -> String {
     out
 }
 
+fn ascii_safe_attachment_name(path: &Path, used_names: &mut HashSet<String>) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    let mut base = sanitize_ascii_attachment_stem(stem);
+    if base.is_empty() {
+        base = "attachment".to_string();
+    }
+
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(sanitize_ascii_attachment_extension)
+        .filter(|value| !value.is_empty());
+
+    uniquify_attachment_name(base, extension.as_deref(), used_names)
+}
+
+fn sanitize_ascii_attachment_stem(value: &str) -> String {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            current.push(ch);
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    let mut deduped = Vec::new();
+    for token in tokens {
+        let duplicate = deduped
+            .last()
+            .map(|last: &String| last.eq_ignore_ascii_case(&token))
+            .unwrap_or(false);
+        if !duplicate {
+            deduped.push(token);
+        }
+    }
+
+    deduped.join("_")
+}
+
+fn sanitize_ascii_attachment_extension(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect()
+}
+
+fn uniquify_attachment_name(
+    base: String,
+    extension: Option<&str>,
+    used_names: &mut HashSet<String>,
+) -> String {
+    let mut suffix = 1;
+
+    loop {
+        let stem = if suffix == 1 {
+            base.clone()
+        } else {
+            format!("{}_{}", base, suffix)
+        };
+        let candidate = match extension {
+            Some(ext) if !ext.is_empty() => format!("{}.{}", stem, ext),
+            _ => stem,
+        };
+        if used_names.insert(candidate.to_ascii_lowercase()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
 fn load_attachments(dir: &Path) -> Result<Vec<PostmarkAttachment>, std::io::Error> {
     if !dir.exists() {
         return Ok(Vec::new());
     }
 
     let mut attachments = Vec::new();
+    let mut used_names = HashSet::new();
     let mut entries: Vec<_> = fs::read_dir(dir)?.collect::<Result<_, _>>()?;
     entries.sort_by_key(|entry| entry.path());
 
@@ -284,11 +366,7 @@ fn load_attachments(dir: &Path) -> Result<Vec<PostmarkAttachment>, std::io::Erro
             .essence_str()
             .to_string();
         let attachment = PostmarkAttachment {
-            name: path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
+            name: ascii_safe_attachment_name(&path, &mut used_names),
             content: BASE64_STANDARD.encode(content),
             content_type: mime,
         };

--- a/DoWhiz_service/send_emails_module/src/send_emails.rs
+++ b/DoWhiz_service/send_emails_module/src/send_emails.rs
@@ -1,6 +1,7 @@
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::env;
 use std::fmt;
 use std::fs;
@@ -216,6 +217,86 @@ fn join_optional(values: Vec<String>) -> Option<String> {
     }
 }
 
+fn ascii_safe_attachment_name(path: &Path, used_names: &mut HashSet<String>) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    let mut base = sanitize_ascii_attachment_stem(stem);
+    if base.is_empty() {
+        base = "attachment".to_string();
+    }
+
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(sanitize_ascii_attachment_extension)
+        .filter(|value| !value.is_empty());
+
+    uniquify_attachment_name(base, extension.as_deref(), used_names)
+}
+
+fn sanitize_ascii_attachment_stem(value: &str) -> String {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            current.push(ch);
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    let mut deduped = Vec::new();
+    for token in tokens {
+        let duplicate = deduped
+            .last()
+            .map(|last: &String| last.eq_ignore_ascii_case(&token))
+            .unwrap_or(false);
+        if !duplicate {
+            deduped.push(token);
+        }
+    }
+
+    deduped.join("_")
+}
+
+fn sanitize_ascii_attachment_extension(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect()
+}
+
+fn uniquify_attachment_name(
+    base: String,
+    extension: Option<&str>,
+    used_names: &mut HashSet<String>,
+) -> String {
+    let mut suffix = 1;
+
+    loop {
+        let stem = if suffix == 1 {
+            base.clone()
+        } else {
+            format!("{}_{}", base, suffix)
+        };
+        let candidate = match extension {
+            Some(ext) if !ext.is_empty() => format!("{}.{}", stem, ext),
+            _ => stem,
+        };
+        if used_names.insert(candidate.to_ascii_lowercase()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
 fn collect_attachments(dir: &Path) -> Result<Vec<PostmarkAttachment>, SendEmailError> {
     if !dir.exists() {
         return Ok(Vec::new());
@@ -232,12 +313,9 @@ fn collect_attachments(dir: &Path) -> Result<Vec<PostmarkAttachment>, SendEmailE
     paths.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
 
     let mut attachments = Vec::new();
+    let mut used_names = HashSet::new();
     for path in paths {
-        let name = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("attachment")
-            .to_string();
+        let name = ascii_safe_attachment_name(&path, &mut used_names);
         let payload = fs::read(&path)?;
         let content_type = mime_guess::from_path(&path)
             .first_or_octet_stream()

--- a/DoWhiz_service/send_emails_module/tests/send_emails_integration.rs
+++ b/DoWhiz_service/send_emails_module/tests/send_emails_integration.rs
@@ -215,6 +215,108 @@ fn send_payload_includes_recipients_and_attachments() -> Result<(), Box<dyn std:
 }
 
 #[test]
+fn send_payload_sanitizes_attachment_names_to_ascii() -> Result<(), Box<dyn std::error::Error>> {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|err| err.into_inner());
+    let temp = TempDir::new()?;
+    let html_path = temp.path().join("reply_email_draft.html");
+    fs::write(&html_path, "<p>Hello</p>")?;
+
+    let attachments_dir = temp.path().join("reply_email_attachments");
+    fs::create_dir(&attachments_dir)?;
+    let attachment_a =
+        attachments_dir.join("VW欧美女性AI疗愈_一年组织架构_AI优化建议版_XMind版_v2.xmind");
+    let attachment_b = attachments_dir.join("doc_方案.txt");
+    let attachment_c = attachments_dir.join("doc_计划.txt");
+    fs::write(&attachment_a, "xmind")?;
+    fs::write(&attachment_b, "alpha")?;
+    fs::write(&attachment_c, "beta")?;
+
+    let mut attachments = vec![
+        attachment_a.clone(),
+        attachment_b.clone(),
+        attachment_c.clone(),
+    ];
+    attachments.sort();
+    let expected_attachments: Vec<serde_json::Value> = attachments
+        .into_iter()
+        .map(|path| {
+            let payload = fs::read(&path).unwrap_or_default();
+            let content_type = mime_guess::from_path(&path)
+                .first_or_octet_stream()
+                .essence_str()
+                .to_string();
+            let expected_name = if path == attachment_a {
+                "VW_AI_XMind_v2.xmind"
+            } else if path == attachment_b {
+                "doc.txt"
+            } else {
+                "doc_2.txt"
+            };
+            json!({
+                "Name": expected_name,
+                "Content": general_purpose::STANDARD.encode(payload),
+                "ContentType": content_type,
+            })
+        })
+        .collect();
+
+    let expected_payload = json!({
+        "From": "sender@example.com",
+        "To": "to@example.com",
+        "Bcc": "sender@example.com",
+        "Subject": "Unicode attachment test",
+        "TextBody": "Hello",
+        "HtmlBody": "<p>Hello</p>",
+        "Attachments": expected_attachments,
+    });
+
+    let response_body = json!({
+        "To": "to@example.com",
+        "SubmittedAt": "2024-01-01T00:00:00Z",
+        "MessageID": "test-message-id",
+        "ErrorCode": 0,
+        "Message": "OK",
+    });
+
+    let mut server = Server::new();
+    let api_base_url = server.url();
+    let mock = server
+        .mock("POST", "/email")
+        .match_header("x-postmark-server-token", "test-token")
+        .match_header("accept", "application/json")
+        .match_header("content-type", "application/json")
+        .match_body(Matcher::Json(expected_payload))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(response_body.to_string())
+        .create();
+
+    let _env = EnvGuard::set(&[
+        ("POSTMARK_SERVER_TOKEN", "test-token"),
+        ("POSTMARK_API_BASE_URL", api_base_url.as_str()),
+    ]);
+
+    let request = SendEmailParams {
+        subject: "Unicode attachment test".to_string(),
+        html_path,
+        attachments_dir,
+        from: Some("sender@example.com".to_string()),
+        to: vec!["to@example.com".to_string()],
+        cc: vec![],
+        bcc: vec![],
+        in_reply_to: None,
+        references: None,
+        reply_to: None,
+    };
+
+    let response = send_email(&request)?;
+    assert_eq!(response.message_id, "test-message-id");
+
+    mock.assert();
+    Ok(())
+}
+
+#[test]
 fn live_postmark_delivery_with_attachments() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap_or_else(|err| err.into_inner());
     let root_env = repo_root().join(".env");


### PR DESCRIPTION
## Summary
- sanitize outgoing attachment names to ASCII-safe filenames before sending via Postmark
- preserve file extensions and add numeric suffixes when sanitized names would collide
- add integration coverage for Unicode attachment names

## Testing
- cargo test -p send_emails_module --test send_emails_integration -- --nocapture

## Notes
- cargo test -p send_emails_module -- --nocapture still hits existing live_postmark tests that require POSTMARK_LIVE_TEST=1 and panic when unset; this change does not modify that behavior.