### PR TITLE
Keep landing hero title on one line

### DIFF
--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -164,12 +164,12 @@
   gap: 0.9rem;
   justify-items: center;
   text-align: center;
-  max-width: 760px;
+  max-width: min(100%, 980px);
   margin: 0 auto;
 }
 
 .hero-title {
-  font-size: clamp(2.4rem, 5.2vw, 3.45rem);
+  font-size: clamp(2.4rem, 5vw, 3.3rem);
   margin: 0;
   line-height: 1.06;
   letter-spacing: -0.045em;


### PR DESCRIPTION
## Summary
- widen the landing hero copy container so the homepage title has enough room on desktop
- slightly reduce the desktop hero heading scale so the title stays on one line without affecting tablet/mobile breakpoints

## Testing
- npm run lint
- npm run build
- npm run test:responsive
- local Playwright visual verification at 1440px, 1100px, and 1024px

## Config / Env Changes
- None