### PR TITLE
Simplify Oliver landing onboarding surface

### DIFF
--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  getDoWhizApiBaseUrl,
   getOrCreateSessionId,
   persistAttributionFromLocation,
   trackAnalyticsEvent
@@ -23,6 +24,18 @@ const LANDING_PAGE_OVERRIDE_PARAM = 'view';
 const LANDING_PAGE_OVERRIDE_VALUE = 'landing';
 const LANDING_PAGE_OVERRIDE_SUFFIX = `?${LANDING_PAGE_OVERRIDE_PARAM}=${LANDING_PAGE_OVERRIDE_VALUE}`;
 const LANDING_DASHBOARD_SUFFIX = '?loggedIn=true#section-overview';
+const LANDING_SETUP_SUFFIX = '#section-workspace';
+const AUTHENTICATED_SETUP_SUFFIX = '?loggedIn=true#section-workspace';
+const LANDING_SETTINGS_SUFFIX = '#section-settings';
+const AUTHENTICATED_SETTINGS_SUFFIX = '?loggedIn=true#section-settings';
+const LANDING_PAGE_VARIANT = 'oliver_onboarding_v2';
+const OAUTH_ENDPOINTS = {
+  discord: '/auth/discord',
+  slack: '/auth/slack',
+  github: '/auth/github',
+  notion: '/auth/notion',
+  lark: '/auth/lark'
+};
 
 const isCnPath = (pathname = '/') =>
   pathname === CN_PATH_PREFIX || pathname === `${CN_PATH_PREFIX}/` || pathname.startsWith(`${CN_PATH_PREFIX}/`);
@@ -101,6 +114,7 @@ function LandingPage({ locale }) {
   const [enableMouseField, setEnableMouseField] = useState(false);
   const [user, setUser] = useState(null);
   const [authStatus, setAuthStatus] = useState('checking');
+  const [activeToolKey, setActiveToolKey] = useState(null);
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [navHidden, setNavHidden] = useState(false);
   const userMenuRef = useRef(null);
@@ -108,6 +122,7 @@ function LandingPage({ locale }) {
   const authRedirectStartedRef = useRef(false);
   const localizedHomePath =
     authStatus === 'authenticated' ? getLocalizedLandingPagePath(pathname) : content.nav.homePath;
+  const isAuthenticated = authStatus === 'authenticated' && Boolean(user);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -139,7 +154,7 @@ function LandingPage({ locale }) {
     trackAnalyticsEvent(
       'landing_page_view',
       {
-        landing_page_variant: 'oliver_consumer_v1',
+        landing_page_variant: LANDING_PAGE_VARIANT,
         landing_page_variant_legacy: 'oliver_consumer_v1',
         language: pageLocale
       },
@@ -379,11 +394,103 @@ function LandingPage({ locale }) {
   };
 
   const oliverContactHref = buildMailtoLink('oliver@dowhiz.com', content.hero.contactSubject, content.hero.contactBody);
-  const primaryCtaHref = user ? getLocalizedDashboardPath(pathname) : getLocalizedAuthPath('', pathname);
-  const secondaryCtaHref = content.hero.secondaryHref || '#use-cases';
+  const primaryCtaHref = isAuthenticated
+    ? getLocalizedAuthPath(AUTHENTICATED_SETUP_SUFFIX, pathname)
+    : getLocalizedAuthPath(LANDING_SETUP_SUFFIX, pathname);
+  const primaryCtaLabel = isAuthenticated
+    ? content.hero.primaryCtaAuthenticated
+    : content.hero.primaryCtaAnonymous;
+  const settingsHref = isAuthenticated
+    ? getLocalizedAuthPath(AUTHENTICATED_SETTINGS_SUFFIX, pathname)
+    : getLocalizedAuthPath(LANDING_SETTINGS_SUFFIX, pathname);
+  const toolHint = isAuthenticated ? content.hero.toolsHintAuthenticated : content.hero.toolsHintAnonymous;
 
   const trackCtaClick = (eventName, properties) => {
     trackAnalyticsEvent(eventName, properties);
+  };
+
+  const startProviderConnect = async (provider) => {
+    const endpoint = OAUTH_ENDPOINTS[provider];
+    if (!endpoint) {
+      window.location.href = settingsHref;
+      return;
+    }
+
+    try {
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        window.location.href = settingsHref;
+        return;
+      }
+
+      const response = await fetch(`${getDoWhizApiBaseUrl()}${endpoint}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` }
+      });
+      const data = await response.json().catch(() => null);
+
+      if (!response.ok || !data?.redirect_url) {
+        throw new Error(data?.error || `Failed to start ${provider} connection`);
+      }
+
+      window.location.href = data.redirect_url;
+    } catch (error) {
+      console.error(`Landing: failed to start ${provider} connect flow`, error);
+      setActiveToolKey(null);
+      window.location.href = settingsHref;
+    }
+  };
+
+  const getHeroToolActionLabel = (toolKey) => {
+    if (activeToolKey === toolKey) {
+      return content.hero.actionLabels.loading;
+    }
+
+    if (toolKey === 'email') {
+      return content.hero.actionLabels.email;
+    }
+
+    return isAuthenticated ? content.hero.actionLabels.connect : content.hero.actionLabels.setup;
+  };
+
+  const handleHeroToolAction = async (tool) => {
+    if (activeToolKey) {
+      return;
+    }
+
+    const actionType =
+      tool.key === 'email'
+        ? 'mailto'
+        : isAuthenticated
+          ? 'oauth'
+          : 'setup';
+
+    trackCtaClick('hero_tool_action_click', {
+      cta_location: 'hero_tool_grid',
+      cta_text: tool.label,
+      tool: tool.key,
+      action_type: actionType,
+      landing_page_variant: LANDING_PAGE_VARIANT
+    });
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (tool.key === 'email') {
+      window.location.href = oliverContactHref;
+      return;
+    }
+
+    if (!isAuthenticated) {
+      window.location.href = settingsHref;
+      return;
+    }
+
+    setActiveToolKey(tool.key);
+    await startProviderConnect(tool.key);
   };
 
   const [openFaq, setOpenFaq] = useState(null);
@@ -528,88 +635,164 @@ function LandingPage({ locale }) {
         <section className="hero-section">
           {enableMouseField ? <MouseField theme={theme} /> : null}
           <div className="halo-effect"></div>
-          <div className="container hero-content hero-content-oliver">
-            <div className="hero-copy">
+          <div className="container hero-content hero-shell">
+            <div className="hero-copy hero-copy-compact">
               <p className="hero-eyebrow">{content.hero.eyebrow}</p>
               <h1 className="hero-title">{content.hero.title}</h1>
               <p className="hero-subtitle">{content.hero.subtitle}</p>
-              <p className="hero-note">{content.hero.note}</p>
-              <div className="hero-chip-row" aria-label={isChinesePage ? 'Oliver 工作的主要表面' : 'Primary surfaces Oliver works in'}>
-                {content.hero.chips.map((chip) => (
-                  <span key={chip} className="hero-chip">
-                    {chip}
-                  </span>
-                ))}
-              </div>
-              <div className="hero-cta-row">
-                <a
-                  className="btn btn-primary"
-                  href={primaryCtaHref}
-                  onClick={() =>
-                    trackCtaClick('primary_cta_click', {
-                      cta_location: 'hero_primary',
-                      cta_text: content.hero.primaryCta
-                    })
-                  }
-                >
-                  {content.hero.primaryCta}
-                </a>
-                <a
-                  className="btn btn-secondary"
-                  href={secondaryCtaHref}
-                  onClick={() =>
-                    trackCtaClick('secondary_cta_click', {
-                      cta_location: 'hero_secondary',
-                      cta_text: content.hero.secondaryCta
-                    })
-                  }
-                >
-                  {content.hero.secondaryCta}
-                </a>
-              </div>
+              <a
+                className="btn btn-primary hero-primary-cta"
+                href={primaryCtaHref}
+                onClick={() =>
+                  trackCtaClick('primary_cta_click', {
+                    cta_location: 'hero_primary',
+                    cta_text: primaryCtaLabel,
+                    landing_page_variant: LANDING_PAGE_VARIANT
+                  })
+                }
+              >
+                {primaryCtaLabel}
+              </a>
+              <p className="hero-caption">{content.hero.caption}</p>
             </div>
 
-            <div className="hero-panel-grid">
-              <article className="hero-spotlight-card">
-                <div className="hero-spotlight-head">
-                  <div className="hero-portrait-wrap">
+            <div className="hero-product-card">
+              <div className="hero-product-head">
+                <div className="hero-product-heading">
+                  <span className="hero-panel-kicker">{content.hero.toolsEyebrow}</span>
+                  <p>{toolHint}</p>
+                </div>
+                <div className="hero-operator-chip">
+                  <div className="hero-operator-portrait">
                     <img src={oliverImg} alt="Oliver" className="hero-portrait" />
                   </div>
-                  <div className="hero-spotlight-copy">
-                    <span className="hero-panel-kicker">{content.hero.profileEyebrow}</span>
-                    <h2>{content.hero.profileTitle}</h2>
-                    <p>{content.hero.profileDescription}</p>
+                  <div className="hero-operator-copy">
+                    <strong>Oliver</strong>
+                    <span>{isChinesePage ? '可信 AI operator' : 'Trusted AI operator'}</span>
                   </div>
                 </div>
-                <ul className="hero-spotlight-list">
-                  {content.hero.profilePoints.map((point) => (
-                    <li key={point}>{point}</li>
-                  ))}
-                </ul>
-                <div className="hero-task-sampler">
-                  <span className="hero-panel-kicker">{content.hero.exampleTitle}</span>
-                  <ul className="hero-task-list">
-                    {content.hero.exampleTasks.map((task) => (
-                      <li key={task}>{task}</li>
+              </div>
+
+              <div className="hero-tool-grid" role="group" aria-label={content.hero.toolsEyebrow}>
+                {content.hero.tools.map((tool) => (
+                  <button
+                    key={tool.key}
+                    type="button"
+                    className="hero-tool-card"
+                    style={{ '--tool-accent': tool.accent }}
+                    onClick={() => handleHeroToolAction(tool)}
+                    disabled={Boolean(activeToolKey)}
+                  >
+                    <div className="hero-tool-card-top">
+                      <span className="hero-tool-badge" aria-hidden="true">
+                        {tool.monogram}
+                      </span>
+                      <span className="hero-tool-action">{getHeroToolActionLabel(tool.key)}</span>
+                    </div>
+                    <div className="hero-tool-card-copy">
+                      <strong>{tool.label}</strong>
+                      <span>{tool.description}</span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+
+              <div className="hero-dock-grid">
+                <article className="hero-flow-card">
+                  <span className="hero-panel-kicker">{content.hero.flowEyebrow}</span>
+                  <div className="hero-flow-steps">
+                    {content.hero.flowSteps.map((step, index) => (
+                      <div key={step} className="hero-flow-step">
+                        <span className="hero-flow-index">{index + 1}</span>
+                        <p>{step}</p>
+                      </div>
                     ))}
-                  </ul>
+                  </div>
+                </article>
+
+                <article className="hero-preview-card">
+                  <span className="hero-panel-kicker">{content.hero.previewEyebrow}</span>
+                  <div className="hero-preview-request">
+                    <span className="hero-preview-label">{isChinesePage ? '任务' : 'Task'}</span>
+                    <p>{content.hero.previewRequest}</p>
+                  </div>
+                  <div className="hero-preview-result">
+                    <span className="hero-preview-label">{content.hero.previewResultTitle}</span>
+                    <ul className="hero-preview-list">
+                      {content.hero.previewResults.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </article>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="examples" className="section demo-showcase-section">
+          <div className="container">
+            <div className="section-heading-shell">
+              <span className="section-kicker">{content.demo.eyebrow}</span>
+              <h2 className="section-title section-title-left">{content.demo.title}</h2>
+              <p className="section-intro section-intro-left">{content.demo.intro}</p>
+            </div>
+
+            <div className="demo-showcase-grid">
+              <article className="demo-feature-card">
+                <div className="demo-card-head">
+                  <div>
+                    <h3>{content.demo.desktopTitle}</h3>
+                    <p>{content.demo.desktopDescription}</p>
+                  </div>
+                  <a
+                    className="demo-inline-link"
+                    href={content.demo.desktopVideoHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {content.demo.desktopCta}
+                  </a>
+                </div>
+                <div className="frame-shell frame-landscape">
+                  <iframe
+                    src={`https://www.youtube.com/embed/${content.demo.desktopVideoId}?rel=0`}
+                    title={content.demo.desktopTitle}
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    referrerPolicy="strict-origin-when-cross-origin"
+                    allowFullScreen
+                  ></iframe>
                 </div>
               </article>
 
-              <aside className="hero-onboarding-card" aria-label={content.hero.onboardingAriaLabel}>
-                <div className="hero-card-header">
-                  <span className="hero-panel-kicker">{content.hero.onboardingTitle}</span>
-                  <p>{content.hero.onboardingDescription}</p>
+              <aside className="demo-short-rail">
+                <div className="demo-short-head">
+                  <h3>{content.demo.shortsTitle}</h3>
+                  <p>{content.demo.shortsDescription}</p>
                 </div>
-                <div className="hero-onboarding-list">
-                  {content.onboardingSteps.map((step) => (
-                    <div key={step.id} className="hero-onboarding-item">
-                      <span className="hero-step-index">{step.id}</span>
-                      <div>
-                        <h3>{step.title}</h3>
-                        <p>{step.desc}</p>
+                <div className="demo-short-grid">
+                  {content.demo.shorts.map((item) => (
+                    <article key={item.videoId} className="demo-short-card">
+                      <div className="frame-shell frame-portrait">
+                        <iframe
+                          src={`https://www.youtube.com/embed/${item.videoId}?rel=0`}
+                          title={item.title}
+                          loading="lazy"
+                          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                          referrerPolicy="strict-origin-when-cross-origin"
+                          allowFullScreen
+                        ></iframe>
                       </div>
-                    </div>
+                      <a
+                        className="demo-short-link"
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {item.title}
+                      </a>
+                    </article>
                   ))}
                 </div>
               </aside>
@@ -617,111 +800,61 @@ function LandingPage({ locale }) {
           </div>
         </section>
 
-        <section id="getting-started" className="section">
-          <div className="container">
-            <h2 className="section-title">{content.sections.gettingStartedTitle}</h2>
-            <p className="section-intro">{content.sections.gettingStartedIntro}</p>
-            <div className="step-grid">
-              {content.onboardingSteps.map((step) => (
-                <article key={step.id} className="step-card">
-                  <span className="step-card-index">{step.id}</span>
+        <section id="how-it-starts" className="section story-section">
+          <div className="container story-stack">
+            <div className="section-heading-shell">
+              <span className="section-kicker">{content.story.eyebrow}</span>
+              <h2 className="section-title section-title-left">{content.story.title}</h2>
+              <p className="section-intro section-intro-left">{content.story.intro}</p>
+            </div>
+
+            <div className="story-step-grid">
+              {content.story.steps.map((step) => (
+                <article key={step.id} className="story-step-card">
+                  <span className="story-step-index">{step.id}</span>
                   <h3>{step.title}</h3>
-                  <p className="step-card-desc">{step.desc}</p>
-                  <p className="step-card-detail">{step.detail}</p>
+                  <p>{step.description}</p>
                 </article>
               ))}
             </div>
-          </div>
-        </section>
 
-        <section id="use-cases" className="section">
-          <div className="container">
-            <h2 className="section-title">{content.sections.useCasesTitle}</h2>
-            <p className="section-intro">{content.sections.useCasesIntro}</p>
-            <div className="use-case-grid">
-              {content.useCases.map((item) => (
-                <article key={item.title} className="use-case-card">
-                  <span className="use-case-tag">{item.tag}</span>
-                  <h3>{item.title}</h3>
-                  <p>{item.desc}</p>
-                </article>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section id="surfaces" className="section features-section">
-          <div className="container">
-            <h2 className="section-title">{content.sections.surfacesTitle}</h2>
-            <p className="section-intro">{content.sections.surfacesIntro}</p>
-            <div className="surface-grid">
-              {content.surfaces.map((surface) => (
-                <article key={surface.title} className="surface-card">
-                  <div className="surface-card-head">
-                    <div className="feature-iconwrap">
-                      <img src={surface.icon} alt={surface.title} className="feature-icon" />
-                    </div>
-                    <span className="use-case-tag">{surface.tag}</span>
-                  </div>
-                  <h3>{surface.title}</h3>
-                  <p>{surface.desc}</p>
-                </article>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section id="control" className="section">
-          <div className="container">
-            <h2 className="section-title">{content.sections.controlTitle}</h2>
-            <p className="section-intro">{content.sections.controlIntro}</p>
-            <div className="control-layout">
-              <div className="control-card-stack">
-                {content.safetyItems.map((item) => (
-                  <article key={item.title} className="control-card">
-                    <div className="control-card-head">
-                      <div className="feature-iconwrap">
-                        <img src={item.icon} alt={item.tag} className="feature-icon" />
-                      </div>
-                      <span className="use-case-tag">{item.tag}</span>
-                    </div>
-                    <h3>{item.title}</h3>
-                    <p>{item.desc}</p>
-                    <ul className="control-point-list">
-                      {item.points.map((point) => (
-                        <li key={point}>{point}</li>
-                      ))}
-                    </ul>
-                  </article>
-                ))}
+            <aside className="control-band">
+              <div className="control-band-copy">
+                <span className="section-kicker">{content.story.controlEyebrow}</span>
+                <h3>{content.story.controlTitle}</h3>
               </div>
-              <aside className="control-steps-card">
-                <h3>{content.labels.accessPlaybookTitle}</h3>
-                <p>{content.labels.accessPlaybookDescription}</p>
-                <div className="control-step-list">
-                  {content.accessFlowSteps.map((step, index) => (
-                    <div key={step.title} className="control-step-item">
-                      <span className="control-step-index">{index + 1}</span>
-                      <div>
-                        <h4>{step.title}</h4>
-                        <p>{step.desc}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-                <a href="/trust-safety/" className="access-playbook-link">
-                  {content.labels.accessPlaybookLink}
-                </a>
-              </aside>
+              <ul className="control-band-list">
+                {content.story.controlPoints.map((point) => (
+                  <li key={point}>{point}</li>
+                ))}
+              </ul>
+            </aside>
+
+            <div className="section-heading-shell examples-heading">
+              <span className="section-kicker">{content.examples.eyebrow}</span>
+              <h2 className="section-title section-title-left">{content.examples.title}</h2>
+            </div>
+
+            <div className="example-card-grid">
+              {content.examples.cards.map((item) => (
+                <article key={item.title} className="example-card">
+                  <span className="example-card-tag">{item.tag}</span>
+                  <h3>{item.title}</h3>
+                  <p>{item.description}</p>
+                </article>
+              ))}
             </div>
           </div>
         </section>
 
         <section id="faq" className="section faq-section">
           <div className="container">
-            <h2 className="section-title">{content.sections.faqTitle}</h2>
-            <p className="section-intro">{content.sections.faqIntro}</p>
-            <div className="faq-accordion">
+            <div className="section-heading-shell">
+              <span className="section-kicker">{content.labels.faqEyebrow}</span>
+              <h2 className="section-title section-title-left">{content.labels.faqTitle}</h2>
+              <p className="section-intro section-intro-left">{content.labels.faqIntro}</p>
+            </div>
+            <div className="faq-accordion faq-compact">
               {content.faqItems.map((item, idx) => {
                 const isOpen = openFaq === idx;
                 return (
@@ -749,41 +882,10 @@ function LandingPage({ locale }) {
                 );
               })}
             </div>
-            <div className="faq-cta">
-              <a className="btn btn-secondary" href="https://www.dowhiz.com/help-center/">
-                {content.labels.faqCta}
+            <div className="faq-link-row">
+              <a className="faq-text-link" href="https://www.dowhiz.com/help-center/">
+                {content.labels.faqLinkLabel}
               </a>
-            </div>
-          </div>
-        </section>
-
-        <section id="blog" className="section blog-section">
-          <div className="container">
-            <div className="blog-header">
-              <div>
-                <span className="blog-eyebrow">{content.labels.blogEyebrow}</span>
-                <h2 className="blog-title">{content.labels.blogTitle}</h2>
-                <p className="blog-intro">{content.labels.blogIntro}</p>
-              </div>
-              <a className="btn btn-secondary blog-header-btn" href="/blog/">
-                {content.labels.blogHeaderButton}
-              </a>
-            </div>
-            <div className="blog-grid">
-              {content.blogPosts.map((post) => (
-                <article key={post.title} className="blog-card" role="article">
-                  <div className="blog-meta">
-                    <span className="blog-tag">{post.tag}</span>
-                    <span className="blog-date">{post.date}</span>
-                  </div>
-                  <h3>{post.title}</h3>
-                  <p>{post.excerpt}</p>
-                  <a className="blog-link" href={post.link}>
-                    {content.labels.blogLinkLabel}
-                    <span aria-hidden="true" className="blog-link-icon"></span>
-                  </a>
-                </article>
-              ))}
             </div>
           </div>
         </section>

--- a/website/src/pages/landingContent.js
+++ b/website/src/pages/landingContent.js
@@ -1,8 +1,8 @@
 const EN_LANDING_CONTENT = {
   metadata: {
-    title: 'DoWhiz | Meet Oliver, your AI operator',
+    title: 'DoWhiz | Oliver works in your tools',
     description:
-      'Meet Oliver, the trusted AI operator for your work and life. Connect the tools you already use, give him one real task, review the result, and turn repeat work into a routine.',
+      'Meet Oliver, the trusted AI operator for work and life. Start from the homepage, connect one app, send one real task, and review the result.',
     canonicalUrl: 'https://dowhiz.com/',
     ogLocale: 'en_US',
     themeColor: '#2C2C2E',
@@ -11,328 +11,240 @@ const EN_LANDING_CONTENT = {
   nav: {
     homePath: '/',
     links: [
-      { href: '#getting-started', label: 'Start here' },
-      { href: '#use-cases', label: 'What Oliver does' },
-      { href: '#surfaces', label: 'Where Oliver works' },
-      { href: '#control', label: 'Review & control' },
-      { href: '#faq', label: 'FAQ' },
-      { href: '#blog', label: 'Blog' }
+      { href: '#examples', label: 'Examples' },
+      { href: '#how-it-starts', label: 'How it starts' },
+      { href: '#faq', label: 'FAQ' }
     ],
     signIn: 'Sign in',
     dashboard: 'Oliver setup',
     signOut: 'Sign out',
     githubAriaLabel: 'GitHub',
     discordAriaLabel: 'Discord',
-    contactAriaLabel: 'Contact Oliver'
+    contactAriaLabel: 'Email Oliver'
   },
   hero: {
     eyebrow: 'Meet Oliver',
-    title: 'Oliver is the AI operator for your work and life.',
+    title: 'Tell Oliver what needs doing.',
     subtitle:
-      'Tell Oliver what needs doing. He works in your tools, returns finished work, and keeps the next step clear.',
-    note: 'Start with one connection and one real task. No giant new system required.',
-    chips: ['Email', 'Slack', 'Discord', 'GitHub', 'Notion', 'Lark'],
-    primaryCta: 'Open your setup',
-    secondaryCta: 'See what Oliver can handle',
-    secondaryHref: '#use-cases',
-    contactSubject: 'Talk to me about Oliver',
+      'Oliver is the trusted AI operator that works in email, Slack, Discord, GitHub, Notion, and Lark, then brings back finished work you can review.',
+    caption: 'Start with one app. Keep the first task small.',
+    primaryCtaAnonymous: 'Start with one app',
+    primaryCtaAuthenticated: 'Continue onboarding',
+    contactSubject: 'A first task for Oliver',
     contactBody:
-      'Hi Oliver,\n\nI want to see whether DoWhiz fits the following work or life tasks:\n-\n-\n-\n\nThanks!',
-    onboardingAriaLabel: 'Oliver onboarding steps',
-    onboardingTitle: 'Start in four simple steps',
-    onboardingDescription:
-      'The first success should feel personal and useful, not like you are deploying a whole new system.',
-    profileEyebrow: 'Trusted AI operator',
-    profileTitle: 'Oliver works where you already are',
-    profileDescription:
-      'Use Oliver for inbox work, research, drafting, coordination, and follow-ups without rebuilding your workflow.',
-    profilePoints: [
-      'Connect only the apps you want Oliver to use',
-      'Review drafts before sensitive actions',
-      'Keep your tone, preferences, and context in one shared memory'
+      'Hi Oliver,\n\nHere is the first task I want help with:\n\n- Context:\n- What done looks like:\n- Any deadline:\n\nThanks!',
+    toolsEyebrow: 'Choose a real starting point',
+    toolsHintAnonymous: 'Email works right away. The other tools take you into setup.',
+    toolsHintAuthenticated: 'If you are signed in, these buttons start the real connect flow.',
+    actionLabels: {
+      email: 'Send now',
+      connect: 'Connect',
+      setup: 'Open setup',
+      loading: 'Opening...'
+    },
+    tools: [
+      {
+        key: 'email',
+        label: 'Email',
+        description: 'Send Oliver a request right away.',
+        monogram: '@',
+        accent: '#ff8a3d'
+      },
+      {
+        key: 'slack',
+        label: 'Slack',
+        description: 'Connect the place where chat work lands.',
+        monogram: 'S',
+        accent: '#36c58b'
+      },
+      {
+        key: 'discord',
+        label: 'Discord',
+        description: 'Start where fast back-and-forth already happens.',
+        monogram: 'D',
+        accent: '#6c78ff'
+      },
+      {
+        key: 'github',
+        label: 'GitHub',
+        description: 'Connect repo work, issues, and follow-up.',
+        monogram: 'GH',
+        accent: '#2c2c2e'
+      },
+      {
+        key: 'notion',
+        label: 'Notion',
+        description: 'Connect docs, notes, and task context.',
+        monogram: 'N',
+        accent: '#6f6b63'
+      },
+      {
+        key: 'lark',
+        label: 'Lark',
+        description: 'Connect operations and coordination.',
+        monogram: 'L',
+        accent: '#3f88ff'
+      }
     ],
-    exampleTitle: 'Good first tasks',
-    exampleTasks: [
-      'Summarize this topic and give me the trade-offs in one page.',
-      'Draft a reply to this email and pull the action items into Notion.',
-      'Organize these tax documents and tell me what is still missing.',
-      'Draft next week’s LinkedIn post and hold it for my approval.'
+    flowEyebrow: 'How onboarding starts',
+    flowSteps: [
+      'Connect one app',
+      'Give Oliver one task',
+      'Review the result',
+      'Repeat what works'
+    ],
+    previewEyebrow: 'A good first task',
+    previewRequest:
+      'Draft a reply to this email, pull the action items into Notion, and hold anything sensitive for review.',
+    previewResultTitle: 'What comes back',
+    previewResults: ['Reply draft ready', 'Tasks captured', 'Approval items flagged']
+  },
+  demo: {
+    eyebrow: 'Real product examples',
+    title: 'See Oliver working, not just described.',
+    intro: 'One desktop walkthrough and three quick mobile demos.',
+    desktopTitle: 'Desktop walkthrough',
+    desktopDescription: 'See the request-to-result loop in one flow.',
+    desktopVideoId: 'IsSOTSYIIIY',
+    desktopVideoHref: 'https://youtu.be/IsSOTSYIIIY',
+    desktopCta: 'Open on YouTube',
+    shortsTitle: 'Mobile quick looks',
+    shortsDescription: 'Short examples built for a faster scan.',
+    shorts: [
+      {
+        title: 'Mobile demo 01',
+        videoId: 'SI9mxW_Top0',
+        href: 'https://www.youtube.com/shorts/SI9mxW_Top0'
+      },
+      {
+        title: 'Mobile demo 02',
+        videoId: 'PSsJ7WBk71w',
+        href: 'https://www.youtube.com/shorts/PSsJ7WBk71w'
+      },
+      {
+        title: 'Mobile demo 03',
+        videoId: '5H9g3LOGkMc',
+        href: 'https://www.youtube.com/shorts/5H9g3LOGkMc'
+      }
     ]
   },
-  sections: {
-    gettingStartedTitle: 'How to get started',
-    gettingStartedIntro: 'The first win should feel small, concrete, and easy to review.',
-    useCasesTitle: 'What Oliver can take off your plate',
-    useCasesIntro: 'Start with the tasks you already repeat, postpone, or keep half-finishing.',
-    surfacesTitle: 'Where Oliver works',
-    surfacesIntro: 'Oliver shows up in the places where requests already land and where work already lives.',
-    controlTitle: 'Review and control',
-    controlIntro: 'You decide what Oliver can access, where he can work, and when a sensitive action should wait for approval.',
-    faqTitle: 'Questions people ask before they trust an AI operator',
-    faqIntro: 'The answers focus on control, clarity, and a realistic first-run experience.'
+  story: {
+    eyebrow: 'How it starts',
+    title: 'The first win should be small, clear, and useful.',
+    intro: 'You are not setting up a whole new system. You are proving one real loop.',
+    steps: [
+      {
+        id: '01',
+        title: 'Connect one app',
+        description: 'Choose the place where work already lands.'
+      },
+      {
+        id: '02',
+        title: 'Give one real task',
+        description: 'Pick something concrete, reviewable, and worth handing off.'
+      },
+      {
+        id: '03',
+        title: 'Review and repeat',
+        description: 'Check the output, save the memory, and only then expand.'
+      }
+    ],
+    controlEyebrow: 'Review and control',
+    controlTitle: 'Oliver works with your approval, not in the dark.',
+    controlPoints: [
+      'Connect only the apps you want Oliver to use',
+      'Review drafts before sensitive actions',
+      'Keep your preferences and memory in one place'
+    ]
   },
-  onboardingSteps: [
-    {
-      id: '01',
-      title: 'Connect one tool',
-      desc: 'Start with the place where work already lands, like email, Notion, Slack, or GitHub.',
-      detail: 'You do not need to connect everything before Oliver is useful.'
-    },
-    {
-      id: '02',
-      title: 'Give Oliver a first task',
-      desc: 'Pick one real task that already exists in your life or work.',
-      detail: 'A good first task is specific, reviewable, and annoying enough that you do not want to do it twice.'
-    },
-    {
-      id: '03',
-      title: 'Review the result',
-      desc: 'Check the draft, summary, note, or follow-up before it goes anywhere important.',
-      detail: 'This is how you learn what Oliver should own, what should stay manual, and what needs approval.'
-    },
-    {
-      id: '04',
-      title: 'Turn repeat work into a routine',
-      desc: 'Once a task works, reuse it, save preferences, and keep future follow-ups faster.',
-      detail: 'DoWhiz starts personal first, then grows into recurring work and shared use when you are ready.'
-    }
-  ],
-  useCases: [
-    {
-      tag: 'Deep research',
-      title: 'Turn open questions into decision-ready research',
-      desc:
-        'Ask Oliver to compare options, gather sources, and return a concise brief you can actually use.'
-    },
-    {
-      tag: 'Inbox',
-      title: 'Draft replies, triage requests, and keep follow-ups moving',
-      desc:
-        'Oliver can read the context you share, draft the response, and keep the next action from falling through.'
-    },
-    {
-      tag: 'Writing support',
-      title: 'Support research, outlining, revision, and structured drafting',
-      desc:
-        'Use Oliver for study support, knowledge work, and document cleanup without turning the experience into chat-for-chat’s-sake.'
-    },
-    {
-      tag: 'Tax prep',
-      title: 'Prepare documents and organize what a filing still needs',
-      desc:
-        'Oliver can sort inputs, summarize gaps, and get materials ready for review before you file.'
-    },
-    {
-      tag: 'Content',
-      title: 'Draft and schedule posts with your approval',
-      desc:
-        'Let Oliver prepare LinkedIn copy, shape a posting cadence, and queue drafts for a final human yes.'
-    },
-    {
-      tag: 'GitHub',
-      title: 'Follow issues, code context, and repo-side tasks',
-      desc:
-        'Oliver can help keep engineering work moving by organizing issue context, summaries, and code-adjacent follow-ups.'
-    }
-  ],
-  surfaces: [
-    {
-      tag: 'Email',
-      title: 'Email and personal admin',
-      desc:
-        'Handle requests, draft replies, organize document-heavy tasks, and keep follow-up work moving from your inbox.',
-      icon: '/icons/The%20Digital%20Employee%20Stack/trigger.svg'
-    },
-    {
-      tag: 'Slack / Discord',
-      title: 'Chat where work actually happens',
-      desc:
-        'Use Oliver in the conversations where people already ask for help, share decisions, and need quick follow-through.',
-      icon: '/icons/The%20Digital%20Employee%20Stack/execute.svg'
-    },
-    {
-      tag: 'GitHub',
-      title: 'Repo context and execution handoffs',
-      desc:
-        'Keep issues, reviews, and code-related requests anchored in the same place your engineering work already lives.',
-      icon: '/icons/The%20Digital%20Employee%20Stack/shared.svg'
-    },
-    {
-      tag: 'Notion',
-      title: 'Notes, plans, and knowledge that stay usable',
-      desc:
-        'Turn raw notes into reusable pages, concise updates, and shared references that do not get lost in chat.',
-      icon: '/icons/The%20Digital%20Employee%20Stack/agent.svg'
-    },
-    {
-      tag: 'Shared docs',
-      title: 'Drafting and structured document workflows',
-      desc:
-        'Use Oliver for Google Docs style workflows, document revision, and formal deliverables that need to stay readable and reviewable.',
-      icon: '/icons/The%20Digital%20Employee%20Stack/collaboration.svg'
-    },
-    {
-      tag: 'Lark',
-      title: 'Cross-team coordination when you need it',
-      desc:
-        'Start as a personal operator today, then extend Oliver into shared SMB surfaces when the workflow proves itself.',
-      icon: '/icons/The%20Digital%20Employee%20Stack/permission.svg'
-    }
-  ],
-  safetyItems: [
-    {
-      tag: 'Control',
-      title: 'You control what Oliver can access',
-      icon: '/icons/key.svg',
-      desc:
-        'Only connect the apps and surfaces you actually want Oliver to use, and remove access whenever you want.',
-      points: [
-        'Access is explicit and revocable',
-        'You can start with one tool instead of a full rollout',
-        'Sensitive actions can stay behind a review step'
-      ]
-    },
-    {
-      tag: 'Review',
-      title: 'You can review before important actions',
-      icon: '/icons/shield_lock.svg',
-      desc:
-        'Use Oliver for drafts, summaries, research, and prep work first, then increase trust step by step.',
-      points: [
-        'Drafts can be checked before sending',
-        'Complex tasks can return a structured result instead of acting blindly',
-        'You decide which routines are ready to repeat'
-      ]
-    },
-    {
-      tag: 'Identity',
-      title: 'No personal credential handoff by default',
-      icon: '/icons/lock_person.svg',
-      desc:
-        'DoWhiz is built around controlled access and operator-style execution, not around asking you to give away personal passwords.',
-      points: [
-        'Agent-owned identity model where applicable',
-        'Less credential sprawl across ad hoc tools',
-        'Clearer boundaries for personal and shared work'
-      ]
-    }
-  ],
-  accessFlowSteps: [
-    {
-      title: 'Connect',
-      desc: 'Choose the first app or surface where Oliver should work.'
-    },
-    {
-      title: 'Scope',
-      desc: 'Keep the initial task narrow enough that you can review it quickly.'
-    },
-    {
-      title: 'Review',
-      desc: 'Check the result, adjust your preferences, and decide whether the task is ready to repeat.'
-    },
-    {
-      title: 'Expand',
-      desc: 'Only after the first task works should you add more apps, more automation, or shared SMB workflows.'
-    }
-  ],
+  examples: {
+    eyebrow: 'Useful from day one',
+    title: 'Good early tasks span both work and life.',
+    cards: [
+      {
+        tag: 'Research',
+        title: 'Deep research briefs',
+        description: 'Compare options and return a concise decision memo.'
+      },
+      {
+        tag: 'Inbox',
+        title: 'Email triage and drafts',
+        description: 'Draft replies and keep follow-ups moving.'
+      },
+      {
+        tag: 'Writing',
+        title: 'Study and drafting support',
+        description: 'Outline, revise, and tighten documents.'
+      },
+      {
+        tag: 'Tax prep',
+        title: 'Document organization',
+        description: 'Sort filing materials and flag what is missing.'
+      },
+      {
+        tag: 'Content',
+        title: 'Posts with approval',
+        description: 'Draft and schedule posts for review.'
+      },
+      {
+        tag: 'GitHub',
+        title: 'Repo follow-up',
+        description: 'Summarize issues and keep code-adjacent work moving.'
+      }
+    ]
+  },
   faqItems: [
     {
       question: 'What is DoWhiz now?',
       answer:
-        'DoWhiz starts with Oliver: a trusted AI operator who works in your tools and brings back finished work you can review and reuse.'
+        'DoWhiz starts with Oliver: a trusted AI operator who works in your tools, returns finished work, and helps you build trust one task at a time.'
     },
     {
-      question: 'How should I start?',
+      question: 'What should I do first?',
       answer:
-        'Connect one tool, give Oliver one real task, review the result, then save the preferences that made it useful.'
+        'Connect one app, give Oliver one real task, review the result, and save the preference or memory that made it useful.'
     },
     {
-      question: 'Does Oliver remember context?',
+      question: 'What kinds of work fit best?',
       answer:
-        'Yes. Oliver can keep shared memory for your preferences, task history, and follow-ups so you do not have to restart from zero each time.'
+        'Good first uses include research, drafting, document organization, inbox follow-up, repo-side coordination, and posts that still wait for your approval.'
     },
     {
-      question: 'Do I need to hand over my passwords?',
+      question: 'Do I stay in control?',
       answer:
-        'No. DoWhiz is designed around controlled access and reviewable execution instead of asking for broad personal credential handoff.'
+        'Yes. You choose what gets connected, you can review sensitive work before it is sent, and you can keep setup narrow while Oliver earns trust.'
     },
     {
-      question: 'Can Oliver help with both personal and work tasks?',
+      question: 'Is DoWhiz only for personal use?',
       answer:
-        'Yes, as long as the task is clear, reviewable, and appropriate. Good examples include research, drafting, document organization, follow-ups, and tool-native task execution.'
-    },
-    {
-      question: 'Is DoWhiz only for individuals?',
-      answer:
-        'The product starts with personal usefulness first. Once Oliver is trusted in one person’s workflow, the same setup can grow into shared SMB routines later.'
-    }
-  ],
-  blogPosts: [
-    {
-      tag: 'Workflow guide',
-      title: 'AI workflow automation checklist for lean teams',
-      date: 'March 27, 2026',
-      excerpt: 'A practical checklist for triggers, quality gates, and reliable delivery across the tools people already use.',
-      link: '/blog/ai-workflow-automation-checklist/'
-    },
-    {
-      tag: 'Engineering',
-      title: 'GitHub issue automation best practices',
-      date: 'February 26, 2026',
-      excerpt: 'A steadier issue-to-PR model with better scoping, validation, and reviewer-ready handoffs.',
-      link: '/blog/github-issue-automation-best-practices/'
-    },
-    {
-      tag: 'Email',
-      title: 'Email task automation playbook for operations teams',
-      date: 'February 26, 2026',
-      excerpt: 'How to turn inbox requests into structured execution, progress updates, and finished deliverables.',
-      link: '/blog/email-task-automation-playbook/'
-    },
-    {
-      tag: 'Memory',
-      title: 'AI agent memory best practices',
-      date: 'February 26, 2026',
-      excerpt: 'What to remember, what to reset, and how to keep cross-channel follow-ups useful instead of noisy.',
-      link: '/blog/ai-agent-memory-best-practices/'
+        'The product starts with personal usefulness first. Once Oliver is trusted in one workflow, the same setup can grow into shared SMB routines later.'
     }
   ],
   labels: {
-    blogEyebrow: 'From the blog',
-    blogTitle: 'Notes on building useful operator-style automation',
-    blogIntro: 'Practical writing about memory, inbox work, automation quality, and where AI operators break down in the real world.',
-    blogHeaderButton: 'View all posts',
-    blogLinkLabel: 'Read article',
-    accessPlaybookTitle: 'How Oliver setup expands',
-    accessPlaybookDescription:
-      'You do not need to do everything at once. Start narrow, prove value, then add the next tool or repeated workflow when it is earned.',
-    accessPlaybookLink: 'Explore Trust & Safety',
-    faqCta: 'Open the full Help Center',
-    footerTitle: 'Explore',
-    footerTagline: 'Oliver helps turn requests into finished work, one connected tool and one reviewed task at a time.',
-    footerPill: 'Personal first. Shared workflows later.',
-    footerBottomSecondary: 'Built for clear onboarding, controlled execution, and real work.'
+    faqEyebrow: 'Questions',
+    faqTitle: 'The essentials before you start',
+    faqIntro: 'Short answers about trust, fit, and what onboarding really looks like.',
+    faqLinkLabel: 'Open the Help Center',
+    footerTitle: 'Resources',
+    footerTagline: 'Oliver helps turn requests into finished work.',
+    footerPill: 'Start personal. Expand carefully.',
+    footerBottomSecondary: 'One app, one task, one reviewable result.'
   },
   footerLinks: [
     { href: '/privacy/', label: 'Privacy' },
     { href: '/terms/', label: 'Terms of Service' },
     { href: '/trust-safety/', label: 'Trust & Safety' },
     { href: '/integrations/', label: 'Integrations' },
-    { href: '/user-guide/', label: 'User Guide' },
     { href: 'https://www.dowhiz.com/help-center/', label: 'Help Center' },
-    { href: '/solutions/ai-workflow-automation/', label: 'AI Workflow Automation' },
-    { href: '/solutions/github-issue-automation/', label: 'GitHub Issue Automation' },
-    { href: '/solutions/slack-task-automation/', label: 'Slack Task Automation' },
-    { href: '/solutions/email-task-automation/', label: 'Email Task Automation' },
-    { href: '/solutions/google-docs-automation/', label: 'Google Docs Automation' }
+    { href: '/user-guide/', label: 'User Guide' }
   ]
 };
 
 const ZH_LANDING_CONTENT = {
   metadata: {
-    title: 'DoWhiz 中文 | 认识 Oliver，你的 AI operator',
+    title: 'DoWhiz 中文 | Oliver 在你的工具里工作',
     description:
-      'Oliver 是一个为工作和生活服务的 AI operator。连接你已经在用的工具，先交给他一个真实任务，再逐步建立你的个人工作流。',
+      '认识 Oliver。它是服务工作和生活的可信 AI operator，可以从首页直接开始：连接一个工具，交给它一个真实任务，再审阅结果。',
     canonicalUrl: 'https://dowhiz.com/cn',
     ogLocale: 'zh_CN',
     themeColor: '#2C2C2E',
@@ -341,304 +253,226 @@ const ZH_LANDING_CONTENT = {
   nav: {
     homePath: '/cn',
     links: [
-      { href: '#getting-started', label: '开始方式' },
-      { href: '#use-cases', label: 'Oliver 能做什么' },
-      { href: '#surfaces', label: 'Oliver 在哪里工作' },
-      { href: '#control', label: '审阅与控制' },
-      { href: '#faq', label: '常见问题' },
-      { href: '#blog', label: '博客' }
+      { href: '#examples', label: '实际例子' },
+      { href: '#how-it-starts', label: '怎么开始' },
+      { href: '#faq', label: '常见问题' }
     ],
     signIn: '登录',
     dashboard: 'Oliver 设置',
     signOut: '退出登录',
     githubAriaLabel: 'GitHub',
     discordAriaLabel: 'Discord',
-    contactAriaLabel: '联系 Oliver'
+    contactAriaLabel: '给 Oliver 发邮件'
   },
   hero: {
     eyebrow: '认识 Oliver',
-    title: 'Oliver 是一个服务你工作和生活的 AI operator。',
+    title: '直接告诉 Oliver 要做什么。',
     subtitle:
-      '告诉 Oliver 你要完成什么。他会在你已有的工具里工作，把结果带回来，并帮你把下一步变清楚。',
-    note: '先从一个连接、一个真实任务开始，不需要先搭新的大系统。',
-    chips: ['Email', 'Slack', 'Discord', 'GitHub', 'Notion', 'Lark'],
-    primaryCta: '打开我的设置',
-    secondaryCta: '看看 Oliver 能处理什么',
-    secondaryHref: '#use-cases',
-    contactSubject: '想了解 Oliver 是否适合我的场景',
+      'Oliver 是一个可信的 AI operator。它会在 email、Slack、Discord、GitHub、Notion 和 Lark 里工作，再把可审阅的结果带回来。',
+    caption: '先从一个工具开始，第一次任务尽量小一点。',
+    primaryCtaAnonymous: '从一个工具开始',
+    primaryCtaAuthenticated: '继续 onboarding',
+    contactSubject: '给 Oliver 的第一个任务',
     contactBody:
-      '你好 Oliver，\n\n我想看看 DoWhiz 是否适合下面这些工作或生活任务：\n-\n-\n-\n\n谢谢！',
-    onboardingAriaLabel: 'Oliver onboarding 步骤',
-    onboardingTitle: '四步上手',
-    onboardingDescription: '第一次成功最好是小而具体、容易审阅，而不是一上来就要部署整套系统。',
-    profileEyebrow: '可信的 AI operator',
-    profileTitle: 'Oliver 在你已经在用的地方工作',
-    profileDescription:
-      '你可以把收件箱、研究、写作、整理、跟进这些事情交给 Oliver，而不用先改造自己的工作方式。',
-    profilePoints: [
-      '只连接你想让 Oliver 使用的工具',
-      '敏感动作前可以先看草稿再确认',
-      '把你的语气、偏好和上下文放进同一份记忆里'
+      '你好 Oliver，\n\n这是我想先让你帮忙处理的第一个任务：\n\n- 背景：\n- 什么算完成：\n- 截止时间：\n\n谢谢！',
+    toolsEyebrow: '从一个真实入口开始',
+    toolsHintAnonymous: 'Email 可以直接发。其他工具会带你进入 setup。',
+    toolsHintAuthenticated: '如果你已经登录，这些按钮会直接启动真实连接流程。',
+    actionLabels: {
+      email: '立即发送',
+      connect: '连接',
+      setup: '打开 setup',
+      loading: '打开中...'
+    },
+    tools: [
+      {
+        key: 'email',
+        label: 'Email',
+        description: '现在就可以直接发请求。',
+        monogram: '@',
+        accent: '#ff8a3d'
+      },
+      {
+        key: 'slack',
+        label: 'Slack',
+        description: '从任务本来就在发生的聊天里开始。',
+        monogram: 'S',
+        accent: '#36c58b'
+      },
+      {
+        key: 'discord',
+        label: 'Discord',
+        description: '在高频来回沟通里接住任务。',
+        monogram: 'D',
+        accent: '#6c78ff'
+      },
+      {
+        key: 'github',
+        label: 'GitHub',
+        description: '连接 repo、issue 和后续动作。',
+        monogram: 'GH',
+        accent: '#2c2c2e'
+      },
+      {
+        key: 'notion',
+        label: 'Notion',
+        description: '连接文档、笔记和任务上下文。',
+        monogram: 'N',
+        accent: '#6f6b63'
+      },
+      {
+        key: 'lark',
+        label: 'Lark',
+        description: '连接协作和运营沟通。',
+        monogram: 'L',
+        accent: '#3f88ff'
+      }
     ],
-    exampleTitle: '适合先试的任务',
-    exampleTasks: [
-      '把这个主题做成一页研究简报，并写清利弊。',
-      '根据这封邮件起草回复，并把待办同步到 Notion。',
-      '帮我整理这些报税材料，并告诉我还缺什么。',
-      '起草下周的 LinkedIn 帖子，等我确认后再发。'
+    flowEyebrow: 'onboarding 怎么开始',
+    flowSteps: ['连接一个工具', '交给 Oliver 一个任务', '审阅结果', '把有效流程复用起来'],
+    previewEyebrow: '适合先试的任务',
+    previewRequest: '帮我起草这封邮件的回复，把 action items 拉进 Notion，敏感内容先保留给我确认。',
+    previewResultTitle: '回来的结果',
+    previewResults: ['回复草稿已准备', '待办已提取', '需要确认的部分已标出']
+  },
+  demo: {
+    eyebrow: '真实产品演示',
+    title: '先看 Oliver 怎么工作，而不是先看一大段解释。',
+    intro: '一个完整桌面演示，加上三个更短的移动端例子。',
+    desktopTitle: '桌面完整演示',
+    desktopDescription: '一条龙看完从请求到结果的过程。',
+    desktopVideoId: 'IsSOTSYIIIY',
+    desktopVideoHref: 'https://youtu.be/IsSOTSYIIIY',
+    desktopCta: '去 YouTube 看',
+    shortsTitle: '移动端快速演示',
+    shortsDescription: '更短、更适合快速浏览的几个例子。',
+    shorts: [
+      {
+        title: '移动端演示 01',
+        videoId: 'SI9mxW_Top0',
+        href: 'https://www.youtube.com/shorts/SI9mxW_Top0'
+      },
+      {
+        title: '移动端演示 02',
+        videoId: 'PSsJ7WBk71w',
+        href: 'https://www.youtube.com/shorts/PSsJ7WBk71w'
+      },
+      {
+        title: '移动端演示 03',
+        videoId: '5H9g3LOGkMc',
+        href: 'https://www.youtube.com/shorts/5H9g3LOGkMc'
+      }
     ]
   },
-  sections: {
-    gettingStartedTitle: '怎么开始',
-    gettingStartedIntro: '第一次成功应该是清楚、具体、能快速复核的。',
-    useCasesTitle: 'Oliver 可以接过哪些事情',
-    useCasesIntro: '从那些你反复在做、总被打断、或者一直拖着没完成的任务开始。',
-    surfacesTitle: 'Oliver 在哪里工作',
-    surfacesIntro: '请求本来就落在哪里，工作本来就发生在哪里，Oliver 就应该在那里出现。',
-    controlTitle: '审阅与控制',
-    controlIntro: '你来决定 Oliver 能访问什么、在哪些地方工作、哪些动作必须等你确认。',
-    faqTitle: '信任一个 AI operator 之前最常见的问题',
-    faqIntro: '重点不是神奇，而是控制感、清晰度和第一次使用是否靠谱。'
+  story: {
+    eyebrow: '怎么开始',
+    title: '第一次成功应该是小而清楚，而且真的有用。',
+    intro: '不是先搭一整套系统，而是先跑通一个真实闭环。',
+    steps: [
+      {
+        id: '01',
+        title: '先连接一个工具',
+        description: '从任务本来就会出现的地方开始。'
+      },
+      {
+        id: '02',
+        title: '交给 Oliver 一个真实任务',
+        description: '选一个具体、可复核、而且值得交出去的任务。'
+      },
+      {
+        id: '03',
+        title: '审阅后再复用',
+        description: '先看结果，再保存偏好，最后再决定是否扩展。'
+      }
+    ],
+    controlEyebrow: '审阅与控制',
+    controlTitle: 'Oliver 的执行建立在你的许可上，而不是背后偷偷做事。',
+    controlPoints: [
+      '只连接你想让 Oliver 用的工具',
+      '敏感动作前先看草稿再放行',
+      '把偏好和 memory 放在一个地方维护'
+    ]
   },
-  onboardingSteps: [
-    {
-      id: '01',
-      title: '先连接一个工具',
-      desc: '从任务本来就会出现的地方开始，比如邮件、Notion、Slack 或 GitHub。',
-      detail: '不用先把所有工具都接上，先让 Oliver 在一个真实场景里证明自己。'
-    },
-    {
-      id: '02',
-      title: '交给 Oliver 一个真实任务',
-      desc: '选一个你本来就要做、而且结果容易检查的任务。',
-      detail: '第一步最好足够具体，这样你能很快判断 Oliver 哪些事能接，哪些事还需要你亲自把关。'
-    },
-    {
-      id: '03',
-      title: '先看结果，再决定怎么继续',
-      desc: '先看草稿、总结、整理结果或跟进建议，再决定要不要继续放行。',
-      detail: '你会慢慢知道 Oliver 适合帮你做什么，也会知道哪些动作要保留审核。'
-    },
-    {
-      id: '04',
-      title: '把重复工作变成惯例',
-      desc: '当某件事跑通以后，再去保存偏好、复用流程、或者扩展到更多工具。',
-      detail: 'DoWhiz 先服务个人，再逐步扩展到共享的 SMB 工作流。'
-    }
-  ],
-  useCases: [
-    {
-      tag: 'Deep research',
-      title: '把模糊问题整理成可以决策的研究结果',
-      desc: '让 Oliver 去比较方案、收集信息、提炼重点，最后给你一份可以直接使用的简报。'
-    },
-    {
-      tag: 'Inbox',
-      title: '起草回复、分拣请求、推进跟进',
-      desc: 'Oliver 可以结合你给出的上下文写回复、整理下一步，让请求不再卡在收件箱里。'
-    },
-    {
-      tag: 'Writing support',
-      title: '支持研究、提纲、改写和结构化写作',
-      desc: '适合学习支持、知识型工作和文稿整理，不把体验做成单纯聊天。'
-    },
-    {
-      tag: 'Tax prep',
-      title: '做报税准备和材料整理',
-      desc: 'Oliver 可以帮你分类文件、指出缺失项、把提交前需要看的内容先整理清楚。'
-    },
-    {
-      tag: 'Content',
-      title: '起草并排期内容，发布前由你确认',
-      desc: '让 Oliver 准备 LinkedIn 文案、安排节奏、生成草稿，最后由你点头。'
-    },
-    {
-      tag: 'GitHub',
-      title: '跟进 issue、代码上下文和 repo 内事务',
-      desc: 'Oliver 可以帮你整理 issue、追踪上下文、推进和代码相关的协作任务。'
-    }
-  ],
-  surfaces: [
-    {
-      tag: 'Email',
-      title: '邮件和个人行政事务',
-      desc: '从收件箱里的请求、材料整理、回复草稿和后续跟进开始。',
-      icon: '/icons/The%20Digital%20Employee%20Stack/trigger.svg'
-    },
-    {
-      tag: 'Slack / Discord',
-      title: '在聊天里接任务、回结果',
-      desc: '工作本来就在这些对话里发生，Oliver 也应该直接在这里接住它。',
-      icon: '/icons/The%20Digital%20Employee%20Stack/execute.svg'
-    },
-    {
-      tag: 'GitHub',
-      title: '在代码库上下文里推进事情',
-      desc: 'issue、review、工程协作都尽量留在同一个地方，不要来回复制粘贴。',
-      icon: '/icons/The%20Digital%20Employee%20Stack/shared.svg'
-    },
-    {
-      tag: 'Notion',
-      title: '把笔记、计划和知识整理成能继续用的东西',
-      desc: '把零散信息变成页面、更新和共享参考，而不是散在聊天记录里。',
-      icon: '/icons/The%20Digital%20Employee%20Stack/agent.svg'
-    },
-    {
-      tag: 'Shared docs',
-      title: '文档起草与正式材料整理',
-      desc: '适合 Google Docs 一类的写作、修订和正式交付场景。',
-      icon: '/icons/The%20Digital%20Employee%20Stack/collaboration.svg'
-    },
-    {
-      tag: 'Lark',
-      title: '准备好以后再扩展到团队协作',
-      desc: '先把个人流程跑通，再把 Oliver 扩展到共享的 SMB 场景。',
-      icon: '/icons/The%20Digital%20Employee%20Stack/permission.svg'
-    }
-  ],
-  safetyItems: [
-    {
-      tag: '控制',
-      title: '你来决定 Oliver 能访问什么',
-      icon: '/icons/key.svg',
-      desc: '只连接你真的想让 Oliver 使用的工具，权限也能随时撤回。',
-      points: [
-        '权限明确、可撤销',
-        '可以先从一个工具开始',
-        '敏感动作前可以保留确认步骤'
-      ]
-    },
-    {
-      tag: '审阅',
-      title: '重要动作前先看结果',
-      icon: '/icons/shield_lock.svg',
-      desc: '先把 Oliver 用在草稿、总结、研究和准备工作上，再逐步扩大信任范围。',
-      points: [
-        '先看草稿再发送',
-        '复杂任务先返回结构化结果',
-        '你来决定哪些流程可以变成惯例'
-      ]
-    },
-    {
-      tag: '身份',
-      title: '默认不需要交出个人密码',
-      icon: '/icons/lock_person.svg',
-      desc: 'DoWhiz 更强调受控访问和可审阅执行，而不是让你把个人账户完全交出去。',
-      points: [
-        '适用场景下使用 agent-owned identity',
-        '减少凭证四处扩散',
-        '个人使用和共享使用的边界更清晰'
-      ]
-    }
-  ],
-  accessFlowSteps: [
-    {
-      title: '连接',
-      desc: '先选 Oliver 真正要工作的第一个入口。'
-    },
-    {
-      title: '收窄范围',
-      desc: '第一次任务尽量足够具体，方便快速审核。'
-    },
-    {
-      title: '审阅',
-      desc: '先看结果，调整偏好，再判断这件事是否适合重复。'
-    },
-    {
-      title: '扩展',
-      desc: '只有当第一件事跑通以后，再接更多工具或更自动化的流程。'
-    }
-  ],
+  examples: {
+    eyebrow: '从第一天就有用',
+    title: '早期最适合的任务，通常横跨工作和生活。',
+    cards: [
+      {
+        tag: 'Research',
+        title: 'Deep research 简报',
+        description: '比较方案，最后给你一份能直接判断的结果。'
+      },
+      {
+        tag: 'Inbox',
+        title: '邮件整理和回复起草',
+        description: '起草回复，同时把后续动作继续往前推。'
+      },
+      {
+        tag: 'Writing',
+        title: '学习支持和文稿起草',
+        description: '做提纲、改写、收紧结构。'
+      },
+      {
+        tag: 'Tax prep',
+        title: '材料整理',
+        description: '整理报税前的文件并指出还缺什么。'
+      },
+      {
+        tag: 'Content',
+        title: '发帖前的草稿与排期',
+        description: '先起草和排期，最终仍由你确认。'
+      },
+      {
+        tag: 'GitHub',
+        title: 'Repo 跟进',
+        description: '整理 issue 上下文，推进和代码相关的后续工作。'
+      }
+    ]
+  },
   faqItems: [
     {
-      question: '现在的 DoWhiz 到底是什么？',
+      question: '现在的 DoWhiz 是什么？',
       answer:
-        '现在 DoWhiz 先从 Oliver 开始：一个会在你的工具里工作、把结果带回来、并且可以逐步建立信任的 AI operator。'
+        'DoWhiz 现在先从 Oliver 开始。它是一个会在你的工具里工作、把结果带回来、并且可以逐步建立信任的 AI operator。'
     },
     {
-      question: '我应该怎么开始？',
+      question: '第一步应该做什么？',
       answer:
-        '先连一个工具，交给 Oliver 一个真实任务，复核结果，然后保存让它更好用的偏好。'
+        '先连接一个工具，交给 Oliver 一个真实任务，审阅结果，再把让它更好用的偏好或 memory 记下来。'
     },
     {
-      question: 'Oliver 会记住上下文吗？',
+      question: '什么样的任务最适合先用？',
       answer:
-        '会。Oliver 可以保存你的偏好、历史任务和后续跟进所需的共享记忆，这样下次不用从头再讲。'
+        '研究、起草、材料整理、收件箱跟进、repo 协调，以及需要你最后确认的内容发布，都是很好的开始。'
     },
     {
-      question: '我需要把个人账号密码交给 DoWhiz 吗？',
+      question: '我还掌控流程吗？',
       answer:
-        '不需要。DoWhiz 更强调受控访问和可审阅执行，而不是让你交出宽泛的个人凭证。'
+        '掌控权在你手里。你决定接哪些工具、哪些动作需要复核，以及 Oliver 什么时候才算真正值得复用。'
     },
     {
-      question: 'Oliver 能同时处理个人和工作任务吗？',
+      question: 'DoWhiz 现在只做个人场景吗？',
       answer:
-        '可以，只要任务本身清楚、可审阅、适合被辅助执行。研究、写作、材料整理、跟进和工具内执行都很适合。'
-    },
-    {
-      question: 'DoWhiz 只做个人场景吗？',
-      answer:
-        '产品先从个人可用性出发。当 Oliver 已经在一个人的工作流里被证明有用，再自然扩展到 SMB 的共享流程。'
-    }
-  ],
-  blogPosts: [
-    {
-      tag: 'Workflow guide',
-      title: 'AI 工作流检查清单',
-      date: '2026 年 3 月 27 日',
-      excerpt: '关于触发器、质量门槛和可靠交付的一份实操清单。',
-      link: '/blog/ai-workflow-automation-checklist/'
-    },
-    {
-      tag: 'Engineering',
-      title: 'GitHub issue 自动化最佳实践',
-      date: '2026 年 2 月 26 日',
-      excerpt: '让 issue 到 PR 的推进更稳、更容易交付的一套做法。',
-      link: '/blog/github-issue-automation-best-practices/'
-    },
-    {
-      tag: 'Email',
-      title: '邮件自动化操作手册',
-      date: '2026 年 2 月 26 日',
-      excerpt: '如何把收件箱里的请求转成结构化执行和明确交付。',
-      link: '/blog/email-task-automation-playbook/'
-    },
-    {
-      tag: 'Memory',
-      title: 'AI agent memory 最佳实践',
-      date: '2026 年 2 月 26 日',
-      excerpt: '哪些该记住，哪些该清掉，以及怎样让跨渠道跟进真的更好用。',
-      link: '/blog/ai-agent-memory-best-practices/'
+        '产品先从个人可用性出发。当 Oliver 已经在一个人的工作流里证明自己，再自然扩展到 SMB 的共享流程。'
     }
   ],
   labels: {
-    blogEyebrow: '博客',
-    blogTitle: '关于 operator-style automation 的一些记录',
-    blogIntro: '围绕记忆、收件箱、自动化质量和真实世界里 AI operator 的边界做的实践总结。',
-    blogHeaderButton: '查看全部',
-    blogLinkLabel: '阅读全文',
-    accessPlaybookTitle: 'Oliver 的扩展方式',
-    accessPlaybookDescription:
-      '不需要一口气做完所有设置。先把一个场景跑通，再增加下一个工具或下一段重复流程。',
-    accessPlaybookLink: '查看 Trust & Safety',
-    faqCta: '打开完整帮助中心',
-    footerTitle: '更多内容',
-    footerTagline: 'Oliver 把请求变成可审阅、可复用、能落地的结果。',
-    footerPill: '先服务个人，再扩展到共享流程。',
-    footerBottomSecondary: '为清楚的 onboarding、受控执行和真实工作而设计。'
+    faqEyebrow: '常见问题',
+    faqTitle: '开始之前最需要知道的几件事',
+    faqIntro: '只回答信任、适配度和 onboarding 相关的核心问题。',
+    faqLinkLabel: '打开帮助中心',
+    footerTitle: '资源',
+    footerTagline: 'Oliver 帮你把请求变成结果。',
+    footerPill: '先服务个人，再谨慎扩展。',
+    footerBottomSecondary: '一个工具，一个任务，一个可审阅的结果。'
   },
   footerLinks: [
     { href: '/privacy/', label: '隐私政策' },
     { href: '/terms/', label: '服务条款' },
     { href: '/trust-safety/', label: 'Trust & Safety' },
     { href: '/integrations/', label: '集成' },
-    { href: '/user-guide/', label: '使用指南' },
     { href: 'https://www.dowhiz.com/help-center/', label: '帮助中心' },
-    { href: '/solutions/ai-workflow-automation/', label: 'AI 工作流自动化' },
-    { href: '/solutions/github-issue-automation/', label: 'GitHub Issue 自动化' },
-    { href: '/solutions/slack-task-automation/', label: 'Slack 自动化' },
-    { href: '/solutions/email-task-automation/', label: '邮件自动化' },
-    { href: '/solutions/google-docs-automation/', label: 'Google Docs 自动化' }
+    { href: '/user-guide/', label: '使用指南' }
   ]
 };
 

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -2117,3 +2117,759 @@
   color: var(--text-secondary);
   font-size: 0.8rem;
 }
+
+/* Simplified Oliver-first landing */
+.landing-page .hero-section {
+  min-height: auto;
+  padding: 9.25rem 2rem 4.75rem;
+}
+
+.landing-page .halo-effect {
+  top: 18rem;
+  width: 760px;
+  height: 760px;
+  opacity: 0.95;
+}
+
+.hero-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 0.84fr) minmax(0, 1.16fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero-copy-compact {
+  justify-items: start;
+  text-align: left;
+  margin: 0;
+  max-width: 34rem;
+  gap: 1rem;
+  animation: landing-fade-up 0.7s ease both;
+}
+
+.hero-copy-compact .hero-eyebrow {
+  border-color: color-mix(in srgb, var(--glass-border) 82%, transparent);
+  background: color-mix(in srgb, var(--surface-primary) 84%, transparent);
+}
+
+.hero-copy-compact .hero-title {
+  max-width: 10ch;
+  font-size: clamp(3rem, 6vw, 4.75rem);
+  line-height: 0.98;
+}
+
+.hero-copy-compact .hero-subtitle {
+  max-width: 34ch;
+  font-size: 1.08rem;
+  line-height: 1.6;
+}
+
+.hero-primary-cta {
+  min-width: 13rem;
+  margin-top: 0.35rem;
+  box-shadow: 0 18px 45px -32px rgba(28, 28, 30, 0.32);
+}
+
+.hero-caption {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.94rem;
+  line-height: 1.55;
+}
+
+.hero-product-card {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  gap: 1rem;
+  padding: 1.35rem;
+  border-radius: 2rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 90%, transparent);
+  background:
+    radial-gradient(circle at top left, rgba(63, 136, 255, 0.12), transparent 34%),
+    radial-gradient(circle at bottom right, rgba(255, 138, 61, 0.1), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(247, 249, 255, 0.96) 100%);
+  box-shadow:
+    0 42px 90px -58px rgba(28, 28, 30, 0.28),
+    0 12px 24px -18px rgba(28, 28, 30, 0.14);
+  animation: landing-fade-up 0.7s ease 0.08s both;
+}
+
+.hero-product-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(120deg, rgba(255, 255, 255, 0.46), transparent 30%),
+    linear-gradient(0deg, rgba(255, 255, 255, 0.22), transparent 45%);
+  pointer-events: none;
+}
+
+.hero-product-head,
+.hero-tool-grid,
+.hero-dock-grid {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-product-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.hero-product-heading {
+  display: grid;
+  gap: 0.45rem;
+  max-width: 30rem;
+}
+
+.hero-product-heading p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.93rem;
+  line-height: 1.58;
+}
+
+.hero-operator-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.72rem;
+  padding: 0.55rem 0.7rem 0.55rem 0.55rem;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: 0 10px 30px -28px rgba(28, 28, 30, 0.28);
+}
+
+.hero-operator-portrait {
+  width: 48px;
+  height: 48px;
+  padding: 2px;
+  border-radius: 1rem;
+  background: linear-gradient(140deg, rgba(63, 136, 255, 0.6), rgba(255, 138, 61, 0.55));
+  flex: 0 0 auto;
+}
+
+.hero-operator-copy {
+  display: grid;
+  gap: 0.05rem;
+}
+
+.hero-operator-copy strong {
+  font-size: 0.96rem;
+  line-height: 1.1;
+}
+
+.hero-operator-copy span {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.3;
+}
+
+.hero-tool-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.hero-tool-card {
+  appearance: none;
+  display: grid;
+  gap: 0.85rem;
+  width: 100%;
+  padding: 0.92rem;
+  text-align: left;
+  border: 1px solid color-mix(in srgb, var(--tool-accent) 22%, var(--glass-border));
+  border-radius: 1.25rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-primary) 94%, #ffffff 6%) 0%,
+    color-mix(in srgb, var(--tool-accent) 6%, #ffffff 94%) 100%
+  );
+  box-shadow: 0 14px 28px -28px rgba(28, 28, 30, 0.28);
+  cursor: pointer;
+  transition: transform 0.24s ease, border-color 0.24s ease, box-shadow 0.24s ease;
+}
+
+.hero-tool-card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--tool-accent) 38%, var(--glass-border));
+  box-shadow: 0 18px 36px -28px rgba(28, 28, 30, 0.28);
+}
+
+.hero-tool-card:disabled {
+  cursor: default;
+  opacity: 0.74;
+  transform: none;
+  box-shadow: 0 14px 28px -28px rgba(28, 28, 30, 0.28);
+}
+
+.hero-tool-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hero-tool-badge {
+  width: 44px;
+  height: 44px;
+  border-radius: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--tool-accent) 28%, var(--glass-border));
+  background: color-mix(in srgb, var(--tool-accent) 12%, #ffffff);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.86);
+}
+
+.hero-tool-action {
+  color: color-mix(in srgb, var(--tool-accent) 54%, var(--text-secondary));
+  font-size: 0.73rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hero-tool-card-copy {
+  display: grid;
+  gap: 0.24rem;
+}
+
+.hero-tool-card-copy strong {
+  font-size: 0.98rem;
+  line-height: 1.2;
+}
+
+.hero-tool-card-copy span {
+  color: var(--text-secondary);
+  font-size: 0.87rem;
+  line-height: 1.48;
+}
+
+.hero-dock-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  gap: 0.8rem;
+}
+
+.hero-flow-card,
+.hero-preview-card,
+.demo-feature-card,
+.demo-short-rail,
+.story-step-card,
+.control-band,
+.example-card {
+  border: 1px solid color-mix(in srgb, var(--glass-border) 94%, transparent);
+  border-radius: 1.45rem;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 16px 32px -30px rgba(28, 28, 30, 0.22);
+}
+
+.hero-flow-card,
+.hero-preview-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+}
+
+.hero-flow-steps {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.55rem;
+}
+
+.hero-flow-step {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.72rem 0.78rem;
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: color-mix(in srgb, var(--surface-primary) 92%, #ffffff 8%);
+}
+
+.hero-flow-index {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  border-radius: var(--radius-full);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--brand-primary) 10%, var(--surface-primary));
+  border: 1px solid color-mix(in srgb, var(--brand-primary) 18%, var(--glass-border));
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.hero-flow-step p {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.hero-preview-request,
+.hero-preview-result {
+  padding: 0.92rem 0.95rem;
+  border-radius: 1.05rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: color-mix(in srgb, var(--surface-primary) 94%, #ffffff 6%);
+}
+
+.hero-preview-label {
+  display: inline-flex;
+  margin-bottom: 0.42rem;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hero-preview-request p {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.hero-preview-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding: 0;
+}
+
+.hero-preview-list li {
+  position: relative;
+  padding-left: 1rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.48;
+}
+
+.hero-preview-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.5rem;
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: var(--radius-full);
+  background: var(--brand-primary);
+}
+
+.section-heading-shell {
+  display: grid;
+  gap: 0.85rem;
+  max-width: 44rem;
+  margin-bottom: 2rem;
+}
+
+.section-kicker {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 0.36rem 0.72rem;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 88%, transparent);
+  background: color-mix(in srgb, var(--surface-primary) 88%, transparent);
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.section-title-left {
+  margin-bottom: 0;
+  max-width: 16ch;
+  text-align: left;
+}
+
+.section-intro-left {
+  margin: 0;
+  max-width: 40rem;
+  text-align: left;
+}
+
+.demo-showcase-section {
+  padding-top: 1.5rem;
+}
+
+.demo-showcase-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.06fr) minmax(320px, 0.94fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.demo-feature-card,
+.demo-short-rail {
+  padding: 1rem;
+}
+
+.demo-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 0.95rem;
+}
+
+.demo-inline-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.56rem 0.88rem;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-primary);
+  font-size: 0.84rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.demo-inline-link:hover {
+  border-color: var(--card-hover-border);
+  background: var(--surface-secondary);
+}
+
+.demo-card-head h3,
+.demo-short-head h3,
+.story-step-card h3,
+.example-card h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1.08rem;
+  line-height: 1.22;
+}
+
+.demo-card-head p,
+.demo-short-head p,
+.story-step-card p,
+.example-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.frame-shell {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1.2rem;
+  background: #121217;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.frame-shell iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.frame-landscape {
+  aspect-ratio: 16 / 9;
+}
+
+.frame-portrait {
+  aspect-ratio: 9 / 16;
+}
+
+.demo-short-rail {
+  display: grid;
+  gap: 1rem;
+}
+
+.demo-short-head {
+  display: grid;
+  gap: 0.28rem;
+}
+
+.demo-short-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.demo-short-card {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.demo-short-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.56rem 0.8rem;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.demo-short-link:hover {
+  border-color: var(--card-hover-border);
+  background: var(--surface-secondary);
+}
+
+.story-stack {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.story-step-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.story-step-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.1rem;
+}
+
+.story-step-index {
+  width: 42px;
+  height: 42px;
+  border-radius: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--brand-primary) 10%, var(--surface-primary));
+  border: 1px solid color-mix(in srgb, var(--brand-primary) 18%, var(--glass-border));
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.control-band {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: 1rem;
+  align-items: center;
+  padding: 1.15rem;
+}
+
+.control-band-copy h3 {
+  margin: 0.45rem 0 0;
+  font-size: clamp(1.34rem, 2.3vw, 1.86rem);
+  line-height: 1.12;
+  max-width: 16ch;
+}
+
+.control-band-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.control-band-list li {
+  position: relative;
+  padding: 0.84rem 0.92rem 0.84rem 1.95rem;
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.52;
+}
+
+.control-band-list li::before {
+  content: '';
+  position: absolute;
+  left: 0.92rem;
+  top: 1.12rem;
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: var(--radius-full);
+  background: var(--brand-primary);
+}
+
+.examples-heading {
+  margin-top: 0.5rem;
+}
+
+.example-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.example-card {
+  display: grid;
+  gap: 0.62rem;
+  padding: 1.05rem;
+}
+
+.example-card-tag {
+  display: inline-flex;
+  width: fit-content;
+  padding: 0.3rem 0.64rem;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--brand-primary) 8%, var(--surface-primary));
+  border: 1px solid color-mix(in srgb, var(--brand-primary) 14%, var(--glass-border));
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.faq-compact {
+  max-width: 54rem;
+}
+
+.faq-link-row {
+  margin-top: 1.05rem;
+}
+
+.faq-text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.faq-text-link:hover {
+  color: var(--brand-primary);
+}
+
+.landing-page-cn .hero-copy-compact .hero-title {
+  max-width: 11ch;
+  white-space: normal;
+}
+
+.landing-page-cn .hero-copy-compact .hero-subtitle {
+  max-width: 30ch;
+}
+
+.landing-page-cn .section-kicker,
+.landing-page-cn .hero-tool-action,
+.landing-page-cn .hero-preview-label,
+.landing-page-cn .example-card-tag {
+  text-transform: none;
+  letter-spacing: 0.05em;
+}
+
+@keyframes landing-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1180px) {
+  .hero-shell,
+  .demo-showcase-grid,
+  .control-band {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-copy-compact {
+    max-width: 42rem;
+  }
+
+  .hero-dock-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .hero-tool-grid,
+  .example-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .story-step-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .control-band-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .landing-page .hero-section {
+    padding: 8rem 1.25rem 3.6rem;
+  }
+
+  .hero-shell {
+    gap: 1.25rem;
+  }
+
+  .hero-copy-compact .hero-title {
+    max-width: 11ch;
+  }
+
+  .hero-product-card,
+  .demo-feature-card,
+  .demo-short-rail,
+  .story-step-card,
+  .control-band,
+  .example-card {
+    padding: 1rem;
+  }
+
+  .hero-product-head,
+  .demo-card-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-tool-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero-flow-steps,
+  .demo-short-grid,
+  .example-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-heading-shell {
+    margin-bottom: 1.5rem;
+  }
+
+  .section-title-left {
+    max-width: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .hero-tool-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-tool-card-copy strong,
+  .story-step-card h3,
+  .example-card h3 {
+    font-size: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-copy-compact,
+  .hero-product-card {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the landing page hero into a direct onboarding surface with one primary CTA
- add meaningful hero tool actions that either start a real connect flow or route honestly into setup
- restore the demo/examples section below the hero and compress the rest of the homepage into fewer sections
- simplify English and Chinese landing copy around Oliver-first onboarding

## What changed
- reduced the landing IA to hero, demos, onboarding/story, examples, FAQ, and footer
- replaced the old text-heavy hero with a product-style panel showing tool entry points, onboarding steps, and a first-task preview
- kept exactly one hero CTA: `Start with one app` / `Continue onboarding`
- wired hero tool actions as follows:
  - `Email`: direct mailto handoff to Oliver
  - `Slack`, `Discord`, `GitHub`, `Notion`, `Lark`: authenticated users start the existing OAuth flow; signed-out users go to setup at `#section-settings`
- restored the older demo intent with the existing desktop walkthrough and three mobile demo videos
- removed the extra landing sections that made the page feel bloated, including the blog-heavy lower funnel from the main flow

## Testing
- `cd website && npm run lint`
- `cd website && npm run build`
- manual checks via Playwright on `http://127.0.0.1:4173/`
  - `/` desktop hero renders with one primary CTA and six hero tool actions
  - `/` primary CTA routes to `/auth/index.html#section-workspace`
  - signed-out `Slack` hero action routes to `/auth/index.html#section-settings`
  - `/cn` renders localized hero copy
  - mobile viewport (`390x844`) keeps a single-column hero/tool layout without horizontal overflow
  - demo section is present with four embedded videos

## Notes
- I validated the email hero action in code as a real `mailto:` handoff; that specific OS-level email client transition is not practical to assert in headless Playwright.
