### PR TITLE
Update blog with March workspace product note

### DIFF
--- a/website/public/blog/index.html
+++ b/website/public/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="DoWhiz blog with founder workspace product updates, the new Chief of Staff recommendation launch, and SEO guides for AI workflow automation across email, GitHub, Slack, and Google Docs."
+      content="DoWhiz blog with startup workspace updates for founders and one-person companies, AI chief of staff recommendations, and SEO guides for automation across email, GitHub, Slack, and Google Workspace."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260311" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260311" />
@@ -35,9 +35,9 @@
           <div class="eyebrow">DoWhiz Blog</div>
           <h1>Founder workspace updates and automation guides from DoWhiz.</h1>
           <p class="lead">
-            Latest notes on our startup workspace for founders, the new Chief of Staff recommendation
-            system, and evergreen SEO guides for multi-channel execution across email, GitHub, Slack,
-            Discord, and Google Workspace.
+            Latest notes on our startup workspace for founders and one-person companies, the new AI
+            Chief of Staff recommendation system, and evergreen SEO guides for multi-channel execution
+            across email, GitHub, Slack, Discord, and Google Workspace.
           </p>
           <div class="updated">Last updated: March 19, 2026</div>
         </section>
@@ -46,7 +46,8 @@
           <h2>Latest product update</h2>
           <p class="related-intro">
             The current product focus is a startup workspace for founders and one-person companies, with
-            channel-native execution still handled by the same DoWhiz digital employees.
+            Team Brief onboarding, Team Workspace, and channel-native execution still handled by the same
+            DoWhiz digital employees.
           </p>
           <div class="related-grid">
             <a class="related-item" href="/blog/startup-workspace-for-founders-product-update/">
@@ -96,12 +97,12 @@
             </div>
             <h2>Startup workspace for founders: DoWhiz product update</h2>
             <p>
-              How DoWhiz is moving from a channel-only assistant into a founder workspace with one-click setup,
-              saved Team Briefs, and Chief of Staff recommendations.
+              How DoWhiz is moving from a channel-only assistant into a startup workspace for founders and
+              one-person companies with Team Brief onboarding, Team Workspace, and AI chief of staff recommendations.
             </p>
             <ul>
-              <li>Primary keywords: startup workspace for founders, AI chief of staff</li>
-              <li>Covers Team Workspace, recommendation modes, and current product focus</li>
+              <li>Primary keywords: startup workspace for founders, AI chief of staff for founders</li>
+              <li>Covers Team Brief onboarding, Team Workspace, recommendation modes, and current product focus</li>
               <li>Owner: Oliver</li>
             </ul>
             <a class="back-link" href="/blog/startup-workspace-for-founders-product-update/">Read article</a>

--- a/website/public/blog/startup-workspace-for-founders-product-update/index.html
+++ b/website/public/blog/startup-workspace-for-founders-product-update/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Read the March 2026 DoWhiz product update covering the startup workspace for founders, Team Brief setup, Team Workspace, and the new Chief of Staff recommendation system."
+      content="Read the March 2026 DoWhiz product update on the startup workspace for founders and one-person companies, including Team Brief onboarding, Team Workspace, and AI chief of staff recommendations."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260311" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260311" />
@@ -15,12 +15,12 @@
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
     <link rel="canonical" href="https://dowhiz.com/blog/startup-workspace-for-founders-product-update/" />
-    <title>Startup Workspace for Founders: DoWhiz Product Update | DoWhiz</title>
+    <title>Startup Workspace for Founders and One-Person Companies | DoWhiz</title>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "BlogPosting",
-        "headline": "Startup Workspace for Founders: DoWhiz Product Update",
+        "headline": "Startup Workspace for Founders and One-Person Companies",
         "datePublished": "2026-03-19",
         "dateModified": "2026-03-19",
         "author": {
@@ -32,7 +32,7 @@
           "name": "DoWhiz",
           "url": "https://dowhiz.com"
         },
-        "description": "A March 2026 product update on how DoWhiz is evolving into a startup workspace for founders with one-click setup, Team Briefs, and Chief of Staff recommendations.",
+        "description": "A March 2026 product update on how DoWhiz is evolving into a startup workspace for founders and one-person companies with Team Brief onboarding, Team Workspace, and AI chief of staff recommendations.",
         "mainEntityOfPage": "https://dowhiz.com/blog/startup-workspace-for-founders-product-update/"
       }
     </script>
@@ -54,15 +54,15 @@
           <div class="eyebrow">Product Update</div>
           <h1>Startup workspace for founders: DoWhiz product update</h1>
           <p class="lead">
-            DoWhiz is shifting from a channel-only automation layer into a startup workspace for founders.
-            The current focus is one-click setup for a one-person company, with a saved Team Brief,
-            a persistent Team Workspace, and a new Chief of Staff recommendation loop.
+            DoWhiz is now focused on a startup workspace for founders and one-person companies.
+            The current release brings one-click Team Brief onboarding, a persistent Team Workspace,
+            and AI chief of staff recommendations that help founders decide the next move faster.
           </p>
           <div class="updated">Published: March 19, 2026 - Owner: Oliver (Generalist)</div>
         </section>
 
         <section class="legal-card">
-          <h2>Why the product focus is changing</h2>
+          <h2>From channel automation to a founder operating system</h2>
           <p>
             Cross-channel execution is still a core part of DoWhiz, but the product home is now the
             workspace itself. Founders need more than isolated task automation. They need one place to
@@ -71,8 +71,8 @@
           </p>
           <p>
             That is why the site now leads with <strong>one-click setup of a one-person company</strong>
-            instead of only describing individual agent actions. The goal is to help a founder or a lean
-            founding team spin up an operating system first, then let digital employees execute from it.
+            instead of only describing individual agent actions. The goal is to give founders a startup
+            workspace operating system first, then let digital employees execute from that shared context.
           </p>
         </section>
 
@@ -84,9 +84,28 @@
             current assets, and requested agents before work starts.
           </p>
           <p>
-            Once that brief is valid, DoWhiz routes the founder into Team Workspace so the saved context
-            is available immediately after sign-in. This keeps setup tighter for new users and makes the
-            workspace feel like the source of truth instead of a secondary dashboard.
+            Once that brief is valid, DoWhiz routes the founder into <a href="/auth/">Team Workspace</a>
+            so the saved context is available immediately after sign-in. This keeps setup tighter for new
+            users and makes the workspace feel like the source of truth instead of a secondary dashboard.
+          </p>
+          <p>
+            For founders evaluating startup workspace software, this matters because onboarding is no
+            longer a detached questionnaire. The brief becomes the execution plan that feeds channel
+            routing, memory, approvals, and recommendations.
+          </p>
+        </section>
+
+        <section class="legal-card">
+          <h2>Team Workspace is now the product center</h2>
+          <p>
+            The most important product-focus change is that Team Workspace is now the operating home.
+            Instead of scattering state across inboxes and chats, founders can review channels, active
+            tasks, saved memo, approvals, and generated artifacts in one place.
+          </p>
+          <p>
+            This shift makes DoWhiz more useful for a one-person company because the founder does not
+            need to restate priorities in every request. The workspace keeps context durable while
+            digital employees continue executing in the original tool where work was requested.
           </p>
         </section>
 
@@ -103,9 +122,10 @@
             <li>Users can refresh, defer with Not now, or switch to alternatives when multiple paths exist.</li>
           </ul>
           <p>
-            This is an important product step because it moves DoWhiz closer to an AI chief of staff
-            model, not only an execution surface. The workspace can now guide founders toward the next
-            best action instead of waiting for every task to be explicitly assigned.
+            This is an important product step because it moves DoWhiz closer to an <strong>AI chief of
+            staff for founders</strong>, not only an execution surface. The workspace can now guide
+            founders toward the next best action instead of waiting for every task to be explicitly
+            assigned.
           </p>
         </section>
 
@@ -137,9 +157,10 @@
             direction behind the landing page, Team Workspace, and recent recommendation work.
           </p>
           <ul>
-            <li>Use the landing page to create your agent team from a founder brief.</li>
+            <li>Use the <a href="/start/">Team Brief flow</a> to create your founder workspace blueprint.</li>
             <li>Use Team Workspace to manage channels, tasks, memo, and account controls in one place.</li>
             <li>Use Chief of Staff suggestions when you want a clearer "what next?" prompt inside the product.</li>
+            <li>Use channel-native execution when work should still happen in email, GitHub, Slack, Discord, or Google Workspace.</li>
           </ul>
         </section>
 

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -7,6 +7,9 @@
     <loc>https://dowhiz.com/blog/</loc>
   </url>
   <url>
+    <loc>https://dowhiz.com/blog/startup-workspace-for-founders-product-update/</loc>
+  </url>
+  <url>
     <loc>https://dowhiz.com/blog/ai-workflow-automation-checklist/</loc>
   </url>
   <url>

--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -813,6 +813,14 @@ function LandingPage() {
 
   const blogPosts = [
     {
+      tag: 'Product Update',
+      title: 'Startup workspace for founders: March 2026 product update',
+      date: 'March 19, 2026',
+      excerpt:
+        'The new product focus: Team Brief onboarding, Team Workspace, and AI chief of staff recommendations for founders.',
+      link: '/blog/startup-workspace-for-founders-product-update/'
+    },
+    {
       tag: 'SEO Guide',
       title: 'AI workflow automation checklist for lean teams',
       date: 'February 26, 2026',
@@ -833,13 +841,6 @@ function LandingPage() {
       date: 'February 26, 2026',
       excerpt: 'How to convert inbound email threads into structured execution, progress updates, and complete deliverables.',
       link: '/blog/email-task-automation-playbook/'
-    },
-    {
-      tag: 'SEO Guide',
-      title: 'AI employee trust, safety, and governance framework',
-      date: 'February 26, 2026',
-      excerpt: 'Governance essentials for permission scopes, audit trails, and escalation paths for high-confidence execution.',
-      link: '/blog/ai-employee-trust-safety-governance/'
     }
   ];
 


### PR DESCRIPTION
## Summary
- refine the March 19 product update article to focus on the startup workspace for founders and one-person companies
- refresh the main blog index copy so the latest product direction is clearer for readers and search engines
- add the product update to the landing page blog cards and sitemap so it is easier to discover

## Testing
- reviewed the rendered file diffs for the updated blog pages, landing page card, and sitemap entry
- previously attempted `npm ci` and `npm run build` in `website/`, but the workspace install did not complete cleanly enough to provide full local build verification

Closes #955
Requested-by: @loganye