### PR TITLE
Surface actionable Browserbase quota failures

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -260,7 +260,10 @@ Azure ACI execution path (required vars):
   only mirrors the durable Browserbase context state between per-user secrets and each
   task workspace; it does not persist `active_session.json` across tasks, so every new
   task restores the user's auth context into a fresh live Browserbase session instead of
-  inheriting a stale expiring session from an older container.
+  inheriting a stale expiring session from an older container. If Browserbase rejects
+  session creation with HTTP 402, `browserbase_session_manager` now surfaces an
+  explicit quota/billing message so operators know why no live browser or handoff
+  link could be created.
 - `human_approval_gate` (via skill `human-approval-gate`) provides a blocking
   approval flow for login CAPTCHA/password/OTP/device-approval steps. In
   run_task/Codex environments, the preferred path is the injected MCP tool

--- a/DoWhiz_service/skills/browserbase-handoff/scripts/browserbase_session_manager.py
+++ b/DoWhiz_service/skills/browserbase-handoff/scripts/browserbase_session_manager.py
@@ -32,9 +32,16 @@ class ApiError(CliError):
     """HTTP/API error with a surfaced status code."""
 
     def __init__(self, status_code: int, path: str, message: str) -> None:
-        super().__init__(f"Browserbase API error {status_code} for {path}: {message}")
         self.status_code = status_code
         self.path = path
+        self.raw_message = message
+        self.body_summary = summarize_api_error_body(message)
+        self.error_kind = classify_api_error(status_code, path, self.body_summary)
+        self.guidance = api_error_guidance(self.error_kind)
+        error_message = f"Browserbase API error {status_code} for {path}: {self.body_summary}"
+        if self.guidance:
+            error_message = f"{error_message} {self.guidance}"
+        super().__init__(error_message)
 
 
 @dataclass
@@ -51,6 +58,67 @@ def utc_now() -> datetime:
 
 def isoformat_utc(value: datetime) -> str:
     return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def summarize_api_error_body(raw: str) -> str:
+    text = raw.strip()
+    if not text:
+        return "empty response body"
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return text[:800]
+    if isinstance(parsed, dict):
+        message = str(parsed.get("message", "")).strip()
+        error = str(parsed.get("error", "")).strip()
+        parts = []
+        if error:
+            parts.append(error)
+        if message and message not in parts:
+            parts.append(message)
+        if parts:
+            return ": ".join(parts)
+    return text[:800]
+
+
+def classify_api_error(status_code: int, path: str, body_summary: str) -> Optional[str]:
+    normalized_path = path.strip()
+    if status_code == 402 and normalized_path == "/v1/sessions":
+        return "browserbase_quota_exhausted"
+    if status_code == 429 and normalized_path == "/v1/sessions":
+        return "browserbase_rate_limited"
+    if status_code == 401:
+        return "browserbase_auth_failed"
+    if "project not found" in body_summary.lower():
+        return "browserbase_project_missing"
+    return None
+
+
+def api_error_guidance(error_kind: Optional[str]) -> Optional[str]:
+    if error_kind == "browserbase_quota_exhausted":
+        return (
+            "Browserbase could not create a live browser session for this task because the "
+            "configured project has no remaining browser minutes or billing is inactive. "
+            "Upgrade the Browserbase plan, or switch DoWhiz to a Browserbase API key/project "
+            "that can create sessions. Until this is fixed, the agent cannot open a live "
+            "Browserbase page or send a live browser handoff link."
+        )
+    if error_kind == "browserbase_rate_limited":
+        return (
+            "Browserbase is rate limiting session creation right now. Retry after the limit "
+            "window, or reduce concurrent Browserbase session starts."
+        )
+    if error_kind == "browserbase_auth_failed":
+        return (
+            "Verify that the Browserbase API key configured for this environment is valid and "
+            "belongs to the intended project."
+        )
+    if error_kind == "browserbase_project_missing":
+        return (
+            "Verify that BROWSERBASE_PROJECT_ID points to a project that exists and is accessible "
+            "by the configured API key."
+        )
+    return None
 
 
 def read_json(path: Path) -> Dict[str, Any]:
@@ -516,16 +584,19 @@ def main(argv: list[str]) -> int:
     try:
         return int(args.func(args))
     except CliError as exc:
-        print(
-            json.dumps(
-                {
-                    "status": "error",
-                    "error": str(exc),
-                },
-                ensure_ascii=True,
-                sort_keys=True,
-            )
-        )
+        payload: Dict[str, Any] = {
+            "status": "error",
+            "error": str(exc),
+        }
+        if isinstance(exc, ApiError):
+            payload["provider"] = "browserbase"
+            payload["provider_path"] = exc.path
+            payload["provider_status_code"] = exc.status_code
+            if exc.error_kind:
+                payload["error_kind"] = exc.error_kind
+            if exc.guidance:
+                payload["action_required"] = exc.guidance
+        print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
         return 1
     except KeyboardInterrupt:
         print(json.dumps({"status": "error", "error": "interrupted"}, ensure_ascii=True, sort_keys=True))

--- a/DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
+++ b/DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
@@ -1,4 +1,5 @@
 import importlib.util
+import io
 import json
 import os
 import sys
@@ -164,6 +165,56 @@ class BrowserbaseSessionManagerTests(unittest.TestCase):
         self.assertIn("export BROWSERBASE_SESSION_ID=sess_test", text)
         self.assertIn("export BROWSERBASE_CONTEXT_ID=ctx_test", text)
         self.assertIn("export PLAYWRIGHT_MCP_CDP_ENDPOINT='wss://connect.example.com?token=abc'", text)
+
+    def test_api_error_classifies_browserbase_quota_exhaustion(self):
+        error = MODULE.ApiError(
+            402,
+            "/v1/sessions",
+            json.dumps(
+                {
+                    "statusCode": 402,
+                    "error": "Payment Required",
+                    "message": "Free plan browser minutes limit reached. Please upgrade your account.",
+                }
+            ),
+        )
+
+        self.assertEqual(error.error_kind, "browserbase_quota_exhausted")
+        self.assertIn("Free plan browser minutes limit reached", error.body_summary)
+        self.assertIn("cannot open a live Browserbase page", str(error))
+
+    def test_main_emits_structured_quota_error_payload(self):
+        original_cmd = MODULE.cmd_ensure_session
+        module_stdout = sys.stdout
+        capture = io.StringIO()
+        sys.stdout = capture
+        try:
+            def fail(_args):
+                raise MODULE.ApiError(
+                    402,
+                    "/v1/sessions",
+                    json.dumps(
+                        {
+                            "statusCode": 402,
+                            "error": "Payment Required",
+                            "message": "Free plan browser minutes limit reached. Please upgrade your account.",
+                        }
+                    ),
+                )
+
+            MODULE.cmd_ensure_session = fail
+            exit_code = MODULE.main(["ensure-session"])
+        finally:
+            MODULE.cmd_ensure_session = original_cmd
+            sys.stdout = module_stdout
+
+        self.assertEqual(exit_code, 1)
+        payload = json.loads(capture.getvalue())
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["provider"], "browserbase")
+        self.assertEqual(payload["provider_status_code"], 402)
+        self.assertEqual(payload["error_kind"], "browserbase_quota_exhausted")
+        self.assertIn("upgrade the browserbase plan", payload["action_required"].lower())
 
 
 if __name__ == "__main__":

--- a/DoWhiz_service/skills/playwright/scripts/playwright_cli.sh
+++ b/DoWhiz_service/skills/playwright/scripts/playwright_cli.sh
@@ -6,6 +6,38 @@ if ! command -v npx >/dev/null 2>&1; then
   exit 1
 fi
 
+print_browserbase_error() {
+  local raw_output="$1"
+  local parsed_message
+
+  if command -v python3 >/dev/null 2>&1; then
+    if parsed_message="$(
+      RAW_OUTPUT="$raw_output" python3 - <<'PY'
+import json
+import os
+import sys
+
+text = os.environ.get("RAW_OUTPUT", "").strip()
+if not text:
+    sys.exit(1)
+try:
+    payload = json.loads(text)
+except json.JSONDecodeError:
+    sys.exit(1)
+message = str(payload.get("error", "")).strip()
+if not message:
+    sys.exit(1)
+print(message)
+PY
+    )"; then
+      echo "$parsed_message" >&2
+      return
+    fi
+  fi
+
+  echo "$raw_output" >&2
+}
+
 ensure_browserbase_session() {
   if [[ -z "${BROWSERBASE_API_KEY:-${BROWSER_BASE_API_KEY:-}}" ]]; then
     return 0
@@ -18,7 +50,7 @@ ensure_browserbase_session() {
   local state_dir="${BROWSERBASE_STATE_DIR:-.secrets/browserbase}"
   local exports
   if ! exports="$(browserbase_session_manager --state-dir "$state_dir" ensure-session --format shell 2>&1)"; then
-    echo "$exports" >&2
+    print_browserbase_error "$exports"
     exit 1
   fi
   eval "$exports"

--- a/DoWhiz_service/skills/playwright/scripts/test_playwright_cli_wrapper.py
+++ b/DoWhiz_service/skills/playwright/scripts/test_playwright_cli_wrapper.py
@@ -83,6 +83,52 @@ class PlaywrightCliWrapperTests(unittest.TestCase):
             )
             self.assertIn("playwright-cli open https://example.com", result.stderr)
 
+    def test_browserbase_json_error_is_rendered_as_plain_text(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            bin_dir = temp / "bin"
+            bin_dir.mkdir()
+
+            write_executable(
+                bin_dir / "browserbase_session_manager",
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf '%s' '{"status":"error","error":"Browserbase API error 402 for /v1/sessions: Free plan browser minutes limit reached."}'
+                    exit 1
+                    """
+                ),
+            )
+
+            write_executable(
+                bin_dir / "npx",
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    echo "npx should not be called" >&2
+                    exit 99
+                    """
+                ),
+            )
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+            env["BROWSERBASE_API_KEY"] = "bb_test"
+
+            result = subprocess.run(
+                [str(SCRIPT_PATH), "open", "https://example.com"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("Free plan browser minutes limit reached", result.stderr)
+            self.assertNotIn('"status":"error"', result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- classify Browserbase API failures so session creation quota/billing issues become actionable errors
- include structured Browserbase provider metadata in session manager error payloads
- render Browserbase JSON failures as plain text in the Playwright wrapper and document the behavior

## Testing
- python3 -m unittest DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
- python3 -m unittest DoWhiz_service/skills/playwright/scripts/test_playwright_cli_wrapper.py
- python3 -m unittest DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py  # fails locally because optional dependency mcp.server.fastmcp is not installed