### PR TITLE
Fix Notion webhook: self-trigger loop, registration tip, account linking

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -106,8 +106,13 @@ Keep your reply concise and helpful. Do not pretend the job has been done withou
     let human_approval_gate_section = build_human_approval_gate_section();
 
     // Build registration prompt section if user doesn't have a unified account
-    // and we haven't prompted them yet in this thread
-    let registration_section = if !has_unified_account && !has_prompted_registration(workspace_dir)
+    // and we haven't prompted them yet in this thread.
+    // Skip for Notion channel since Notion users can't easily link accounts from there,
+    // and the webhook sender identity doesn't map to DoWhiz accounts.
+    let is_notion_channel = channel.eq_ignore_ascii_case("notion");
+    let registration_section = if !has_unified_account
+        && !has_prompted_registration(workspace_dir)
+        && !is_notion_channel
     {
         // Mark that we've prompted so we don't repeat
         mark_registration_prompted(workspace_dir);

--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
@@ -242,6 +242,37 @@ async fn handle_comment_created(
     event: &NotionWebhookEvent,
     _raw_body: &[u8],
 ) -> (StatusCode, Json<serde_json::Value>) {
+    // Check if the comment author is a bot (integration's own comment)
+    // This prevents self-trigger loops where bot's reply triggers another task
+    if let Some(authors) = &event.authors {
+        if let Some(first_author) = authors.first() {
+            // Skip if author is a bot
+            if first_author.author_type.as_deref() == Some("bot") {
+                info!(
+                    "Skipping comment.created from bot author (self-trigger prevention): author_id={:?}",
+                    first_author.id
+                );
+                return (
+                    StatusCode::OK,
+                    Json(json!({"status": "skipped", "reason": "bot_author"})),
+                );
+            }
+            // Also check if author ID matches integration_id (double check)
+            if let (Some(author_id), Some(integration_id)) = (&first_author.id, &event.integration_id) {
+                if author_id == integration_id {
+                    info!(
+                        "Skipping comment.created from integration itself: integration_id={}",
+                        integration_id
+                    );
+                    return (
+                        StatusCode::OK,
+                        Json(json!({"status": "skipped", "reason": "self_integration"})),
+                    );
+                }
+            }
+        }
+    }
+
     // Extract comment ID from entity
     let comment_id = match event.entity.as_ref() {
         Some(entity) => entity.id.clone(),

--- a/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
@@ -51,13 +51,72 @@ pub(crate) fn process_notion_message(
         .as_deref()
         .unwrap_or("Untitled");
 
-    // Extract sender email, with fallbacks
-    let extracted_email = extract_emails(&message.sender).into_iter().next();
-    let user_email = match extracted_email {
-        Some(email) if email != "unknown@unknown.com" => email,
-        _ => {
-            // Use sender name or ID as fallback
-            format!("notion_{}@local", message.sender.replace(' ', "_"))
+    // Try to get the linked account from NotionCredential first (for webhook flow)
+    // This allows us to use the account's real email instead of synthetic one
+    let notion_linked_account = if workspace_id != "unknown" {
+        match NotionStore::new() {
+            Ok(store) => match store.get_credential_by_workspace(workspace_id) {
+                Ok(cred) => {
+                    // Found credential - look up the linked account
+                    match account_store.get_account(cred.account_id) {
+                        Ok(Some(account)) => {
+                            // Get the account's email identifier to use as reply_to
+                            let account_email = account_store
+                                .list_identifiers(account.id)
+                                .ok()
+                                .and_then(|ids| {
+                                    ids.into_iter()
+                                        .find(|id| id.identifier_type == "email" && id.verified)
+                                        .map(|id| id.identifier)
+                                });
+                            info!(
+                                "Found linked DoWhiz account {} for Notion workspace {} (email: {:?})",
+                                account.id, workspace_id, account_email
+                            );
+                            Some((cred, account, account_email))
+                        }
+                        Ok(None) => {
+                            warn!(
+                                "NotionCredential references account {} but account not found",
+                                cred.account_id
+                            );
+                            None
+                        }
+                        Err(e) => {
+                            warn!("Failed to look up account {}: {}", cred.account_id, e);
+                            None
+                        }
+                    }
+                }
+                Err(crate::notion_store::NotionStoreError::NotFound(_)) => {
+                    info!("No OAuth credential found for Notion workspace_id={}", workspace_id);
+                    None
+                }
+                Err(e) => {
+                    warn!("Failed to look up Notion credential: {}", e);
+                    None
+                }
+            },
+            Err(e) => {
+                warn!("Failed to connect to NotionStore: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // Determine user email: prefer linked account's email, fall back to extracted/synthetic
+    let user_email = if let Some((_, _, Some(ref email))) = notion_linked_account {
+        email.clone()
+    } else {
+        let extracted_email = extract_emails(&message.sender).into_iter().next();
+        match extracted_email {
+            Some(email) if email != "unknown@unknown.com" => email,
+            _ => {
+                // Use sender name or ID as fallback
+                format!("notion_{}@local", message.sender.replace(' ', "_"))
+            }
         }
     };
 
@@ -102,30 +161,13 @@ pub(crate) fn process_notion_message(
     // Write Notion context to workspace for agent
     write_notion_context_to_workspace(&workspace, &mention, page_id, page_title)?;
 
-    // Look up OAuth token by workspace_id and write to .notion_env
-    if workspace_id != "unknown" {
-        match NotionStore::new() {
-            Ok(store) => {
-                match store.get_credential_by_workspace(workspace_id) {
-                    Ok(cred) => {
-                        let env_path = workspace.join(".notion_env");
-                        if let Err(e) = std::fs::write(&env_path, format!("NOTION_API_TOKEN={}\n", cred.access_token)) {
-                            warn!("Failed to write .notion_env: {}", e);
-                        } else {
-                            info!("Wrote Notion OAuth token to workspace for workspace_id={}", workspace_id);
-                        }
-                    }
-                    Err(crate::notion_store::NotionStoreError::NotFound(_)) => {
-                        warn!("No OAuth credential found for Notion workspace_id={}", workspace_id);
-                    }
-                    Err(e) => {
-                        warn!("Failed to look up Notion credential: {}", e);
-                    }
-                }
-            }
-            Err(e) => {
-                warn!("Failed to connect to NotionStore: {}", e);
-            }
+    // Write OAuth token to .notion_env if we have a credential
+    if let Some((ref cred, _, _)) = notion_linked_account {
+        let env_path = workspace.join(".notion_env");
+        if let Err(e) = std::fs::write(&env_path, format!("NOTION_API_TOKEN={}\n", cred.access_token)) {
+            warn!("Failed to write .notion_env: {}", e);
+        } else {
+            info!("Wrote Notion OAuth token to workspace for workspace_id={}", workspace_id);
         }
     }
 
@@ -184,60 +226,67 @@ pub(crate) fn process_notion_message(
         thread_state.epoch
     );
 
-    // Check for linked account
-    match account_store.get_account_by_identifier("email", &user_email) {
-        Ok(Some(account)) => {
-            info!("Found account {} for Notion user {}", account.id, user_email);
-            let account_tasks_dir = config.users_root.join(account.id.to_string()).join("state");
-            if let Err(err) = std::fs::create_dir_all(&account_tasks_dir) {
+    // Check for linked account - prefer the one we already found from NotionCredential
+    let linked_account = if let Some((_, account, _)) = notion_linked_account {
+        Some(account)
+    } else {
+        // Fall back to email-based lookup
+        match account_store.get_account_by_identifier("email", &user_email) {
+            Ok(account) => account,
+            Err(err) => {
                 warn!(
-                    "failed to create account tasks dir for account {}: {}",
-                    account.id, err
+                    "Failed to look up account for Notion user '{}': {}",
+                    user_email, err
                 );
-            } else {
-                let account_tasks_db_path = account_tasks_dir.join("tasks.db");
-                match Scheduler::load(&account_tasks_db_path, ModuleExecutor::default()) {
-                    Ok(mut account_scheduler) => {
-                        match account_scheduler.add_one_shot_in_with_id(
-                            task_id,
-                            Duration::from_secs(0),
-                            TaskKind::RunTask(run_task_for_account),
-                        ) {
-                            Ok(()) => {
-                                info!(
-                                    "also enqueued task to account-level storage account={} task_id={} channel=Notion",
-                                    account.id, task_id
-                                );
-                            }
-                            Err(err) => {
-                                warn!(
-                                    "failed to add task to account scheduler for account {}: {}",
-                                    account.id, err
-                                );
-                            }
+                None
+            }
+        }
+    };
+
+    if let Some(account) = linked_account {
+        info!("Found account {} for Notion user {}", account.id, user_email);
+        let account_tasks_dir = config.users_root.join(account.id.to_string()).join("state");
+        if let Err(err) = std::fs::create_dir_all(&account_tasks_dir) {
+            warn!(
+                "failed to create account tasks dir for account {}: {}",
+                account.id, err
+            );
+        } else {
+            let account_tasks_db_path = account_tasks_dir.join("tasks.db");
+            match Scheduler::load(&account_tasks_db_path, ModuleExecutor::default()) {
+                Ok(mut account_scheduler) => {
+                    match account_scheduler.add_one_shot_in_with_id(
+                        task_id,
+                        Duration::from_secs(0),
+                        TaskKind::RunTask(run_task_for_account),
+                    ) {
+                        Ok(()) => {
+                            info!(
+                                "also enqueued task to account-level storage account={} task_id={} channel=Notion",
+                                account.id, task_id
+                            );
+                        }
+                        Err(err) => {
+                            warn!(
+                                "failed to add task to account scheduler for account {}: {}",
+                                account.id, err
+                            );
                         }
                     }
-                    Err(err) => {
-                        warn!(
-                            "failed to load account scheduler for account {}: {}",
-                            account.id, err
-                        );
-                    }
+                }
+                Err(err) => {
+                    warn!(
+                        "failed to load account scheduler for account {}: {}",
+                        account.id, err
+                    );
                 }
             }
         }
-        Ok(None) => {
-            info!(
-                "No account linked for Notion user '{}', skipping account-level task",
-                user_email
-            );
-        }
-        Err(err) => {
-            warn!(
-                "Failed to look up account for Notion user '{}': {}",
-                user_email, err
-            );
-        }
+    } else {
+        info!(
+            "No account linked for Notion user '{}', skipping account-level task",
+            user_email
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
Fixes three bugs in Notion webhook flow:

1. **Self-trigger loop** - Bot's own comments triggered infinite task loop
2. **Registration tip spam** - "Link your DoWhiz account" showing for linked accounts
3. **Account not linked** - Webhook flow didn't use NotionCredential's account_id

## Changes

### notion_webhook.rs
- Added check for `author_type == "bot"` to skip bot-authored comments
- Added check if `author_id == integration_id` as backup

### prompt.rs
- Skip registration tip for Notion channel (can't link accounts the same way)

### notion.rs
- Use NotionCredential's `account_id` to directly look up DoWhiz account
- Get account's email identifier for proper `reply_to` (enables account linking)
- This makes `has_unified_account = true` work correctly

## Test plan
- [ ] @mention Proto in Notion
- [ ] Verify only ONE reply (no self-trigger loop)
- [ ] Verify NO registration tip in reply
- [ ] Check logs show "Found linked DoWhiz account"

🤖 Generated with [Claude Code](https://claude.com/claude-code)