### PR TITLE
Fix Browserbase handoff workspace state paths

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/browserbase.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/browserbase.rs
@@ -34,19 +34,22 @@ const POSTMARK_INBOUND_HOOK_URL_ENV_KEY: &str = "POSTMARK_INBOUND_HOOK_URL";
 const FRONTEND_URL_ENV_KEY: &str = "FRONTEND_URL";
 const SESSION_MANAGER_RELEASE_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub(super) fn collect_browserbase_env_overrides() -> Vec<(String, String)> {
+pub(super) fn collect_browserbase_env_overrides(workspace_dir: &Path) -> Vec<(String, String)> {
+    let state_dir = workspace_browserbase_state_dir(workspace_dir);
+    let registry_path = workspace_browserbase_registry_path(workspace_dir);
+    let active_session_path = workspace_browserbase_active_session_path(workspace_dir);
     let mut overrides = vec![
         (
             BROWSERBASE_STATE_DIR_ENV_KEY.to_string(),
-            DEFAULT_BROWSERBASE_STATE_DIR.to_string(),
+            state_dir.to_string_lossy().into_owned(),
         ),
         (
             BROWSERBASE_REGISTRY_PATH_ENV_KEY.to_string(),
-            DEFAULT_BROWSERBASE_REGISTRY_PATH.to_string(),
+            registry_path.to_string_lossy().into_owned(),
         ),
         (
             BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY.to_string(),
-            DEFAULT_BROWSERBASE_ACTIVE_SESSION_PATH.to_string(),
+            active_session_path.to_string_lossy().into_owned(),
         ),
         (
             BROWSERBASE_API_BASE_URL_ENV_KEY.to_string(),
@@ -90,7 +93,15 @@ pub(super) fn browserbase_enabled() -> bool {
 }
 
 pub(super) fn workspace_browserbase_state_dir(workspace_dir: &Path) -> PathBuf {
-    workspace_dir.join(DEFAULT_BROWSERBASE_STATE_DIR)
+    browserbase_workspace_root(workspace_dir).join(DEFAULT_BROWSERBASE_STATE_DIR)
+}
+
+pub(super) fn workspace_browserbase_registry_path(workspace_dir: &Path) -> PathBuf {
+    browserbase_workspace_root(workspace_dir).join(DEFAULT_BROWSERBASE_REGISTRY_PATH)
+}
+
+pub(super) fn workspace_browserbase_active_session_path(workspace_dir: &Path) -> PathBuf {
+    browserbase_workspace_root(workspace_dir).join(DEFAULT_BROWSERBASE_ACTIVE_SESSION_PATH)
 }
 
 pub(super) struct BrowserbaseSessionCleanupGuard {
@@ -105,6 +116,16 @@ impl BrowserbaseSessionCleanupGuard {
             state_dir: workspace_browserbase_state_dir(workspace_dir),
         }
     }
+}
+
+fn browserbase_workspace_root(workspace_dir: &Path) -> PathBuf {
+    if workspace_dir.is_absolute() {
+        return workspace_dir.to_path_buf();
+    }
+
+    env::current_dir()
+        .map(|cwd| cwd.join(workspace_dir))
+        .unwrap_or_else(|_| workspace_dir.to_path_buf())
 }
 
 impl Drop for BrowserbaseSessionCleanupGuard {
@@ -295,6 +316,7 @@ mod tests {
     #[test]
     fn collect_browserbase_env_overrides_canonicalizes_aliases() {
         let _lock = ENV_LOCK.lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
         let _api_key = EnvGuard::set(BROWSERBASE_API_KEY_ALIAS_ENV_KEY, "bb_test");
         let _project_id = EnvGuard::set(BROWSERBASE_PROJECT_ID_ALIAS_ENV_KEY, "proj_test");
         let _unset_api = EnvGuard::unset(BROWSERBASE_API_KEY_ENV_KEY);
@@ -302,7 +324,7 @@ mod tests {
         let _unset_direct_secret = EnvGuard::unset(BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY);
         let _unset_chat_secret = EnvGuard::unset(CHAT_HISTORY_SCOPE_SIGNING_SECRET_ENV_KEY);
         let _unset_slack_secret = EnvGuard::unset(SLACK_SIGNING_SECRET_ENV_KEY);
-        let overrides = collect_browserbase_env_overrides();
+        let overrides = collect_browserbase_env_overrides(temp.path());
 
         assert!(overrides
             .iter()
@@ -311,21 +333,67 @@ mod tests {
             .iter()
             .any(|(key, value)| { key == BROWSERBASE_PROJECT_ID_ENV_KEY && value == "proj_test" }));
         assert!(overrides.iter().any(|(key, value)| {
-            key == BROWSERBASE_STATE_DIR_ENV_KEY && value == DEFAULT_BROWSERBASE_STATE_DIR
+            key == BROWSERBASE_STATE_DIR_ENV_KEY
+                && value
+                    == &temp
+                        .path()
+                        .join(DEFAULT_BROWSERBASE_STATE_DIR)
+                        .to_string_lossy()
+        }));
+        assert!(overrides.iter().any(|(key, value)| {
+            key == BROWSERBASE_REGISTRY_PATH_ENV_KEY
+                && value
+                    == &temp
+                        .path()
+                        .join(DEFAULT_BROWSERBASE_REGISTRY_PATH)
+                        .to_string_lossy()
+        }));
+        assert!(overrides.iter().any(|(key, value)| {
+            key == BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY
+                && value
+                    == &temp
+                        .path()
+                        .join(DEFAULT_BROWSERBASE_ACTIVE_SESSION_PATH)
+                        .to_string_lossy()
         }));
     }
 
     #[test]
     fn collect_browserbase_env_overrides_uses_handoff_secret_fallbacks() {
         let _lock = ENV_LOCK.lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
         let _unset_direct = EnvGuard::unset(BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY);
         let _chat_secret = EnvGuard::set(CHAT_HISTORY_SCOPE_SIGNING_SECRET_ENV_KEY, "scope-secret");
         let _unset_slack = EnvGuard::unset(SLACK_SIGNING_SECRET_ENV_KEY);
 
-        let overrides = collect_browserbase_env_overrides();
+        let overrides = collect_browserbase_env_overrides(temp.path());
 
         assert!(overrides.iter().any(|(key, value)| {
             key == BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY && value == "scope-secret"
+        }));
+    }
+
+    #[test]
+    fn collect_browserbase_env_overrides_resolves_relative_workspace_paths_against_cwd() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let cwd = env::current_dir().expect("current dir");
+        let overrides = collect_browserbase_env_overrides(Path::new("workspace"));
+
+        assert!(overrides.iter().any(|(key, value)| {
+            key == BROWSERBASE_STATE_DIR_ENV_KEY
+                && value
+                    == &cwd
+                        .join("workspace")
+                        .join(DEFAULT_BROWSERBASE_STATE_DIR)
+                        .to_string_lossy()
+        }));
+        assert!(overrides.iter().any(|(key, value)| {
+            key == BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY
+                && value
+                    == &cwd
+                        .join("workspace")
+                        .join(DEFAULT_BROWSERBASE_ACTIVE_SESSION_PATH)
+                        .to_string_lossy()
         }));
     }
 

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -366,7 +366,12 @@ pub(super) fn run_codex_task(
             .as_deref()
             .unwrap_or(request.workspace_dir),
     )?;
-    let browserbase_env_overrides = collect_browserbase_env_overrides();
+    let browserbase_workspace_dir = if use_docker {
+        PathBuf::from(DOCKER_WORKSPACE_DIR)
+    } else {
+        canonicalize_dir(request.workspace_dir)?
+    };
+    let browserbase_env_overrides = collect_browserbase_env_overrides(&browserbase_workspace_dir);
     let human_approval_gate_env_overrides = collect_human_approval_gate_env_overrides();
 
     let memory_context = load_memory_context(request.workspace_dir, request.memory_dir)?;
@@ -882,7 +887,7 @@ fn run_codex_task_azure_aci(
     let bright_data_env_overrides = collect_bright_data_env_overrides();
     let google_workspace_cli_env_overrides =
         collect_google_workspace_cli_env_overrides(&host_workspace_dir)?;
-    let browserbase_env_overrides = collect_browserbase_env_overrides();
+    let browserbase_env_overrides = collect_browserbase_env_overrides(&container_workspace_dir);
     let human_approval_gate_env_overrides = collect_human_approval_gate_env_overrides();
 
     let memory_context = load_memory_context(request.workspace_dir, request.memory_dir)?;

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -629,7 +629,7 @@ def build_subject(challenge_id: str, account_label: str, challenge_type: str) ->
     subject_prefix = {
         "captcha": "CAPTCHA help needed",
         "password": "Password needed",
-        "two_factor": "2FA approval needed",
+        "two_factor": "2FA help needed",
     }[challenge_type]
     if account_label.strip():
         return f"{token} {subject_prefix} for {account_label.strip()}"
@@ -733,8 +733,8 @@ def summarize_required_help(
 
     if page_state == "waiting_for_device_approval":
         if live_browser_available:
-            return f"Open the real browser page, complete the {method_description} approval, then reply \"done\"."
-        return f"Complete the {method_description} approval, then reply \"done\"."
+            return 'Open the real browser page, approve the sign-in, then reply "done".'
+        return 'Approve the sign-in, then reply "done".'
 
     if live_browser_available:
         return f"Open the real browser page and enter the required {method_description}."
@@ -769,7 +769,7 @@ def build_text_body(state: Dict[str, Any]) -> str:
         browser_handoff_url,
     )
 
-    lines = ["DoWhiz needs help with a sign-in step.", ""]
+    lines = ["DoWhiz is blocked on sign-in.", ""]
     if browser_handoff_url:
         lines.extend(
             [
@@ -887,7 +887,7 @@ def build_html_body(state: Dict[str, Any], text_body: str) -> str:
         "<div style=\"max-width:640px;margin:0 auto;background:#ffffff;border-radius:16px;"
         "padding:24px;border:1px solid #e5e7eb;\">"
         f"{button_html}"
-        "<p style=\"margin:0 0 16px 0;font-size:18px;font-weight:600;\">DoWhiz needs help with a sign-in step.</p>"
+        "<p style=\"margin:0 0 16px 0;font-size:18px;font-weight:600;\">DoWhiz is blocked on sign-in.</p>"
         '<div style="margin:0 0 16px 0;padding:16px;border:1px solid #e5e7eb;border-radius:12px;background:#f9fafb;">'
         f'<p style="margin:0 0 8px 0;"><strong>Blocked on:</strong> {escape(blocked_on)}</p>'
         f'<p style="margin:0;"><strong>Help needed:</strong> {escape(required_help)}</p>'

--- a/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
@@ -394,7 +394,7 @@ class HumanApprovalGateTests(unittest.TestCase):
             if path == "/messages/inbound/msg-1/details":
                 return {
                     "From": "deep-tutor+bb-handoff-123@deep-tutor.com",
-                    "Subject": "Re: [HAG:abc-123] 2FA approval needed for Browserbase handoff demo",
+                    "Subject": "Re: [HAG:abc-123] 2FA help needed for Browserbase handoff demo",
                     "TextBody": "424242",
                     "Date": "2026-03-25T17:50:00Z",
                     "OriginalRecipient": "alias@inbound.postmarkapp.com",


### PR DESCRIPTION
## Summary
- fix Browserbase state env overrides to use the runtime workspace root instead of relative paths
- keep Browserbase registry/active session files stable for local, Docker, and Azure ACI runs
- tighten HAG 2FA email wording while keeping the live browser button at the top

## Why
Staging live phase 1 exposed that Browserbase state could be written under a nested cwd like `output/playwright/handoff/.secrets/browserbase`, which made HAG miss the live session unless the agent manually copied the files back to workspace root.

## Test Evidence
- `python3 -m unittest DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py`
- `python3 -m unittest DoWhiz_service/skills/playwright/scripts/test_playwright_cli_wrapper.py`
- `python3 -m unittest DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py`
- `cargo test -p run_task_module`
- `cargo test -p scheduler_module` locally still hits existing env-dependent failures because `MONGODB_URI` is not set in this machine; no new scheduler regression was introduced by this patch
