### PR TITLE
Allow forwarded Notion emails to bypass sender blacklist

### DIFF
--- a/DoWhiz_service/scheduler_module/src/service/ingestion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/ingestion.rs
@@ -128,13 +128,31 @@ fn process_ingestion_envelope(
 ) -> Result<(), BoxError> {
     match envelope.channel {
         Channel::Email => {
+            let (payload, raw_payload) = resolve_email_payload(envelope)?;
+            let subject = payload.subject.as_deref().unwrap_or("");
+
+            // Check if this looks like a forwarded Notion notification (by subject pattern)
+            // This allows self-forwarded Notion emails to pass the blacklist
+            let looks_like_notion = subject.contains("mentioned you")
+                || subject.contains("replied to")
+                || subject.contains("commented in")
+                || subject.contains("commented on")
+                || subject.contains("发表了评论")
+                || subject.contains("中提及了您");
+
             let sender = envelope.payload.sender.trim();
-            if is_blacklisted_email_sender(sender, &config.employee_directory.service_addresses) {
+            if !looks_like_notion
+                && is_blacklisted_email_sender(sender, &config.employee_directory.service_addresses)
+            {
                 info!("skipping blacklisted sender: {}", sender);
                 return Ok(());
             }
-            let (payload, raw_payload) = resolve_email_payload(envelope)?;
-            let subject = payload.subject.as_deref().unwrap_or("");
+            if looks_like_notion && is_blacklisted_email_sender(sender, &config.employee_directory.service_addresses) {
+                info!(
+                    "allowing forwarded Notion email from blacklisted sender: {} (subject: {})",
+                    sender, subject
+                );
+            }
             if is_human_approval_gate_subject(subject) {
                 info!(
                     "skipping human approval gate reply from ingestion workflow: subject={}",


### PR DESCRIPTION
## Summary
- **Problem**: When Notion emails are forwarded from Proto's mailbox to Postmark, the sender becomes `dowhiz@deep-tutor.com` instead of `notify@mail.notion.so`. This caused legitimate Notion notifications to be blocked by the self-sender blacklist.

- **Fix**: Check if email subject matches Notion notification patterns **before** applying the blacklist. If it looks like a Notion notification, allow it through even if the sender is blacklisted.

## Patterns detected:
- `mentioned you`
- `replied to`  
- `commented in` / `commented on`
- Chinese: `发表了评论`, `中提及了您`

## Test Plan
- [ ] Deploy to staging
- [ ] Send @mention to Proto-DoWhiz on Notion
- [ ] Verify Proto receives the notification and responds
- [ ] Check logs show "allowing forwarded Notion email from blacklisted sender"

🤖 Generated with [Claude Code](https://claude.com/claude-code)