### PR TITLE
Restore signed-in landing redirect behavior

### DIFF
--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1502,7 +1502,7 @@
 
     <div class="page">
       <header class="page-header">
-        <a class="brand" href="../">Do<span class="accent">Whiz</span></a>
+        <a class="brand" href="../?view=landing">Do<span class="accent">Whiz</span></a>
         <nav class="header-links">
           <a href="../user-guide/">User Guide</a>
           <a href="mailto:admin@dowhiz.com">Contact</a>
@@ -1513,7 +1513,7 @@
         <section class="legal-hero">
           <div class="eyebrow">Account</div>
           <div class="dashboard-title-wrap">
-            <a class="dashboard-home-link" href="../" aria-label="Back to the DoWhiz landing page">
+            <a class="dashboard-home-link" href="../?view=landing" aria-label="Back to the DoWhiz landing page">
               <span class="dashboard-home-link-icon" aria-hidden="true">
                 <svg viewBox="0 0 20 20" width="12" height="12" fill="none">
                   <path
@@ -1893,7 +1893,7 @@
       </main>
 
       <footer class="page-footer">
-        <a class="back-link" href="../">Back to DoWhiz</a>
+        <a class="back-link" href="../?view=landing">Back to DoWhiz</a>
         <span>Need help? Contact admin@dowhiz.com.</span>
       </footer>
     </div>

--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -20,6 +20,8 @@ const LOGO_URL = `${SITE_URL}/assets/DoWhiz.svg`;
 const SUPPORT_EMAIL = 'admin@dowhiz.com';
 const ORG_NAME = 'DoWhiz';
 const CN_PATH_PREFIX = '/cn';
+const LANDING_PAGE_OVERRIDE_PARAM = 'view';
+const LANDING_PAGE_OVERRIDE_VALUE = 'landing';
 const LANDING_DASHBOARD_SUFFIX = '?loggedIn=true#section-overview';
 const LANDING_SETTINGS_SUFFIX = '#section-settings';
 const AUTHENTICATED_SETTINGS_SUFFIX = '?loggedIn=true#section-settings';
@@ -122,6 +124,44 @@ const getLocalizedDashboardPath = (
   pathname = typeof window !== 'undefined' ? window.location.pathname : '/'
 ) => getLocalizedAuthPath(LANDING_DASHBOARD_SUFFIX, pathname);
 
+const getLocalizedLandingPagePath = (
+  pathname = typeof window !== 'undefined' ? window.location.pathname : '/'
+) => {
+  const basePath = isCnPath(pathname) ? CN_PATH_PREFIX : '/';
+  return `${basePath}?${LANDING_PAGE_OVERRIDE_PARAM}=${LANDING_PAGE_OVERRIDE_VALUE}`;
+};
+
+const hasSameOriginReferrer = () => {
+  if (typeof window === 'undefined' || typeof document === 'undefined' || !document.referrer) {
+    return false;
+  }
+
+  try {
+    return new URL(document.referrer, window.location.origin).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+};
+
+const shouldStayOnLandingPage = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const { hash, search } = window.location;
+  const searchParams = new URLSearchParams(search);
+
+  if (searchParams.get(LANDING_PAGE_OVERRIDE_PARAM) === LANDING_PAGE_OVERRIDE_VALUE) {
+    return true;
+  }
+
+  if (hash) {
+    return true;
+  }
+
+  return hasSameOriginReferrer();
+};
+
 const updateMetaContent = (selector, content) => {
   if (typeof document === 'undefined' || !content) {
     return;
@@ -161,8 +201,9 @@ function LandingPage({ locale }) {
   const [navHidden, setNavHidden] = useState(false);
   const userMenuRef = useRef(null);
   const lastScrollY = useRef(0);
-  const localizedHomePath = content.nav.homePath;
+  const authRedirectStartedRef = useRef(false);
   const isAuthenticated = authStatus === 'authenticated' && Boolean(user);
+  const localizedHomePath = isAuthenticated ? getLocalizedLandingPagePath(pathname) : content.nav.homePath;
   const heroTools = content.hero.tools;
   const activeHeroTool = heroTools[activeShowcaseIndex] || heroTools[0];
 
@@ -275,6 +316,14 @@ function LandingPage({ locale }) {
 
       if (currentUser) {
         setAuthStatus('authenticated');
+        if (
+          !authRedirectStartedRef.current &&
+          typeof window !== 'undefined' &&
+          !shouldStayOnLandingPage()
+        ) {
+          authRedirectStartedRef.current = true;
+          window.location.replace(getLocalizedDashboardPath(window.location.pathname));
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- restore the signed-in homepage redirect so plain visits to `dowhiz.com` go to the personal dashboard overview
- preserve explicit landing-page visits when users click Back to DoWhiz or other landing links
- reapply the auth-page home/back links needed to keep intentional landing visits on the landing page

## Testing
- npm run lint
- npm run build

## Notes
- this fixes the regression in the current landing-page implementation rather than reverting the newer design changes