### PR TITLE
Add task update logging for debugging duplicate Notion execution

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -100,9 +100,10 @@ impl MongoSchedulerStore {
     pub(crate) fn insert_task(&self, task: &ScheduledTask) -> Result<(), SchedulerError> {
         let task_json = serde_json::to_string(task)
             .map_err(|err| SchedulerError::Storage(format!("serialize task failed: {err}")))?;
-        self.tasks
+        let filter = self.task_filter(&task.id.to_string());
+        let result = self.tasks
             .update_one(
-                self.task_filter(&task.id.to_string()),
+                filter.clone(),
                 doc! {
                     "$set": {
                         "owner_scope": self.owner_scope_doc(),
@@ -122,15 +123,25 @@ impl MongoSchedulerStore {
                 UpdateOptions::builder().upsert(Some(true)).build(),
             )
             .map_err(mongo_err)?;
+
+        tracing::info!(
+            "insert_task: task_id={} owner_scope=({}, {}) upserted={} matched={}",
+            task.id,
+            self.owner_kind,
+            self.owner_id,
+            result.upserted_id.is_some(),
+            result.matched_count
+        );
         Ok(())
     }
 
     pub(crate) fn update_task(&self, task: &ScheduledTask) -> Result<(), SchedulerError> {
         let task_json = serde_json::to_string(task)
             .map_err(|err| SchedulerError::Storage(format!("serialize task failed: {err}")))?;
-        self.tasks
+        let filter = self.task_filter(&task.id.to_string());
+        let result = self.tasks
             .update_one(
-                self.task_filter(&task.id.to_string()),
+                filter.clone(),
                 doc! {
                     "$set": {
                         "enabled": task.enabled,
@@ -142,6 +153,25 @@ impl MongoSchedulerStore {
                 None,
             )
             .map_err(mongo_err)?;
+
+        // Log warning if no document was matched - this indicates a bug
+        if result.matched_count == 0 {
+            tracing::warn!(
+                "update_task matched 0 documents! task_id={} owner_scope=({}, {}) filter={:?}",
+                task.id,
+                self.owner_kind,
+                self.owner_id,
+                filter
+            );
+        } else {
+            tracing::debug!(
+                "update_task succeeded: task_id={} matched={} modified={} enabled={}",
+                task.id,
+                result.matched_count,
+                result.modified_count,
+                task.enabled
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Add logging to `insert_task` and `update_task` in MongoDB store
- Logs `owner_scope` and `matched_count` to debug why tasks may be re-executed
- Warns when `update_task` matches 0 documents (indicates silent failure)

## Purpose
Debug the issue where Proto (staging) keeps replying multiple times to the same Notion @mention.

## Test plan
- [ ] Deploy to staging
- [ ] Send a Notion @mention
- [ ] Check worker logs for `insert_task` and `update_task` messages
- [ ] Look for "matched 0 documents" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)