### PR TITLE
Fix HAG reply polling for inbound alias deliveries

### DIFF
--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -1013,6 +1013,15 @@ def build_reply_payload(details: Dict[str, Any], message_id: str, received_at: O
     }
 
 
+def extract_inbound_messages(search_response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    messages = search_response.get("InboundMessages")
+    if not isinstance(messages, list):
+        messages = search_response.get("Messages")
+    if not isinstance(messages, list):
+        return []
+    return [message for message in messages if isinstance(message, dict)]
+
+
 def poll_for_reply_once(
     *,
     api_base: str,
@@ -1039,11 +1048,20 @@ def poll_for_reply_once(
         query["recipient"] = recipient_filter
 
     search_response = http_json_request("GET", api_base, token, "/messages/inbound", query=query)
-    messages = search_response.get("InboundMessages")
-    if not isinstance(messages, list):
-        messages = search_response.get("Messages")
-    if not isinstance(messages, list):
-        messages = []
+    messages = extract_inbound_messages(search_response)
+    if recipient_filter and not messages:
+        # Postmark inbound replies often land on the server alias address rather than the
+        # human-facing Reply-To mailbox, so retry without recipient narrowing before giving up.
+        query_without_recipient = dict(query)
+        query_without_recipient.pop("recipient", None)
+        search_response = http_json_request(
+            "GET",
+            api_base,
+            token,
+            "/messages/inbound",
+            query=query_without_recipient,
+        )
+        messages = extract_inbound_messages(search_response)
 
     seen = set(challenge.get("seen_inbound_message_ids", []))
     new_seen: List[str] = []

--- a/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
@@ -366,6 +366,59 @@ class HumanApprovalGateTests(unittest.TestCase):
             claims = self.decode_token_claims(token)
             self.assertEqual(claims["page_id"], "page_from_debug")
 
+    def test_poll_for_reply_once_retries_without_recipient_filter_for_alias_deliveries(self):
+        challenge = {
+            "challenge_id": "abc-123",
+            "created_at": "2026-03-25T17:48:42Z",
+            "expected_reply_from": "deep-tutor+bb-handoff-123@deep-tutor.com",
+            "reply_to": "dowhiz@deep-tutor.com",
+            "seen_inbound_message_ids": [],
+        }
+        recorded_queries = []
+
+        original_http = MODULE.http_json_request
+
+        def fake_http(method, api_base, token, path, query=None, body=None):
+            recorded_queries.append((path, dict(query or {})))
+            if path == "/messages/inbound":
+                if query and query.get("recipient") == "dowhiz@deep-tutor.com":
+                    return {"TotalCount": 0, "InboundMessages": []}
+                return {
+                    "TotalCount": 1,
+                    "InboundMessages": [{"MessageID": "msg-1"}],
+                }
+            if path == "/messages/inbound/msg-1/details":
+                return {
+                    "From": "deep-tutor+bb-handoff-123@deep-tutor.com",
+                    "Subject": "Re: [HAG:abc-123] 2FA approval needed for Browserbase handoff demo",
+                    "TextBody": "424242",
+                    "Date": "2026-03-25T17:50:00Z",
+                    "OriginalRecipient": "alias@inbound.postmarkapp.com",
+                    "To": "alias@inbound.postmarkapp.com",
+                }
+            raise AssertionError(f"unexpected request path: {path}")
+
+        MODULE.http_json_request = fake_http
+        try:
+            reply, new_seen = MODULE.poll_for_reply_once(
+                api_base="https://api.postmarkapp.com",
+                token="token",
+                challenge=challenge,
+            )
+        finally:
+            MODULE.http_json_request = original_http
+
+        self.assertIsNotNone(reply)
+        assert reply is not None
+        self.assertEqual(reply["from_email"], "deep-tutor+bb-handoff-123@deep-tutor.com")
+        self.assertEqual(reply["text_body"], "424242")
+        self.assertEqual(new_seen, ["msg-1"])
+
+        inbound_queries = [query for path, query in recorded_queries if path == "/messages/inbound"]
+        self.assertEqual(len(inbound_queries), 2)
+        self.assertEqual(inbound_queries[0]["recipient"], "dowhiz@deep-tutor.com")
+        self.assertNotIn("recipient", inbound_queries[1])
+
     def test_cli_rejects_shell_usage_when_mcp_required(self):
         previous = os.environ.get(MODULE.HAG_REQUIRE_MCP_ENV_KEY)
         os.environ[MODULE.HAG_REQUIRE_MCP_ENV_KEY] = "1"


### PR DESCRIPTION
## Summary
- retry Postmark inbound search without the recipient filter when the reply-to mailbox search returns no messages
- handle alias-delivered inbound replies without losing sender/subject validation
- add a regression test for the staging Browserbase handoff failure mode

## Testing
- PYTHONPATH=<temp_stub>:DoWhiz_service/skills/human-approval-gate/scripts python3 DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py

## Context
Staging Browserbase handoff emails were sent successfully and the handoff URL opened the exact stuck page, but user replies were not detected because Postmark stored inbound replies under the alias recipient instead of the human-facing reply-to mailbox.