### PR TITLE
Refine landing hero into animated channel showcase

### DIFF
--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -23,7 +23,8 @@ const CN_PATH_PREFIX = '/cn';
 const LANDING_DASHBOARD_SUFFIX = '?loggedIn=true#section-overview';
 const LANDING_SETTINGS_SUFFIX = '#section-settings';
 const AUTHENTICATED_SETTINGS_SUFFIX = '?loggedIn=true#section-settings';
-const LANDING_PAGE_VARIANT = 'oliver_channel_first_v1';
+const LANDING_PAGE_VARIANT = 'oliver_channel_showcase_v2';
+const HERO_SHOWCASE_INTERVAL_MS = 4200;
 const PUBLIC_CHANNEL_URLS = {
   slack:
     'https://slack.com/oauth/v2/authorize?client_id=5584751405762.10556678065461&scope=app_mentions:read,channels:history,channels:read,chat:write,groups:history,groups:read,im:history,im:read,mpim:history,mpim:read,users:read&user_scope=',
@@ -70,10 +71,30 @@ function NotionIcon({ className }) {
   );
 }
 
-function HeroToolIcon({ toolKey, label }) {
+function EmailIcon({ className }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <rect x="3" y="5" width="18" height="14" rx="3" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M4.5 7l7.5 6 7.5-6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ToolFallbackIcon({ className }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <rect x="4.5" y="4.5" width="15" height="15" rx="4" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="12" cy="12" r="2.6" fill="currentColor" />
+    </svg>
+  );
+}
+
+function HeroToolIcon({ toolKey }) {
   const iconClassName = 'hero-tool-icon';
 
   switch (toolKey) {
+    case 'email':
+      return <EmailIcon className={iconClassName} />;
     case 'slack':
       return <SlackIcon className={iconClassName} />;
     case 'discord':
@@ -85,7 +106,7 @@ function HeroToolIcon({ toolKey, label }) {
     case 'lark':
       return <img src="/svgs/lark.svg" alt="" className={`${iconClassName} hero-tool-icon-image`} aria-hidden="true" />;
     default:
-      return <span className={`${iconClassName} hero-tool-fallback`}>{label.slice(0, 1)}</span>;
+      return <ToolFallbackIcon className={iconClassName} />;
   }
 }
 
@@ -132,13 +153,18 @@ function LandingPage({ locale }) {
   const [enableMouseField, setEnableMouseField] = useState(false);
   const [user, setUser] = useState(null);
   const [authStatus, setAuthStatus] = useState('checking');
-  const [activeToolKey, setActiveToolKey] = useState(null);
+  const [loadingToolKey, setLoadingToolKey] = useState(null);
+  const [activeShowcaseIndex, setActiveShowcaseIndex] = useState(0);
+  const [showcasePaused, setShowcasePaused] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [navHidden, setNavHidden] = useState(false);
   const userMenuRef = useRef(null);
   const lastScrollY = useRef(0);
   const localizedHomePath = content.nav.homePath;
   const isAuthenticated = authStatus === 'authenticated' && Boolean(user);
+  const heroTools = content.hero.tools;
+  const activeHeroTool = heroTools[activeShowcaseIndex] || heroTools[0];
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -358,6 +384,45 @@ function LandingPage({ locale }) {
     };
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const syncMotionPreference = (event) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', syncMotionPreference);
+      return () => mediaQuery.removeEventListener('change', syncMotionPreference);
+    }
+
+    mediaQuery.addListener(syncMotionPreference);
+    return () => mediaQuery.removeListener(syncMotionPreference);
+  }, []);
+
+  useEffect(() => {
+    setActiveShowcaseIndex(0);
+  }, [pageLocale]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || heroTools.length <= 1 || showcasePaused || prefersReducedMotion) {
+      return undefined;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setActiveShowcaseIndex((currentIndex) => (currentIndex + 1) % heroTools.length);
+    }, HERO_SHOWCASE_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [heroTools.length, prefersReducedMotion, showcasePaused]);
+
   const buildMailtoLink = (email, subject, body) => {
     const encodedSubject = encodeURIComponent(subject);
     const encodedBody = encodeURIComponent(body);
@@ -445,13 +510,15 @@ function LandingPage({ locale }) {
   };
 
   const oliverContactHref = buildMailtoLink('oliver@dowhiz.com', content.hero.contactSubject, content.hero.contactBody);
+  const heroPrimaryHref = isAuthenticated
+    ? getLocalizedDashboardPath(pathname)
+    : getLocalizedAuthPath('', pathname);
   const settingsHref = isAuthenticated
     ? getLocalizedAuthPath(AUTHENTICATED_SETTINGS_SUFFIX, pathname)
     : getLocalizedAuthPath(LANDING_SETTINGS_SUFFIX, pathname);
   const manageSetupLabel = isAuthenticated
     ? content.hero.manageAuthenticated
     : content.hero.manageAnonymous;
-  const toolHint = isAuthenticated ? content.hero.toolsHintAuthenticated : content.hero.toolsHintAnonymous;
 
   const trackCtaClick = (eventName, properties) => {
     trackAnalyticsEvent(eventName, properties);
@@ -486,36 +553,62 @@ function LandingPage({ locale }) {
       window.location.href = data.redirect_url;
     } catch (error) {
       console.error(`Landing: failed to start ${provider} connect flow`, error);
-      setActiveToolKey(null);
+      setLoadingToolKey(null);
       window.location.href = settingsHref;
     }
   };
 
   const getHeroToolActionLabel = (tool) => {
-    if (activeToolKey === tool.key) {
+    if (loadingToolKey === tool.key) {
       return content.hero.actionLabels.loading;
     }
 
-    return isAuthenticated ? content.hero.actionLabels.connect : tool.anonymousActionLabel;
+    if (tool.key === 'email') {
+      return tool.authenticatedActionLabel || tool.anonymousActionLabel;
+    }
+
+    if (isAuthenticated) {
+      return tool.authenticatedActionLabel || content.hero.actionLabels.connect;
+    }
+
+    return tool.anonymousActionLabel;
   };
 
   const getHeroToolStatus = (tool) => {
     return isAuthenticated ? tool.authenticatedStatus : tool.anonymousStatus;
   };
 
-  const handleHeroToolAction = async (tool) => {
-    if (activeToolKey) {
+  const getHeroToolAction = (tool) => {
+    if (tool.key === 'email') {
+      return {
+        href: oliverContactHref,
+        type: 'mailto',
+        openInNewTab: false
+      };
+    }
+
+    if (!isAuthenticated) {
+      return getAnonymousHeroToolAction(tool);
+    }
+
+    return {
+      type: 'oauth',
+      provider: tool.key
+    };
+  };
+
+  const handleHeroToolAction = async (tool, ctaLocation = 'hero_channel_widget') => {
+    if (loadingToolKey) {
       return;
     }
 
-    const anonymousAction = isAuthenticated ? null : getAnonymousHeroToolAction(tool);
-    const actionType = isAuthenticated ? 'oauth' : anonymousAction?.type || 'tool_trial_email';
+    const action = getHeroToolAction(tool);
 
     trackCtaClick('hero_tool_action_click', {
-      cta_location: 'hero_tool_grid',
+      cta_location: ctaLocation,
       cta_text: tool.label,
       tool: tool.key,
-      action_type: actionType,
+      action_type: action.type,
       landing_page_variant: LANDING_PAGE_VARIANT
     });
 
@@ -523,16 +616,16 @@ function LandingPage({ locale }) {
       return;
     }
 
-    if (!isAuthenticated) {
-      if (anonymousAction?.openInNewTab) {
-        openExternalHref(anonymousAction.href);
-      } else if (anonymousAction?.href) {
-        window.location.href = anonymousAction.href;
+    if (action.type !== 'oauth') {
+      if (action.openInNewTab) {
+        openExternalHref(action.href);
+      } else if (action.href) {
+        window.location.href = action.href;
       }
       return;
     }
 
-    setActiveToolKey(tool.key);
+    setLoadingToolKey(tool.key);
     await startProviderConnect(tool.key);
   };
 
@@ -678,18 +771,18 @@ function LandingPage({ locale }) {
         <section id="channels" className="hero-section">
           {enableMouseField ? <MouseField theme={theme} /> : null}
           <div className="halo-effect"></div>
-          <div className="container hero-content hero-shell">
-            <div className="hero-copy hero-copy-compact">
+          <div className="container hero-content hero-showcase-layout">
+            <div className="hero-copy hero-copy-showcase">
               <p className="hero-eyebrow">{content.hero.eyebrow}</p>
               <h1 className="hero-title">{content.hero.title}</h1>
               <p className="hero-subtitle">{content.hero.subtitle}</p>
               <div className="hero-cta-row">
                 <a
                   className="btn btn-primary hero-primary-cta"
-                  href={oliverContactHref}
+                  href={heroPrimaryHref}
                   onClick={() =>
                     trackCtaClick('primary_cta_click', {
-                      cta_location: 'hero_primary_email',
+                      cta_location: 'hero_primary_get_dowhiz_free',
                       cta_text: content.hero.primaryCta,
                       landing_page_variant: LANDING_PAGE_VARIANT
                     })
@@ -711,14 +804,27 @@ function LandingPage({ locale }) {
                   {content.hero.secondaryCta}
                 </a>
               </div>
-              <p className="hero-caption">{content.hero.caption}</p>
             </div>
 
-            <div className="hero-product-card">
-              <div className="hero-product-head">
-                <div className="hero-product-heading">
+            <div
+              className={`hero-channel-showcase${showcasePaused || prefersReducedMotion ? ' is-paused' : ''}`}
+              onMouseEnter={() => setShowcasePaused(true)}
+              onMouseLeave={() => setShowcasePaused(false)}
+              onFocusCapture={() => setShowcasePaused(true)}
+              onBlurCapture={(event) => {
+                if (!event.currentTarget.contains(event.relatedTarget)) {
+                  setShowcasePaused(false);
+                }
+              }}
+            >
+              <div className="hero-showcase-topbar">
+                <div className="hero-showcase-heading">
                   <span className="hero-panel-kicker">{content.hero.toolsEyebrow}</span>
-                  <p>{toolHint}</p>
+                  <span className="hero-showcase-mode">
+                    {showcasePaused || prefersReducedMotion
+                      ? content.hero.pausedLabel
+                      : content.hero.autoplayLabel}
+                  </span>
                 </div>
                 <div className="hero-operator-chip">
                   <div className="hero-operator-portrait">
@@ -731,55 +837,81 @@ function LandingPage({ locale }) {
                 </div>
               </div>
 
-              <article className="hero-direct-card">
-                <div className="hero-direct-copy">
-                  <span className="hero-panel-kicker">{content.hero.directEyebrow}</span>
-                  <h2>{content.hero.directTitle}</h2>
-                  <p>{content.hero.directDescription}</p>
-                  <div className="hero-direct-meta">
-                    <span className="hero-direct-badge">{content.hero.directBadge}</span>
-                    <span className="hero-direct-subnote">{content.hero.directSubnote}</span>
-                  </div>
-                </div>
-                <a
-                  className="btn btn-primary hero-direct-cta"
-                  href={oliverContactHref}
-                  onClick={() =>
-                    trackCtaClick('primary_cta_click', {
-                      cta_location: 'hero_direct_email',
-                      cta_text: content.hero.directActionLabel,
-                      landing_page_variant: LANDING_PAGE_VARIANT
-                    })
-                  }
-                >
-                  {content.hero.directActionLabel}
-                </a>
-              </article>
-
-              <div className="hero-tool-grid" role="group" aria-label={content.hero.toolsEyebrow}>
-                {content.hero.tools.map((tool) => (
+              <div className="hero-channel-dock" role="group" aria-label={content.hero.toolsEyebrow}>
+                {heroTools.map((tool, index) => (
                   <button
                     key={tool.key}
                     type="button"
-                    className="hero-tool-card"
+                    className={`hero-channel-pill${index === activeShowcaseIndex ? ' is-active' : ''}`}
                     style={{ '--tool-accent': tool.accent }}
-                    onClick={() => handleHeroToolAction(tool)}
-                    disabled={Boolean(activeToolKey)}
+                    onMouseEnter={() => setActiveShowcaseIndex(index)}
+                    onFocus={() => setActiveShowcaseIndex(index)}
+                    onClick={() => handleHeroToolAction(tool, 'hero_channel_pill')}
+                    disabled={Boolean(loadingToolKey)}
                   >
-                    <div className="hero-tool-card-top">
-                      <span className="hero-tool-badge" aria-hidden="true">
-                        <HeroToolIcon toolKey={tool.key} label={tool.label} />
+                    <span className="hero-channel-pill-main">
+                      <span className="hero-tool-badge hero-tool-badge-pill" aria-hidden="true">
+                        <HeroToolIcon toolKey={tool.key} />
                       </span>
-                      <span className="hero-tool-action">{getHeroToolActionLabel(tool)}</span>
-                    </div>
-                    <div className="hero-tool-card-copy">
-                      <strong>{tool.label}</strong>
-                      <span className="hero-tool-status">{getHeroToolStatus(tool)}</span>
-                      <span>{tool.description}</span>
-                    </div>
+                      <span className="hero-channel-pill-copy">
+                        <strong>{tool.label}</strong>
+                        <span>{tool.anonymousActionLabel}</span>
+                      </span>
+                    </span>
+                    <span className="hero-channel-pill-progress" aria-hidden="true">
+                      <span className="hero-channel-pill-progress-fill"></span>
+                    </span>
                   </button>
                 ))}
               </div>
+
+              {activeHeroTool ? (
+                <article
+                  key={activeHeroTool.key}
+                  className="hero-channel-stage"
+                  style={{ '--tool-accent': activeHeroTool.accent }}
+                >
+                  <div className="hero-channel-stage-head">
+                    <div className="hero-channel-stage-title">
+                      <span className="hero-tool-badge hero-tool-badge-stage" aria-hidden="true">
+                        <HeroToolIcon toolKey={activeHeroTool.key} />
+                      </span>
+                      <div className="hero-channel-stage-copy">
+                        <h2>{activeHeroTool.label}</h2>
+                        <p>{getHeroToolStatus(activeHeroTool)}</p>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      className="btn btn-primary hero-stage-action"
+                      onClick={() => handleHeroToolAction(activeHeroTool, 'hero_channel_stage')}
+                      disabled={Boolean(loadingToolKey)}
+                    >
+                      {getHeroToolActionLabel(activeHeroTool)}
+                    </button>
+                  </div>
+
+                  <div className="hero-channel-stage-grid">
+                    <div className="hero-stage-entry-card">
+                      <span className="hero-preview-label">{content.hero.entryEyebrow}</span>
+                      <strong>{getHeroToolActionLabel(activeHeroTool)}</strong>
+                      <p>{activeHeroTool.description}</p>
+                    </div>
+
+                    <div className="hero-stage-thread" aria-label={content.hero.previewEyebrow}>
+                      <span className="hero-preview-label">{content.hero.previewEyebrow}</span>
+                      <div className="hero-thread-bubble hero-thread-user">
+                        <span className="hero-thread-role">{content.hero.youLabel}</span>
+                        <p>{activeHeroTool.samplePrompt}</p>
+                      </div>
+                      <div className="hero-thread-bubble hero-thread-oliver">
+                        <span className="hero-thread-role">Oliver</span>
+                        <p>{activeHeroTool.sampleReply}</p>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              ) : null}
 
               <div className="hero-channel-footnote">
                 <p>{content.hero.toolsFootnote}</p>

--- a/website/src/pages/landingContent.js
+++ b/website/src/pages/landingContent.js
@@ -24,43 +24,54 @@ const EN_LANDING_CONTENT = {
   },
   hero: {
     eyebrow: 'Start with a real request',
-    title: 'Use Oliver in a channel you already have open.',
+    title: 'Use Oliver where you already work',
     subtitle:
-      'Start in email, Slack, or Discord right away. For GitHub, Notion, or Lark work, send the first request now and connect the app later only if it helps.',
-    caption:
-      'Get first value before setup. Oliver can guide linking, saved memory, and deeper app access inside the conversation when needed.',
-    primaryCta: 'Email Oliver now',
-    secondaryCta: 'See real examples',
-    manageAnonymous: 'Manage setup later',
+      'Start in email, Slack, or Discord right away. GitHub, Notion, and Lark can start with a real request and connect later if it helps',
+    primaryCta: 'Get DoWhiz free',
+    secondaryCta: 'See example',
+    manageAnonymous: 'Manage setup',
     manageAuthenticated: 'Open your setup',
     contactSubject: 'A first task for Oliver',
     contactBody:
       'Hi Oliver,\n\nHere is the first task I want help with:\n\n- Context:\n- What done looks like:\n- Any deadline:\n\nThanks!',
-    toolsEyebrow: 'Where Oliver works today',
+    toolsEyebrow: 'Choose a channel',
     toolsHintAnonymous:
-      'Slack and Discord open public add flows. GitHub, Notion, and Lark start with a real request first, then connect later if you want saved access.',
-    toolsHintAuthenticated: 'If you are signed in, these buttons start the real connect flow.',
+      'Hover to pause. Click a channel to start. GitHub, Notion, and Lark can begin from email first.',
+    toolsHintAuthenticated: 'Hover to pause. Signed-in channels can open direct connect flows when needed.',
     toolsFootnote:
-      'Sign in only when you want saved memory, linked identities, or deeper app access. It does not need to be your first step.',
-    directEyebrow: 'Fastest first move',
-    directTitle: 'Email is still the simplest first move.',
-    directDescription:
-      'If you want the lightest no-login start, send the first request by email and let Oliver guide any later setup in context.',
-    directBadge: 'Fastest no-login path',
-    directSubnote: 'Best for a brand-new request, a follow-up, or any drafting-heavy task.',
-    directActionLabel: 'Compose email',
+      'Start in a channel now. Use setup only when you want saved memory or deeper app access.',
+    autoplayLabel: 'Autoplay',
+    pausedLabel: 'Paused',
+    entryEyebrow: 'Fastest start',
+    previewEyebrow: 'What it looks like',
+    youLabel: 'You',
     actionLabels: {
       connect: 'Connect',
       loading: 'Opening...'
     },
     tools: [
       {
+        key: 'email',
+        label: 'Email',
+        anonymousStatus: 'Direct compose',
+        authenticatedStatus: 'Direct compose',
+        anonymousActionLabel: 'Send request',
+        authenticatedActionLabel: 'Send request',
+        description: 'Send the request you already have in mind',
+        samplePrompt: 'Turn these notes into a concise follow-up email',
+        sampleReply: 'I can draft the reply, tighten the tone, and point out what is still missing',
+        accent: '#ff8a3d'
+      },
+      {
         key: 'slack',
         label: 'Slack',
         anonymousStatus: 'Public install',
         authenticatedStatus: 'Connect workspace',
         anonymousActionLabel: 'Add bot',
-        description: 'Add Oliver to a workspace in one click, then ask the first thing you need handled in Slack.',
+        authenticatedActionLabel: 'Connect',
+        description: 'Install Oliver and ask in Slack',
+        samplePrompt: 'Summarize this channel and list the next three actions',
+        sampleReply: 'I can pull the thread context and return a clean action list',
         accent: '#36c58b'
       },
       {
@@ -69,7 +80,10 @@ const EN_LANDING_CONTENT = {
         anonymousStatus: 'Public invite',
         authenticatedStatus: 'Connect server',
         anonymousActionLabel: 'Add bot',
-        description: 'Invite Oliver into your server and start with a real request there.',
+        authenticatedActionLabel: 'Connect',
+        description: 'Invite Oliver and start in your server',
+        samplePrompt: 'Read this discussion and turn it into a plan for the week',
+        sampleReply: 'I can organize the thread into owners, deadlines, and a reply-ready summary',
         accent: '#6c78ff'
       },
       {
@@ -78,7 +92,10 @@ const EN_LANDING_CONTENT = {
         anonymousStatus: 'Start with email',
         authenticatedStatus: 'Connect repo access',
         anonymousActionLabel: 'Send request',
-        description: 'Send repo context right away, then connect GitHub later for saved repo-side follow-up.',
+        authenticatedActionLabel: 'Connect',
+        description: 'Start with repo context, connect later if needed',
+        samplePrompt: 'Review these issues and tell me what should be fixed first',
+        sampleReply: 'I can rank the work, flag blockers, and draft the next follow-up',
         accent: '#2c2c2e'
       },
       {
@@ -87,7 +104,10 @@ const EN_LANDING_CONTENT = {
         anonymousStatus: 'Start with email',
         authenticatedStatus: 'Connect docs access',
         anonymousActionLabel: 'Send request',
-        description: 'Start with a docs or notes request now, then connect Notion when you want workspace context.',
+        authenticatedActionLabel: 'Connect',
+        description: 'Start with docs or notes work, connect later if helpful',
+        samplePrompt: 'Turn these notes into a clean study outline',
+        sampleReply: 'I can organize the draft, tighten the structure, and flag what still needs research',
         accent: '#6f6b63'
       },
       {
@@ -96,7 +116,10 @@ const EN_LANDING_CONTENT = {
         anonymousStatus: 'Start with email',
         authenticatedStatus: 'Connect workspace',
         anonymousActionLabel: 'Send request',
-        description: 'Start ops and coordination work now, then connect Lark when you want persistent access.',
+        authenticatedActionLabel: 'Connect',
+        description: 'Start ops follow-up now, connect later if needed',
+        samplePrompt: 'Draft a follow-up plan from this meeting summary',
+        sampleReply: 'I can turn it into owners, deadlines, and an update you can send',
         accent: '#3f88ff'
       }
     ]
@@ -249,43 +272,54 @@ const ZH_LANDING_CONTENT = {
   },
   hero: {
     eyebrow: '先从一个真实请求开始',
-    title: '在你已经打开的渠道里直接开始用 Oliver。',
+    title: '在你常用的渠道里用 Oliver',
     subtitle:
-      '你现在就可以直接通过 Email、Slack 或 Discord 开始。对于 GitHub、Notion 或 Lark 相关任务，也可以先发出第一个请求，只有在真正有帮助时再连接 app。',
-    caption:
-      '先拿到第一轮价值，再决定要不要 setup。真正需要的时候，Oliver 可以在对话里继续引导账号绑定、memory 和更深的 app 接入。',
-    primaryCta: '现在给 Oliver 发邮件',
-    secondaryCta: '看真实例子',
-    manageAnonymous: '稍后再管理 setup',
+      '现在就可以从 Email、Slack 或 Discord 开始，GitHub、Notion 和 Lark 相关工作也可以先从一个真实请求开始，之后再按需连接',
+    primaryCta: '免费开始用 DoWhiz',
+    secondaryCta: '看示例',
+    manageAnonymous: '管理 setup',
     manageAuthenticated: '打开你的 setup',
     contactSubject: '给 Oliver 的第一个任务',
     contactBody:
       '你好 Oliver，\n\n这是我想先让你帮忙处理的第一个任务：\n\n- 背景：\n- 什么算完成：\n- 截止时间：\n\n谢谢！',
-    toolsEyebrow: 'Oliver 现在可工作的渠道',
+    toolsEyebrow: '选择一个渠道',
     toolsHintAnonymous:
-      'Slack 和 Discord 会直接打开公开安装入口。GitHub、Notion 和 Lark 则可以先发出真实请求，之后如果你希望保存访问权限，再去连接。',
-    toolsHintAuthenticated: '如果你已经登录，这些按钮会直接启动真实连接流程。',
+      '悬停会暂停轮播，点击就直接开始。GitHub、Notion 和 Lark 可以先从邮件请求开始。',
+    toolsHintAuthenticated: '悬停会暂停轮播。登录后，这些入口也可以在需要时直接启动连接流程。',
     toolsFootnote:
-      '只有当你希望 Oliver 记住更多上下文、绑定身份、或接入更深的 app 权限时，才需要登录进入 setup。',
-    directEyebrow: '最快的第一步',
-    directTitle: 'Email 仍然是最轻的第一步。',
-    directDescription:
-      '如果你想用最轻的无登录方式开始，先直接发邮件就可以。后续真的有帮助时，再让 Oliver 在对话里引导 setup。',
-    directBadge: '最快的无登录入口',
-    directSubnote: '尤其适合第一次尝试、后续追问，或任何需要起草的任务。',
-    directActionLabel: '写邮件给 Oliver',
+      '现在就先在一个渠道里开始。只有当你想保存 memory 或接入更深权限时，再进入 setup。',
+    autoplayLabel: '自动播放',
+    pausedLabel: '已暂停',
+    entryEyebrow: '最快开始方式',
+    previewEyebrow: '交互会是什么样',
+    youLabel: '你',
     actionLabels: {
       connect: '连接',
       loading: '打开中...'
     },
     tools: [
       {
+        key: 'email',
+        label: 'Email',
+        anonymousStatus: '直接写邮件',
+        authenticatedStatus: '直接写邮件',
+        anonymousActionLabel: '发送请求',
+        authenticatedActionLabel: '发送请求',
+        description: '把你已经想好的请求直接发出去',
+        samplePrompt: '把这些要点整理成一封简洁的跟进邮件',
+        sampleReply: '我可以先起草回复、收紧语气，并指出还缺什么信息',
+        accent: '#ff8a3d'
+      },
+      {
         key: 'slack',
         label: 'Slack',
         anonymousStatus: '公开安装',
         authenticatedStatus: '连接工作区',
         anonymousActionLabel: '添加机器人',
-        description: '一键把 Oliver 加进 Slack workspace，然后直接在里面发出第一个请求。',
+        authenticatedActionLabel: '连接',
+        description: '装好 Oliver 后直接在 Slack 里开始',
+        samplePrompt: '帮我总结这个频道，并列出接下来三件事',
+        sampleReply: '我可以把线程上下文整理成清晰的行动清单',
         accent: '#36c58b'
       },
       {
@@ -294,7 +328,10 @@ const ZH_LANDING_CONTENT = {
         anonymousStatus: '公开邀请',
         authenticatedStatus: '连接服务器',
         anonymousActionLabel: '添加机器人',
-        description: '把 Oliver 邀请进你的 server，然后直接在那里开始真实任务。',
+        authenticatedActionLabel: '连接',
+        description: '邀请 Oliver 后直接在 server 里开始',
+        samplePrompt: '读一下这段讨论，并把它整理成本周执行计划',
+        sampleReply: '我可以把讨论整理成负责人、截止时间和可直接发送的总结',
         accent: '#6c78ff'
       },
       {
@@ -303,7 +340,10 @@ const ZH_LANDING_CONTENT = {
         anonymousStatus: '先发邮件开始',
         authenticatedStatus: '连接仓库权限',
         anonymousActionLabel: '发送请求',
-        description: '先把 repo 上下文发给 Oliver，之后如果你希望它持续跟进，再连接 GitHub。',
+        authenticatedActionLabel: '连接',
+        description: '先带着 repo 上下文开始，需要时再连接',
+        samplePrompt: '看看这些 issues，告诉我应该先修哪几个',
+        sampleReply: '我可以帮你排优先级、指出 blocker，并起草下一步跟进',
         accent: '#2c2c2e'
       },
       {
@@ -312,7 +352,10 @@ const ZH_LANDING_CONTENT = {
         anonymousStatus: '先发邮件开始',
         authenticatedStatus: '连接文档权限',
         anonymousActionLabel: '发送请求',
-        description: '先从文档或笔记相关请求开始，等你希望 Oliver 进入 workspace 上下文时再连接 Notion。',
+        authenticatedActionLabel: '连接',
+        description: '先从文档或笔记任务开始，有需要再连接',
+        samplePrompt: '把这些笔记整理成一份清楚的学习提纲',
+        sampleReply: '我可以先整理结构、收紧逻辑，并指出还要补哪些研究',
         accent: '#6f6b63'
       },
       {
@@ -321,7 +364,10 @@ const ZH_LANDING_CONTENT = {
         anonymousStatus: '先发邮件开始',
         authenticatedStatus: '连接工作区',
         anonymousActionLabel: '发送请求',
-        description: '先从协作运营或跟进型任务开始，之后如果需要持续权限，再连接 Lark。',
+        authenticatedActionLabel: '连接',
+        description: '先从协作跟进任务开始，需要时再连接',
+        samplePrompt: '根据这次会议总结，起草一个后续推进计划',
+        sampleReply: '我可以把它整理成负责人、时间点和一段可直接发送的更新',
         accent: '#3f88ff'
       }
     ]

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -2121,115 +2121,118 @@
 /* Simplified Oliver-first landing */
 .landing-page .hero-section {
   min-height: auto;
-  padding: 9.25rem 2rem 4.75rem;
+  padding: 9.25rem 2rem 4.9rem;
 }
 
 .landing-page .halo-effect {
-  top: 18rem;
-  width: 760px;
-  height: 760px;
-  opacity: 0.95;
+  top: 17rem;
+  width: 820px;
+  height: 820px;
+  opacity: 0.92;
 }
 
-.hero-shell {
-  display: grid;
-  grid-template-columns: minmax(0, 0.84fr) minmax(0, 1.16fr);
-  gap: 2rem;
-  align-items: center;
+.hero-showcase-layout {
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: stretch;
+  gap: 2.1rem;
 }
 
-.hero-copy-compact {
-  justify-items: start;
-  text-align: left;
-  margin: 0;
-  max-width: 34rem;
-  gap: 1rem;
+.hero-copy-showcase {
+  margin: 0 auto;
+  max-width: min(100%, 60rem);
+  gap: 0.95rem;
   animation: landing-fade-up 0.7s ease both;
 }
 
-.hero-copy-compact .hero-eyebrow {
+.hero-copy-showcase .hero-eyebrow {
   border-color: color-mix(in srgb, var(--glass-border) 82%, transparent);
   background: color-mix(in srgb, var(--surface-primary) 84%, transparent);
 }
 
-.hero-copy-compact .hero-title {
-  max-width: 10ch;
-  font-size: clamp(3rem, 6vw, 4.75rem);
+.hero-copy-showcase .hero-title {
+  width: 100%;
+  max-width: none;
+  font-size: clamp(2.75rem, 4.85vw, 3.85rem);
   line-height: 0.98;
+  white-space: nowrap;
 }
 
-.hero-copy-compact .hero-subtitle {
-  max-width: 34ch;
+.hero-copy-showcase .hero-subtitle {
+  max-width: 42ch;
   font-size: 1.08rem;
   line-height: 1.6;
 }
 
 .hero-primary-cta {
-  min-width: 13rem;
-  margin-top: 0.35rem;
+  min-width: 13.75rem;
   box-shadow: 0 18px 45px -32px rgba(28, 28, 30, 0.32);
 }
 
-.hero-caption {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.94rem;
-  line-height: 1.55;
-}
-
-.hero-product-card {
+.hero-channel-showcase {
   position: relative;
   overflow: hidden;
   display: grid;
-  gap: 1rem;
+  gap: 1.15rem;
+  max-width: 1120px;
+  margin: 0 auto;
   padding: 1.35rem;
-  border-radius: 2rem;
+  border-radius: 2.1rem;
   border: 1px solid color-mix(in srgb, var(--glass-border) 90%, transparent);
   background:
-    radial-gradient(circle at top left, rgba(63, 136, 255, 0.12), transparent 34%),
-    radial-gradient(circle at bottom right, rgba(255, 138, 61, 0.1), transparent 30%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(247, 249, 255, 0.96) 100%);
+    radial-gradient(circle at top left, rgba(63, 136, 255, 0.14), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(255, 138, 61, 0.12), transparent 24%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.985) 0%, rgba(247, 249, 255, 0.97) 100%);
   box-shadow:
-    0 42px 90px -58px rgba(28, 28, 30, 0.28),
-    0 12px 24px -18px rgba(28, 28, 30, 0.14);
+    0 46px 96px -58px rgba(28, 28, 30, 0.3),
+    0 14px 28px -18px rgba(28, 28, 30, 0.14);
   animation: landing-fade-up 0.7s ease 0.08s both;
 }
 
-.hero-product-card::before {
+.hero-channel-showcase::before {
   content: '';
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(120deg, rgba(255, 255, 255, 0.46), transparent 30%),
+    linear-gradient(120deg, rgba(255, 255, 255, 0.5), transparent 30%),
     linear-gradient(0deg, rgba(255, 255, 255, 0.22), transparent 45%);
   pointer-events: none;
 }
 
-.hero-product-head,
-.hero-tool-grid,
-.hero-dock-grid {
+.hero-showcase-topbar,
+.hero-channel-dock,
+.hero-channel-stage {
   position: relative;
   z-index: 1;
 }
 
-.hero-product-head {
+.hero-showcase-topbar {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 1rem;
 }
 
-.hero-product-heading {
-  display: grid;
-  gap: 0.45rem;
-  max-width: 30rem;
+.hero-showcase-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
 }
 
-.hero-product-heading p {
-  margin: 0;
+.hero-showcase-mode {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.9rem;
+  padding: 0.32rem 0.68rem;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.82);
   color: var(--text-secondary);
-  font-size: 0.93rem;
-  line-height: 1.58;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
 .hero-operator-chip {
@@ -2268,114 +2271,50 @@
   line-height: 1.3;
 }
 
-.hero-direct-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.05rem;
-  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
-  border-radius: 1.35rem;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(247, 249, 255, 0.92) 100%),
-    radial-gradient(circle at top left, rgba(255, 138, 61, 0.08), transparent 36%);
-  box-shadow: 0 16px 32px -30px rgba(28, 28, 30, 0.2);
-}
-
-.hero-direct-copy {
+.hero-channel-dock {
   display: grid;
-  gap: 0.42rem;
-  max-width: 34rem;
-}
-
-.hero-direct-copy h2 {
-  margin: 0;
-  font-size: clamp(1.2rem, 2vw, 1.42rem);
-  line-height: 1.16;
-  letter-spacing: -0.03em;
-}
-
-.hero-direct-copy p {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.93rem;
-  line-height: 1.56;
-}
-
-.hero-direct-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem 0.8rem;
-  align-items: center;
-}
-
-.hero-direct-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.34rem 0.68rem;
-  border-radius: var(--radius-full);
-  border: 1px solid color-mix(in srgb, var(--brand-primary) 18%, var(--glass-border));
-  background: color-mix(in srgb, var(--brand-primary) 7%, #ffffff);
-  color: var(--text-primary);
-  font-size: 0.78rem;
-  font-weight: 700;
-}
-
-.hero-direct-subnote {
-  color: var(--text-secondary);
-  font-size: 0.82rem;
-  line-height: 1.4;
-}
-
-.hero-direct-cta {
-  min-width: 13rem;
-  justify-content: center;
-  flex: 0 0 auto;
-}
-
-.hero-tool-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 0.75rem;
 }
 
-.hero-tool-card {
+.hero-channel-pill {
   appearance: none;
   display: grid;
-  gap: 0.85rem;
+  gap: 0.55rem;
   width: 100%;
-  padding: 0.92rem;
+  padding: 0.85rem 0.88rem 0.8rem;
   text-align: left;
   border: 1px solid color-mix(in srgb, var(--tool-accent) 22%, var(--glass-border));
-  border-radius: 1.25rem;
+  border-radius: 1.2rem;
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--surface-primary) 94%, #ffffff 6%) 0%,
-    color-mix(in srgb, var(--tool-accent) 6%, #ffffff 94%) 100%
+    color-mix(in srgb, var(--surface-primary) 95%, #ffffff 5%) 0%,
+    color-mix(in srgb, var(--tool-accent) 7%, #ffffff 93%) 100%
   );
   box-shadow: 0 14px 28px -28px rgba(28, 28, 30, 0.28);
   cursor: pointer;
   transition: transform 0.24s ease, border-color 0.24s ease, box-shadow 0.24s ease;
 }
 
-.hero-tool-card:hover {
+.hero-channel-pill:hover,
+.hero-channel-pill.is-active {
   transform: translateY(-2px);
-  border-color: color-mix(in srgb, var(--tool-accent) 38%, var(--glass-border));
-  box-shadow: 0 18px 36px -28px rgba(28, 28, 30, 0.28);
+  border-color: color-mix(in srgb, var(--tool-accent) 42%, var(--glass-border));
+  box-shadow: 0 22px 38px -30px rgba(28, 28, 30, 0.32);
 }
 
-.hero-tool-card:disabled {
+.hero-channel-pill:disabled {
   cursor: default;
-  opacity: 0.74;
+  opacity: 0.8;
   transform: none;
   box-shadow: 0 14px 28px -28px rgba(28, 28, 30, 0.28);
 }
 
-.hero-tool-card-top {
-  display: flex;
-  justify-content: space-between;
+.hero-channel-pill-main {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.72rem;
 }
 
 .hero-tool-badge {
@@ -2393,6 +2332,17 @@
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.86);
 }
 
+.hero-tool-badge-pill {
+  width: 42px;
+  height: 42px;
+}
+
+.hero-tool-badge-stage {
+  width: 52px;
+  height: 52px;
+  border-radius: 1.15rem;
+}
+
 .hero-tool-icon {
   width: 22px;
   height: 22px;
@@ -2406,64 +2356,198 @@
   object-fit: contain;
 }
 
-.hero-tool-fallback {
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+.hero-channel-pill-copy {
+  display: grid;
+  gap: 0.16rem;
+  min-width: 0;
 }
 
-.hero-tool-action {
+.hero-channel-pill-copy strong {
+  font-size: 0.96rem;
+  line-height: 1.18;
+}
+
+.hero-channel-pill-copy span {
   color: color-mix(in srgb, var(--tool-accent) 54%, var(--text-secondary));
-  font-size: 0.73rem;
+  font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
-.hero-tool-card-copy {
+.hero-channel-pill-progress {
+  position: relative;
+  overflow: hidden;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--tool-accent) 10%, rgba(255, 255, 255, 0.95));
+}
+
+.hero-channel-pill-progress-fill {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--tool-accent) 78%, #ffffff 22%),
+    color-mix(in srgb, var(--tool-accent) 92%, #ffffff 8%)
+  );
+}
+
+.hero-channel-pill.is-active .hero-channel-pill-progress-fill {
+  animation: hero-pill-progress 4.2s linear both;
+}
+
+.hero-channel-showcase.is-paused .hero-channel-pill.is-active .hero-channel-pill-progress-fill {
+  animation-play-state: paused;
+}
+
+.hero-channel-stage {
   display: grid;
-  gap: 0.24rem;
+  gap: 1.15rem;
+  padding: 1.2rem;
+  border-radius: 1.75rem;
+  border: 1px solid color-mix(in srgb, var(--tool-accent) 18%, var(--glass-border));
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(246, 249, 255, 0.94) 100%),
+    radial-gradient(circle at top left, color-mix(in srgb, var(--tool-accent) 10%, transparent), transparent 34%);
+  box-shadow: 0 22px 42px -34px rgba(28, 28, 30, 0.24);
+  animation: hero-stage-in 0.42s ease both;
 }
 
-.hero-tool-card-copy strong {
-  font-size: 0.98rem;
-  line-height: 1.2;
+.hero-channel-stage-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
 }
 
-.hero-tool-card-copy span {
-  color: var(--text-secondary);
-  font-size: 0.87rem;
-  line-height: 1.48;
+.hero-channel-stage-title {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
 }
 
-.hero-tool-card-copy .hero-tool-status {
+.hero-channel-stage-copy {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.hero-channel-stage-copy h2 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2vw, 1.52rem);
+  line-height: 1.12;
+  letter-spacing: -0.03em;
+}
+
+.hero-channel-stage-copy p {
   display: inline-flex;
   width: fit-content;
-  padding: 0.2rem 0.52rem;
+  margin: 0;
+  padding: 0.2rem 0.56rem;
   border-radius: var(--radius-full);
   border: 1px solid color-mix(in srgb, var(--tool-accent) 18%, var(--glass-border));
   background: color-mix(in srgb, var(--tool-accent) 8%, #ffffff);
   color: color-mix(in srgb, var(--tool-accent) 62%, var(--text-secondary));
-  font-size: 0.74rem;
+  font-size: 0.76rem;
   font-weight: 700;
   line-height: 1.2;
 }
 
+.hero-stage-action {
+  min-width: 11.5rem;
+  justify-content: center;
+  box-shadow: 0 18px 42px -32px rgba(28, 28, 30, 0.26);
+}
+
+.hero-channel-stage-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.72fr) minmax(0, 1.28fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.hero-stage-entry-card,
+.hero-stage-thread {
+  display: grid;
+  gap: 0.72rem;
+  padding: 1rem;
+  border-radius: 1.35rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.86);
+}
+
+.hero-stage-entry-card strong {
+  font-size: 1.35rem;
+  line-height: 1.06;
+  letter-spacing: -0.04em;
+}
+
+.hero-stage-entry-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.94rem;
+  line-height: 1.58;
+}
+
+.hero-stage-thread {
+  align-content: start;
+}
+
+.hero-thread-bubble {
+  display: grid;
+  gap: 0.32rem;
+  padding: 0.88rem 0.95rem;
+  border-radius: 1.05rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: color-mix(in srgb, var(--surface-primary) 94%, #ffffff 6%);
+}
+
+.hero-thread-user {
+  margin-left: auto;
+  width: min(100%, 31rem);
+  background: color-mix(in srgb, var(--tool-accent) 8%, #ffffff);
+}
+
+.hero-thread-oliver {
+  width: min(100%, 34rem);
+  border-color: color-mix(in srgb, var(--tool-accent) 18%, var(--glass-border));
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(248, 250, 255, 0.92) 100%),
+    radial-gradient(circle at top left, color-mix(in srgb, var(--tool-accent) 8%, transparent), transparent 36%);
+}
+
+.hero-thread-role {
+  color: color-mix(in srgb, var(--tool-accent) 54%, var(--text-secondary));
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.hero-thread-bubble p {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 0.93rem;
+  line-height: 1.58;
+}
+
 .hero-channel-footnote {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding-top: 0.15rem;
+  padding-top: 0.1rem;
   border-top: 1px solid color-mix(in srgb, var(--glass-border) 78%, transparent);
 }
 
 .hero-channel-footnote p {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   line-height: 1.55;
-  max-width: 38rem;
+  max-width: 42rem;
 }
 
 .hero-channel-footnote a {
@@ -2475,6 +2559,44 @@
 
 .hero-channel-footnote a:hover {
   color: var(--brand-primary);
+}
+
+.landing-page-cn .hero-copy-showcase .hero-title {
+  max-width: none;
+  white-space: nowrap;
+}
+
+.landing-page-cn .hero-copy-showcase .hero-subtitle {
+  max-width: 34ch;
+}
+
+.landing-page-cn .hero-showcase-mode,
+.landing-page-cn .hero-channel-pill-copy span,
+.landing-page-cn .hero-thread-role {
+  text-transform: none;
+  letter-spacing: 0.05em;
+}
+
+@keyframes hero-stage-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes hero-pill-progress {
+  from {
+    width: 0;
+  }
+
+  to {
+    width: 100%;
+  }
 }
 
 .hero-flow-card,
@@ -2870,17 +2992,7 @@
   color: var(--brand-primary);
 }
 
-.landing-page-cn .hero-copy-compact .hero-title {
-  max-width: 11ch;
-  white-space: normal;
-}
-
-.landing-page-cn .hero-copy-compact .hero-subtitle {
-  max-width: 30ch;
-}
-
 .landing-page-cn .section-kicker,
-.landing-page-cn .hero-tool-action,
 .landing-page-cn .hero-preview-label,
 .landing-page-cn .example-card-tag {
   text-transform: none;
@@ -2900,23 +3012,21 @@
 }
 
 @media (max-width: 1180px) {
-  .hero-shell,
   .demo-showcase-grid,
   .control-band {
     grid-template-columns: 1fr;
   }
 
-  .hero-copy-compact {
-    max-width: 42rem;
+  .hero-channel-dock {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .hero-direct-card {
-    align-items: flex-start;
+  .hero-channel-stage-grid {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 900px) {
-  .hero-tool-grid,
   .example-card-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -2935,15 +3045,16 @@
     padding: 8rem 1.25rem 3.6rem;
   }
 
-  .hero-shell {
+  .hero-showcase-layout {
     gap: 1.25rem;
   }
 
-  .hero-copy-compact .hero-title {
+  .hero-copy-showcase .hero-title {
     max-width: 11ch;
+    white-space: normal;
   }
 
-  .hero-product-card,
+  .hero-channel-showcase,
   .demo-feature-card,
   .demo-short-rail,
   .story-step-card,
@@ -2952,18 +3063,18 @@
     padding: 1rem;
   }
 
-  .hero-product-head,
-  .hero-direct-card,
+  .hero-showcase-topbar,
+  .hero-channel-stage-head,
   .demo-card-head {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .hero-direct-cta {
+  .hero-stage-action {
     width: 100%;
   }
 
-  .hero-tool-grid {
+  .hero-channel-dock {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -2975,6 +3086,7 @@
 
   .hero-channel-footnote {
     flex-direction: column;
+    align-items: flex-start;
   }
 
   .section-heading-shell {
@@ -2987,11 +3099,11 @@
 }
 
 @media (max-width: 560px) {
-  .hero-tool-grid {
+  .hero-channel-dock {
     grid-template-columns: 1fr;
   }
 
-  .hero-tool-card-copy strong,
+  .hero-stage-entry-card strong,
   .story-step-card h3,
   .example-card h3 {
     font-size: 1rem;
@@ -2999,8 +3111,14 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hero-copy-compact,
-  .hero-product-card {
+  .hero-copy-showcase,
+  .hero-channel-showcase,
+  .hero-channel-stage,
+  .hero-channel-pill.is-active .hero-channel-pill-progress-fill {
     animation: none;
+  }
+
+  .hero-channel-pill.is-active .hero-channel-pill-progress-fill {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- refactor the landing hero into a vertical Oliver-first layout with a central animated 6-channel showcase
- add Email as a first-class hero channel, keep truthful no-login entry paths, and switch the hero to tool icons instead of letter fallbacks
- tighten EN/ZH hero copy, simplify the title, and fix hero alignment so the copy and showcase stay centered on desktop and mobile

## Testing
- npm run lint
- npm run build

## Notes
- fetched the latest `origin/dev` before opening this PR
- `origin/dev` was already an ancestor of this branch, so there were no merge conflicts to resolve
