### PR TITLE
Calm workspace recommendation refresh cadence

### DIFF
--- a/docs/proactive-chief-of-staff-v1.md
+++ b/docs/proactive-chief-of-staff-v1.md
@@ -1,7 +1,7 @@
 # DoWhiz Proactive Chief of Staff V1
 
-- Status: Proposed
-- Last updated: 2026-03-17
+- Status: Implemented in V1
+- Last updated: 2026-03-19
 - Audience: Product, design, frontend, backend
 - Scope: V1 product spec for a proactive, low-annoyance recommendation layer
 
@@ -102,7 +102,15 @@ Recommended controls:
 1. `Do it`
 2. `Show 2 options`
 3. `Not now`
-4. `Why am I seeing this?`
+4. `Refresh`
+5. `Why am I seeing this?`
+
+Refresh cadence:
+
+1. Auto-refresh at most once per user's local calendar day, on the first dashboard open that day.
+2. Do not silently reshuffle the recommendation in the background during routine task polling.
+3. Always offer a manual `Refresh` control so the user can explicitly ask for a fresh read.
+4. If the user chooses `Not now`, hide the current recommendation for the rest of the local day unless they manually refresh.
 
 ### 7.2 Post-task continuation suggestion
 
@@ -266,6 +274,7 @@ Guardrails are a core part of the product, not an afterthought.
 
 1. Do not repeat the same recommendation for 7 days unless the underlying state changes.
 2. If the user dismisses two proactive suggestions in a row, automatically downgrade them to a more conservative proactivity mode until new meaningful state change occurs.
+3. Routine dashboard polling should not trigger a fresh recommendation fetch; recommendation cadence should feel like a daily brief, not a live ticker.
 
 ## 13. Proactivity Settings
 
@@ -358,10 +367,9 @@ Suggested first analytics step:
 
 These should be resolved before full implementation:
 
-1. Should "Not now" simply hide the current recommendation, or explicitly create a cooldown record?
-2. Should continuation suggestions be hardcoded by task type at first, or inferred from recent `request_summary` patterns?
-3. Which settings surface should own proactivity controls: Team Workspace, Settings, or both?
-4. Should approval-related recommendations be handled by the same recommendation layer or a distinct approval inbox pattern?
+1. Should continuation suggestions be hardcoded by task type at first, or inferred from recent `request_summary` patterns?
+2. Which settings surface should own proactivity controls: Team Workspace, Settings, or both?
+3. Should approval-related recommendations be handled by the same recommendation layer or a distinct approval inbox pattern?
 
 ## 19. Decision
 

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1808,6 +1808,8 @@
         'section-tasks': 'Open Task Center',
         'section-workspace': 'Open Team Workspace'
       };
+      const WORKSPACE_RECOMMENDATION_CACHE_KEY = 'dowhiz_workspace_recommendation_cache_v2';
+      const WORKSPACE_RECOMMENDATION_SUPPRESSION_KEY = 'dowhiz_workspace_recommendation_suppression_v1';
       const recommendationShownKeys = new Set();
       const recommendationInteractionKeys = new Set();
       let workspaceRecommendationResponse = null;
@@ -1818,6 +1820,8 @@
       let workspaceRecommendationWhyVisible = false;
       let workspaceRecommendationBusy = false;
       let workspaceRecommendationRequestNonce = 0;
+      let workspaceRecommendationLastFetchedAt = null;
+      let workspaceRecommendationDismissedForDay = false;
 
       // Check if user came from logged-in state (expecting dashboard)
       const authQueryParams = new URLSearchParams(window.location.search);
@@ -2242,6 +2246,155 @@
         };
       }
 
+      function workspaceRecommendationDayKey(date = new Date()) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+      }
+
+      function hashWorkspaceRecommendationFingerprint(input) {
+        let hash = 2166136261;
+        for (let i = 0; i < input.length; i += 1) {
+          hash ^= input.charCodeAt(i);
+          hash = Math.imul(hash, 16777619);
+        }
+        return (hash >>> 0).toString(16);
+      }
+
+      function workspaceRecommendationFingerprint(requestPayload) {
+        try {
+          return hashWorkspaceRecommendationFingerprint(JSON.stringify({
+            blueprint: requestPayload?.blueprint || null,
+            current_surface: requestPayload?.current_surface || null,
+            proactivity_level: proactivityLevelSelect?.value || 'minimal'
+          }));
+        } catch {
+          return '';
+        }
+      }
+
+      function readJsonStorage(key) {
+        try {
+          const rawValue = localStorage.getItem(key);
+          return rawValue ? JSON.parse(rawValue) : null;
+        } catch {
+          return null;
+        }
+      }
+
+      function writeJsonStorage(key, value) {
+        try {
+          localStorage.setItem(key, JSON.stringify(value));
+        } catch {
+          // Ignore storage write failures so recommendation rendering still works.
+        }
+      }
+
+      function clearWorkspaceRecommendationCache() {
+        try {
+          localStorage.removeItem(WORKSPACE_RECOMMENDATION_CACHE_KEY);
+        } catch {
+          // Ignore storage clear failures.
+        }
+      }
+
+      function readWorkspaceRecommendationCache(requestFingerprint) {
+        const entry = readJsonStorage(WORKSPACE_RECOMMENDATION_CACHE_KEY);
+        if (!entry) {
+          return null;
+        }
+        if (entry.day_key !== workspaceRecommendationDayKey()) {
+          return null;
+        }
+        if (entry.request_fingerprint !== requestFingerprint) {
+          return null;
+        }
+        return entry;
+      }
+
+      function writeWorkspaceRecommendationCache(requestFingerprint, response, selectedKey, fetchedAt) {
+        writeJsonStorage(WORKSPACE_RECOMMENDATION_CACHE_KEY, {
+          day_key: workspaceRecommendationDayKey(),
+          request_fingerprint: requestFingerprint,
+          fetched_at: fetchedAt,
+          response,
+          selected_key: selectedKey || null
+        });
+      }
+
+      function clearWorkspaceRecommendationSuppression() {
+        workspaceRecommendationDismissedForDay = false;
+        try {
+          localStorage.removeItem(WORKSPACE_RECOMMENDATION_SUPPRESSION_KEY);
+        } catch {
+          // Ignore storage clear failures.
+        }
+      }
+
+      function readWorkspaceRecommendationSuppression(requestFingerprint) {
+        const entry = readJsonStorage(WORKSPACE_RECOMMENDATION_SUPPRESSION_KEY);
+        if (!entry) {
+          return null;
+        }
+        if (entry.day_key !== workspaceRecommendationDayKey()) {
+          return null;
+        }
+        if (entry.request_fingerprint !== requestFingerprint) {
+          return null;
+        }
+        return entry;
+      }
+
+      function suppressWorkspaceRecommendationForDay(requestFingerprint, recommendationIdentityValue) {
+        const dismissedAt = new Date().toISOString();
+        workspaceRecommendationDismissedForDay = true;
+        workspaceRecommendationLastFetchedAt = dismissedAt;
+        writeJsonStorage(WORKSPACE_RECOMMENDATION_SUPPRESSION_KEY, {
+          day_key: workspaceRecommendationDayKey(),
+          request_fingerprint: requestFingerprint,
+          recommendation_identity: recommendationIdentityValue || null,
+          dismissed_at: dismissedAt
+        });
+      }
+
+      function workspaceRecommendationFreshnessMessage() {
+        if (!workspaceRecommendationLastFetchedAt) {
+          return '';
+        }
+        const fetchedAt = new Date(workspaceRecommendationLastFetchedAt);
+        if (Number.isNaN(fetchedAt.getTime())) {
+          return '';
+        }
+        const timeLabel = fetchedAt.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+        if (workspaceRecommendationDayKey(fetchedAt) === workspaceRecommendationDayKey()) {
+          return `Updated today at ${timeLabel}`;
+        }
+        return `Updated ${fetchedAt.toLocaleDateString()} at ${timeLabel}`;
+      }
+
+      function applyWorkspaceRecommendationResponse(response, options = {}) {
+        const {
+          fetchedAt = new Date().toISOString(),
+          selectedKey = null,
+          dismissedForDay = false
+        } = options;
+        workspaceRecommendationResponse = response;
+        workspaceRecommendationStatus = 'ready';
+        workspaceRecommendationAlternativesVisible = false;
+        workspaceRecommendationWhyVisible = false;
+        workspaceRecommendationLastFetchedAt = fetchedAt;
+        workspaceRecommendationDismissedForDay = dismissedForDay;
+
+        const effectiveLevel = response?.preferences?.effective_proactivity_level || response?.preferences?.proactivity_level;
+        if (effectiveLevel) {
+          setProactivityLevelUi(effectiveLevel);
+        }
+
+        const defaultRecommendation = response?.recommendation || response?.alternatives?.[0] || null;
+        workspaceRecommendationSelectedKey = selectedKey || recommendationIdentity(defaultRecommendation);
+      }
+
       async function readApiErrorMessage(res, fallbackMessage) {
         try {
           const text = await res.text();
@@ -2324,19 +2477,32 @@
           document.getElementById('workspace-recommendation-retry')?.addEventListener('click', async () => {
             const { data: { session } } = await supabase.auth.getSession();
             if (session) {
-              await loadWorkspaceRecommendation(session.access_token);
+              await loadWorkspaceRecommendation(session.access_token, { force: true });
             }
           });
           return;
         }
 
         if (!current) {
-          const emptyMessage = currentLevel === 'off'
-            ? 'Proactive suggestions are off. Turn them back on in Settings whenever you want a clear “what next?” nudge.'
-            : 'No proactive recommendation right now. As soon as DoWhiz sees a clear next move, it will show up here.';
+          const freshnessMessage = workspaceRecommendationFreshnessMessage();
+          const canManualRefresh = currentLevel !== 'off';
+          const emptyMessage = workspaceRecommendationDismissedForDay
+            ? 'You dismissed today\'s recommendation. Refresh anytime or check back tomorrow.'
+            : currentLevel === 'off'
+              ? 'Proactive suggestions are off. Turn them back on in Settings whenever you want a clear “what next?” nudge.'
+              : 'No proactive recommendation right now. As soon as DoWhiz sees a clear next move, it will show up here.';
           workspaceRecommendationCard.innerHTML = `
             <div class="workspace-recommendation-empty">${escapeHtml(emptyMessage)}</div>
+            ${(canManualRefresh || freshnessMessage) ? `
+              <div class="workspace-recommendation-actions">
+                ${canManualRefresh ? '<button id="workspace-recommendation-refresh" class="auth-btn auth-btn-oauth">Refresh</button>' : ''}
+                <span class="workspace-recommendation-status">${escapeHtml(freshnessMessage || '')}</span>
+              </div>
+            ` : ''}
           `;
+          document.getElementById('workspace-recommendation-refresh')?.addEventListener('click', () => {
+            handleWorkspaceRecommendationManualRefresh();
+          });
           return;
         }
 
@@ -2345,9 +2511,10 @@
         );
         const busyAttribute = workspaceRecommendationBusy ? ' disabled' : '';
         const statusClass = workspaceRecommendationErrorMessage ? 'workspace-recommendation-status is-error' : 'workspace-recommendation-status';
+        const freshnessMessage = workspaceRecommendationFreshnessMessage();
         const statusMessage = workspaceRecommendationBusy
           ? 'Working on this recommendation...'
-          : workspaceRecommendationErrorMessage || '&nbsp;';
+          : workspaceRecommendationErrorMessage || freshnessMessage || '';
         const triggerLabel = RECOMMENDATION_TRIGGER_LABELS[current.trigger_type] || formatRecommendationToken(current.trigger_type);
 
         const alternativesHtml = workspaceRecommendationAlternativesVisible && alternatives.length > 0
@@ -2371,7 +2538,7 @@
           ? `
             <div class="workspace-recommendation-why">
               <p>We only surface one recommendation at a time, using your saved brief, connected tools, and recent task outcomes.</p>
-              <p>This one is showing because it matches the <strong>${escapeHtml(triggerLabel)}</strong> trigger class. Choosing “Not now” cools down this exact suggestion for about a week unless the underlying state changes.</p>
+              <p>This one is showing because it matches the <strong>${escapeHtml(triggerLabel)}</strong> trigger class. Choosing “Not now” hides it for the rest of today unless you manually refresh.</p>
             </div>
           `
           : '';
@@ -2404,19 +2571,24 @@
                   ${workspaceRecommendationAlternativesVisible ? 'Hide options' : `Show ${Math.min(alternatives.length, 2)} options`}
                 </button>
               ` : ''}
+              <button id="workspace-recommendation-refresh" class="workspace-recommendation-text-btn"${busyAttribute}>Refresh</button>
               <button id="workspace-recommendation-defer" class="workspace-recommendation-text-btn"${busyAttribute}>Not now</button>
               <button id="workspace-recommendation-why-btn" class="workspace-recommendation-text-btn"${busyAttribute}>
                 ${workspaceRecommendationWhyVisible ? 'Hide details' : 'Why am I seeing this?'}
               </button>
             </div>
           </div>
-          <div class="${statusClass}">${statusMessage}</div>
+          <div class="${statusClass}">${statusMessage ? escapeHtml(statusMessage) : '&nbsp;'}</div>
           ${whyHtml}
           ${alternativesHtml}
         `;
 
         document.getElementById('workspace-recommendation-primary')?.addEventListener('click', () => {
           handleWorkspaceRecommendationPrimaryAction();
+        });
+
+        document.getElementById('workspace-recommendation-refresh')?.addEventListener('click', () => {
+          handleWorkspaceRecommendationManualRefresh();
         });
 
         document.getElementById('workspace-recommendation-defer')?.addEventListener('click', () => {
@@ -2509,22 +2681,59 @@
         }
       }
 
-      async function loadWorkspaceRecommendation(accessToken) {
+      async function loadWorkspaceRecommendation(accessToken, options = {}) {
+        const { force = false } = options;
         const requestPayload = buildWorkspaceRecommendationRequest();
+        const requestFingerprint = requestPayload ? workspaceRecommendationFingerprint(requestPayload) : '';
         workspaceRecommendationRequestNonce += 1;
         const requestNonce = workspaceRecommendationRequestNonce;
         workspaceRecommendationErrorMessage = '';
 
         if (!requestPayload) {
+          clearWorkspaceRecommendationCache();
+          clearWorkspaceRecommendationSuppression();
           workspaceRecommendationResponse = null;
           workspaceRecommendationSelectedKey = null;
           workspaceRecommendationAlternativesVisible = false;
           workspaceRecommendationWhyVisible = false;
+          workspaceRecommendationLastFetchedAt = null;
+          workspaceRecommendationDismissedForDay = false;
           workspaceRecommendationStatus = 'needs_brief';
           renderWorkspaceRecommendationCard();
           return null;
         }
 
+        if (!force) {
+          const suppressedEntry = readWorkspaceRecommendationSuppression(requestFingerprint);
+          if (suppressedEntry) {
+            workspaceRecommendationResponse = null;
+            workspaceRecommendationSelectedKey = null;
+            workspaceRecommendationAlternativesVisible = false;
+            workspaceRecommendationWhyVisible = false;
+            workspaceRecommendationStatus = 'ready';
+            workspaceRecommendationLastFetchedAt = suppressedEntry.dismissed_at || null;
+            workspaceRecommendationDismissedForDay = true;
+            renderWorkspaceRecommendationCard();
+            return null;
+          }
+
+          const cachedEntry = readWorkspaceRecommendationCache(requestFingerprint);
+          if (cachedEntry) {
+            if (requestNonce !== workspaceRecommendationRequestNonce) {
+              return cachedEntry.response;
+            }
+            applyWorkspaceRecommendationResponse(cachedEntry.response, {
+              fetchedAt: cachedEntry.fetched_at,
+              selectedKey: cachedEntry.selected_key,
+              dismissedForDay: false
+            });
+            renderWorkspaceRecommendationCard();
+            await maybeTrackWorkspaceRecommendationShown(accessToken);
+            return cachedEntry.response;
+          }
+        }
+
+        clearWorkspaceRecommendationSuppression();
         workspaceRecommendationStatus = 'loading';
         renderWorkspaceRecommendationCard();
 
@@ -2547,18 +2756,15 @@
             return data;
           }
 
-          workspaceRecommendationResponse = data;
-          workspaceRecommendationStatus = 'ready';
-          workspaceRecommendationAlternativesVisible = false;
-          workspaceRecommendationWhyVisible = false;
-
-          const effectiveLevel = data?.preferences?.effective_proactivity_level || data?.preferences?.proactivity_level;
-          if (effectiveLevel) {
-            setProactivityLevelUi(effectiveLevel);
-          }
-
           const defaultRecommendation = data?.recommendation || data?.alternatives?.[0] || null;
-          workspaceRecommendationSelectedKey = recommendationIdentity(defaultRecommendation);
+          const selectedKey = recommendationIdentity(defaultRecommendation);
+          const fetchedAt = new Date().toISOString();
+          applyWorkspaceRecommendationResponse(data, {
+            fetchedAt,
+            selectedKey,
+            dismissedForDay: false
+          });
+          writeWorkspaceRecommendationCache(requestFingerprint, data, selectedKey, fetchedAt);
           renderWorkspaceRecommendationCard();
           await maybeTrackWorkspaceRecommendationShown(accessToken);
           return data;
@@ -2684,12 +2890,50 @@
             )
           ]);
           workspaceRecommendationBusy = false;
-          await loadWorkspaceRecommendation(session.access_token);
+          const requestPayload = buildWorkspaceRecommendationRequest();
+          if (requestPayload) {
+            suppressWorkspaceRecommendationForDay(
+              workspaceRecommendationFingerprint(requestPayload),
+              identity
+            );
+          }
+          workspaceRecommendationResponse = null;
+          workspaceRecommendationSelectedKey = null;
+          workspaceRecommendationAlternativesVisible = false;
+          workspaceRecommendationWhyVisible = false;
+          workspaceRecommendationStatus = 'ready';
+          renderWorkspaceRecommendationCard();
         } catch (err) {
           workspaceRecommendationBusy = false;
           workspaceRecommendationErrorMessage = err.message || 'Failed to update recommendation.';
           renderWorkspaceRecommendationCard();
         }
+      }
+
+      async function handleWorkspaceRecommendationManualRefresh() {
+        if (workspaceRecommendationBusy || workspaceRecommendationStatus === 'loading') {
+          return;
+        }
+
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session) {
+          showMessage('Please sign in first.');
+          return;
+        }
+
+        workspaceRecommendationErrorMessage = '';
+        clearWorkspaceRecommendationSuppression();
+        await Promise.allSettled([
+          trackAnalyticsEvent(
+            'workspace_recommendation_manual_refresh',
+            {
+              current_surface: 'dashboard',
+              had_recommendation: Boolean(currentWorkspaceRecommendation())
+            },
+            { accessToken: session.access_token }
+          )
+        ]);
+        await loadWorkspaceRecommendation(session.access_token, { force: true });
       }
 
       async function performWorkspaceRecommendationAction(accessToken, recommendation) {
@@ -3403,7 +3647,7 @@
             { accessToken: session.access_token }
           );
 
-          await loadWorkspaceRecommendation(session.access_token);
+          await loadWorkspaceRecommendation(session.access_token, { force: true });
         } catch (err) {
           console.error('Failed to save recommendation preference:', err);
           setProactivityLevelUi(previousLevel);
@@ -4089,7 +4333,7 @@
           taskList.innerHTML = `<li class="task-item" style="text-align: center; color: #ef4444;">Error loading tasks: ${err.message}</li>`;
         } finally {
           if (refreshRecommendation) {
-            await loadWorkspaceRecommendation(accessToken);
+            await loadWorkspaceRecommendation(accessToken, { force: true });
           }
         }
       }
@@ -4283,7 +4527,7 @@
         taskPollingInterval = setInterval(async () => {
           const { data: { session } } = await supabase.auth.getSession();
           if (session) {
-            loadTasks(session.access_token, { refreshRecommendation: true });
+            loadTasks(session.access_token);
           } else {
             // Session expired completely, stop polling
             stopTaskPolling();
@@ -4304,7 +4548,7 @@
         const { data: { session } } = await supabase.auth.getSession();
         if (session) {
           document.getElementById('tasks-status').textContent = 'Refreshing...';
-          await loadTasks(session.access_token, { refreshRecommendation: true });
+          await loadTasks(session.access_token);
         }
       });
 


### PR DESCRIPTION
## Summary
- change the Chief of Staff card to auto-fetch at most once per local day on first dashboard open
- add a manual `Refresh` control and make `Not now` hide the current recommendation for the rest of the day unless the user refreshes
- stop background task polling from silently reshuffling recommendations, while preserving explicit refreshes after meaningful user-driven state changes
- update the proactive Chief of Staff spec to document the calmer daily cadence

## Testing
- `node --check /tmp/dowhiz-auth-dashboard.mjs`
- `git diff --check`

## Notes
- This is a UI behavior change in the existing dashboard card; no screenshot is attached yet.
- `output/` remains untracked and is not part of this PR.