### PR TITLE
fix: Prevent Notion double-reply by adding channel to reply path detection

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/claude.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/claude.rs
@@ -39,6 +39,10 @@ fn resolve_expected_reply_path(workspace_dir: &Path, default_path: PathBuf) -> P
         "slack" | "discord" | "telegram" | "sms" | "whatsapp" | "bluebubbles" => {
             workspace_dir.join("reply_message.txt")
         }
+        "notion" => {
+            // Notion agent posts directly via API and creates .notion_api_replied marker
+            workspace_dir.join(".notion_api_replied")
+        }
         _ => default_path,
     }
 }

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -217,6 +217,10 @@ fn resolve_expected_reply_path(workspace_dir: &Path, default_path: PathBuf) -> P
         "slack" | "discord" | "telegram" | "sms" | "whatsapp" | "bluebubbles" => {
             workspace_dir.join("reply_message.txt")
         }
+        "notion" => {
+            // Notion agent posts directly via API and creates .notion_api_replied marker
+            workspace_dir.join(".notion_api_replied")
+        }
         _ => default_path,
     }
 }

--- a/DoWhiz_service/run_task_module/src/run_task/workspace.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/workspace.rs
@@ -112,10 +112,15 @@ pub(super) fn prepare_workspace(
 
     // Use channel-specific reply file and attachments directory
     // Non-email channels use plain text reply_message.txt
+    // Notion uses .notion_api_replied marker file (agent posts via API directly)
     // Email and GoogleDocs use HTML reply_email_draft.html
     let (reply_path, reply_attachments_dir) = match request.channel.to_lowercase().as_str() {
         "slack" | "discord" | "telegram" | "sms" | "bluebubbles" => (
             request.workspace_dir.join("reply_message.txt"),
+            request.workspace_dir.join("reply_attachments"),
+        ),
+        "notion" => (
+            request.workspace_dir.join(".notion_api_replied"),
             request.workspace_dir.join("reply_attachments"),
         ),
         _ => (


### PR DESCRIPTION
## Summary

- Fix Notion tasks triggering retry logic due to `OutputMissing` error
- Add "notion" channel to reply path detection in `workspace.rs`, `codex.rs`, and `claude.rs`
- **NEW**: Filter `PageComment` notifications to only process explicit @mentions

## Root Cause Analysis

### Issue 1: Double-reply from OutputMissing
When Oliver posts a Notion comment via API, the agent creates `.notion_api_replied` marker file. However, the task completion check was looking for `reply_email_draft.html`, triggering retries.

### Issue 2: Proto responding to Oliver's text mentions
Notion sends `PageComment` notifications to ALL Integration subscribers when anyone comments on a page. When Oliver wrote "Hey Proto, check this" (text, not @mention), Proto received the notification and responded incorrectly.

## Changes

| File | Change |
|------|--------|
| `workspace.rs` | Add "notion" to channel match, use `.notion_api_replied` |
| `codex.rs` | Add "notion" to `resolve_expected_reply_path` |
| `claude.rs` | Add "notion" to `resolve_expected_reply_path` |
| `notion_email.rs` | **NEW**: Filter `PageComment`/`Other` notifications - only process if `comment_preview` or `subject` contains explicit @mention (e.g., `@proto`, `@oliver`) |

## Notification Type Filtering

| Type | Behavior |
|------|----------|
| `CommentMention` | Direct @mention → Process immediately |
| `PageMention` | Direct @mention in page → Process immediately |
| `CommentReply` | Reply to your comment → Process immediately |
| `PageComment` | General activity → **Only process if @mentioned in content** |
| `Other` | Unknown → **Only process if @mentioned in content** |

## Test plan

- [ ] Deploy to staging
- [ ] Test 1: Send `@Proto check this` in Notion → Proto should respond
- [ ] Test 2: Send `Hey Proto, check this` (no @) in Notion → Proto should NOT respond  
- [ ] Test 3: Oliver comments without mentioning Proto → Proto should NOT respond
- [ ] Verify no `OutputMissing` errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)