### PR TITLE
Fix Google Workspace CLI auth: add GOOGLE_WORKSPACE_CLI_TOKEN and google-docs symlink

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -390,6 +390,10 @@ pub(super) fn run_codex_task(
         // (Codex sandbox may not pass environment variables to tools it spawns)
         if let Some(ref token) = request.google_access_token {
             cmd.arg("-e").arg(format!("GOOGLE_ACCESS_TOKEN={}", token));
+            // Also set GOOGLE_WORKSPACE_CLI_TOKEN for gws CLI (third-party @googleworkspace/cli)
+            // This takes highest priority and avoids OAuth refresh_token issues (invalid_rapt)
+            cmd.arg("-e")
+                .arg(format!("GOOGLE_WORKSPACE_CLI_TOKEN={}", token));
             // Also write to file as backup since Codex sandbox may strip env vars
             let token_file = host_workspace_dir.join(".google_access_token");
             if let Err(e) = std::fs::write(&token_file, token) {
@@ -523,6 +527,9 @@ pub(super) fn run_codex_task(
         // (Codex sandbox may not pass environment variables to tools it spawns)
         if let Some(ref token) = request.google_access_token {
             cmd.env("GOOGLE_ACCESS_TOKEN", token);
+            // Also set GOOGLE_WORKSPACE_CLI_TOKEN for gws CLI (third-party @googleworkspace/cli)
+            // This takes highest priority and avoids OAuth refresh_token issues (invalid_rapt)
+            cmd.env("GOOGLE_WORKSPACE_CLI_TOKEN", token);
             // Also write to file as backup since Codex sandbox may strip env vars
             let token_file = request.workspace_dir.join(".google_access_token");
             if let Err(e) = fs::write(&token_file, token) {
@@ -822,8 +829,11 @@ fn run_codex_task_azure_aci(
     for (key, value) in github_auth.env_overrides {
         env_overrides.push((key, value));
     }
-    if let Some(token) = request.google_access_token {
+    if let Some(ref token) = request.google_access_token {
         env_overrides.push(("GOOGLE_ACCESS_TOKEN".to_string(), token.to_string()));
+        // Also set GOOGLE_WORKSPACE_CLI_TOKEN for gws CLI (third-party @googleworkspace/cli)
+        // This takes highest priority and avoids OAuth refresh_token issues (invalid_rapt)
+        env_overrides.push(("GOOGLE_WORKSPACE_CLI_TOKEN".to_string(), token.to_string()));
     }
     if let Some(container_path) = askpass_container_path {
         env_overrides.push((

--- a/Dockerfile.aci
+++ b/Dockerfile.aci
@@ -22,6 +22,8 @@ COPY DoWhiz_service/skills/ /app/DoWhiz_service/skills/
 RUN chmod +x /app/bin/human_approval_gate /app/bin/human_approval_gate_mcp || true
 RUN ln -sf /app/bin/human_approval_gate /usr/local/bin/human_approval_gate
 RUN ln -sf /app/bin/human_approval_gate_mcp /usr/local/bin/human_approval_gate_mcp
+# Create symlink for google-docs CLI so it's accessible even if Codex sandbox resets PATH
+RUN ln -sf /app/bin/google-docs /usr/local/bin/google-docs || true
 RUN chown -R app:nogroup /app/DoWhiz_service /app/bin /app/rust_service /app/inbound_fanout /app/inbound_gateway
 
 USER app


### PR DESCRIPTION
## Summary

- Fix Google Workspace CLI authentication issues in Codex sandbox
- Ensure both our `google-docs` CLI and third-party `gws` CLI work correctly

## Problem

When running tasks in Codex sandbox:
1. **PATH is reset** - Agent can't find `/app/bin/google-docs` (our Rust CLI)
2. **Agent falls back to `gws`** - Third-party CLI installed globally
3. **`gws` uses OAuth refresh_token** - Triggers `invalid_rapt` error requiring re-authentication
4. **Human Approval Gate timeout** - Task fails

## Solution

### 1. Add `GOOGLE_WORKSPACE_CLI_TOKEN` environment variable
- Passes our Service Account access token to `gws` CLI
- This env var has **highest priority** in `gws`, bypassing OAuth refresh
- Added in all three execution modes: Docker, local, and Azure ACI

### 2. Create symlink for `google-docs` CLI
- `/usr/local/bin/google-docs` -> `/app/bin/google-docs`
- `/usr/local/bin` is always in default PATH (even when Codex resets it)
- Ensures our Rust CLI is accessible regardless of sandbox behavior

## Test plan

- [ ] Verify `cargo check -p run_task_module` passes
- [ ] Deploy to staging via CICD
- [ ] Send test email to `dowhiz@deep-tutor.com` requesting Google Doc creation
- [ ] Verify agent uses `google-docs` CLI (check logs for CLI output)
- [ ] Verify no `invalid_rapt` or auth errors

## Files changed

| File | Change |
|------|--------|
| `codex.rs` | Add `GOOGLE_WORKSPACE_CLI_TOKEN` env var in 3 places |
| `Dockerfile.aci` | Add symlink for `google-docs` CLI |

🤖 Generated with [Claude Code](https://claude.com/claude-code)