### PR TITLE
Avoid blank Browserbase handoff tabs

### DIFF
--- a/DoWhiz_service/scheduler_module/src/service/browser_handoff.rs
+++ b/DoWhiz_service/scheduler_module/src/service/browser_handoff.rs
@@ -203,7 +203,7 @@ fn select_debug_url(
         if let Some(url) = payload
             .pages
             .iter()
-            .find(|page| page.id == page_id)
+            .find(|page| page.id == page_id && page_looks_live(page))
             .and_then(page_debug_url)
         {
             return Some(url);
@@ -973,6 +973,45 @@ mod tests {
                     id: "page-live".to_string(),
                     url: "https://example.com/login".to_string(),
                     title: "Login".to_string(),
+                    debugger_url: Some("https://page-live.example.com".to_string()),
+                    debugger_fullscreen_url: Some("https://page-live-full.example.com".to_string()),
+                },
+            ],
+        };
+
+        assert_eq!(
+            select_debug_url(&claims, &payload).as_deref(),
+            Some("https://page-live-full.example.com")
+        );
+    }
+
+    #[test]
+    fn select_debug_url_ignores_blank_specific_page_and_falls_back_to_live_page() {
+        let claims = BrowserHandoffGrant {
+            version: 1,
+            challenge_id: "hag-123".to_string(),
+            session_id: "sess-123".to_string(),
+            page_id: Some("page-blank".to_string()),
+            iat: 1,
+            exp: usize::MAX,
+        };
+        let payload = BrowserbaseDebugUrls {
+            debugger_url: Some("https://session.example.com".to_string()),
+            debugger_fullscreen_url: Some("https://session-full.example.com".to_string()),
+            pages: vec![
+                BrowserbaseDebugPage {
+                    id: "page-blank".to_string(),
+                    url: "about:blank".to_string(),
+                    title: "about:blank".to_string(),
+                    debugger_url: Some("https://page-blank.example.com".to_string()),
+                    debugger_fullscreen_url: Some(
+                        "https://page-blank-full.example.com".to_string(),
+                    ),
+                },
+                BrowserbaseDebugPage {
+                    id: "page-live".to_string(),
+                    url: "https://accounts.google.com/signin/v2/challenge/ipp".to_string(),
+                    title: "2-Step Verification".to_string(),
                     debugger_url: Some("https://page-live.example.com".to_string()),
                     debugger_fullscreen_url: Some("https://page-live-full.example.com".to_string()),
                 },

--- a/DoWhiz_service/skills/browserbase-handoff/scripts/browserbase_session_manager.py
+++ b/DoWhiz_service/skills/browserbase-handoff/scripts/browserbase_session_manager.py
@@ -360,9 +360,6 @@ def select_page_id_from_debug_payload(debug_urls: Dict[str, Any]) -> Optional[st
         if page_looks_live(page):
             return page_id
 
-    for _page, page_id in iter_candidates():
-        return page_id
-
     return None
 
 

--- a/DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
+++ b/DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py
@@ -290,6 +290,33 @@ class BrowserbaseSessionManagerTests(unittest.TestCase):
         self.assertTrue(page_id_known)
         self.assertEqual(page_id, "page_live")
 
+    def test_resolve_page_id_for_session_omits_blank_page_when_no_live_tab_exists(self):
+        config = MODULE.BrowserbaseConfig(
+            api_key="bb_test",
+            project_id="proj_test",
+            api_base=MODULE.API_BASE_DEFAULT,
+            timeout_seconds=3600,
+        )
+
+        original_debug = MODULE.get_debug_urls
+        MODULE.get_debug_urls = lambda *_args, **_kwargs: {
+            "pages": [
+                {
+                    "id": "page_blank",
+                    "url": "about:blank",
+                    "title": "about:blank",
+                    "debuggerFullscreenUrl": "https://blank.example.com",
+                }
+            ]
+        }
+        try:
+            page_id, page_id_known = MODULE.resolve_page_id_for_session(config, "sess_blank")
+        finally:
+            MODULE.get_debug_urls = original_debug
+
+        self.assertTrue(page_id_known)
+        self.assertIsNone(page_id)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/human_approval_gate.py
@@ -199,6 +199,24 @@ def page_looks_live(page: Dict[str, Any]) -> bool:
     return not page_text_is_blank(page.get("url")) or not page_text_is_blank(page.get("title"))
 
 
+def find_debug_page_by_id(payload: Dict[str, Any], page_id: str) -> Optional[Dict[str, Any]]:
+    pages = payload.get("pages")
+    if not isinstance(pages, list):
+        return None
+
+    for raw_page in pages:
+        if not isinstance(raw_page, dict):
+            continue
+        current_page_id = str(raw_page.get("id", "")).strip()
+        if current_page_id != page_id:
+            continue
+        if not page_debug_url(raw_page):
+            return None
+        return raw_page
+
+    return None
+
+
 def resolve_browserbase_debug_page_id(payload: Dict[str, Any]) -> str:
     pages = payload.get("pages")
     if not isinstance(pages, list):
@@ -217,24 +235,25 @@ def resolve_browserbase_debug_page_id(payload: Dict[str, Any]) -> str:
         if page_looks_live(page):
             return page_id
 
-    for _page, page_id in iter_candidates():
-        return page_id
-
     return ""
 
 
 def resolve_browser_handoff_page_id(active_session: Dict[str, Any]) -> str:
     page_id = str(active_session.get("page_id", "")).strip()
-    if page_id:
-        return page_id
 
     session_id = str(active_session.get("session_id", "")).strip()
     if not session_id:
-        return ""
+        return page_id
 
     payload = fetch_browserbase_debug_payload(session_id)
     if not payload:
-        return ""
+        return page_id
+
+    if page_id:
+        page = find_debug_page_by_id(payload, page_id)
+        if page is not None and page_looks_live(page):
+            return page_id
+
     return resolve_browserbase_debug_page_id(payload)
 
 

--- a/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
+++ b/DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py
@@ -207,6 +207,17 @@ class HumanApprovalGateTests(unittest.TestCase):
             os.environ[MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY] = "https://api.example.com/service"
             os.environ[MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY] = "secret-key"
             os.environ[MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY] = str(active_session_path)
+            original_fetch = MODULE.fetch_browserbase_debug_payload
+            MODULE.fetch_browserbase_debug_payload = lambda session_id: {
+                "pages": [
+                    {
+                        "id": "page_live_456",
+                        "url": "https://example.com/captcha",
+                        "title": "Captcha",
+                        "debuggerFullscreenUrl": "https://live.example.com",
+                    }
+                ]
+            }
             try:
                 args = self.parse_request(
                     "--challenge-type",
@@ -220,6 +231,7 @@ class HumanApprovalGateTests(unittest.TestCase):
                 )
                 state = MODULE.build_request_state(args)
             finally:
+                MODULE.fetch_browserbase_debug_payload = original_fetch
                 for key, value in previous.items():
                     if value is None:
                         os.environ.pop(key, None)
@@ -369,6 +381,73 @@ class HumanApprovalGateTests(unittest.TestCase):
             token = state["browser_handoff_url"].split("token=", 1)[1]
             claims = self.decode_token_claims(token)
             self.assertEqual(claims["page_id"], "page_from_debug")
+
+    def test_browser_handoff_replaces_stored_blank_page_id_with_live_debug_page(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            screenshot = self.create_screenshot(temp_dir)
+            active_session_path = Path(temp_dir) / "active_session.json"
+            active_session_path.write_text(
+                json.dumps({"session_id": "sess_live_123", "page_id": "page_blank"}),
+                encoding="utf-8",
+            )
+
+            previous = {
+                MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY: os.environ.get(MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY),
+                MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY: os.environ.get(MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY),
+                MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY: os.environ.get(MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY),
+            }
+            os.environ[MODULE.BROWSER_HANDOFF_BASE_URL_ENV_KEY] = "https://api.example.com/service"
+            os.environ[MODULE.BROWSER_HANDOFF_SIGNING_SECRET_ENV_KEY] = "secret-key"
+            os.environ[MODULE.BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY] = str(active_session_path)
+
+            original_fetch = MODULE.fetch_browserbase_debug_payload
+            MODULE.fetch_browserbase_debug_payload = lambda session_id: {
+                "pages": [
+                    {
+                        "id": "page_blank",
+                        "url": "about:blank",
+                        "title": "about:blank",
+                        "debuggerFullscreenUrl": "https://blank.example.com",
+                    },
+                    {
+                        "id": "page_live",
+                        "url": "https://accounts.google.com/signin/v2/challenge/ipp",
+                        "title": "2-Step Verification",
+                        "debuggerFullscreenUrl": "https://live.example.com",
+                    },
+                ]
+            }
+            try:
+                args = self.parse_request(
+                    "--challenge-type",
+                    "two_factor",
+                    "--page-state",
+                    "waiting_for_code_input",
+                    "--scope",
+                    "admin",
+                    "--account-label",
+                    "dowhiz@deep-tutor.com Google account",
+                    "--screenshot",
+                    screenshot,
+                    "--verification-destination",
+                    "phone ending in 15",
+                    "--two-factor-method",
+                    "sms",
+                )
+                state = MODULE.build_request_state(args)
+            finally:
+                MODULE.fetch_browserbase_debug_payload = original_fetch
+                for key, value in previous.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
+
+            self.assertEqual(state["browser_session_id"], "sess_live_123")
+            self.assertEqual(state["browser_page_id"], "page_live")
+            token = state["browser_handoff_url"].split("token=", 1)[1]
+            claims = self.decode_token_claims(token)
+            self.assertEqual(claims["page_id"], "page_live")
 
     def test_poll_for_reply_once_retries_without_recipient_filter_for_alias_deliveries(self):
         challenge = {


### PR DESCRIPTION
## Summary
- stop Browserbase handoff tokens from carrying a stale blank `page_id` when a live page is available
- make the handoff route ignore an exact `about:blank` page match and fall back to the live tab in the same Browserbase session
- stop persisting blank-only Browserbase page ids into active session state and add regression coverage for the blank-tab case seen on staging

## Why
The staging HAG email `[HAG:d218c175-efce-4b1e-a93a-cd7e38a32927]` pointed at Browserbase session `88c5c383-7de2-4a13-a8e1-e8f7fd2626a9`, page `433314D9135004047C04E80DEB436186`, and Browserbase debug showed that page as `about:blank`. That made the shared handoff button open a blank page even though the desired behavior is to expose the live stuck tab.

## Test Evidence
- `python3 -m unittest DoWhiz_service/skills/browserbase-handoff/scripts/test_browserbase_session_manager.py`
- `python3 -m unittest DoWhiz_service/skills/playwright/scripts/test_playwright_cli_wrapper.py`
- `python3 -m unittest DoWhiz_service/skills/human-approval-gate/scripts/test_human_approval_gate.py`
- `cargo test -p run_task_module`
- `cargo test -p scheduler_module select_debug_url`
- `cargo test -p scheduler_module` still has existing local-environment failures unrelated to this patch because this workstation does not have required test env like `MONGODB_URI`, and one discord official-search test also expects external auth. The Browserbase handoff subset passes.
