### PR TITLE
Improve local dashboard testing diagnostics

### DIFF
--- a/DoWhiz_service/scheduler_module/src/service/server.rs
+++ b/DoWhiz_service/scheduler_module/src/service/server.rs
@@ -19,6 +19,7 @@ use crate::ingestion_queue::{build_queue_from_env, IngestionQueue};
 use crate::message_router::MessageRouter;
 use crate::mongo_store::{
     bootstrap_indexes_from_env, health_check_from_env, mongo_database_name_from_env,
+    MongoStoreError,
 };
 use crate::slack_store::{SlackInstallation, SlackStore};
 use crate::storage_backend::StorageBackend;
@@ -39,18 +40,53 @@ use super::scheduler::start_scheduler_threads;
 use super::state::AppState;
 use super::BoxError;
 
+fn format_mongo_startup_error_message(raw: &str, missing_uri: bool) -> String {
+    if missing_uri {
+        return "MongoDB is required for local auth/dashboard flows, but MONGODB_URI is not set. Add it to DoWhiz_service/.env and retry.".to_string();
+    }
+
+    let lower = raw.to_ascii_lowercase();
+    if lower.contains("outofdiskspace") {
+        return "MongoDB is running but refusing requests because the machine is below MongoDB's free-disk threshold. Free at least 500 MB on the volume backing MONGODB_URI, then retry.".to_string();
+    }
+    if lower.contains("server selection timeout")
+        || lower.contains("no available servers")
+        || lower.contains("connection refused")
+    {
+        return "MongoDB is not reachable at the configured MONGODB_URI. Start a local mongod (or point MONGODB_URI at a reachable deployment) before running ./DoWhiz_service/scripts/run_employee.sh.".to_string();
+    }
+
+    format!(
+        "MongoDB health check failed. Ensure MONGODB_URI points to a reachable MongoDB instance with enough free disk space. Original error: {raw}"
+    )
+}
+
+fn format_mongo_startup_error(err: &MongoStoreError) -> String {
+    format_mongo_startup_error_message(
+        &err.to_string(),
+        matches!(err, MongoStoreError::MissingMongoUri),
+    )
+}
+
 pub async fn run_server(
     config: ServiceConfig,
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), BoxError> {
     let storage_backend = StorageBackend::from_env();
     if storage_backend.uses_mongo() {
-        task::spawn_blocking(health_check_from_env)
+        let mongo_health = task::spawn_blocking(health_check_from_env)
             .await
-            .map_err(|err| -> BoxError { err.into() })??;
-        task::spawn_blocking(bootstrap_indexes_from_env)
+            .map_err(|err| -> BoxError { err.into() })?;
+        if let Err(err) = mongo_health {
+            return Err(std::io::Error::other(format_mongo_startup_error(&err)).into());
+        }
+
+        let mongo_bootstrap = task::spawn_blocking(bootstrap_indexes_from_env)
             .await
-            .map_err(|err| -> BoxError { err.into() })??;
+            .map_err(|err| -> BoxError { err.into() })?;
+        if let Err(err) = mongo_bootstrap {
+            return Err(std::io::Error::other(format_mongo_startup_error(&err)).into());
+        }
         info!(
             "mongo backend enabled backend={:?} database={}",
             storage_backend,
@@ -264,6 +300,35 @@ pub async fn run_server(
 
     serve_result?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_mongo_startup_error_message;
+
+    #[test]
+    fn mongo_startup_error_mentions_missing_uri() {
+        let message = format_mongo_startup_error_message("mongodb error: missing uri", true);
+        assert!(message.contains("MONGODB_URI"));
+    }
+
+    #[test]
+    fn mongo_startup_error_mentions_reachability() {
+        let message = format_mongo_startup_error_message(
+            "mongodb error: Server selection timeout: No available servers. Topology: { Type: Unknown, Servers: [ { Address: 127.0.0.1:27017, Type: Unknown, Error: Kind: I/O error: Connection refused (os error 61), labels: {} } ] }",
+            false,
+        );
+        assert!(message.contains("not reachable"));
+    }
+
+    #[test]
+    fn mongo_startup_error_mentions_disk_threshold() {
+        let message = format_mongo_startup_error_message(
+            "mongodb error: Command failed: OutOfDiskSpace",
+            false,
+        );
+        assert!(message.contains("500 MB"));
+    }
 }
 
 async fn health() -> impl IntoResponse {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DoWhiz - One-click startup workspace for founders and digital founding teams.
+# DoWhiz - Oliver, a trusted AI operator for work and life.
 
 <p align="center"><strong>Product Shorts</strong></p>
 
@@ -29,20 +29,22 @@
 
 <p align="center"><sub>Tap any preview to watch the full Shorts video.</sub></p>
 
-DoWhiz is an agent-native startup workspace platform.
+DoWhiz is an agent-native product built around Oliver, the trusted AI operator that works in your existing tools and brings back finished work.
 
 Current product model:
-- Solo-founder-first onboarding to generate a startup workspace blueprint.
-- Workspace-first operating surface for resources, tasks, artifacts, approvals, and memory.
+- Oliver-first landing and onboarding for consumer adoption.
+- Personal setup dashboard for connected apps, tasks, memory, and settings.
 - Multi-channel execution across email, Slack/Discord, GitHub, Google Docs, and related surfaces.
+- Legacy startup/workspace routes remain available for backward compatibility, but they are no longer the primary product journey.
 
 Primary web routes:
 - `/`: public landing
-- `/start`: founder intake -> canonical startup workspace blueprint
-- `/workspace`: workspace home (brief/resources/agents/tasks/artifacts/approvals)
+- `/auth/index.html`: Oliver setup dashboard
+- `/start`: legacy startup intake flow
+- `/workspace`: legacy workspace route, softened away from the main journey
 - `/dashboard`: internal analytics/supporting page
 
-Startup workspace backend layer:
+Startup workspace legacy backend layer:
 - `DoWhiz_service/scheduler_module/src/domain/*`
 - `DoWhiz_service/scheduler_module/src/service/startup_workspace/*`
 - `DoWhiz_service/scheduler_module/src/service/workspace.rs` (persist bootstrap artifacts in workspace)
@@ -57,6 +59,7 @@ Current production model:
 Prerequisites:
 - Rust toolchain
 - Node.js 20+
+- MongoDB available at the `MONGODB_URI` configured in `DoWhiz_service/.env`
 - `ngrok` (only for local public webhook testing)
 
 1. Configure env:
@@ -82,6 +85,15 @@ cd DoWhiz_service
 cargo run -p scheduler_module --bin set_postmark_inbound_hook -- \
   --hook-url https://YOUR-NGROK-DOMAIN/postmark/inbound
 ```
+
+5. Test the personal dashboard locally:
+```bash
+cd website
+npm install
+npm run dev
+```
+
+Open `http://localhost:5173/auth/index.html` after the Rust service is up. If the auth page shows a network error, confirm MongoDB is running first, then re-run the worker command above.
 
 ## Runtime Flow
 

--- a/website/README.md
+++ b/website/README.md
@@ -4,8 +4,8 @@
   <img src="public/assets/DoWhiz.svg" alt="Do icon" width="96" />
 </p>
 
-Workspace-first product shell for DoWhiz, built with Vite + React.
-The web app handles founder onboarding (inline hero intake on `/` plus `/start`), workspace home (`/workspace`), and supporting internal analytics (`/dashboard`).
+Oliver-first product shell for DoWhiz, built with Vite + React.
+The web app handles the public landing story, auth onboarding, Oliver setup dashboard, and supporting internal analytics.
 
 ## Prerequisites
 - Node.js 18+ (20+ recommended).
@@ -72,11 +72,11 @@ If you are using a dedicated API subdomain (example: `api.dowhiz.com`) for the R
 - `website/vercel.json`: hosting redirects/rewrites for Vercel deployment.
 
 ## Core route map
-- `/`: Landing page with inline conversational startup intake in the hero.
-- `/start`: Backward-compatible founder intake route (same conversational flow + edit questionnaire mode).
-- `/workspace`: Workspace home showing startup brief, resources, agents, tasks, artifacts, approvals, and next actions.
+- `/`: Oliver-first landing page with a clear onboarding path.
+- `/start`: Legacy startup intake route retained for backward compatibility.
+- `/workspace`: Legacy workspace route that is no longer part of the primary product journey.
 - `/dashboard`: Internal analytics dashboard (supporting page, not the primary product home).
-- `/auth/index.html`: Unified team + personal dashboard (channels, tasks, memo, settings).
+- `/auth/index.html`: Oliver setup dashboard (connections, tasks, memory, settings).
 - `/cn`: Localized landing path.
 
 ## Routing and hosting notes
@@ -90,4 +90,5 @@ Provider-runtime overlays gracefully degrade when the user is not authenticated.
 
 ## Troubleshooting
 - Port 5173 in use: run `npm run dev -- --port 5174` or stop the other process.
+- `/auth/index.html` shows `Failed to fetch`: make sure MongoDB is reachable at `MONGODB_URI`, then start `./DoWhiz_service/scripts/run_employee.sh little_bear 9001 --skip-hook --skip-ngrok`. The auth page treats loopback hosts such as `localhost`, `127.0.0.1`, `0.0.0.0`, and `::1` as local development URLs.
 - Clean install: remove `website/node_modules/` and run `npm install` again.

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1944,12 +1944,14 @@
       const SUPABASE_URL = 'https://resmseutzmwumflevfqw.supabase.co';
       const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJlc21zZXV0em13dW1mbGV2ZnF3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzAxNTQ1MjIsImV4cCI6MjA4NTczMDUyMn0.-QMndwi4m8nBtjMeS5WbDmrHZSe2l1UFY-UQJCl0Frc';
       const isStaging = window.location.hostname.includes('staging') || window.location.hostname.includes('dowhizstaging');
-      const DOWHIZ_API_URL = window.location.hostname === 'localhost'
+      const LOCAL_DEV_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]']);
+      const isLocalDevHost = LOCAL_DEV_HOSTNAMES.has(window.location.hostname);
+      const DOWHIZ_API_URL = isLocalDevHost
         ? 'http://localhost:9001'
         : isStaging
           ? 'https://api.staging.dowhiz.com/service'
           : 'https://api.production1.dowhiz.com/service';
-      const DOWHIZ_GATEWAY_URL = window.location.hostname === 'localhost'
+      const DOWHIZ_GATEWAY_URL = isLocalDevHost
         ? 'http://localhost:9100'
         : isStaging
           ? 'https://api.staging.dowhiz.com'
@@ -2371,6 +2373,23 @@
           return 'Password must be at least 6 characters.';
         }
         return message;
+      }
+
+      function normalizeApiFetchError(error, context = 'service') {
+        if (!error) return 'Something went wrong.';
+        const message = error.message || 'Something went wrong.';
+        const lower = message.toLowerCase();
+        const isNetworkError = lower.includes('failed to fetch') || lower.includes('networkerror');
+        if (!isNetworkError) {
+          return message;
+        }
+        if (!isLocalDevHost) {
+          return message;
+        }
+        if (context === 'gateway') {
+          return 'Could not reach the local DoWhiz gateway. Start it with ./DoWhiz_service/scripts/run_gateway_local.sh and try again.';
+        }
+        return 'Could not reach the local DoWhiz service. Make sure MongoDB is running, then start ./DoWhiz_service/scripts/run_employee.sh little_bear 9001 --skip-hook --skip-ngrok and reload this page.';
       }
 
       function normalizeWorkspaceText(value, fallback = 'Not set') {
@@ -3810,7 +3829,7 @@
           await loadTasks(accessToken, { refreshRecommendation: true });
         } catch (err) {
           console.error('Failed to create brief:', err);
-          showMessage(err.message || 'Failed to create brief. Please try again.');
+          showMessage(normalizeApiFetchError(err, 'gateway'));
         } finally {
           if (btn) {
             btn.disabled = false;
@@ -3882,7 +3901,7 @@
           await loadTasks(accessToken, { refreshRecommendation: true });
         } catch (err) {
           console.error('Failed to create 90-day plan:', err);
-          showMessage(err.message || 'Failed to create 90-day plan. Please try again.');
+          showMessage(normalizeApiFetchError(err, 'gateway'));
         } finally {
           if (btn) {
             btn.disabled = false;
@@ -4583,6 +4602,7 @@
 
           showDashboard(session, accountData);
         } catch (err) {
+          const displayMessage = normalizeApiFetchError(err);
           // On error, show sign-in form with error message
           setDashboardMode(false);
           signinFormContainer.classList.remove('hidden');
@@ -4592,7 +4612,7 @@
             error_type: 'post_auth_signup_failed',
             error: err.message
           });
-          showMessage(err.message);
+          showMessage(displayMessage);
         }
       }
 
@@ -4676,7 +4696,10 @@
           loadWorkspaceSummaryFromStorage();
           renderNextSteps(cachedIdentifiers);
         } catch (err) {
+          const displayMessage = normalizeApiFetchError(err);
           console.error('Failed to load identifiers:', err);
+          list.innerHTML = `<li class="identifier-item">${escapeHtml(displayMessage)}</li>`;
+          showMessage(displayMessage);
         }
       }
 
@@ -4702,7 +4725,7 @@
           // Refresh tasks to remove tasks from the unlinked channel
           await loadTasks(accessToken, { refreshRecommendation: true });
         } catch (err) {
-          showMessage(err.message);
+          showMessage(normalizeApiFetchError(err));
         }
       }
 
@@ -4723,8 +4746,9 @@
           memoContent.value = data.content;
           cachedMemoContent = data.content || '';
         } catch (err) {
+          const displayMessage = normalizeApiFetchError(err);
           console.error('Failed to load memo:', err);
-          memoContent.value = `Error loading memo: ${err.message}`;
+          memoContent.value = `Error loading memory: ${displayMessage}`;
           cachedMemoContent = '';
         }
         loadWorkspaceSummaryFromStorage();
@@ -5387,9 +5411,10 @@
           loadWorkspaceSummaryFromStorage();
           renderNextSteps(cachedIdentifiers);
         } catch (err) {
+          const displayMessage = normalizeApiFetchError(err);
           console.error('Failed to load tasks:', err);
           cachedTasks = [];
-          taskList.innerHTML = `<li class="task-item" style="text-align: center; color: #ef4444;">Error loading tasks: ${err.message}</li>`;
+          taskList.innerHTML = `<li class="task-item" style="text-align: center; color: #ef4444;">Error loading tasks: ${escapeHtml(displayMessage)}</li>`;
           loadWorkspaceSummaryFromStorage();
           renderNextSteps(cachedIdentifiers);
         } finally {


### PR DESCRIPTION
## Summary
- treat loopback hosts like `127.0.0.1`, `0.0.0.0`, and `::1` as local dashboard URLs
- replace generic local auth/dashboard `Failed to fetch` errors with actionable startup guidance
- make Rust service startup failures explain Mongo reachability and disk-space problems
- document the local personal dashboard testing flow in the repo READMEs

## Testing
- `cd website && npm run lint`
- `cd website && npm run build`
- `cd DoWhiz_service && cargo test -p scheduler_module mongo_startup_error -- --nocapture`
- manual smoke check for `/auth/index.html` on both `localhost` and `127.0.0.1`
- verified `curl http://localhost:9001/auth/account` returns the expected `401 Missing Authorization header` when the service is running

## Notes
- this PR only changes local diagnostics and docs; auth, task, memo, and connection flows remain intact
- the earlier Oliver landing/dashboard refactor was already merged via #1120