### PR TITLE
Fix ACI Browserbase handoff completion detection

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -210,6 +210,13 @@ struct AzureAciExecutionArtifacts {
     container_state: String,
     container_logs: String,
     container_show_json: Option<String>,
+    remote_artifact_completion: bool,
+}
+
+#[derive(Debug, Clone)]
+struct AciPollState {
+    container_state: String,
+    remote_artifact_completion: bool,
 }
 
 /// Check if cross-channel routing was requested and return the correct expected reply path.
@@ -1047,6 +1054,7 @@ fn run_codex_task_azure_aci(
         &container_name,
         &container_workspace_dir,
         &add_dirs,
+        &remote_exit_code_path,
         &model_name,
         &sandbox_mode,
         bypass_sandbox,
@@ -1092,8 +1100,8 @@ fn run_codex_task_azure_aci(
         }
     };
     eprintln!(
-        "[run_task] azure_aci finished container={} state={}",
-        container_name, execution.container_state
+        "[run_task] azure_aci finished container={} state={} remote_artifact_completion={}",
+        container_name, execution.container_state, execution.remote_artifact_completion
     );
     if let Some(show_json) = execution.container_show_json.as_deref() {
         let _ = trace.record_text("aci/container_show.json", show_json);
@@ -1120,12 +1128,13 @@ fn run_codex_task_azure_aci(
     let token_usage = extract_token_usage(&combined_output);
     let output_tail = tail_string(&combined_output, 4000);
 
-    if execution.container_state != "Succeeded" || exit_status != Some(0) {
+    if !azure_aci_execution_succeeded(&execution, exit_status) {
         let err = RunTaskError::CodexFailed {
             status: exit_status,
             output: format!(
-                "azure_aci_state={}{}\n{}",
+                "azure_aci_state={} remote_artifact_completion={}{}\n{}",
                 execution.container_state,
+                execution.remote_artifact_completion,
                 match exit_status {
                     Some(code) => format!(" exit_code={code}"),
                     None => String::new(),
@@ -1319,6 +1328,7 @@ fn run_azure_aci_execution(
     container_name: &str,
     container_workspace_dir: &Path,
     add_dirs: &[String],
+    remote_exit_code_path: &Path,
     model_name: &str,
     sandbox_mode: &str,
     bypass_sandbox: bool,
@@ -1483,24 +1493,42 @@ exit \"$status\"\n",
         });
     }
     let poll_timeout = timeout.saturating_sub(elapsed_after_create);
-    let container_state = poll_aci_state(config, container_name, poll_timeout, cancel_monitor)?;
+    let poll_state = poll_aci_state(
+        config,
+        container_name,
+        remote_exit_code_path,
+        poll_timeout,
+        cancel_monitor,
+    )?;
     let logs = fetch_aci_logs(config, container_name).unwrap_or_default();
     let container_show_json = fetch_aci_show_json(config, container_name).ok();
     Ok(AzureAciExecutionArtifacts {
-        container_state,
+        container_state: poll_state.container_state,
         container_logs: logs,
         container_show_json,
+        remote_artifact_completion: poll_state.remote_artifact_completion,
     })
 }
 
 fn poll_aci_state(
     config: &AzureAciConfig,
     container_name: &str,
+    remote_exit_code_path: &Path,
     timeout: Duration,
     cancel_monitor: Option<&ThreadSupersedeMonitor>,
-) -> Result<String, RunTaskError> {
+) -> Result<AciPollState, RunTaskError> {
     let start = Instant::now();
+    let mut last_state: Option<String> = None;
     loop {
+        if remote_aci_result_ready(remote_exit_code_path) {
+            return Ok(AciPollState {
+                container_state: last_state
+                    .clone()
+                    .unwrap_or_else(|| "remote_artifact_completion".to_string()),
+                remote_artifact_completion: true,
+            });
+        }
+
         if let Some(reason) = cancel_monitor.and_then(ThreadSupersedeMonitor::supersede_reason) {
             let cleanup_message = match delete_aci_container_with_retry(config, container_name) {
                 Ok(()) => "remote container deleted after supersede".to_string(),
@@ -1550,12 +1578,22 @@ fn poll_aci_state(
             });
         }
         let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        last_state = Some(state.clone());
+        if remote_aci_result_ready(remote_exit_code_path) {
+            return Ok(AciPollState {
+                container_state: state,
+                remote_artifact_completion: true,
+            });
+        }
         if state.eq_ignore_ascii_case("Succeeded")
             || state.eq_ignore_ascii_case("Failed")
             || state.eq_ignore_ascii_case("Terminated")
             || state.eq_ignore_ascii_case("Stopped")
         {
-            return Ok(state);
+            return Ok(AciPollState {
+                container_state: state,
+                remote_artifact_completion: false,
+            });
         }
         if start.elapsed() >= timeout {
             return Err(RunTaskError::CommandTimeout {
@@ -1569,6 +1607,19 @@ fn poll_aci_state(
             thread::sleep(sleep_for);
         }
     }
+}
+
+fn remote_aci_result_ready(remote_exit_code_path: &Path) -> bool {
+    remote_exit_code_path.is_file()
+}
+
+fn azure_aci_execution_succeeded(
+    execution: &AzureAciExecutionArtifacts,
+    exit_status: Option<i32>,
+) -> bool {
+    (execution.container_state.eq_ignore_ascii_case("Succeeded")
+        || execution.remote_artifact_completion)
+        && exit_status == Some(0)
 }
 
 fn fetch_aci_logs(config: &AzureAciConfig, container_name: &str) -> Result<String, RunTaskError> {
@@ -3777,6 +3828,83 @@ printf '%s\n' "$@" > "$capture_file"
                 ("SECOND".to_string(), "2".to_string()),
                 ("SHARED".to_string(), "new".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn test_azure_aci_execution_succeeded_accepts_remote_artifact_completion() {
+        let execution = AzureAciExecutionArtifacts {
+            container_state: "Running".to_string(),
+            container_logs: String::new(),
+            container_show_json: None,
+            remote_artifact_completion: true,
+        };
+
+        assert!(azure_aci_execution_succeeded(&execution, Some(0)));
+        assert!(!azure_aci_execution_succeeded(&execution, Some(1)));
+        assert!(!azure_aci_execution_succeeded(&execution, None));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_poll_aci_state_returns_immediately_when_remote_exit_code_exists() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+        let capture_path = temp.path().join("az-called.txt");
+        let az_path = bin_dir.join("az");
+        fs::write(
+            &az_path,
+            format!(
+                "#!/bin/sh\nset -e\nprintf 'called' > '{}'\nprintf 'Running'\n",
+                capture_path.display()
+            ),
+        )
+        .expect("write fake az");
+        let mut perms = fs::metadata(&az_path).expect("az metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&az_path, perms).expect("chmod fake az");
+
+        let remote_exit_code_path = temp.path().join(REMOTE_EXIT_CODE_FILENAME);
+        fs::write(&remote_exit_code_path, "0").expect("write remote exit code");
+
+        let original_path = env::var("PATH").unwrap_or_default();
+        let path_value = format!("{}:{}", bin_dir.display(), original_path);
+        let _guards = vec![EnvVarGuard::set("PATH", &path_value)];
+
+        let config = AzureAciConfig {
+            resource_group: "stg-rg".to_string(),
+            image: "stg.azurecr.io/dowhiz-service:test".to_string(),
+            location: None,
+            registry_server: None,
+            registry_username: None,
+            registry_password: None,
+            cpu: "1.0".to_string(),
+            memory_gb: "2.0".to_string(),
+            storage_account: "storageacct".to_string(),
+            storage_key: "storagekey".to_string(),
+            file_share: "run-task-share".to_string(),
+            host_share_root: PathBuf::from("/host/share"),
+            container_share_root: PathBuf::from("/mnt/dowhiz-share"),
+        };
+
+        let poll_state = poll_aci_state(
+            &config,
+            "dwz-codex-test",
+            &remote_exit_code_path,
+            Duration::from_secs(2),
+            None,
+        )
+        .expect("poll state");
+
+        assert_eq!(poll_state.container_state, "remote_artifact_completion");
+        assert!(poll_state.remote_artifact_completion);
+        assert!(
+            !capture_path.exists(),
+            "az should not be queried once the remote exit artifact is already present"
         );
     }
 


### PR DESCRIPTION
## Summary
- treat the remote `.codex_remote_exit_code` artifact as a valid completion signal for Azure ACI Codex runs
- stop waiting indefinitely for ACI to flip from `Running` to a terminal state after Codex has already finished and written the reply draft
- add unit coverage for the remote-artifact completion path

## Staging Repro
- On March 25, 2026, the real staging Google login handoff for `dowhiz@deep-tutor.com` completed inside the shared Browserbase tab after admin 2FA help.
- The resumed ACI rollout (`rollout-2026-03-25T21-23-33-019d26e1-9daf-7de1-aa94-96663bd4b23f.jsonl`) reached `task_complete` at `2026-03-25T21:28:47Z` and wrote `.codex_remote_exit_code=0` plus the final `reply_email_draft.html`.
- The Azure container `dwz-codex-1774473857369-125800-0` still reported `Running`, so the scheduler never advanced into the post-run auto-reply stage.

## Test Evidence
- `cargo test -p run_task_module`
