### PR TITLE
Prefer live Browserbase page for handoff

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -287,7 +287,10 @@ Azure ACI execution path (required vars):
   signed browser handoff link under the configured public service base (for example
   `/service/auth/browser-handoff`) so the human can open the same live Browserbase
   session, finish the blocker in-browser, and then reply in the email thread to
-  resume the agent. HAG-thread replies (`[HAG:...]`) are ignored by normal inbound
+  resume the agent. When Browserbase keeps auxiliary blank tabs around, the
+  handoff flow now prefers the most recent non-blank debuggable page instead of
+  dropping the user into a session-level `about:blank` inspector. HAG-thread
+  replies (`[HAG:...]`) are ignored by normal inbound
   task routing to prevent recursive Email->task loops.
 - ACI run_task sets Playwright/NPM runtime defaults for mounted workspaces:
   `PLAYWRIGHT_MCP_EXECUTABLE_PATH` auto-discovery (`chrome-linux` / `chrome-linux64`),

--- a/DoWhiz_service/scheduler_module/src/service/browser_handoff.rs
+++ b/DoWhiz_service/scheduler_module/src/service/browser_handoff.rs
@@ -194,8 +194,8 @@ fn select_debug_url(
         }
     }
 
-    if payload.pages.len() == 1 {
-        if let Some(url) = page_debug_url(&payload.pages[0]) {
+    if let Some(page) = select_fallback_page(payload) {
+        if let Some(url) = page_debug_url(page) {
             return Some(url);
         }
     }
@@ -211,6 +211,35 @@ fn page_debug_url(page: &BrowserbaseDebugPage) -> Option<String> {
     page.debugger_fullscreen_url
         .clone()
         .or_else(|| page.debugger_url.clone())
+}
+
+fn select_fallback_page(payload: &BrowserbaseDebugUrls) -> Option<&BrowserbaseDebugPage> {
+    payload
+        .pages
+        .iter()
+        .rev()
+        .find(|page| page_debug_url(page).is_some() && page_looks_live(page))
+        .or_else(|| {
+            payload
+                .pages
+                .iter()
+                .rev()
+                .find(|page| page_debug_url(page).is_some())
+        })
+}
+
+fn page_looks_live(page: &BrowserbaseDebugPage) -> bool {
+    !page_text_is_blank(&page.url) || !page_text_is_blank(&page.title)
+}
+
+fn page_text_is_blank(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    normalized.is_empty()
+        || normalized == "about:blank"
+        || normalized == "new tab"
+        || normalized.starts_with("chrome://newtab")
+        || normalized.starts_with("edge://newtab")
+        || normalized.starts_with("chrome-search://local-ntp")
 }
 
 fn render_browser_handoff_html(
@@ -541,6 +570,43 @@ mod tests {
         assert_eq!(
             select_debug_url(&claims, &payload).as_deref(),
             Some("https://page-b-full.example.com")
+        );
+    }
+
+    #[test]
+    fn select_debug_url_prefers_live_page_over_session_level_blank_debugger() {
+        let claims = BrowserHandoffGrant {
+            version: 1,
+            challenge_id: "hag-123".to_string(),
+            session_id: "sess-123".to_string(),
+            page_id: None,
+            iat: 1,
+            exp: usize::MAX,
+        };
+        let payload = BrowserbaseDebugUrls {
+            debugger_url: Some("https://session.example.com".to_string()),
+            debugger_fullscreen_url: Some("https://session-full.example.com".to_string()),
+            pages: vec![
+                BrowserbaseDebugPage {
+                    id: "page-a".to_string(),
+                    url: "about:blank".to_string(),
+                    title: "about:blank".to_string(),
+                    debugger_url: Some("https://page-a.example.com".to_string()),
+                    debugger_fullscreen_url: Some("https://page-a-full.example.com".to_string()),
+                },
+                BrowserbaseDebugPage {
+                    id: "page-live".to_string(),
+                    url: "https://example.com/login".to_string(),
+                    title: "Login".to_string(),
+                    debugger_url: Some("https://page-live.example.com".to_string()),
+                    debugger_fullscreen_url: Some("https://page-live-full.example.com".to_string()),
+                },
+            ],
+        };
+
+        assert_eq!(
+            select_debug_url(&claims, &payload).as_deref(),
+            Some("https://page-live-full.example.com")
         );
     }
 

--- a/DoWhiz_service/skills/browserbase-handoff/scripts/browserbase_session_manager.py
+++ b/DoWhiz_service/skills/browserbase-handoff/scripts/browserbase_session_manager.py
@@ -302,6 +302,54 @@ def get_debug_urls(config: BrowserbaseConfig, session_id: str) -> Dict[str, Any]
     )
 
 
+def page_debug_url(page: Dict[str, Any]) -> str:
+    for key in ("debuggerFullscreenUrl", "debuggerUrl"):
+        value = str(page.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def page_text_is_blank(value: Any) -> bool:
+    normalized = str(value or "").strip().lower()
+    return (
+        normalized == ""
+        or normalized == "about:blank"
+        or normalized == "new tab"
+        or normalized.startswith("chrome://newtab")
+        or normalized.startswith("edge://newtab")
+        or normalized.startswith("chrome-search://local-ntp")
+    )
+
+
+def page_looks_live(page: Dict[str, Any]) -> bool:
+    return not page_text_is_blank(page.get("url")) or not page_text_is_blank(page.get("title"))
+
+
+def select_page_id_from_debug_payload(debug_urls: Dict[str, Any]) -> Optional[str]:
+    pages = debug_urls.get("pages")
+    if not isinstance(pages, list):
+        return None
+
+    def iter_candidates():
+        for raw_page in reversed(pages):
+            if not isinstance(raw_page, dict):
+                continue
+            page_id = str(raw_page.get("id", "")).strip()
+            if not page_id or not page_debug_url(raw_page):
+                continue
+            yield raw_page, page_id
+
+    for page, page_id in iter_candidates():
+        if page_looks_live(page):
+            return page_id
+
+    for _page, page_id in iter_candidates():
+        return page_id
+
+    return None
+
+
 def create_session(config: BrowserbaseConfig, context_id: str) -> Dict[str, Any]:
     body: Dict[str, Any] = {
         "browserSettings": {
@@ -346,16 +394,7 @@ def resolve_page_id_for_session(
     except CliError:
         return None, False
 
-    pages = debug_urls.get("pages")
-    if not isinstance(pages, list):
-        return None, True
-    if len(pages) != 1:
-        return None, True
-
-    page = pages[0]
-    if not isinstance(page, dict):
-        return None, True
-    page_id = str(page.get("id", "")).strip()
+    page_id = select_page_id_from_debug_payload(debug_urls)
     if not page_id:
         return None, True
     return page_id, True

--- a/DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
+++ b/DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
@@ -97,7 +97,14 @@ class BrowserbaseSessionManagerTests(unittest.TestCase):
                 "expiresAt": "2026-03-24T01:00:00Z",
             }
             MODULE.get_debug_urls = lambda *_args, **_kwargs: {
-                "pages": [{"id": "page_live"}],
+                "pages": [
+                    {
+                        "id": "page_live",
+                        "url": "https://example.com/login",
+                        "title": "Login",
+                        "debuggerFullscreenUrl": "https://page-live.example.com",
+                    }
+                ],
             }
             MODULE.create_session = lambda *_args, **_kwargs: (_ for _ in ()).throw(
                 AssertionError("create_session should not be called")
@@ -215,6 +222,45 @@ class BrowserbaseSessionManagerTests(unittest.TestCase):
         self.assertEqual(payload["provider_status_code"], 402)
         self.assertEqual(payload["error_kind"], "browserbase_quota_exhausted")
         self.assertIn("upgrade the browserbase plan", payload["action_required"].lower())
+
+    def test_resolve_page_id_for_session_prefers_live_page_when_blank_tabs_exist(self):
+        config = MODULE.BrowserbaseConfig(
+            api_key="bb_test",
+            project_id="proj_test",
+            api_base=MODULE.API_BASE_DEFAULT,
+            timeout_seconds=3600,
+        )
+
+        original_debug = MODULE.get_debug_urls
+        MODULE.get_debug_urls = lambda *_args, **_kwargs: {
+            "pages": [
+                {
+                    "id": "page_blank",
+                    "url": "about:blank",
+                    "title": "about:blank",
+                    "debuggerFullscreenUrl": "https://blank.example.com",
+                },
+                {
+                    "id": "page_live",
+                    "url": "https://example.com/2fa",
+                    "title": "2FA",
+                    "debuggerFullscreenUrl": "https://live.example.com",
+                },
+                {
+                    "id": "page_blank_tail",
+                    "url": "about:blank",
+                    "title": "about:blank",
+                    "debuggerFullscreenUrl": "https://blank-tail.example.com",
+                },
+            ]
+        }
+        try:
+            page_id, page_id_known = MODULE.resolve_page_id_for_session(config, "sess_live")
+        finally:
+            MODULE.get_debug_urls = original_debug
+
+        self.assertTrue(page_id_known)
+        self.assertEqual(page_id, "page_live")
 
 
 if __name__ == "__main__":

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -175,6 +175,54 @@ def fetch_browserbase_debug_payload(session_id: str) -> Optional[Dict[str, Any]]
     return parsed
 
 
+def page_debug_url(page: Dict[str, Any]) -> str:
+    for key in ("debuggerFullscreenUrl", "debuggerUrl"):
+        value = str(page.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def page_text_is_blank(value: Any) -> bool:
+    normalized = str(value or "").strip().lower()
+    return (
+        normalized == ""
+        or normalized == "about:blank"
+        or normalized == "new tab"
+        or normalized.startswith("chrome://newtab")
+        or normalized.startswith("edge://newtab")
+        or normalized.startswith("chrome-search://local-ntp")
+    )
+
+
+def page_looks_live(page: Dict[str, Any]) -> bool:
+    return not page_text_is_blank(page.get("url")) or not page_text_is_blank(page.get("title"))
+
+
+def resolve_browserbase_debug_page_id(payload: Dict[str, Any]) -> str:
+    pages = payload.get("pages")
+    if not isinstance(pages, list):
+        return ""
+
+    def iter_candidates():
+        for raw_page in reversed(pages):
+            if not isinstance(raw_page, dict):
+                continue
+            page_id = str(raw_page.get("id", "")).strip()
+            if not page_id or not page_debug_url(raw_page):
+                continue
+            yield raw_page, page_id
+
+    for page, page_id in iter_candidates():
+        if page_looks_live(page):
+            return page_id
+
+    for _page, page_id in iter_candidates():
+        return page_id
+
+    return ""
+
+
 def resolve_browser_handoff_page_id(active_session: Dict[str, Any]) -> str:
     page_id = str(active_session.get("page_id", "")).strip()
     if page_id:
@@ -187,15 +235,7 @@ def resolve_browser_handoff_page_id(active_session: Dict[str, Any]) -> str:
     payload = fetch_browserbase_debug_payload(session_id)
     if not payload:
         return ""
-
-    pages = payload.get("pages")
-    if not isinstance(pages, list) or len(pages) != 1:
-        return ""
-
-    page = pages[0]
-    if not isinstance(page, dict):
-        return ""
-    return str(page.get("id", "")).strip()
+    return resolve_browserbase_debug_page_id(payload)
 
 
 def encode_browser_handoff_token(claims: Dict[str, Any], secret: str) -> str:

--- a/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
@@ -241,7 +241,81 @@ class HumanApprovalGateTests(unittest.TestCase):
 
             original_fetch = MODULE.fetch_browserbase_debug_payload
             MODULE.fetch_browserbase_debug_payload = lambda session_id: {
-                "pages": [{"id": "page_from_debug"}]
+                "pages": [
+                    {
+                        "id": "page_from_debug",
+                        "url": "https://example.com/verify",
+                        "title": "Verify code",
+                        "debuggerFullscreenUrl": "https://live.example.com",
+                    }
+                ]
+            }
+            try:
+                args = self.parse_request(
+                    "--challenge-type",
+                    "captcha",
+                    "--scope",
+                    "admin",
+                    "--account-label",
+                    "Oliver Google account",
+                    "--screenshot",
+                    screenshot,
+                )
+                state = MODULE.build_request_state(args)
+            finally:
+                MODULE.fetch_browserbase_debug_payload = original_fetch
+                for key, value in previous.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
+
+            self.assertEqual(state["browser_session_id"], "sess_live_123")
+            self.assertEqual(state["browser_page_id"], "page_from_debug")
+            token = state["browser_handoff_url"].split("token=", 1)[1]
+            claims = self.decode_token_claims(token)
+            self.assertEqual(claims["page_id"], "page_from_debug")
+
+    def test_browser_handoff_refreshes_live_page_id_from_multi_tab_debug_payload(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            active_session_path = Path(temp_dir) / "active_session.json"
+            active_session_path.write_text(
+                json.dumps({"session_id": "sess_live_123"}),
+                encoding="utf-8",
+            )
+
+            previous = {
+                MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY: os.environ.get(MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY),
+                MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY: os.environ.get(MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY),
+                MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY: os.environ.get(MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY),
+            }
+            os.environ[MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY] = "https://api.example.com/service"
+            os.environ[MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY] = "secret-key"
+            os.environ[MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY] = str(active_session_path)
+
+            original_fetch = MODULE.fetch_browserbase_debug_payload
+            MODULE.fetch_browserbase_debug_payload = lambda session_id: {
+                "pages": [
+                    {
+                        "id": "page_blank",
+                        "url": "about:blank",
+                        "title": "about:blank",
+                        "debuggerFullscreenUrl": "https://blank.example.com",
+                    },
+                    {
+                        "id": "page_from_debug",
+                        "url": "https://example.com/verify",
+                        "title": "Verify code",
+                        "debuggerFullscreenUrl": "https://live.example.com",
+                    },
+                    {
+                        "id": "page_blank_tail",
+                        "url": "about:blank",
+                        "title": "about:blank",
+                        "debuggerFullscreenUrl": "https://blank-tail.example.com",
+                    },
+                ]
             }
             try:
                 args = self.parse_request(


### PR DESCRIPTION
## Summary
- prefer the most recent non-blank Browserbase page when generating human handoff targets
- let HAG/session-state logic recover a usable page id from Browserbase debug payloads even when extra blank tabs exist
- add regression tests and README notes for multi-tab Browserbase handoff behavior

## Testing
- python3 -m unittest skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
- python3 stub run for skills/human-approval-gate/scripts/test_human_approval_gate.py (with temporary FastMCP stub)
- cargo test -p scheduler_module browser_handoff::tests --manifest-path DoWhiz_service/Cargo.toml -- --nocapture
