### PR TITLE
Avoid reusing stale Browserbase live sessions across tasks

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -255,10 +255,12 @@ Azure ACI execution path (required vars):
   When configured, run_task forwards these env vars into local, docker, and Azure ACI
   task environments. The bundled `playwright-cli` wrapper then calls
   `browserbase_session_manager` to create or reuse a persistent Browserbase Context,
-  storing durable state in `.secrets/browserbase/registry.json` and the currently live
-  session in `.secrets/browserbase/active_session.json`. `scheduler_module` mirrors that
-  directory between durable per-user secrets and each task workspace so auth survives ACI
-  container deletion and later recreation.
+  storing durable per-user auth state in `.secrets/browserbase/registry.json` and the
+  currently live task session in `.secrets/browserbase/active_session.json`. `scheduler_module`
+  only mirrors the durable Browserbase context state between per-user secrets and each
+  task workspace; it does not persist `active_session.json` across tasks, so every new
+  task restores the user's auth context into a fresh live Browserbase session instead of
+  inheriting a stale expiring session from an older container.
 - `human_approval_gate` (via skill `human-approval-gate`) provides a blocking
   approval flow for login CAPTCHA/password/OTP/device-approval steps. In
   run_task/Codex environments, the preferred path is the injected MCP tool

--- a/DoWhiz_service/scheduler_module/src/secrets_store.rs
+++ b/DoWhiz_service/scheduler_module/src/secrets_store.rs
@@ -9,6 +9,7 @@ const USER_ENV_FILENAME: &str = ".env";
 const USER_BROWSERBASE_DIR: &str = "browserbase";
 const WORKSPACE_SECRETS_DIR: &str = ".secrets";
 const WORKSPACE_BROWSERBASE_DIR: &str = "browserbase";
+const BROWSERBASE_ACTIVE_SESSION_FILENAME: &str = "active_session.json";
 
 pub(crate) fn resolve_user_secrets_path(task: &RunTaskTask) -> Option<PathBuf> {
     if let Some(archive_root) = task.archive_root.as_ref() {
@@ -65,7 +66,11 @@ pub(crate) fn sync_user_browserbase_state_to_workspace(
     workspace_dir: &Path,
 ) -> Result<(), io::Error> {
     let workspace_browserbase_dir = workspace_browserbase_dir(workspace_dir);
-    mirror_optional_dir(user_browserbase_dir, &workspace_browserbase_dir)
+    mirror_optional_dir_filtered(
+        user_browserbase_dir,
+        &workspace_browserbase_dir,
+        &browserbase_path_should_sync,
+    )
 }
 
 pub(crate) fn sync_workspace_browserbase_state_to_user(
@@ -73,7 +78,11 @@ pub(crate) fn sync_workspace_browserbase_state_to_user(
     user_browserbase_dir: &Path,
 ) -> Result<(), io::Error> {
     let workspace_browserbase_dir = workspace_browserbase_dir(workspace_dir);
-    mirror_optional_dir(&workspace_browserbase_dir, user_browserbase_dir)
+    mirror_optional_dir_filtered(
+        &workspace_browserbase_dir,
+        user_browserbase_dir,
+        &browserbase_path_should_sync,
+    )
 }
 
 fn copy_file_with_fallback(src: &Path, dest: &Path) -> Result<(), io::Error> {
@@ -103,7 +112,24 @@ fn workspace_browserbase_dir(workspace_dir: &Path) -> PathBuf {
         .join(WORKSPACE_BROWSERBASE_DIR)
 }
 
-fn mirror_optional_dir(src: &Path, dest: &Path) -> Result<(), io::Error> {
+fn browserbase_path_should_sync(relative_path: &Path) -> bool {
+    let file_name = relative_path.file_name().and_then(|value| value.to_str());
+    if let Some(file_name) = file_name {
+        if file_name == BROWSERBASE_ACTIVE_SESSION_FILENAME {
+            return false;
+        }
+        if file_name.ends_with(".tmp") {
+            return false;
+        }
+    }
+    true
+}
+
+fn mirror_optional_dir_filtered(
+    src: &Path,
+    dest: &Path,
+    should_copy: &dyn Fn(&Path) -> bool,
+) -> Result<(), io::Error> {
     if !src.exists() {
         if dest.exists() {
             fs::remove_dir_all(dest)?;
@@ -121,15 +147,21 @@ fn mirror_optional_dir(src: &Path, dest: &Path) -> Result<(), io::Error> {
         fs::remove_file(dest)?;
     }
     fs::create_dir_all(dest)?;
-    mirror_dir_recursive(src, dest)
+    mirror_dir_recursive_filtered(src, dest, Path::new(""), should_copy)
 }
 
-fn mirror_dir_recursive(src: &Path, dest: &Path) -> Result<(), io::Error> {
+fn mirror_dir_recursive_filtered(
+    src: &Path,
+    dest: &Path,
+    relative_root: &Path,
+    should_copy: &dyn Fn(&Path) -> bool,
+) -> Result<(), io::Error> {
     for entry in fs::read_dir(dest)? {
         let entry = entry?;
         let dest_path = entry.path();
         let src_path = src.join(entry.file_name());
-        if !src_path.exists() {
+        let relative_path = relative_root.join(entry.file_name());
+        if !src_path.exists() || !should_copy(&relative_path) {
             remove_path(&dest_path)?;
             continue;
         }
@@ -141,13 +173,17 @@ fn mirror_dir_recursive(src: &Path, dest: &Path) -> Result<(), io::Error> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let src_path = entry.path();
+        let relative_path = relative_root.join(entry.file_name());
+        if !should_copy(&relative_path) {
+            continue;
+        }
         let dest_path = dest.join(entry.file_name());
         if src_path.is_dir() {
             if dest_path.exists() && !dest_path.is_dir() {
                 remove_path(&dest_path)?;
             }
             fs::create_dir_all(&dest_path)?;
-            mirror_dir_recursive(&src_path, &dest_path)?;
+            mirror_dir_recursive_filtered(&src_path, &dest_path, &relative_path, should_copy)?;
         } else if src_path.is_file() {
             if let Some(parent) = dest_path.parent() {
                 fs::create_dir_all(parent)?;
@@ -265,6 +301,11 @@ mod tests {
             "{\"context\":\"ctx_1\"}",
         )
         .expect("registry");
+        fs::write(
+            user_browserbase.join(BROWSERBASE_ACTIVE_SESSION_FILENAME),
+            "{\"session_id\":\"sess_stale\"}",
+        )
+        .expect("active_session");
         fs::write(user_browserbase.join("nested").join("note.txt"), "hello").expect("nested file");
 
         sync_user_browserbase_state_to_workspace(&user_browserbase, &workspace_dir).expect("sync");
@@ -279,6 +320,9 @@ mod tests {
                 .expect("nested"),
             "hello"
         );
+        assert!(!workspace_browserbase
+            .join(BROWSERBASE_ACTIVE_SESSION_FILENAME)
+            .exists());
     }
 
     #[test]
@@ -292,10 +336,20 @@ mod tests {
             "{\"context\":\"ctx_2\"}",
         )
         .expect("registry");
+        fs::write(
+            workspace_browserbase.join(BROWSERBASE_ACTIVE_SESSION_FILENAME),
+            "{\"session_id\":\"sess_workspace\"}",
+        )
+        .expect("active_session");
         let user_browserbase = temp.path().join("user-secrets").join("browserbase");
         fs::create_dir_all(user_browserbase.join("nested")).expect("user browserbase");
         fs::write(user_browserbase.join("stale.json"), "stale").expect("stale file");
         fs::write(user_browserbase.join("nested").join("old.txt"), "old").expect("old file");
+        fs::write(
+            user_browserbase.join(BROWSERBASE_ACTIVE_SESSION_FILENAME),
+            "{\"session_id\":\"sess_old\"}",
+        )
+        .expect("old active session");
 
         sync_workspace_browserbase_state_to_user(&workspace_dir, &user_browserbase).expect("sync");
 
@@ -305,5 +359,8 @@ mod tests {
             fs::read_to_string(user_browserbase.join("registry.json")).expect("registry"),
             "{\"context\":\"ctx_2\"}"
         );
+        assert!(!user_browserbase
+            .join(BROWSERBASE_ACTIVE_SESSION_FILENAME)
+            .exists());
     }
 }

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -54,6 +54,10 @@ BROWSERBASE_STATE_DIR_DEFAULT = ".secrets/browserbase"
 BROWSERBASE_ACTIVE_SESSION_FILENAME = "active_session.json"
 BROWSERBASE_STATE_DIR_ENV_KEY = "BROWSERBASE_STATE_DIR"
 BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY = "BROWSERBASE_ACTIVE_SESSION_PATH"
+BROWSERBASE_API_KEY_ENV_KEY = "BROWSERBASE_API_KEY"
+BROWSERBASE_API_KEY_ALIAS_ENV_KEY = "BROWSER_BASE_API_KEY"
+BROWSERBASE_API_BASE_URL_ENV_KEY = "BROWSERBASE_API_BASE_URL"
+DEFAULT_BROWSERBASE_API_BASE_URL = "https://api.browserbase.com"
 BROWSER_HANDOFF_BASE_URL_ENV_KEY = "BROWSER_HANDOFF_BASE_URL"
 BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY = "BROWSER_HANDOFF_SIGNING_SECRET"
 PAGE_STATES_BY_TYPE = {
@@ -144,6 +148,56 @@ def load_active_browserbase_session() -> Optional[Dict[str, Any]]:
     return payload
 
 
+def fetch_browserbase_debug_payload(session_id: str) -> Optional[Dict[str, Any]]:
+    api_key = get_env_first(BROWSERBASE_API_KEY_ENV_KEY, BROWSERBASE_API_KEY_ALIAS_ENV_KEY)
+    if not api_key:
+        return None
+    api_base = (get_env_first(BROWSERBASE_API_BASE_URL_ENV_KEY) or DEFAULT_BROWSERBASE_API_BASE_URL).rstrip(
+        "/"
+    )
+    encoded_session_id = urllib.parse.quote(session_id, safe="")
+    request = urllib.request.Request(
+        f"{api_base}/v1/sessions/{encoded_session_id}/debug",
+        headers={"Accept": "application/json", "X-BB-API-Key": api_key},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+    except Exception:
+        return None
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+def resolve_browser_handoff_page_id(active_session: Dict[str, Any]) -> str:
+    page_id = str(active_session.get("page_id", "")).strip()
+    if page_id:
+        return page_id
+
+    session_id = str(active_session.get("session_id", "")).strip()
+    if not session_id:
+        return ""
+
+    payload = fetch_browserbase_debug_payload(session_id)
+    if not payload:
+        return ""
+
+    pages = payload.get("pages")
+    if not isinstance(pages, list) or len(pages) != 1:
+        return ""
+
+    page = pages[0]
+    if not isinstance(page, dict):
+        return ""
+    return str(page.get("id", "")).strip()
+
+
 def encode_browser_handoff_token(claims: Dict[str, Any], secret: str) -> str:
     header = {"alg": "HS256", "typ": "JWT"}
     encoded_header = base64.urlsafe_b64encode(
@@ -168,7 +222,7 @@ def build_browser_handoff_details(challenge_id: str, expires_at: str) -> Optiona
     session_id = str(active_session.get("session_id", "")).strip()
     if not session_id:
         return None
-    page_id = str(active_session.get("page_id", "")).strip()
+    page_id = resolve_browser_handoff_page_id(active_session)
 
     now = utc_now()
     expires = parse_iso8601(expires_at)

--- a/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
@@ -221,6 +221,54 @@ class HumanApprovalGateTests(unittest.TestCase):
             self.assertIn("Live browser handoff:", state["_rendered_email"]["text_body"])
             self.assertIn("Open live browser handoff", state["_rendered_email"]["html_body"])
 
+    def test_browser_handoff_refreshes_single_live_page_id_when_missing_from_state(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            active_session_path = Path(temp_dir) / "active_session.json"
+            active_session_path.write_text(
+                json.dumps({"session_id": "sess_live_123"}),
+                encoding="utf-8",
+            )
+
+            previous = {
+                MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY: os.environ.get(MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY),
+                MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY: os.environ.get(MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY),
+                MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY: os.environ.get(MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY),
+            }
+            os.environ[MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY] = "https://api.example.com/service"
+            os.environ[MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY] = "secret-key"
+            os.environ[MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY] = str(active_session_path)
+
+            original_fetch = MODULE.fetch_browserbase_debug_payload
+            MODULE.fetch_browserbase_debug_payload = lambda session_id: {
+                "pages": [{"id": "page_from_debug"}]
+            }
+            try:
+                args = self.parse_request(
+                    "--challenge-type",
+                    "captcha",
+                    "--scope",
+                    "admin",
+                    "--account-label",
+                    "Oliver Google account",
+                    "--screenshot",
+                    screenshot,
+                )
+                state = MODULE.build_request_state(args)
+            finally:
+                MODULE.fetch_browserbase_debug_payload = original_fetch
+                for key, value in previous.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
+
+            self.assertEqual(state["browser_session_id"], "sess_live_123")
+            self.assertEqual(state["browser_page_id"], "page_from_debug")
+            token = state["browser_handoff_url"].split("token=", 1)[1]
+            claims = self.decode_token_claims(token)
+            self.assertEqual(claims["page_id"], "page_from_debug")
+
     def test_cli_rejects_shell_usage_when_mcp_required(self):
         previous = os.environ.get(MODULE.HAG_REQUIRE_MCP_ENV_KEY)
         os.environ[MODULE.HAG_REQUIRE_MCP_ENV_KEY] = "1"


### PR DESCRIPTION
## Summary
- stop persisting `active_session.json` between per-user Browserbase secrets and task workspaces
- keep Browserbase context state durable while forcing each new task to attach a fresh live session
- refresh the Browserbase page id when building HAG handoff links if the active session file does not already have one

## Testing
- `cargo test -p scheduler_module secrets_store`
- `python3 -m unittest DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py`
- `python3 -m unittest DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py` with a temporary stub `mcp.server.fastmcp` module
- ad hoc Python check that `build_browser_handoff_details()` populates `browser_page_id` from Browserbase debug payload when the active session file only contains `session_id`
