### PR TITLE
Clarify dashboard home button

### DIFF
--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -158,6 +158,17 @@
       .dashboard-home-link {
         display: none;
       }
+      .dashboard-home-link-icon,
+      .dashboard-home-link-mark {
+        flex: 0 0 auto;
+      }
+      .dashboard-home-link-copy {
+        display: grid;
+      }
+      .dashboard-home-link-label,
+      .dashboard-home-link-name {
+        display: block;
+      }
       .dashboard-section {
         margin-top: 2rem;
       }
@@ -671,20 +682,64 @@
       .dashboard-mode .dashboard-home-link {
         display: inline-flex;
         align-items: center;
-        justify-content: center;
-        padding: 0.48rem 0.92rem;
+        gap: 0.65rem;
+        padding: 0.55rem 0.9rem 0.55rem 0.7rem;
         border: 1px solid var(--border, #333);
-        border-radius: 999px;
+        border-radius: 1rem;
         background: color-mix(in srgb, var(--surface, #1a1a1a) 88%, transparent);
         box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
         color: var(--text, #fff);
-        font-size: 1rem;
+        text-align: left;
+        text-decoration: none;
         white-space: nowrap;
       }
 
       .dashboard-mode .dashboard-home-link:hover {
         border-color: color-mix(in srgb, var(--accent, #38bdf8) 35%, var(--border, #333));
         background: color-mix(in srgb, var(--accent, #38bdf8) 10%, var(--surface, #1a1a1a));
+        box-shadow: 0 14px 30px rgba(56, 189, 248, 0.12);
+      }
+
+      .dashboard-mode .dashboard-home-link-icon {
+        width: 1.55rem;
+        height: 1.55rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--accent, #38bdf8) 15%, var(--surface, #1a1a1a));
+        color: color-mix(in srgb, var(--accent, #38bdf8) 78%, var(--text, #fff));
+        transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+      }
+
+      .dashboard-mode .dashboard-home-link:hover .dashboard-home-link-icon {
+        transform: translateX(-2px);
+        background: color-mix(in srgb, var(--accent, #38bdf8) 22%, var(--surface, #1a1a1a));
+      }
+
+      .dashboard-mode .dashboard-home-link-mark {
+        width: 1.7rem;
+        height: 1.7rem;
+        border-radius: 0.45rem;
+      }
+
+      .dashboard-mode .dashboard-home-link-copy {
+        gap: 0.08rem;
+        line-height: 1.05;
+      }
+
+      .dashboard-mode .dashboard-home-link-label {
+        font-size: 0.62rem;
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--text-muted, #888);
+      }
+
+      .dashboard-mode .dashboard-home-link-name {
+        font-size: 0.95rem;
+        font-weight: 700;
+        color: var(--text, #fff);
       }
 
       .dashboard-mode .legal-hero .lead {
@@ -1283,8 +1338,23 @@
         <section class="legal-hero">
           <div class="eyebrow">Account</div>
           <div class="dashboard-title-wrap">
-            <a class="brand dashboard-home-link" href="../" aria-label="Back to the DoWhiz landing page">
-              Do<span class="accent">Whiz</span>
+            <a class="dashboard-home-link" href="../" aria-label="Back to the DoWhiz landing page">
+              <span class="dashboard-home-link-icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20" width="12" height="12" fill="none">
+                  <path
+                    d="M8.2 4.2 2.6 9.8l5.6 5.6M3.3 9.8h14.1"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+              <img class="dashboard-home-link-mark" src="/assets/DoWhiz.svg" alt="" aria-hidden="true" />
+              <span class="dashboard-home-link-copy">
+                <span class="dashboard-home-link-label">Back to</span>
+                <span class="dashboard-home-link-name">DoWhiz Home</span>
+              </span>
             </a>
             <h1 id="page-title">Sign in to DoWhiz</h1>
           </div>


### PR DESCRIPTION
## Summary
- replace the small dashboard badge with a clearer home-action button beside the dashboard title
- keep the DoWhiz logo mark visible while adding explicit Back to / DoWhiz Home copy
- preserve the clean dashboard layout with the floating shared nav still hidden in dashboard mode

## Testing
- npm run lint
- Playwright sanity check against static `/auth/index.html` confirming `navbarDisplay: none`, `homeLinkLabel: Back to`, `homeLinkText: DoWhiz Home`, and the DoWhiz logo asset is present in dashboard mode

Follow-up to merged PR #984.