### PR TITLE
Fix Browserbase active session write race

### DIFF
--- a/DoWhiz_service/skills/browserbase-handoff/scripts/browserbase_session_manager.py
+++ b/DoWhiz_service/skills/browserbase-handoff/scripts/browserbase_session_manager.py
@@ -8,6 +8,7 @@ import json
 import os
 import shlex
 import sys
+import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -127,9 +128,24 @@ def read_json(path: Path) -> Dict[str, Any]:
 
 def write_json(path: Path, payload: Dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_suffix(".tmp")
-    temp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-    temp_path.replace(path)
+    temp_path_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f"{path.stem}-",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temp_path_name = handle.name
+            handle.write(json.dumps(payload, indent=2, sort_keys=True))
+        Path(temp_path_name).replace(path)
+    finally:
+        if temp_path_name:
+            temp_path = Path(temp_path_name)
+            if temp_path.exists():
+                temp_path.unlink()
 
 
 def get_env_first(*keys: str) -> Optional[str]:

--- a/DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
+++ b/DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 
@@ -152,6 +153,33 @@ class BrowserbaseSessionManagerTests(unittest.TestCase):
             self.assertFalse((state_dir / MODULE.ACTIVE_SESSION_FILENAME).exists())
             self.assertEqual(calls[0][0], "POST")
             self.assertIn("REQUEST_RELEASE", json.dumps(calls[0][2], sort_keys=True))
+
+    def test_write_json_uses_unique_temp_files_for_parallel_writers(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_dir = Path(temp_dir)
+            target = state_dir / MODULE.ACTIVE_SESSION_FILENAME
+            start = threading.Barrier(6)
+            errors = []
+
+            def writer(index: int) -> None:
+                try:
+                    start.wait(timeout=5)
+                    MODULE.write_json(target, {"version": 1, "writer": index})
+                except Exception as exc:  # pragma: no cover - failure path asserted below
+                    errors.append(exc)
+
+            threads = [threading.Thread(target=writer, args=(index,)) for index in range(6)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=5)
+
+            self.assertEqual(errors, [])
+            payload = json.loads(target.read_text(encoding="utf-8"))
+            self.assertEqual(payload["version"], 1)
+            self.assertIn(payload["writer"], range(6))
+            leftovers = sorted(path.name for path in state_dir.iterdir())
+            self.assertEqual(leftovers, [MODULE.ACTIVE_SESSION_FILENAME])
 
     def test_emit_shell_outputs_expected_exports(self):
         payload = {


### PR DESCRIPTION
## Summary
- fix the Browserbase session-manager write path to use a unique temp file per write before the atomic replace
- add a regression test that writes `active_session.json` from parallel threads so wrapper commands cannot race on a shared `.tmp` file
- keep the change scoped to the live Phase 1 failure uncovered after HAG resume

## Live bug evidence
- staging Phase 1 demo reached HAG, the shared Browserbase tab was completed, and HAG marked the reply as `replied`
- after resume, the ACI rollout log showed parallel Browserbase wrapper commands racing on `.secrets/browserbase/active_session.tmp`
- the concrete failure was `FileNotFoundError` while replacing `active_session.tmp -> active_session.json`, which interrupted the resumed verification flow

## Testing
- `python3 -m unittest DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py`
- `python3 -m unittest DoWhiz_service/skills/playwright/scripts/test_playwright_cli_wrapper.py`
- `python3 -m unittest DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py`
- `cargo test -p run_task_module`