### PR TITLE
Notion webhook improvements: workspace isolation + verification handshake

### DIFF
--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
@@ -401,6 +401,18 @@ pub async fn ingest_notion_webhook(
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
+    // Check for verification token (webhook setup handshake)
+    // Notion sends {"verification_token": "<token>"} and expects it echoed back
+    if let Ok(verification) = serde_json::from_slice::<serde_json::Value>(&body) {
+        if let Some(token) = verification.get("verification_token").and_then(|v| v.as_str()) {
+            info!("notion webhook verification request received");
+            return (
+                StatusCode::OK,
+                Json(json!({"verification_token": token})),
+            );
+        }
+    }
+
     // Verify signature
     if let Err(reason) = super::verify::verify_notion(&headers, &body) {
         warn!("notion webhook signature verification failed: {}", reason);


### PR DESCRIPTION
## Summary
- **Workspace isolation**: Enforce `.notion_context.json` workspace_id to prevent cross-workspace access
- **Verification handshake**: Echo back `verification_token` for webhook setup
- **New CLI commands**: list-pages, bulk-read, export-workspace for workspace exploration

## Changes
- `notion_api_cli.rs`: Added `resolve_workspace_id()` to enforce user isolation
- `notion_webhook.rs`: Handle verification_token for webhook subscription setup

## Test Plan
- [x] E2E test on staging: workspace isolation working
- [x] E2E test on staging: new CLI commands working
- [ ] Production webhook verification after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)