### PR TITLE
fix: Filter Notion PageComment notifications to require explicit @mention

### DIFF
--- a/DoWhiz_service/scheduler_module/src/service/inbound/notion_email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/notion_email.rs
@@ -19,9 +19,10 @@ use chrono::Utc;
 use tracing::{info, warn};
 
 use crate::account_store::AccountStore;
+use crate::adapters::google_docs::contains_employee_mention;
 use crate::channel::Channel;
 use crate::index_store::IndexStore;
-use crate::notion_email_detector::NotionEmailNotification;
+use crate::notion_email_detector::{NotionEmailNotification, NotionNotificationType};
 use crate::notion_store::NotionStore;
 use crate::user_store::{extract_emails, UserStore};
 use crate::{ModuleExecutor, RunTaskTask, Scheduler, TaskKind};
@@ -102,6 +103,40 @@ pub(crate) fn process_notion_email(
                 actor
             );
             return Ok(());
+        }
+    }
+
+    // Filter notifications based on type - only respond to explicit @mentions
+    // CommentMention/PageMention/CommentReply indicate direct targeting
+    // PageComment/Other require checking if the employee was actually @mentioned in the content
+    match notification.notification_type {
+        NotionNotificationType::CommentMention
+        | NotionNotificationType::PageMention
+        | NotionNotificationType::CommentReply => {
+            // Direct mentions - process these
+            info!(
+                "processing direct mention notification type={:?}",
+                notification.notification_type
+            );
+        }
+        NotionNotificationType::PageComment | NotionNotificationType::Other => {
+            // General page activity - only process if we were explicitly @mentioned
+            let content_to_check = format!(
+                "{}\n{}",
+                notification.comment_preview.as_deref().unwrap_or(""),
+                notification.subject.as_str()
+            );
+            if !contains_employee_mention(&content_to_check) {
+                info!(
+                    "skipping PageComment notification - employee not @mentioned in content (type={:?}, actor={:?})",
+                    notification.notification_type,
+                    notification.actor_name
+                );
+                return Ok(());
+            }
+            info!(
+                "processing PageComment notification with explicit @mention in content",
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Filter `PageComment` and `Other` Notion notifications to only process when the employee was explicitly @mentioned in the content.

## Problem

Notion sends `PageComment` notifications to ALL Integration subscribers when anyone comments on a page, regardless of who was @mentioned. This caused:

- Proto responds when Oliver writes "Hey Proto, check this" (text, not @mention)
- Multiple employees respond to the same comment

## Solution

Add filtering in `notion_email.rs` ([lines 107-144](https://github.com/KnoWhiz/DoWhiz/blob/fix/notion-pagecomment-filter/DoWhiz_service/scheduler_module/src/service/inbound/notion_email.rs#L107-L144)):

| Notification Type | Behavior |
|-------------------|----------|
| `CommentMention` | Direct @mention → Process immediately |
| `PageMention` | @mention in page → Process immediately |
| `CommentReply` | Reply to your comment → Process immediately |
| `PageComment` | General activity → **Only if @mentioned in content** |
| `Other` | Unknown → **Only if @mentioned in content** |

Reuses `contains_employee_mention()` from Google Docs adapter which requires `@` prefix (e.g., `@proto`, `@oliver`).

## Test plan

- [ ] Deploy to staging
- [ ] `@Proto check this` → Proto should respond ✅
- [ ] `Hey Proto, check this` → Proto should NOT respond ❌
- [ ] Oliver comments without mentioning Proto → Proto should NOT respond ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code)