### PR TITLE
Consolidate dashboard app connections

### DIFF
--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -865,48 +865,6 @@
         margin-bottom: 1rem;
       }
 
-      .overview-callout {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-        margin: 0 0 1rem;
-        padding: 1rem;
-        border-radius: 0.95rem;
-        border: 1px solid color-mix(in srgb, var(--accent, #38bdf8) 30%, var(--border, #333));
-        background:
-          linear-gradient(
-            135deg,
-            color-mix(in srgb, var(--surface, #1a1a1a) 88%, rgba(56, 189, 248, 0.16)),
-            color-mix(in srgb, var(--surface, #1a1a1a) 96%, rgba(15, 23, 42, 0.42))
-          );
-      }
-
-      .overview-callout-copy {
-        display: grid;
-        gap: 0.35rem;
-      }
-
-      .overview-kicker {
-        font-size: 0.72rem;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-        color: var(--text-muted, #888);
-        font-weight: 700;
-      }
-
-      .overview-callout-copy h3 {
-        margin: 0;
-        font-size: 1.12rem;
-        line-height: 1.3;
-      }
-
-      .overview-callout-copy p {
-        margin: 0;
-        color: var(--text-muted, #888);
-        line-height: 1.5;
-      }
-
       .workspace-recommendation-card {
         display: grid;
         gap: 0.9rem;
@@ -1375,7 +1333,6 @@
       }
 
       @media (max-width: 780px) {
-        .overview-callout,
         .workspace-recommendation-actions,
         .next-step-item {
           flex-direction: column;
@@ -1654,15 +1611,7 @@
                       Account and billing
                     </button>
                   </div>
-                  <div class="overview-callout">
-                    <div class="overview-callout-copy">
-                      <span class="overview-kicker">First run</span>
-                      <h3>Keep the first setup light and useful</h3>
-                      <p>Connect one app, try one real request, save one preference, and review the result before you add more.</p>
-                    </div>
-                    <a class="auth-btn auth-btn-primary" href="#section-workspace">Open getting started</a>
-                  </div>
-                  <p class="dashboard-overview-copy">Account basics and the current state of your Oliver setup.</p>
+                  <p class="dashboard-overview-copy">Your account and current Oliver setup.</p>
                   <div class="account-grid">
                     <div class="account-meta-item">
                       <p class="account-meta-label">Account</p>
@@ -1678,7 +1627,7 @@
                 <section id="section-workspace" class="legal-card dashboard-section">
                   <div class="dashboard-header">
                     <h2>Getting Started</h2>
-                    <a id="update-team-brief-btn" class="auth-btn auth-btn-oauth" href="#section-settings">Open Settings</a>
+                    <a id="update-team-brief-btn" class="auth-btn auth-btn-oauth" href="#section-channels">Open Connected Apps</a>
                   </div>
                   <p class="dashboard-overview-copy">
                     Start with one connected app, one real task, and one saved preference. Expand only after the first useful result.
@@ -1706,7 +1655,48 @@
 
                 <section id="section-channels" class="legal-card dashboard-section">
                   <h2>Connected Apps</h2>
-                  <p>These are the apps and entry points Oliver can currently work in for you.</p>
+                  <p>Connect and manage the apps Oliver can use for your account.</p>
+                  <div class="settings-panel">
+                    <h3>Add a connection</h3>
+                    <p>Connect the apps Oliver can already work in.</p>
+                    <div class="channel-connect-actions">
+                      <button id="discord-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+                        </svg>
+                        Connect Discord
+                      </button>
+                      <button id="slack-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
+                        </svg>
+                        Connect Slack
+                      </button>
+                      <button id="github-connect-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M12 0C5.37 0 0 5.37 0 12a12 12 0 0 0 8.2 11.4c.6.1.8-.2.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.6-1.4-1.3-1.8-1.3-1.8-1.1-.8.1-.8.1-.8 1.2.1 1.9 1.3 1.9 1.3 1.1 1.9 2.9 1.3 3.6 1 .1-.8.4-1.3.8-1.7-2.7-.3-5.5-1.3-5.5-6a4.7 4.7 0 0 1 1.3-3.3c-.1-.3-.6-1.5.1-3.2 0 0 1-.3 3.4 1.3a11.7 11.7 0 0 1 6.2 0c2.4-1.6 3.4-1.3 3.4-1.3.7 1.7.2 2.9.1 3.2a4.7 4.7 0 0 1 1.3 3.3c0 4.7-2.8 5.7-5.5 6 .4.4.8 1 .8 2.1v3.1c0 .4.2.7.8.6A12 12 0 0 0 24 12C24 5.37 18.63 0 12 0z"/>
+                        </svg>
+                        Connect GitHub
+                      </button>
+                      <button id="notion-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L18.4 2.297c-.466-.373-.98-.56-2.055-.466L3.525 3.033c-.466.047-.56.28-.373.466l1.307.709zM5.252 7.27v14.083c0 .793.466 1.073 1.446.933l14.008-.793c.98-.14 1.073-.606 1.073-1.306V6.29c0-.7-.28-1.026-.933-.933l-14.615.84c-.653.094-.98.467-.98 1.073zm13.868.84c.14.653 0 1.306-.653 1.353l-.7.14v10.41c-.606.327-1.166.514-1.632.514-.746 0-.933-.234-1.493-.933l-4.666-7.334v7.1l1.446.327s0 1.306-1.819 1.306l-5.006.28c-.14-.28 0-.98.466-1.12l1.213-.327V9.476L4.679 9.29c-.14-.653.234-1.586 1.306-1.68l5.359-.327 4.852 7.428V8.083l-1.213-.14c-.14-.793.42-1.353 1.12-1.4l5.016-.326z"/>
+                        </svg>
+                        Connect Notion
+                      </button>
+                      <button id="lark-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
+                        <img src="../svgs/lark.svg" width="20" height="20" alt="Lark">
+                        Connect Lark
+                      </button>
+                    </div>
+                    <div class="settings-status-stack">
+                      <span id="discord-oauth-status"></span>
+                      <span id="slack-oauth-status"></span>
+                      <span id="github-connect-status"></span>
+                      <span id="notion-oauth-status"></span>
+                      <span id="lark-oauth-status"></span>
+                    </div>
+                  </div>
                   <ul id="identifier-list" class="identifier-list">
                     <li class="identifier-item">Loading...</li>
                   </ul>
@@ -1763,50 +1753,8 @@
 
                 <section id="section-settings" class="legal-card dashboard-section">
                   <h2>Settings</h2>
-                  <p>Connect apps, manage entry points, and choose how proactive Oliver should be.</p>
+                  <p>Manage entry points and choose how proactive Oliver should be.</p>
                   <div class="settings-grid">
-                    <div class="settings-panel">
-                      <h3>Connect apps</h3>
-                      <p>Use one-click OAuth for the apps Oliver can already work in.</p>
-                      <div class="channel-connect-actions">
-                        <button id="discord-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
-                          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
-                          </svg>
-                          Connect Discord
-                        </button>
-                        <button id="slack-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
-                          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
-                          </svg>
-                          Connect Slack
-                        </button>
-                        <button id="github-connect-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
-                          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M12 0C5.37 0 0 5.37 0 12a12 12 0 0 0 8.2 11.4c.6.1.8-.2.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.6-1.4-1.3-1.8-1.3-1.8-1.1-.8.1-.8.1-.8 1.2.1 1.9 1.3 1.9 1.3 1.1 1.9 2.9 1.3 3.6 1 .1-.8.4-1.3.8-1.7-2.7-.3-5.5-1.3-5.5-6a4.7 4.7 0 0 1 1.3-3.3c-.1-.3-.6-1.5.1-3.2 0 0 1-.3 3.4 1.3a11.7 11.7 0 0 1 6.2 0c2.4-1.6 3.4-1.3 3.4-1.3.7 1.7.2 2.9.1 3.2a4.7 4.7 0 0 1 1.3 3.3c0 4.7-2.8 5.7-5.5 6 .4.4.8 1 .8 2.1v3.1c0 .4.2.7.8.6A12 12 0 0 0 24 12C24 5.37 18.63 0 12 0z"/>
-                          </svg>
-                          Connect GitHub
-                        </button>
-                        <button id="notion-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
-                          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L18.4 2.297c-.466-.373-.98-.56-2.055-.466L3.525 3.033c-.466.047-.56.28-.373.466l1.307.709zM5.252 7.27v14.083c0 .793.466 1.073 1.446.933l14.008-.793c.98-.14 1.073-.606 1.073-1.306V6.29c0-.7-.28-1.026-.933-.933l-14.615.84c-.653.094-.98.467-.98 1.073zm13.868.84c.14.653 0 1.306-.653 1.353l-.7.14v10.41c-.606.327-1.166.514-1.632.514-.746 0-.933-.234-1.493-.933l-4.666-7.334v7.1l1.446.327s0 1.306-1.819 1.306l-5.006.28c-.14-.28 0-.98.466-1.12l1.213-.327V9.476L4.679 9.29c-.14-.653.234-1.586 1.306-1.68l5.359-.327 4.852 7.428V8.083l-1.213-.14c-.14-.793.42-1.353 1.12-1.4l5.016-.326z"/>
-                          </svg>
-                          Connect Notion
-                        </button>
-                        <button id="lark-oauth-btn" class="auth-btn auth-btn-oauth" style="display: flex; align-items: center; gap: 0.5rem;">
-                          <img src="../svgs/lark.svg" width="20" height="20" alt="Lark">
-                          Connect Lark
-                        </button>
-                      </div>
-                      <div class="settings-status-stack">
-                        <span id="discord-oauth-status"></span>
-                        <span id="slack-oauth-status"></span>
-                        <span id="github-connect-status"></span>
-                        <span id="notion-oauth-status"></span>
-                        <span id="lark-oauth-status"></span>
-                      </div>
-                    </div>
-
                     <div class="settings-panel">
                       <h3>Manual linking</h3>
                       <p>Add an email, phone number, or chat identifier Oliver should recognize for your account.</p>
@@ -2410,7 +2358,7 @@
         if (!updateTeamBriefBtn) {
           return;
         }
-        updateTeamBriefBtn.setAttribute('href', '#section-settings');
+        updateTeamBriefBtn.setAttribute('href', '#section-channels');
       }
 
       function loadWorkspaceSummaryFromStorage() {
@@ -2633,15 +2581,15 @@
             outcome: 'Once one app is connected, you can send a real request and review the result here.',
             action: unconnectedProviders[0]
               ? { kind: 'connect_provider', provider: unconnectedProviders[0] }
-              : { kind: 'open_dashboard_section', section: 'section-settings' }
+              : { kind: 'open_dashboard_section', section: 'section-channels' }
           });
           pushRecommendation({
-            key: 'open_settings',
+            key: 'open_connected_apps',
             triggerType: 'setup_blocker',
-            title: 'Open Settings and choose your first connection',
+            title: 'Open Connected Apps and choose your first connection',
             whyNow: 'The first setup step should stay small and reversible.',
             outcome: 'You can connect one tool without changing the rest of your workflow.',
-            action: { kind: 'open_dashboard_section', section: 'section-settings' }
+            action: { kind: 'open_dashboard_section', section: 'section-channels' }
           });
           if (unconnectedProviders[1]) {
             pushRecommendation({
@@ -2779,12 +2727,12 @@
             action: { kind: 'open_dashboard_section', section: 'section-tasks' }
           });
           pushRecommendation({
-            key: 'check_settings',
+            key: 'check_connected_apps',
             triggerType: 'continuation_opportunity',
-            title: 'Revisit Settings only if you want broader coverage',
+            title: 'Open Connected Apps if you want broader coverage',
             whyNow: 'More connections help only when they support work you already trust Oliver with.',
             outcome: 'Expansion stays deliberate instead of noisy.',
-            action: { kind: 'open_dashboard_section', section: 'section-settings' }
+            action: { kind: 'open_dashboard_section', section: 'section-channels' }
           });
         }
 
@@ -3094,12 +3042,12 @@
               <p>Once Oliver has one approved app and one small task, this card will start surfacing the clearest next step automatically.</p>
             </div>
             <div class="workspace-recommendation-actions">
-              <button id="workspace-recommendation-edit-brief" class="auth-btn auth-btn-primary">Open Settings</button>
+              <button id="workspace-recommendation-edit-brief" class="auth-btn auth-btn-primary">Open Connected Apps</button>
               <span class="workspace-recommendation-status">Recommendations turn on automatically as your setup becomes more complete.</span>
             </div>
           `;
           document.getElementById('workspace-recommendation-edit-brief')?.addEventListener('click', () => {
-            openDashboardSection('section-settings');
+            openDashboardSection('section-channels');
           });
           return;
         }
@@ -3576,7 +3524,7 @@
             throw new Error(`Connecting ${formatRecommendationToken(provider)} is not available from this dashboard yet.`);
           }
 
-          openDashboardSection('section-settings');
+          openDashboardSection('section-channels');
           window.setTimeout(() => {
             document.getElementById(buttonId)?.click();
           }, 120);
@@ -3934,8 +3882,8 @@
             description: 'Start with the first app where Oliver should receive or complete work.',
             status: hasAnyConnected ? 'complete' : 'pending',
             completeLabel: `${connectedTypes.length} connected`,
-            actionLabel: 'Open Settings',
-            href: '#section-settings'
+            actionLabel: 'Open Connected Apps',
+            href: '#section-channels'
           },
           {
             id: 'try-first-task',
@@ -4017,7 +3965,7 @@
             return `<a href="${task.externalUrl}" target="_blank" rel="noopener noreferrer" class="auth-btn auth-btn-primary">${escapeHtml(task.actionLabel || 'Open')}</a>`;
           }
 
-          return `<a class="auth-btn auth-btn-oauth" href="#section-settings">Open Settings</a>`;
+          return `<a class="auth-btn auth-btn-oauth" href="#section-channels">Open Connected Apps</a>`;
         }
 
         function renderTaskItem(task) {
@@ -4619,6 +4567,7 @@
 
       // Load linked identifiers
       async function loadIdentifiers(accessToken) {
+        const list = document.getElementById('identifier-list');
         try {
           const res = await fetch(`${DOWHIZ_API_URL}/auth/account`, {
             headers: { 'Authorization': `Bearer ${accessToken}` }
@@ -4627,7 +4576,6 @@
           if (!res.ok) throw new Error('Failed to load account');
 
           const data = await res.json();
-          const list = document.getElementById('identifier-list');
 
           // Update cached identifiers for task loading
           cachedIdentifiers = data.identifiers || [];
@@ -4654,7 +4602,7 @@
               });
             });
           } else {
-            list.innerHTML = '<li class="identifier-item">No apps connected yet.</li>';
+            list.innerHTML = '<li class="identifier-item">No apps connected yet. Add one above.</li>';
           }
 
           loadWorkspaceSummaryFromStorage();


### PR DESCRIPTION
## Summary
- move the OAuth connect actions out of Settings and make Connected Apps the single place to add app connections
- update Getting Started, recommendations, and checklist links so first-connection flows now point to Connected Apps
- simplify Settings to keep only manual linking and Oliver guidance, and harden the connected-apps load error path

## Testing
- cd website && npm run build

## Notes
- rebased onto the latest origin/dev before opening this PR
- no rebase conflicts occurred