### PR TITLE
feat(tpm): add TPM infrastructure for cross-channel task management

### DIFF
--- a/.claude/skills/discord-messaging/SKILL.md
+++ b/.claude/skills/discord-messaging/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: discord-messaging
+description: Send proactive messages to Discord users and channels using discord_cli
+allowed-tools: Bash(discord_cli:*)
+---
+
+# Discord Messaging Skill
+
+Send messages to Discord users and channels for TPM follow-ups, notifications, and reports.
+
+## Quick Reference
+
+```bash
+# Send DM to user
+discord_cli send-dm --user-id 123456789012345678 --message "Hi! Checking in on task X"
+
+# Send message to channel
+discord_cli send-channel --channel-id 123456789012345678 --message "Weekly status update..."
+
+# Reply to message
+discord_cli send-channel --channel-id 123456789012345678 --reply-to 123456789012345678 --message "Thanks!"
+
+# Auto-detect (prefix dm: for DM)
+discord_cli send --to dm:123456789012345678 --message "Hello!"
+```
+
+## Commands
+
+### send-dm
+Send a direct message to a Discord user.
+
+```bash
+discord_cli send-dm --user-id <USER_ID> --message "<TEXT>"
+```
+
+**Parameters:**
+- `--user-id`: Discord user ID (snowflake, 18+ digits)
+- `--message`: Message content (max 2000 characters)
+
+**Example:**
+```bash
+discord_cli send-dm \
+  --user-id 123456789012345678 \
+  --message "Hi! This is Oliver from DoWhiz. Can you provide an update on the authentication task?"
+```
+
+### send-channel
+Send a message to a Discord channel.
+
+```bash
+discord_cli send-channel --channel-id <CHANNEL_ID> --message "<TEXT>" [--reply-to <MSG_ID>]
+```
+
+**Parameters:**
+- `--channel-id`: Discord channel ID (snowflake)
+- `--message`: Message content
+- `--reply-to`: (Optional) Message ID to reply to
+
+**Example:**
+```bash
+discord_cli send-channel \
+  --channel-id 123456789012345678 \
+  --message "📋 **Weekly TPM Report**\n\n**Completed:** 5 tasks\n**In Progress:** 3 tasks\n**Blocked:** 1 task"
+```
+
+### send
+Auto-detect destination and send message.
+
+```bash
+discord_cli send --to <ID> --message "<TEXT>" [--reply-to <MSG_ID>]
+```
+
+Use `dm:USER_ID` prefix to force DM creation.
+
+## Message Formatting
+
+Discord supports markdown formatting:
+
+| Format | Syntax | Example |
+|--------|--------|---------|
+| Bold | `**text**` | `**important**` |
+| Italic | `*text*` or `_text_` | `*emphasis*` |
+| Underline | `__text__` | `__underlined__` |
+| Strikethrough | `~~text~~` | `~~deleted~~` |
+| Code | `` `code` `` | `` `variable` `` |
+| Code block | ` ```language\ncode\n``` ` | Multi-line code |
+| Quote | `> text` | Block quote |
+| Spoiler | `||text||` | Hidden text |
+| User mention | `<@USER_ID>` | `<@123456789>` |
+| Channel link | `<#CHANNEL_ID>` | `<#123456789>` |
+| Role mention | `<@&ROLE_ID>` | `<@&123456789>` |
+
+## TPM Use Cases
+
+### 1. Task Follow-up DM
+```bash
+discord_cli send-dm \
+  --user-id 123456789012345678 \
+  --message "👋 Hi! Checking in on task **API Integration**. What's your current progress?"
+```
+
+### 2. Weekly Report to Channel
+```bash
+discord_cli send-channel \
+  --channel-id 123456789012345678 \
+  --message "📊 **Weekly TPM Report - $(date +%Y-%m-%d)**
+
+**Completed This Week:**
+• Task A - ✅ Done
+• Task B - ✅ Done
+
+**In Progress:**
+• Task C - 70% complete
+• Task D - Starting
+
+**Blockers:**
+• ⚠️ Waiting on API documentation
+
+_Reply to this message for questions._"
+```
+
+### 3. Deadline Reminder
+```bash
+discord_cli send-dm \
+  --user-id 123456789012345678 \
+  --message "⏰ **Reminder:** Task **Database Migration** is due tomorrow. Please update the status in Notion."
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DISCORD_BOT_TOKEN` | Yes | Bot token from Discord Developer Portal |
+| `DISCORD_API_BASE_URL` | No | Override API base (default: `https://discord.com/api/v10`) |
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Unknown Channel` | Invalid channel ID | Verify channel ID |
+| `Cannot send messages to this user` | User has DMs disabled or bot blocked | Use channel instead |
+| `Missing Permissions` | Bot lacks permissions | Check bot role permissions |
+| `50007` | Cannot DM user | User must share a server with bot |
+
+## Required Bot Permissions
+
+For the bot to work properly, it needs these Discord permissions:
+
+- `Send Messages` - Send messages in channels
+- `Read Message History` - Read messages for replies
+- `Create Private Threads` (optional) - For threaded discussions
+
+## Character Limits
+
+- **Message content**: 2000 characters
+- **Embeds**: 6000 characters total
+- **Messages per channel**: ~5/second rate limit
+
+Messages exceeding 2000 characters will be automatically truncated with `...`
+
+## Tips
+
+1. **DM limitations**: Users must share a server with the bot and have DMs enabled
+2. **Use channel for reliability**: Channel messages work even if user has DMs disabled
+3. **Include context**: Always mention task name, deadline, etc.
+4. **Rate limits**: Discord limits ~5 messages/second per channel
+5. **Snowflake IDs**: Discord IDs are 18+ digit numbers
+
+## Integration with TPM
+
+When contacting task owners from Notion:
+
+```bash
+# 1. Get contact info from TPM directory
+contact=$(tpm_cli get-contact --notion-user-id abc123)
+discord_id=$(echo "$contact" | jq -r '.discord_user_id')
+
+# 2. Send follow-up if Discord is preferred
+if [ -n "$discord_id" ]; then
+  discord_cli send-dm \
+    --user-id "$discord_id" \
+    --message "Hi! Checking in on your assigned task..."
+fi
+```

--- a/.claude/skills/notion-tpm/SKILL.md
+++ b/.claude/skills/notion-tpm/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: notion-tpm
+description: Manage Notion task boards as a Technical Program Manager - track tasks, contact assignees, update status, and generate reports
+allowed-tools: Bash(notion_api_cli:*), Bash(tpm_cli:*), Bash(slack_cli:*), Bash(discord_cli:*)
+---
+
+# Notion TPM Skill
+
+Act as a Technical Program Manager (TPM) to manage Notion task boards, track progress, contact assignees, and generate reports.
+
+## Overview
+
+This skill enables you to:
+1. **Read task boards** - Query Notion databases to see all tasks and their status
+2. **Contact assignees** - Look up owner contact info and send follow-ups via Slack/Discord
+3. **Update status** - Record progress updates as comments on tasks
+4. **Generate reports** - Aggregate task data and send summaries to channels
+
+## Workflow
+
+### Step 1: Read the Task Board
+
+```bash
+# Get database schema to understand properties
+notion_api_cli get-database --database-id <DATABASE_ID>
+
+# Query all incomplete tasks
+notion_api_cli query-database --database-id <DATABASE_ID> \
+  --filter '{"property": "Status", "status": {"does_not_equal": "Done"}}'
+```
+
+**Common filters:**
+```json
+// Tasks in specific status
+{"property": "Status", "status": {"equals": "In Progress"}}
+
+// Tasks assigned to someone
+{"property": "Assignee", "people": {"is_not_empty": true}}
+
+// Overdue tasks (if Due Date property exists)
+{"property": "Due Date", "date": {"before": "2024-01-01"}}
+```
+
+### Step 2: Get Contact Info for Assignees
+
+For each task assignee (Notion person ID), look up their contact info:
+
+```bash
+# Get contact info (Slack/Discord handles)
+tpm_cli get-contact --notion-user-id <NOTION_USER_ID>
+```
+
+**Response:**
+```json
+{
+  "notion_user_id": "abc123",
+  "slack_user_id": "U12345ABC",
+  "discord_user_id": "123456789012345678",
+  "preferred_channel": "slack"
+}
+```
+
+### Step 3: Send Follow-up Messages
+
+Based on preferred channel, contact the assignee:
+
+**Via Slack:**
+```bash
+slack_cli send-dm \
+  --user-id U12345ABC \
+  --message "Hi! 👋 Checking in on task *API Integration*. What's your current progress? Any blockers?"
+```
+
+**Via Discord:**
+```bash
+discord_cli send-dm \
+  --user-id 123456789012345678 \
+  --message "Hi! 👋 Checking in on task **API Integration**. What's your current progress? Any blockers?"
+```
+
+### Step 4: Log Progress Updates
+
+After receiving updates, log them as comments on the task:
+
+```bash
+notion_api_cli create-comment --page-id <TASK_ID> \
+  --content "**TPM Update ($(date +%Y-%m-%d))**: Contacted @assignee via Slack. Status: On track, 70% complete. ETA: Friday."
+```
+
+Also update task properties if needed:
+
+```bash
+notion_api_cli update-page --page-id <TASK_ID> \
+  --properties '{"Status": {"status": {"name": "In Progress"}}}'
+```
+
+### Step 5: Mark Contact Completed
+
+After successful follow-up, update the last_contacted timestamp:
+
+```bash
+tpm_cli update-contacted --contact-id <CONTACT_UUID>
+```
+
+## Full TPM Workflow Example
+
+```bash
+#!/bin/bash
+# TPM Daily Check-in Script
+
+DATABASE_ID="your-database-id"
+
+# 1. Get all in-progress tasks
+tasks=$(notion_api_cli query-database --database-id "$DATABASE_ID" \
+  --filter '{"property": "Status", "status": {"equals": "In Progress"}}')
+
+# 2. For each task, get assignee and contact them
+for task in $(echo "$tasks" | jq -c '.[]'); do
+  task_id=$(echo "$task" | jq -r '.id')
+  task_title=$(echo "$task" | jq -r '.properties.Name.title[0].plain_text')
+  assignee_id=$(echo "$task" | jq -r '.properties.Assignee.people[0].id')
+
+  # Skip if no assignee
+  [ -z "$assignee_id" ] && continue
+
+  # Get contact info
+  contact=$(tpm_cli get-contact --notion-user-id "$assignee_id")
+  preferred=$(echo "$contact" | jq -r '.preferred_channel')
+
+  # Send follow-up based on preferred channel
+  message="Hi! Checking in on task *$task_title*. What's your progress?"
+
+  if [ "$preferred" = "slack" ]; then
+    slack_id=$(echo "$contact" | jq -r '.slack_user_id')
+    slack_cli send-dm --user-id "$slack_id" --message "$message"
+  elif [ "$preferred" = "discord" ]; then
+    discord_id=$(echo "$contact" | jq -r '.discord_user_id')
+    discord_cli send-dm --user-id "$discord_id" --message "$message"
+  fi
+
+  # Update contacted timestamp
+  contact_uuid=$(echo "$contact" | jq -r '.id')
+  tpm_cli update-contacted --contact-id "$contact_uuid"
+done
+```
+
+## Weekly Report Generation
+
+Generate and send a weekly summary:
+
+```bash
+# 1. Query all tasks
+all_tasks=$(notion_api_cli query-database --database-id "$DATABASE_ID")
+
+# 2. Count by status
+done_count=$(echo "$all_tasks" | jq '[.[] | select(.properties.Status.status.name == "Done")] | length')
+progress_count=$(echo "$all_tasks" | jq '[.[] | select(.properties.Status.status.name == "In Progress")] | length')
+blocked_count=$(echo "$all_tasks" | jq '[.[] | select(.properties.Status.status.name == "Blocked")] | length')
+
+# 3. Format report
+report="📊 **Weekly TPM Report - $(date +%Y-%m-%d)**
+
+✅ **Completed:** $done_count tasks
+🔄 **In Progress:** $progress_count tasks
+⚠️ **Blocked:** $blocked_count tasks
+
+_Generated by TPM Bot_"
+
+# 4. Send to team channel
+slack_cli send-channel --channel-id C12345ABC --message "$report"
+```
+
+## CLI Commands Reference
+
+### notion_api_cli (Task Board Operations)
+| Command | Purpose |
+|---------|---------|
+| `get-database` | Get database schema |
+| `query-database` | Query tasks with filters |
+| `update-page` | Update task properties |
+| `create-comment` | Add progress comment |
+| `search` | Find pages by keyword |
+
+### tpm_cli (Contact Directory)
+| Command | Purpose |
+|---------|---------|
+| `get-contact` | Look up contact by Notion user ID |
+| `list-contacts` | List all configured contacts |
+| `update-contacted` | Mark contact as recently contacted |
+
+### slack_cli (Slack Messaging)
+| Command | Purpose |
+|---------|---------|
+| `send-dm` | Send direct message |
+| `send-channel` | Post to channel |
+
+### discord_cli (Discord Messaging)
+| Command | Purpose |
+|---------|---------|
+| `send-dm` | Send direct message |
+| `send-channel` | Post to channel |
+
+## Best Practices
+
+1. **Check before contacting**: Use `contact_frequency_days` to avoid over-pinging
+2. **Log all interactions**: Create comments on tasks for audit trail
+3. **Respect preferences**: Use the assignee's `preferred_channel`
+4. **Aggregate reports**: Don't send individual task updates, summarize
+5. **Handle missing contacts**: If no contact info, add comment requesting setup
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| No contact info for assignee | Comment on task asking them to configure contact |
+| DM fails (user blocked) | Try channel message or email |
+| Task has no assignee | Skip or flag for team review |
+| Notion API rate limited | Wait and retry |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `EMPLOYEE_ID` | For OAuth token lookup |
+| `ACCOUNT_ID` | For contact directory lookup |
+| `SLACK_BOT_TOKEN` | Slack messaging |
+| `DISCORD_BOT_TOKEN` | Discord messaging |
+| `SUPABASE_DB_URL` | Contact directory database |

--- a/.claude/skills/slack-messaging/SKILL.md
+++ b/.claude/skills/slack-messaging/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: slack-messaging
+description: Send proactive messages to Slack users and channels using slack_cli
+allowed-tools: Bash(slack_cli:*)
+---
+
+# Slack Messaging Skill
+
+Send messages to Slack users and channels for TPM follow-ups, notifications, and reports.
+
+## Quick Reference
+
+```bash
+# Send DM to user
+slack_cli send-dm --user-id U12345ABC --message "Hi! Checking in on task X"
+
+# Send message to channel
+slack_cli send-channel --channel-id C12345ABC --message "Weekly status update..."
+
+# Reply in thread
+slack_cli send-channel --channel-id C12345ABC --thread-ts "1234567890.123456" --message "Thanks!"
+
+# Auto-detect (user ID creates DM, channel ID posts to channel)
+slack_cli send --to U12345ABC --message "Hello!"
+```
+
+## Commands
+
+### send-dm
+Send a direct message to a Slack user.
+
+```bash
+slack_cli send-dm --user-id <USER_ID> --message "<TEXT>"
+```
+
+**Parameters:**
+- `--user-id`: Slack user ID (starts with `U`, e.g., `U12345ABC`)
+- `--message`: Message content (supports Slack mrkdwn formatting)
+
+**Example:**
+```bash
+slack_cli send-dm \
+  --user-id U0123456789 \
+  --message "Hi! This is Oliver from DoWhiz. Can you provide an update on the authentication task?"
+```
+
+### send-channel
+Send a message to a Slack channel.
+
+```bash
+slack_cli send-channel --channel-id <CHANNEL_ID> --message "<TEXT>" [--thread-ts <TS>]
+```
+
+**Parameters:**
+- `--channel-id`: Slack channel ID (starts with `C`, e.g., `C12345ABC`)
+- `--message`: Message content
+- `--thread-ts`: (Optional) Message timestamp to reply in thread
+
+**Example:**
+```bash
+slack_cli send-channel \
+  --channel-id C0123456789 \
+  --message ":memo: Weekly TPM Report\n\n*Completed:* 5 tasks\n*In Progress:* 3 tasks\n*Blocked:* 1 task"
+```
+
+### send
+Auto-detect destination and send message.
+
+```bash
+slack_cli send --to <ID> --message "<TEXT>" [--thread-ts <TS>]
+```
+
+If `--to` starts with `U`, creates a DM. Otherwise, sends to channel.
+
+## Message Formatting
+
+Slack supports mrkdwn formatting:
+
+| Format | Syntax | Example |
+|--------|--------|---------|
+| Bold | `*text*` | `*important*` |
+| Italic | `_text_` | `_emphasis_` |
+| Strikethrough | `~text~` | `~deleted~` |
+| Code | `` `code` `` | `` `variable` `` |
+| Code block | ` ```code``` ` | Multi-line code |
+| Link | `<URL|text>` | `<https://example.com|Click here>` |
+| User mention | `<@USER_ID>` | `<@U12345>` |
+| Channel link | `<#CHANNEL_ID>` | `<#C12345>` |
+| Emoji | `:emoji_name:` | `:white_check_mark:` |
+
+## TPM Use Cases
+
+### 1. Task Follow-up
+```bash
+slack_cli send-dm \
+  --user-id U0123456789 \
+  --message "Hi! :wave: Checking in on task *API Integration*. What's your current progress?"
+```
+
+### 2. Weekly Report to Channel
+```bash
+slack_cli send-channel \
+  --channel-id C0123456789 \
+  --message ":chart_with_upwards_trend: *Weekly TPM Report - $(date +%Y-%m-%d)*
+
+*Completed This Week:*
+• Task A - Done
+• Task B - Done
+
+*In Progress:*
+• Task C - 70% complete
+• Task D - Starting
+
+*Blockers:*
+• Waiting on API documentation
+
+_Reply in thread for questions._"
+```
+
+### 3. Reminder DM
+```bash
+slack_cli send-dm \
+  --user-id U0123456789 \
+  --message ":alarm_clock: Reminder: Task *Database Migration* is due tomorrow. Please update the status in Notion."
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SLACK_BOT_TOKEN` | Yes | Bot OAuth token (`xoxb-...`) |
+| `SLACK_API_BASE_URL` | No | Override API base (default: `https://slack.com/api`) |
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `channel_not_found` | Invalid channel ID | Verify channel ID and bot membership |
+| `not_in_channel` | Bot not in channel | Invite bot to the channel |
+| `user_not_found` | Invalid user ID | Verify user ID format |
+| `cannot_dm_bot` | Trying to DM a bot | Use channel instead |
+| `no_permission` | Missing scopes | Check bot OAuth scopes |
+
+## Required Bot Scopes
+
+- `chat:write` - Send messages
+- `channels:read` - List channels
+- `users:read` - Look up users
+- `im:write` - Send DMs
+- `groups:write` - Post to private channels
+
+## Tips
+
+1. **Always confirm user IDs** before sending DMs to avoid contacting wrong person
+2. **Use threads** for follow-up messages to keep channels organized
+3. **Include context** in messages (task name, deadline, etc.)
+4. **Rate limits**: Slack limits ~1 message per second per channel

--- a/DoWhiz_service/migrations/001_user_contact_directory.sql
+++ b/DoWhiz_service/migrations/001_user_contact_directory.sql
@@ -1,0 +1,88 @@
+-- User Contact Directory for TPM Cross-Channel Messaging
+--
+-- Maps Notion task assignees to their Slack/Discord handles for proactive outreach.
+-- Used by TPM agents to contact team members about task progress.
+--
+-- Run this in Supabase SQL Editor or via psql.
+
+CREATE TABLE IF NOT EXISTS user_contact_directory (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+
+    -- Notion identity
+    notion_user_id TEXT,               -- Notion person ID (from task assignee)
+    notion_workspace_id TEXT,          -- Which Notion workspace
+
+    -- Slack identity
+    slack_user_id TEXT,                -- Slack member ID (e.g., U12345ABC)
+    slack_workspace_id TEXT,           -- Slack team ID
+
+    -- Discord identity
+    discord_user_id TEXT,              -- Discord user ID (snowflake)
+    discord_guild_id TEXT,             -- Discord server ID
+
+    -- Contact preferences
+    preferred_channel TEXT,            -- 'slack', 'discord', or 'email'
+    contact_frequency_days INTEGER,    -- How often to check in (days)
+
+    -- Tracking
+    last_contacted_at TIMESTAMPTZ,     -- Last TPM follow-up time
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Ensure unique mapping per account+workspace+notion_user
+    CONSTRAINT unique_notion_user_per_workspace
+        UNIQUE (account_id, notion_user_id, notion_workspace_id)
+);
+
+-- Index for fast lookup by Notion user
+CREATE INDEX IF NOT EXISTS idx_user_contact_notion_lookup
+    ON user_contact_directory (account_id, notion_workspace_id, notion_user_id);
+
+-- Index for finding contacts due for follow-up
+CREATE INDEX IF NOT EXISTS idx_user_contact_due_followup
+    ON user_contact_directory (account_id, last_contacted_at, contact_frequency_days)
+    WHERE contact_frequency_days IS NOT NULL;
+
+-- Enable Row Level Security
+ALTER TABLE user_contact_directory ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can only see their own contacts
+CREATE POLICY "Users can view own contacts" ON user_contact_directory
+    FOR SELECT USING (
+        account_id IN (
+            SELECT id FROM accounts WHERE auth_user_id = auth.uid()
+        )
+    );
+
+-- Policy: Users can insert their own contacts
+CREATE POLICY "Users can insert own contacts" ON user_contact_directory
+    FOR INSERT WITH CHECK (
+        account_id IN (
+            SELECT id FROM accounts WHERE auth_user_id = auth.uid()
+        )
+    );
+
+-- Policy: Users can update their own contacts
+CREATE POLICY "Users can update own contacts" ON user_contact_directory
+    FOR UPDATE USING (
+        account_id IN (
+            SELECT id FROM accounts WHERE auth_user_id = auth.uid()
+        )
+    );
+
+-- Policy: Users can delete their own contacts
+CREATE POLICY "Users can delete own contacts" ON user_contact_directory
+    FOR DELETE USING (
+        account_id IN (
+            SELECT id FROM accounts WHERE auth_user_id = auth.uid()
+        )
+    );
+
+-- Service role can do anything (for backend operations)
+CREATE POLICY "Service role full access" ON user_contact_directory
+    FOR ALL USING (auth.role() = 'service_role');
+
+COMMENT ON TABLE user_contact_directory IS 'Maps Notion users to Slack/Discord handles for TPM follow-ups';
+COMMENT ON COLUMN user_contact_directory.notion_user_id IS 'Notion person ID from task assignee field';
+COMMENT ON COLUMN user_contact_directory.preferred_channel IS 'Contact channel preference: slack, discord, or email';
+COMMENT ON COLUMN user_contact_directory.contact_frequency_days IS 'Days between automated check-ins (null = no automation)';

--- a/DoWhiz_service/migrations/002_scheduled_jobs.sql
+++ b/DoWhiz_service/migrations/002_scheduled_jobs.sql
@@ -1,0 +1,118 @@
+-- Scheduled Jobs for TPM and other recurring tasks
+--
+-- Enables cron-based autonomous task execution without inbound triggers.
+-- Used by job_runner to poll and execute due jobs.
+--
+-- Run this in Supabase SQL Editor or via psql.
+
+CREATE TABLE IF NOT EXISTS scheduled_jobs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+
+    -- Job configuration
+    employee_id TEXT NOT NULL,         -- Which employee runs this job
+    job_type TEXT NOT NULL,            -- 'tpm_checkin', 'tpm_report', etc.
+    cron_expression TEXT NOT NULL,     -- Standard 5-field cron: 'min hour day month weekday'
+    timezone TEXT DEFAULT 'UTC',       -- Timezone for cron interpretation
+
+    -- Job-specific configuration (JSON)
+    config JSONB NOT NULL DEFAULT '{}',
+
+    -- Execution tracking
+    last_run_at TIMESTAMPTZ,           -- Last successful execution
+    next_run_at TIMESTAMPTZ,           -- Pre-computed next run time
+    last_error TEXT,                   -- Error from last failed run
+
+    -- Status
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Constraints
+    CONSTRAINT valid_cron_expression CHECK (
+        cron_expression ~ '^(\*|[0-9,\-\/]+)\s+(\*|[0-9,\-\/]+)\s+(\*|[0-9,\-\/]+)\s+(\*|[0-9,\-\/]+)\s+(\*|[0-9,\-\/]+)$'
+    )
+);
+
+-- Index for job_runner polling
+CREATE INDEX IF NOT EXISTS idx_scheduled_jobs_due
+    ON scheduled_jobs (next_run_at, enabled)
+    WHERE enabled = true;
+
+-- Index for listing jobs by account
+CREATE INDEX IF NOT EXISTS idx_scheduled_jobs_account
+    ON scheduled_jobs (account_id, job_type);
+
+-- Trigger to update updated_at
+CREATE OR REPLACE FUNCTION update_scheduled_jobs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_scheduled_jobs_updated_at
+    BEFORE UPDATE ON scheduled_jobs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_scheduled_jobs_updated_at();
+
+-- Enable Row Level Security
+ALTER TABLE scheduled_jobs ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view own jobs
+CREATE POLICY "Users can view own jobs" ON scheduled_jobs
+    FOR SELECT USING (
+        account_id IN (
+            SELECT id FROM accounts WHERE auth_user_id = auth.uid()
+        )
+    );
+
+-- Policy: Users can create own jobs
+CREATE POLICY "Users can create own jobs" ON scheduled_jobs
+    FOR INSERT WITH CHECK (
+        account_id IN (
+            SELECT id FROM accounts WHERE auth_user_id = auth.uid()
+        )
+    );
+
+-- Policy: Users can update own jobs
+CREATE POLICY "Users can update own jobs" ON scheduled_jobs
+    FOR UPDATE USING (
+        account_id IN (
+            SELECT id FROM accounts WHERE auth_user_id = auth.uid()
+        )
+    );
+
+-- Policy: Users can delete own jobs
+CREATE POLICY "Users can delete own jobs" ON scheduled_jobs
+    FOR DELETE USING (
+        account_id IN (
+            SELECT id FROM accounts WHERE auth_user_id = auth.uid()
+        )
+    );
+
+-- Service role can do anything
+CREATE POLICY "Service role full access" ON scheduled_jobs
+    FOR ALL USING (auth.role() = 'service_role');
+
+COMMENT ON TABLE scheduled_jobs IS 'Cron-based scheduled jobs for TPM and other recurring tasks';
+COMMENT ON COLUMN scheduled_jobs.cron_expression IS 'Standard 5-field cron: minute hour day month weekday';
+COMMENT ON COLUMN scheduled_jobs.config IS 'Job-specific config, e.g., {"database_id": "...", "report_recipients": [...]}';
+COMMENT ON COLUMN scheduled_jobs.next_run_at IS 'Pre-computed next execution time for efficient polling';
+
+-- Example job types and their config schemas:
+--
+-- tpm_checkin:
+--   config: {
+--     "notion_database_id": "abc123",     -- Task board to monitor
+--     "status_filter": ["In Progress"],   -- Only check tasks with these statuses
+--     "assignee_property": "Assignee"     -- Property name for task owner
+--   }
+--
+-- tpm_report:
+--   config: {
+--     "notion_database_id": "abc123",
+--     "report_recipients": ["slack:U123", "discord:456"],
+--     "report_type": "weekly_summary"
+--   }

--- a/DoWhiz_service/scheduler_module/Cargo.toml
+++ b/DoWhiz_service/scheduler_module/Cargo.toml
@@ -71,6 +71,18 @@ path = "src/bin/google_sheets_cli.rs"
 name = "google-slides"
 path = "src/bin/google_slides_cli.rs"
 
+[[bin]]
+name = "tpm_cli"
+path = "src/bin/tpm_cli.rs"
+
+[[bin]]
+name = "slack_cli"
+path = "src/bin/slack_cli.rs"
+
+[[bin]]
+name = "discord_cli"
+path = "src/bin/discord_cli.rs"
+
 [dev-dependencies]
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "builder"] }
 mockito = "1"

--- a/DoWhiz_service/scheduler_module/src/account_store.rs
+++ b/DoWhiz_service/scheduler_module/src/account_store.rs
@@ -154,6 +154,34 @@ pub struct RecommendationFeedbackRecord {
     pub created_at: DateTime<Utc>,
 }
 
+/// User contact directory entry for TPM cross-channel messaging.
+///
+/// Maps a Notion user to their Slack/Discord handles for proactive outreach.
+#[derive(Debug, Clone)]
+pub struct UserContact {
+    pub id: Uuid,
+    pub account_id: Uuid,
+    /// Notion person ID (e.g., from task assignee)
+    pub notion_user_id: Option<String>,
+    /// Notion workspace this mapping applies to
+    pub notion_workspace_id: Option<String>,
+    /// Slack member ID (e.g., U12345ABC)
+    pub slack_user_id: Option<String>,
+    /// Slack workspace/team ID
+    pub slack_workspace_id: Option<String>,
+    /// Discord user ID (snowflake)
+    pub discord_user_id: Option<String>,
+    /// Discord guild/server ID
+    pub discord_guild_id: Option<String>,
+    /// Preferred contact channel: "slack", "discord", or "email"
+    pub preferred_channel: Option<String>,
+    /// How often to check in (days), e.g., 3 means every 3 days
+    pub contact_frequency_days: Option<i32>,
+    /// Last time this user was contacted for TPM follow-up
+    pub last_contacted_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum AccountStoreError {
     #[error("postgres error: {0}")]
@@ -1076,6 +1104,191 @@ impl AccountStore {
                 }
             })
             .collect())
+    }
+
+    // =========================================================================
+    // User Contact Directory (TPM Cross-Channel Messaging)
+    // =========================================================================
+
+    /// Create or update a user contact entry.
+    ///
+    /// Used by TPM to map Notion task assignees to their Slack/Discord handles.
+    pub fn upsert_user_contact(
+        &self,
+        account_id: Uuid,
+        notion_user_id: Option<&str>,
+        notion_workspace_id: Option<&str>,
+        slack_user_id: Option<&str>,
+        slack_workspace_id: Option<&str>,
+        discord_user_id: Option<&str>,
+        discord_guild_id: Option<&str>,
+        preferred_channel: Option<&str>,
+        contact_frequency_days: Option<i32>,
+    ) -> Result<UserContact, AccountStoreError> {
+        let mut conn = self.conn()?;
+        let id = Uuid::new_v4();
+
+        let row = conn.query_one(
+            "INSERT INTO user_contact_directory (
+                id, account_id, notion_user_id, notion_workspace_id,
+                slack_user_id, slack_workspace_id, discord_user_id, discord_guild_id,
+                preferred_channel, contact_frequency_days, created_at
+             )
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+             ON CONFLICT (account_id, notion_user_id, notion_workspace_id)
+             DO UPDATE SET
+                slack_user_id = COALESCE(EXCLUDED.slack_user_id, user_contact_directory.slack_user_id),
+                slack_workspace_id = COALESCE(EXCLUDED.slack_workspace_id, user_contact_directory.slack_workspace_id),
+                discord_user_id = COALESCE(EXCLUDED.discord_user_id, user_contact_directory.discord_user_id),
+                discord_guild_id = COALESCE(EXCLUDED.discord_guild_id, user_contact_directory.discord_guild_id),
+                preferred_channel = COALESCE(EXCLUDED.preferred_channel, user_contact_directory.preferred_channel),
+                contact_frequency_days = COALESCE(EXCLUDED.contact_frequency_days, user_contact_directory.contact_frequency_days)
+             RETURNING id, account_id, notion_user_id, notion_workspace_id,
+                       slack_user_id, slack_workspace_id, discord_user_id, discord_guild_id,
+                       preferred_channel, contact_frequency_days, last_contacted_at, created_at",
+            &[
+                &id,
+                &account_id,
+                &notion_user_id,
+                &notion_workspace_id,
+                &slack_user_id,
+                &slack_workspace_id,
+                &discord_user_id,
+                &discord_guild_id,
+                &preferred_channel,
+                &contact_frequency_days,
+            ],
+        )?;
+
+        Ok(UserContact {
+            id: row.get(0),
+            account_id: row.get(1),
+            notion_user_id: row.get(2),
+            notion_workspace_id: row.get(3),
+            slack_user_id: row.get(4),
+            slack_workspace_id: row.get(5),
+            discord_user_id: row.get(6),
+            discord_guild_id: row.get(7),
+            preferred_channel: row.get(8),
+            contact_frequency_days: row.get(9),
+            last_contacted_at: row.get(10),
+            created_at: row.get(11),
+        })
+    }
+
+    /// Get user contact by Notion user ID within a workspace.
+    ///
+    /// This is the primary lookup for TPM: given a task assignee (Notion user),
+    /// find their Slack/Discord handles for follow-up.
+    pub fn get_user_contact_by_notion_user(
+        &self,
+        account_id: Uuid,
+        notion_workspace_id: &str,
+        notion_user_id: &str,
+    ) -> Result<Option<UserContact>, AccountStoreError> {
+        let mut conn = self.conn()?;
+        let rows = conn.query(
+            "SELECT id, account_id, notion_user_id, notion_workspace_id,
+                    slack_user_id, slack_workspace_id, discord_user_id, discord_guild_id,
+                    preferred_channel, contact_frequency_days, last_contacted_at, created_at
+             FROM user_contact_directory
+             WHERE account_id = $1 AND notion_workspace_id = $2 AND notion_user_id = $3",
+            &[&account_id, &notion_workspace_id, &notion_user_id],
+        )?;
+
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        let row = &rows[0];
+        Ok(Some(UserContact {
+            id: row.get(0),
+            account_id: row.get(1),
+            notion_user_id: row.get(2),
+            notion_workspace_id: row.get(3),
+            slack_user_id: row.get(4),
+            slack_workspace_id: row.get(5),
+            discord_user_id: row.get(6),
+            discord_guild_id: row.get(7),
+            preferred_channel: row.get(8),
+            contact_frequency_days: row.get(9),
+            last_contacted_at: row.get(10),
+            created_at: row.get(11),
+        }))
+    }
+
+    /// List all user contacts for an account within a Notion workspace.
+    pub fn list_user_contacts(
+        &self,
+        account_id: Uuid,
+        notion_workspace_id: Option<&str>,
+    ) -> Result<Vec<UserContact>, AccountStoreError> {
+        let mut conn = self.conn()?;
+
+        let rows = if let Some(ws_id) = notion_workspace_id {
+            conn.query(
+                "SELECT id, account_id, notion_user_id, notion_workspace_id,
+                        slack_user_id, slack_workspace_id, discord_user_id, discord_guild_id,
+                        preferred_channel, contact_frequency_days, last_contacted_at, created_at
+                 FROM user_contact_directory
+                 WHERE account_id = $1 AND notion_workspace_id = $2
+                 ORDER BY created_at DESC",
+                &[&account_id, &ws_id],
+            )?
+        } else {
+            conn.query(
+                "SELECT id, account_id, notion_user_id, notion_workspace_id,
+                        slack_user_id, slack_workspace_id, discord_user_id, discord_guild_id,
+                        preferred_channel, contact_frequency_days, last_contacted_at, created_at
+                 FROM user_contact_directory
+                 WHERE account_id = $1
+                 ORDER BY created_at DESC",
+                &[&account_id],
+            )?
+        };
+
+        Ok(rows
+            .iter()
+            .map(|row| UserContact {
+                id: row.get(0),
+                account_id: row.get(1),
+                notion_user_id: row.get(2),
+                notion_workspace_id: row.get(3),
+                slack_user_id: row.get(4),
+                slack_workspace_id: row.get(5),
+                discord_user_id: row.get(6),
+                discord_guild_id: row.get(7),
+                preferred_channel: row.get(8),
+                contact_frequency_days: row.get(9),
+                last_contacted_at: row.get(10),
+                created_at: row.get(11),
+            })
+            .collect())
+    }
+
+    /// Update the last_contacted_at timestamp for a user contact.
+    ///
+    /// Called by TPM after sending a follow-up message.
+    pub fn update_user_contact_last_contacted(
+        &self,
+        contact_id: Uuid,
+    ) -> Result<(), AccountStoreError> {
+        let mut conn = self.conn()?;
+        conn.execute(
+            "UPDATE user_contact_directory SET last_contacted_at = NOW() WHERE id = $1",
+            &[&contact_id],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a user contact entry.
+    pub fn delete_user_contact(&self, contact_id: Uuid) -> Result<(), AccountStoreError> {
+        let mut conn = self.conn()?;
+        conn.execute(
+            "DELETE FROM user_contact_directory WHERE id = $1",
+            &[&contact_id],
+        )?;
+        Ok(())
     }
 
     /// Create an email verification token (expires in 24 hours)

--- a/DoWhiz_service/scheduler_module/src/bin/discord_cli.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/discord_cli.rs
@@ -1,0 +1,422 @@
+//! Discord CLI for agent use.
+//!
+//! Provides commands for sending messages to Discord channels and users.
+//! Used by TPM agents for proactive follow-ups.
+//!
+//! Usage:
+//!   discord_cli send-dm --user-id <id> --message <text>
+//!   discord_cli send-channel --channel-id <id> --message <text>
+//!   discord_cli send --to <id> --message <text> [--reply-to <msg_id>]
+
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    dotenvy::dotenv().ok();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        print_usage();
+        return ExitCode::FAILURE;
+    }
+
+    let command = &args[1];
+    match command.as_str() {
+        "send" => cmd_send(&args[2..]),
+        "send-dm" => cmd_send_dm(&args[2..]),
+        "send-channel" => cmd_send_channel(&args[2..]),
+        "help" | "--help" | "-h" => {
+            print_usage();
+            ExitCode::SUCCESS
+        }
+        _ => {
+            eprintln!("Unknown command: {}", command);
+            print_usage();
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        r#"Discord CLI - Send messages to Discord
+
+Usage:
+  discord_cli <command> [options]
+
+Commands:
+  send           Send message (auto-detects channel vs DM)
+    --to <id>           Channel ID or User ID (snowflake)
+    --message <text>    Message content
+    --reply-to <id>     Reply to message ID (optional)
+
+  send-dm        Send direct message to user
+    --user-id <id>      Discord user ID (snowflake)
+    --message <text>    Message content
+
+  send-channel   Send message to channel
+    --channel-id <id>   Discord channel ID (snowflake)
+    --message <text>    Message content
+    --reply-to <id>     Reply to message ID (optional)
+
+Environment:
+  DISCORD_BOT_TOKEN     Required. Bot token
+  DISCORD_API_BASE_URL  Optional. Override API base (default: https://discord.com/api/v10)
+
+Context Files:
+  .discord_context.json   Auto-loaded for bot token lookup
+
+Output:
+  JSON to stdout on success, error message to stderr on failure.
+
+Notes:
+  - Discord message content limit is 2000 characters
+  - DM requires the bot and user to share a server
+"#
+    );
+}
+
+/// Get Discord bot token from environment or context file.
+fn get_bot_token() -> Option<String> {
+    // Try environment variable first
+    if let Ok(token) = env::var("DISCORD_BOT_TOKEN") {
+        if !token.trim().is_empty() {
+            return Some(token);
+        }
+    }
+
+    // Try employee-specific token
+    if let Ok(employee_id) = env::var("EMPLOYEE_ID") {
+        let key = format!(
+            "{}_DISCORD_BOT_TOKEN",
+            employee_id.to_uppercase().replace('-', "_")
+        );
+        if let Ok(token) = env::var(&key) {
+            if !token.trim().is_empty() {
+                return Some(token);
+            }
+        }
+    }
+
+    // Try .discord_context.json
+    let context_path = std::path::Path::new(".discord_context.json");
+    if context_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(context_path) {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(token) = json["bot_token"].as_str() {
+                    return Some(token.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn get_api_base() -> String {
+    env::var("DISCORD_API_BASE_URL").unwrap_or_else(|_| "https://discord.com/api/v10".to_string())
+}
+
+#[derive(Debug, Serialize)]
+struct CreateDmRequest {
+    recipient_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DmChannelResponse {
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateMessageRequest {
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message_reference: Option<MessageReference>,
+}
+
+#[derive(Debug, Serialize)]
+struct MessageReference {
+    message_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessageResponse {
+    id: String,
+    channel_id: String,
+}
+
+fn create_dm_channel(token: &str, user_id: &str) -> Result<String, String> {
+    let client = Client::new();
+    let url = format!("{}/users/@me/channels", get_api_base().trim_end_matches('/'));
+
+    let request = CreateDmRequest {
+        recipient_id: user_id.to_string(),
+    };
+
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bot {}", token))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    if response.status().is_success() {
+        let dm_response: DmChannelResponse = response
+            .json()
+            .map_err(|e| format!("Failed to parse response: {}", e))?;
+        Ok(dm_response.id)
+    } else {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        Err(format!("DM channel creation failed ({}): {}", status, error_text))
+    }
+}
+
+fn send_message(
+    token: &str,
+    channel_id: &str,
+    content: &str,
+    reply_to: Option<&str>,
+) -> Result<MessageResponse, String> {
+    let client = Client::new();
+    let url = format!(
+        "{}/channels/{}/messages",
+        get_api_base().trim_end_matches('/'),
+        channel_id
+    );
+
+    // Discord has a 2000 character limit
+    let content = if content.len() > 2000 {
+        format!("{}...", &content[..1997])
+    } else {
+        content.to_string()
+    };
+
+    let request = CreateMessageRequest {
+        content,
+        message_reference: reply_to.map(|id| MessageReference {
+            message_id: id.to_string(),
+        }),
+    };
+
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bot {}", token))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    if response.status().is_success() {
+        response
+            .json()
+            .map_err(|e| format!("Failed to parse response: {}", e))
+    } else {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        Err(format!("Message send failed ({}): {}", status, error_text))
+    }
+}
+
+fn cmd_send(args: &[String]) -> ExitCode {
+    let mut to: Option<String> = None;
+    let mut message: Option<String> = None;
+    let mut reply_to: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--to" => {
+                i += 1;
+                to = args.get(i).cloned();
+            }
+            "--message" => {
+                i += 1;
+                message = args.get(i).cloned();
+            }
+            "--reply-to" => {
+                i += 1;
+                reply_to = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(to) = to else {
+        eprintln!("Error: --to is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(message) = message else {
+        eprintln!("Error: --message is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(token) = get_bot_token() else {
+        eprintln!("Error: DISCORD_BOT_TOKEN not configured");
+        return ExitCode::FAILURE;
+    };
+
+    // Heuristic: if ID is less than 18 digits, treat as user ID and create DM
+    // Channel IDs and User IDs are both snowflakes, but this is a reasonable guess
+    // In practice, use send-dm or send-channel explicitly
+    let channel_id = if to.len() < 18 || to.starts_with("dm:") {
+        let user_id = to.strip_prefix("dm:").unwrap_or(&to);
+        match create_dm_channel(&token, user_id) {
+            Ok(id) => id,
+            Err(e) => {
+                eprintln!("Error creating DM channel: {}", e);
+                return ExitCode::FAILURE;
+            }
+        }
+    } else {
+        to
+    };
+
+    match send_message(&token, &channel_id, &message, reply_to.as_deref()) {
+        Ok(response) => {
+            let output = json!({
+                "success": true,
+                "channel_id": response.channel_id,
+                "message_id": response.id,
+                "message": "Message sent successfully"
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_send_dm(args: &[String]) -> ExitCode {
+    let mut user_id: Option<String> = None;
+    let mut message: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--user-id" => {
+                i += 1;
+                user_id = args.get(i).cloned();
+            }
+            "--message" => {
+                i += 1;
+                message = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(user_id) = user_id else {
+        eprintln!("Error: --user-id is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(message) = message else {
+        eprintln!("Error: --message is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(token) = get_bot_token() else {
+        eprintln!("Error: DISCORD_BOT_TOKEN not configured");
+        return ExitCode::FAILURE;
+    };
+
+    // Create DM channel first
+    let channel_id = match create_dm_channel(&token, &user_id) {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!("Error creating DM channel: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match send_message(&token, &channel_id, &message, None) {
+        Ok(response) => {
+            let output = json!({
+                "success": true,
+                "user_id": user_id,
+                "channel_id": channel_id,
+                "message_id": response.id,
+                "message": "DM sent successfully"
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_send_channel(args: &[String]) -> ExitCode {
+    let mut channel_id: Option<String> = None;
+    let mut message: Option<String> = None;
+    let mut reply_to: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--channel-id" => {
+                i += 1;
+                channel_id = args.get(i).cloned();
+            }
+            "--message" => {
+                i += 1;
+                message = args.get(i).cloned();
+            }
+            "--reply-to" => {
+                i += 1;
+                reply_to = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(channel_id) = channel_id else {
+        eprintln!("Error: --channel-id is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(message) = message else {
+        eprintln!("Error: --message is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(token) = get_bot_token() else {
+        eprintln!("Error: DISCORD_BOT_TOKEN not configured");
+        return ExitCode::FAILURE;
+    };
+
+    match send_message(&token, &channel_id, &message, reply_to.as_deref()) {
+        Ok(response) => {
+            let output = json!({
+                "success": true,
+                "channel_id": channel_id,
+                "message_id": response.id,
+                "message": "Message sent to channel"
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/bin/slack_cli.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/slack_cli.rs
@@ -1,0 +1,480 @@
+//! Slack CLI for agent use.
+//!
+//! Provides commands for sending messages to Slack channels and users.
+//! Used by TPM agents for proactive follow-ups.
+//!
+//! Usage:
+//!   slack_cli send-dm --user-id <id> --message <text>
+//!   slack_cli send-channel --channel-id <id> --message <text>
+//!   slack_cli send --to <id> --message <text> [--thread-ts <ts>]
+
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    dotenvy::dotenv().ok();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        print_usage();
+        return ExitCode::FAILURE;
+    }
+
+    let command = &args[1];
+    match command.as_str() {
+        "send" => cmd_send(&args[2..]),
+        "send-dm" => cmd_send_dm(&args[2..]),
+        "send-channel" => cmd_send_channel(&args[2..]),
+        "open-dm" => cmd_open_dm(&args[2..]),
+        "help" | "--help" | "-h" => {
+            print_usage();
+            ExitCode::SUCCESS
+        }
+        _ => {
+            eprintln!("Unknown command: {}", command);
+            print_usage();
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        r#"Slack CLI - Send messages to Slack
+
+Usage:
+  slack_cli <command> [options]
+
+Commands:
+  send           Send message to channel or DM
+    --to <id>           Channel ID (C...) or User ID (U...) to send to
+    --message <text>    Message content (supports mrkdwn)
+    --thread-ts <ts>    Reply in thread (optional)
+
+  send-dm        Send direct message to user
+    --user-id <id>      Slack user ID (U...)
+    --message <text>    Message content
+
+  send-channel   Send message to channel
+    --channel-id <id>   Slack channel ID (C...)
+    --message <text>    Message content
+    --thread-ts <ts>    Reply in thread (optional)
+
+  open-dm        Open/get DM channel with user
+    --user-id <id>      Slack user ID (U...)
+    Returns the channel ID for DM
+
+Environment:
+  SLACK_BOT_TOKEN    Required. Bot OAuth token (xoxb-...)
+  SLACK_API_BASE_URL Optional. Override API base (default: https://slack.com/api)
+
+Context Files:
+  .slack_context.json   Auto-loaded for workspace token lookup
+
+Output:
+  JSON to stdout on success, error message to stderr on failure.
+"#
+    );
+}
+
+/// Get Slack bot token from environment or context file.
+fn get_bot_token() -> Option<String> {
+    // Try environment variable first
+    if let Ok(token) = env::var("SLACK_BOT_TOKEN") {
+        if !token.trim().is_empty() {
+            return Some(token);
+        }
+    }
+
+    // Try employee-specific token
+    if let Ok(employee_id) = env::var("EMPLOYEE_ID") {
+        let key = format!(
+            "{}_SLACK_BOT_TOKEN",
+            employee_id.to_uppercase().replace('-', "_")
+        );
+        if let Ok(token) = env::var(&key) {
+            if !token.trim().is_empty() {
+                return Some(token);
+            }
+        }
+    }
+
+    // Try .slack_context.json
+    let context_path = std::path::Path::new(".slack_context.json");
+    if context_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(context_path) {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(token) = json["bot_token"].as_str() {
+                    return Some(token.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn get_api_base() -> String {
+    env::var("SLACK_API_BASE_URL").unwrap_or_else(|_| "https://slack.com/api".to_string())
+}
+
+#[derive(Debug, Serialize)]
+struct PostMessageRequest {
+    channel: String,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thread_ts: Option<String>,
+    mrkdwn: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackApiResponse {
+    ok: bool,
+    error: Option<String>,
+    ts: Option<String>,
+    channel: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenDmRequest {
+    users: String, // Comma-separated user IDs
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenDmResponse {
+    ok: bool,
+    error: Option<String>,
+    channel: Option<OpenDmChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenDmChannel {
+    id: String,
+}
+
+fn send_message(
+    token: &str,
+    channel: &str,
+    text: &str,
+    thread_ts: Option<&str>,
+) -> Result<SlackApiResponse, String> {
+    let client = Client::new();
+    let url = format!("{}/chat.postMessage", get_api_base().trim_end_matches('/'));
+
+    let request = PostMessageRequest {
+        channel: channel.to_string(),
+        text: text.to_string(),
+        thread_ts: thread_ts.map(|s| s.to_string()),
+        mrkdwn: true,
+    };
+
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    response
+        .json::<SlackApiResponse>()
+        .map_err(|e| format!("Failed to parse response: {}", e))
+}
+
+fn open_dm_channel(token: &str, user_id: &str) -> Result<String, String> {
+    let client = Client::new();
+    let url = format!(
+        "{}/conversations.open",
+        get_api_base().trim_end_matches('/')
+    );
+
+    let request = OpenDmRequest {
+        users: user_id.to_string(),
+    };
+
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    let dm_response: OpenDmResponse = response
+        .json()
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    if dm_response.ok {
+        dm_response
+            .channel
+            .map(|c| c.id)
+            .ok_or_else(|| "No channel in response".to_string())
+    } else {
+        Err(dm_response.error.unwrap_or_else(|| "Unknown error".to_string()))
+    }
+}
+
+fn cmd_send(args: &[String]) -> ExitCode {
+    let mut to: Option<String> = None;
+    let mut message: Option<String> = None;
+    let mut thread_ts: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--to" => {
+                i += 1;
+                to = args.get(i).cloned();
+            }
+            "--message" => {
+                i += 1;
+                message = args.get(i).cloned();
+            }
+            "--thread-ts" => {
+                i += 1;
+                thread_ts = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(to) = to else {
+        eprintln!("Error: --to is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(message) = message else {
+        eprintln!("Error: --message is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(token) = get_bot_token() else {
+        eprintln!("Error: SLACK_BOT_TOKEN not configured");
+        return ExitCode::FAILURE;
+    };
+
+    // If "to" starts with U (user ID), open DM first
+    let channel_id = if to.starts_with('U') {
+        match open_dm_channel(&token, &to) {
+            Ok(channel_id) => channel_id,
+            Err(e) => {
+                eprintln!("Error opening DM channel: {}", e);
+                return ExitCode::FAILURE;
+            }
+        }
+    } else {
+        to
+    };
+
+    match send_message(&token, &channel_id, &message, thread_ts.as_deref()) {
+        Ok(response) => {
+            if response.ok {
+                let output = json!({
+                    "success": true,
+                    "channel": response.channel,
+                    "ts": response.ts,
+                    "message": "Message sent successfully"
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+                ExitCode::SUCCESS
+            } else {
+                let output = json!({
+                    "success": false,
+                    "error": response.error
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+                ExitCode::FAILURE
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_send_dm(args: &[String]) -> ExitCode {
+    let mut user_id: Option<String> = None;
+    let mut message: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--user-id" => {
+                i += 1;
+                user_id = args.get(i).cloned();
+            }
+            "--message" => {
+                i += 1;
+                message = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(user_id) = user_id else {
+        eprintln!("Error: --user-id is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(message) = message else {
+        eprintln!("Error: --message is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(token) = get_bot_token() else {
+        eprintln!("Error: SLACK_BOT_TOKEN not configured");
+        return ExitCode::FAILURE;
+    };
+
+    // Open DM channel first
+    let channel_id = match open_dm_channel(&token, &user_id) {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!("Error opening DM channel: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match send_message(&token, &channel_id, &message, None) {
+        Ok(response) => {
+            if response.ok {
+                let output = json!({
+                    "success": true,
+                    "channel": channel_id,
+                    "user_id": user_id,
+                    "ts": response.ts,
+                    "message": "DM sent successfully"
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+                ExitCode::SUCCESS
+            } else {
+                let output = json!({
+                    "success": false,
+                    "error": response.error
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+                ExitCode::FAILURE
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_send_channel(args: &[String]) -> ExitCode {
+    let mut channel_id: Option<String> = None;
+    let mut message: Option<String> = None;
+    let mut thread_ts: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--channel-id" => {
+                i += 1;
+                channel_id = args.get(i).cloned();
+            }
+            "--message" => {
+                i += 1;
+                message = args.get(i).cloned();
+            }
+            "--thread-ts" => {
+                i += 1;
+                thread_ts = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(channel_id) = channel_id else {
+        eprintln!("Error: --channel-id is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(message) = message else {
+        eprintln!("Error: --message is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(token) = get_bot_token() else {
+        eprintln!("Error: SLACK_BOT_TOKEN not configured");
+        return ExitCode::FAILURE;
+    };
+
+    match send_message(&token, &channel_id, &message, thread_ts.as_deref()) {
+        Ok(response) => {
+            if response.ok {
+                let output = json!({
+                    "success": true,
+                    "channel": channel_id,
+                    "ts": response.ts,
+                    "message": "Message sent to channel"
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+                ExitCode::SUCCESS
+            } else {
+                let output = json!({
+                    "success": false,
+                    "error": response.error
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+                ExitCode::FAILURE
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_open_dm(args: &[String]) -> ExitCode {
+    let mut user_id: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--user-id" => {
+                i += 1;
+                user_id = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(user_id) = user_id else {
+        eprintln!("Error: --user-id is required");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(token) = get_bot_token() else {
+        eprintln!("Error: SLACK_BOT_TOKEN not configured");
+        return ExitCode::FAILURE;
+    };
+
+    match open_dm_channel(&token, &user_id) {
+        Ok(channel_id) => {
+            let output = json!({
+                "success": true,
+                "user_id": user_id,
+                "channel_id": channel_id,
+                "message": "DM channel opened/retrieved"
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/bin/tpm_cli.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/tpm_cli.rs
@@ -1,0 +1,297 @@
+//! TPM (Technical Program Manager) CLI for agent use.
+//!
+//! Provides commands for TPM workflows:
+//! - User contact directory lookup and management
+//! - Task board status aggregation
+//! - Cross-channel messaging coordination
+//!
+//! Usage:
+//!   tpm_cli get-contact --notion-user-id <id> [--workspace-id <ws>]
+//!   tpm_cli list-contacts [--workspace-id <ws>]
+//!   tpm_cli update-contacted --contact-id <id>
+
+use scheduler_module::account_store::{AccountStore, UserContact};
+use serde_json::json;
+use std::env;
+use std::process::ExitCode;
+use uuid::Uuid;
+
+fn main() -> ExitCode {
+    dotenvy::dotenv().ok();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        print_usage();
+        return ExitCode::FAILURE;
+    }
+
+    let command = &args[1];
+    match command.as_str() {
+        "get-contact" => cmd_get_contact(&args[2..]),
+        "list-contacts" => cmd_list_contacts(&args[2..]),
+        "update-contacted" => cmd_update_contacted(&args[2..]),
+        "help" | "--help" | "-h" => {
+            print_usage();
+            ExitCode::SUCCESS
+        }
+        _ => {
+            eprintln!("Unknown command: {}", command);
+            print_usage();
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        r#"TPM CLI - Technical Program Manager tools
+
+Usage:
+  tpm_cli <command> [options]
+
+Commands:
+  get-contact       Get contact info for a Notion user
+    --notion-user-id <id>    Notion person ID (from task assignee)
+    --workspace-id <ws>      Notion workspace ID (required)
+
+  list-contacts     List all configured contacts
+    --workspace-id <ws>      Filter by Notion workspace (optional)
+
+  update-contacted  Mark a contact as recently contacted
+    --contact-id <id>        Contact entry UUID
+
+Environment:
+  SUPABASE_DB_URL        Required for database access
+  ACCOUNT_ID             Account UUID (from .notion_context.json or env)
+
+Context Files:
+  .notion_context.json   Auto-loaded for account_id and workspace_id
+
+Output:
+  JSON to stdout on success, error message to stderr on failure.
+"#
+    );
+}
+
+/// Get account_id from environment or context file.
+fn get_account_id() -> Option<Uuid> {
+    // First try environment variable
+    if let Ok(id) = env::var("ACCOUNT_ID") {
+        if let Ok(uuid) = Uuid::parse_str(&id) {
+            return Some(uuid);
+        }
+    }
+
+    // Then try .notion_context.json
+    let context_path = std::path::Path::new(".notion_context.json");
+    if context_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(context_path) {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(id) = json["account_id"].as_str() {
+                    if let Ok(uuid) = Uuid::parse_str(id) {
+                        return Some(uuid);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Get workspace_id from environment or context file.
+fn get_workspace_id() -> Option<String> {
+    // First try argument (handled by caller)
+    // Then try .notion_context.json
+    let context_path = std::path::Path::new(".notion_context.json");
+    if context_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(context_path) {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(ws_id) = json["workspace_id"].as_str() {
+                    return Some(ws_id.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn user_contact_to_json(contact: &UserContact) -> serde_json::Value {
+    json!({
+        "id": contact.id.to_string(),
+        "account_id": contact.account_id.to_string(),
+        "notion_user_id": contact.notion_user_id,
+        "notion_workspace_id": contact.notion_workspace_id,
+        "slack_user_id": contact.slack_user_id,
+        "slack_workspace_id": contact.slack_workspace_id,
+        "discord_user_id": contact.discord_user_id,
+        "discord_guild_id": contact.discord_guild_id,
+        "preferred_channel": contact.preferred_channel,
+        "contact_frequency_days": contact.contact_frequency_days,
+        "last_contacted_at": contact.last_contacted_at.map(|t| t.to_rfc3339()),
+        "created_at": contact.created_at.to_rfc3339(),
+    })
+}
+
+fn cmd_get_contact(args: &[String]) -> ExitCode {
+    let mut notion_user_id: Option<String> = None;
+    let mut workspace_id: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--notion-user-id" => {
+                i += 1;
+                notion_user_id = args.get(i).cloned();
+            }
+            "--workspace-id" => {
+                i += 1;
+                workspace_id = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(notion_user_id) = notion_user_id else {
+        eprintln!("Error: --notion-user-id is required");
+        return ExitCode::FAILURE;
+    };
+
+    let workspace_id = workspace_id.or_else(get_workspace_id);
+    let Some(workspace_id) = workspace_id else {
+        eprintln!("Error: --workspace-id is required (or set via .notion_context.json)");
+        return ExitCode::FAILURE;
+    };
+
+    let Some(account_id) = get_account_id() else {
+        eprintln!("Error: ACCOUNT_ID not found (check env or .notion_context.json)");
+        return ExitCode::FAILURE;
+    };
+
+    let store = match AccountStore::from_env() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error: Failed to connect to database: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match store.get_user_contact_by_notion_user(account_id, &workspace_id, &notion_user_id) {
+        Ok(Some(contact)) => {
+            let output = user_contact_to_json(&contact);
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS
+        }
+        Ok(None) => {
+            let output = json!({
+                "error": "not_found",
+                "message": format!("No contact found for Notion user {} in workspace {}", notion_user_id, workspace_id)
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS // Not an error, just no data
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_list_contacts(args: &[String]) -> ExitCode {
+    let mut workspace_id: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--workspace-id" => {
+                i += 1;
+                workspace_id = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    // Try to get workspace_id from context if not provided
+    let workspace_id = workspace_id.or_else(get_workspace_id);
+
+    let Some(account_id) = get_account_id() else {
+        eprintln!("Error: ACCOUNT_ID not found (check env or .notion_context.json)");
+        return ExitCode::FAILURE;
+    };
+
+    let store = match AccountStore::from_env() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error: Failed to connect to database: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match store.list_user_contacts(account_id, workspace_id.as_deref()) {
+        Ok(contacts) => {
+            let output: Vec<serde_json::Value> =
+                contacts.iter().map(user_contact_to_json).collect();
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_update_contacted(args: &[String]) -> ExitCode {
+    let mut contact_id: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--contact-id" => {
+                i += 1;
+                contact_id = args.get(i).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let Some(contact_id) = contact_id else {
+        eprintln!("Error: --contact-id is required");
+        return ExitCode::FAILURE;
+    };
+
+    let contact_uuid = match Uuid::parse_str(&contact_id) {
+        Ok(uuid) => uuid,
+        Err(_) => {
+            eprintln!("Error: Invalid contact-id UUID format");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let store = match AccountStore::from_env() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error: Failed to connect to database: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match store.update_user_contact_last_contacted(contact_uuid) {
+        Ok(()) => {
+            let output = json!({
+                "status": "success",
+                "message": format!("Updated last_contacted_at for contact {}", contact_id)
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Technical Program Manager (TPM) capabilities for digital employees:

- **Contact Directory** - `user_contact_directory` table maps Notion users to Slack/Discord handles
- **Scheduled Jobs** - `scheduled_jobs` table enables cron-based autonomous tasks
- **CLIs** - `tpm_cli`, `slack_cli`, `discord_cli` for agent use
- **Skills** - Complete TPM workflow documentation in skill files

## New Files

### CLIs (Rust binaries)
- `scheduler_module/src/bin/tpm_cli.rs` - Contact directory operations
- `scheduler_module/src/bin/slack_cli.rs` - Proactive Slack messaging
- `scheduler_module/src/bin/discord_cli.rs` - Proactive Discord messaging

### Skills
- `.claude/skills/notion-tpm/SKILL.md` - Full TPM workflow
- `.claude/skills/slack-messaging/SKILL.md` - Slack messaging guide
- `.claude/skills/discord-messaging/SKILL.md` - Discord messaging guide

### Database Migrations
- `migrations/001_user_contact_directory.sql` - Contact mapping table
- `migrations/002_scheduled_jobs.sql` - Cron job scheduling table

## TPM Workflow

1. Query Notion task board for in-progress tasks
2. Look up assignee's Slack/Discord handle via `tpm_cli get-contact`
3. Send follow-up message via `slack_cli send-dm` or `discord_cli send-dm`
4. Log progress update as Notion comment
5. Update `last_contacted_at` timestamp

## Test Plan

- [ ] Verify CLIs compile on staging
- [ ] Test `tpm_cli get-contact` with mock data
- [ ] Test `slack_cli send-dm` / `discord_cli send-dm` API calls
- [ ] E2E: Full TPM workflow on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)