### PR TITLE
Finish website SEO metadata refresh

### DIFF
--- a/website/public/blog/github-issue-automation-best-practices/index.html
+++ b/website/public/blog/github-issue-automation-best-practices/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
     <link rel="canonical" href="https://dowhiz.com/blog/github-issue-automation-best-practices/" />
-    <title>GitHub Issue Automation Best Practices for Engineering Teams | DoWhiz</title>
+    <title>GitHub Issue Automation Best Practices | DoWhiz</title>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/website/public/blog/index.html
+++ b/website/public/blog/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="DoWhiz blog with startup workspace updates for founders and one-person companies, AI chief of staff recommendations, and SEO guides for automation across email, GitHub, Slack, and Google Workspace."
+      content="Read founder workspace updates, AI operations guides, and multi-channel automation playbooks for email, GitHub, Slack, and Google Docs."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260311" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260311" />
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="/blog/blog.css" />
     <script src="/theme.js"></script>
     <link rel="canonical" href="https://dowhiz.com/blog/" />
-    <title>DoWhiz Blog | Founder Workspace Updates and Automation Guides</title>
+    <title>DoWhiz Blog | Founder Workspace and AI Operations Guides</title>
   </head>
   <body>
     <div class="page">

--- a/website/public/blog/startup-workspace-for-founders-product-update/index.html
+++ b/website/public/blog/startup-workspace-for-founders-product-update/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Read the March 2026 DoWhiz product update on the startup workspace for founders and one-person companies, including Team Brief onboarding, Team Workspace, and AI chief of staff recommendations."
+      content="See how DoWhiz is refactoring into a startup workspace for founders and one-person companies with Team Brief, Team Workspace, and AI chief of staff guidance."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260311" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260311" />
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
     <link rel="canonical" href="https://dowhiz.com/blog/startup-workspace-for-founders-product-update/" />
-    <title>Startup Workspace for Founders and One-Person Companies | DoWhiz</title>
+    <title>Startup Workspace Product Update for Founders | DoWhiz</title>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/website/public/demo-videos/index.html
+++ b/website/public/demo-videos/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Watch DoWhiz demo videos: one full desktop walkthrough and three mobile Shorts."
+      content="Watch DoWhiz demo videos with one full desktop walkthrough and quick mobile examples across channels."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260311" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260311" />
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="/demo-videos.css" />
     <script src="/theme.js"></script>
     <link rel="canonical" href="https://dowhiz.com/demo-videos/" />
-    <title>Demo Videos | DoWhiz</title>
+    <title>DoWhiz Demo Videos | AI Digital Employee Walkthroughs</title>
   </head>
   <body>
     <nav class="navbar">

--- a/website/public/help-center/index.html
+++ b/website/public/help-center/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="DoWhiz Help Center: top 20 common user questions across setup, integrations, permissions, outputs, and support."
+      content="Get answers about setup, integrations, permissions, memory, outputs, and support for DoWhiz AI digital employees."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260311" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260311" />
@@ -15,7 +15,7 @@
     <link rel="canonical" href="https://dowhiz.com/help-center/" />
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
-    <title>DoWhiz Help Center | Top 20 User Questions</title>
+    <title>DoWhiz Help Center FAQ | Setup, Integrations, Security</title>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/website/public/integrations/index.html
+++ b/website/public/integrations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="DoWhiz integrations across email, Slack, Discord, GitHub, Google Docs, and Notion with trigger + outcome examples."
+      content="See how DoWhiz AI digital employees work across email, Slack, Discord, GitHub, Google Docs, and Notion with trigger-to-outcome examples."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260311" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260311" />
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
     <link rel="canonical" href="https://dowhiz.com/integrations/" />
-    <title>Integrations | DoWhiz</title>
+    <title>DoWhiz Integrations | Email, Slack, GitHub, Docs, Notion</title>
   </head>
   <body>
     <div class="page">

--- a/website/public/trust-safety/index.html
+++ b/website/public/trust-safety/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="DoWhiz Trust & Safety: isolated execution, permission-based workspace access, no personal credential handoff, and data handling basics."
+      content="See how DoWhiz secures AI digital employee workflows with isolated execution, permission-based access, auditability, and no credential handoff."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260311" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=20260311" />
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="/legal.css" />
     <script src="/theme.js"></script>
     <link rel="canonical" href="https://dowhiz.com/trust-safety/" />
-    <title>Trust &amp; Safety | DoWhiz</title>
+    <title>DoWhiz Trust &amp; Safety | Secure AI Digital Employee Ops</title>
   </head>
   <body>
     <div class="page">

--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -768,7 +768,8 @@ function LandingPage({ locale }) {
           </div>
         </nav>
 
-        <section id="channels" className="hero-section">
+        <main>
+          <section id="channels" className="hero-section">
           {enableMouseField ? <MouseField theme={theme} /> : null}
           <div className="halo-effect"></div>
           <div className="container hero-content hero-showcase-layout">
@@ -932,7 +933,7 @@ function LandingPage({ locale }) {
           </div>
         </section>
 
-        <section id="watch" className="section demo-showcase-section">
+          <section id="watch" className="section demo-showcase-section">
           <div className="container">
             <div className="section-heading-shell">
               <span className="section-kicker">{content.demo.eyebrow}</span>
@@ -1002,7 +1003,7 @@ function LandingPage({ locale }) {
           </div>
         </section>
 
-        <section id="examples" className="section example-showcase-section">
+          <section id="examples" className="section example-showcase-section">
           <div className="container story-stack">
             <div className="section-heading-shell">
               <span className="section-kicker">{content.examples.eyebrow}</span>
@@ -1012,58 +1013,64 @@ function LandingPage({ locale }) {
 
             <div className="example-card-grid">
               {content.examples.cards.map((item) => (
-                <article key={item.title} className="example-card">
+                <a
+                  key={item.title}
+                  className={`example-card${item.href ? ' example-card-link' : ''}`}
+                  href={item.href || undefined}
+                >
                   <span className="example-card-tag">{item.tag}</span>
                   <h3>{item.title}</h3>
                   <p>{item.description}</p>
-                </article>
+                  {item.ctaLabel ? <span className="example-card-cta">{item.ctaLabel}</span> : null}
+                </a>
               ))}
             </div>
           </div>
         </section>
 
-        <section id="faq" className="section faq-section">
-          <div className="container">
-            <div className="section-heading-shell">
-              <span className="section-kicker">{content.labels.faqEyebrow}</span>
-              <h2 className="section-title section-title-left">{content.labels.faqTitle}</h2>
-              <p className="section-intro section-intro-left">{content.labels.faqIntro}</p>
+          <section id="faq" className="section faq-section">
+            <div className="container">
+              <div className="section-heading-shell">
+                <span className="section-kicker">{content.labels.faqEyebrow}</span>
+                <h2 className="section-title section-title-left">{content.labels.faqTitle}</h2>
+                <p className="section-intro section-intro-left">{content.labels.faqIntro}</p>
+              </div>
+              <div className="faq-accordion faq-compact">
+                {content.faqItems.map((item, idx) => {
+                  const isOpen = openFaq === idx;
+                  return (
+                    <article key={item.question} className={`faq-accordion-item ${isOpen ? 'open' : ''}`}>
+                      <button
+                        type="button"
+                        className="faq-accordion-header"
+                        onClick={() => toggleFaq(idx)}
+                        aria-expanded={isOpen}
+                        aria-controls={`faq-panel-${idx}`}
+                      >
+                        <span className="faq-question">{item.question}</span>
+                        <span className="faq-toggle" aria-hidden="true">
+                          {isOpen ? '−' : '+'}
+                        </span>
+                      </button>
+                      <div
+                        id={`faq-panel-${idx}`}
+                        className="faq-accordion-panel"
+                        style={{ display: isOpen ? 'block' : 'none' }}
+                      >
+                        <p>{item.answer}</p>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+              <div className="faq-link-row">
+                <a className="faq-text-link" href="/help-center/">
+                  {content.labels.faqLinkLabel}
+                </a>
+              </div>
             </div>
-            <div className="faq-accordion faq-compact">
-              {content.faqItems.map((item, idx) => {
-                const isOpen = openFaq === idx;
-                return (
-                  <article key={item.question} className={`faq-accordion-item ${isOpen ? 'open' : ''}`}>
-                    <button
-                      type="button"
-                      className="faq-accordion-header"
-                      onClick={() => toggleFaq(idx)}
-                      aria-expanded={isOpen}
-                      aria-controls={`faq-panel-${idx}`}
-                    >
-                      <span className="faq-question">{item.question}</span>
-                      <span className="faq-toggle" aria-hidden="true">
-                        {isOpen ? '−' : '+'}
-                      </span>
-                    </button>
-                    <div
-                      id={`faq-panel-${idx}`}
-                      className="faq-accordion-panel"
-                      style={{ display: isOpen ? 'block' : 'none' }}
-                    >
-                      <p>{item.answer}</p>
-                    </div>
-                  </article>
-                );
-              })}
-            </div>
-            <div className="faq-link-row">
-              <a className="faq-text-link" href="https://www.dowhiz.com/help-center/">
-                {content.labels.faqLinkLabel}
-              </a>
-            </div>
-          </div>
-        </section>
+          </section>
+        </main>
 
         <footer className="site-footer">
           <div className="container footer-content">

--- a/website/src/pages/landingContent.js
+++ b/website/src/pages/landingContent.js
@@ -1,8 +1,8 @@
 const EN_LANDING_CONTENT = {
   metadata: {
-    title: 'DoWhiz | Oliver works in your tools',
+    title: 'DoWhiz | AI digital employees in email, Slack, and GitHub',
     description:
-      'Start with Oliver in email, Slack, or Discord without logging in first. GitHub, Notion, and Lark work can start with a real request now and connect later when you want saved workflows.',
+      'Start with Oliver in email, Slack, or Discord. DoWhiz turns real requests into finished work across GitHub, docs, and shared tools.',
     canonicalUrl: 'https://dowhiz.com/',
     ogLocale: 'en_US',
     themeColor: '#2C2C2E',
@@ -161,32 +161,44 @@ const EN_LANDING_CONTENT = {
       {
         tag: 'Research',
         title: 'Deep research briefs',
-        description: 'Compare options and return a concise decision memo.'
+        description: 'Compare options and return a concise decision memo.',
+        href: '/agents/oliver/',
+        ctaLabel: 'Meet Oliver'
       },
       {
         tag: 'Inbox',
         title: 'Email triage and drafts',
-        description: 'Draft replies and keep follow-ups moving.'
+        description: 'Draft replies and keep follow-ups moving.',
+        href: '/solutions/email-task-automation/',
+        ctaLabel: 'Explore email workflows'
       },
       {
         tag: 'Writing',
         title: 'Study and drafting support',
-        description: 'Outline, revise, and tighten documents.'
+        description: 'Outline, revise, and tighten documents.',
+        href: '/solutions/google-docs-automation/',
+        ctaLabel: 'Open docs workflow'
       },
       {
         tag: 'Tax prep',
         title: 'Document organization',
-        description: 'Sort filing materials and flag what is missing.'
+        description: 'Sort filing materials and flag what is missing.',
+        href: '/help-center/',
+        ctaLabel: 'Read the FAQ'
       },
       {
         tag: 'Content',
         title: 'Posts with approval',
-        description: 'Draft and schedule posts for review.'
+        description: 'Draft and schedule posts for review.',
+        href: '/agents/rachel/',
+        ctaLabel: 'Meet Rachel'
       },
       {
         tag: 'GitHub',
         title: 'Repo follow-up',
-        description: 'Summarize issues and keep code-adjacent work moving.'
+        description: 'Summarize issues and keep code-adjacent work moving.',
+        href: '/solutions/github-issue-automation/',
+        ctaLabel: 'See GitHub workflow'
       }
     ]
   },
@@ -232,6 +244,7 @@ const EN_LANDING_CONTENT = {
     { href: '/terms/', label: 'Terms of Service' },
     { href: '/trust-safety/', label: 'Trust & Safety' },
     { href: '/integrations/', label: 'Integrations' },
+    { href: '/blog/', label: 'Blog' },
     { href: 'https://www.dowhiz.com/help-center/', label: 'Help Center' },
     { href: '/user-guide/', label: 'User Guide' }
   ]
@@ -239,9 +252,9 @@ const EN_LANDING_CONTENT = {
 
 const ZH_LANDING_CONTENT = {
   metadata: {
-    title: 'DoWhiz 中文 | Oliver 在你的工具里工作',
+    title: 'DoWhiz 中文 | Email、Slack、GitHub 里的 AI 数字员工',
     description:
-      '认识 Oliver。你不需要先登录再开始：现在就可以直接通过 Email、Slack 或 Discord 开始使用。GitHub、Notion 和 Lark 相关任务也可以先发出真实请求，之后再决定是否连接。',
+      '先从 Email、Slack 或 Discord 里的 Oliver 开始。DoWhiz 会把真实请求推进到 GitHub、文档和更多协作工具里，直接返回完成结果。',
     canonicalUrl: 'https://dowhiz.com/cn',
     ogLocale: 'zh_CN',
     themeColor: '#2C2C2E',
@@ -400,32 +413,44 @@ const ZH_LANDING_CONTENT = {
       {
         tag: 'Research',
         title: 'Deep research 简报',
-        description: '比较方案，最后给你一份能直接判断的结果。'
+        description: '比较方案，最后给你一份能直接判断的结果。',
+        href: '/agents/oliver/',
+        ctaLabel: '认识 Oliver'
       },
       {
         tag: 'Inbox',
         title: '邮件整理和回复起草',
-        description: '起草回复，同时把后续动作继续往前推。'
+        description: '起草回复，同时把后续动作继续往前推。',
+        href: '/solutions/email-task-automation/',
+        ctaLabel: '查看邮件工作流'
       },
       {
         tag: 'Writing',
         title: '学习支持和文稿起草',
-        description: '做提纲、改写、收紧结构。'
+        description: '做提纲、改写、收紧结构。',
+        href: '/solutions/google-docs-automation/',
+        ctaLabel: '打开文档工作流'
       },
       {
         tag: 'Tax prep',
         title: '材料整理',
-        description: '整理报税前的文件并指出还缺什么。'
+        description: '整理报税前的文件并指出还缺什么。',
+        href: '/help-center/',
+        ctaLabel: '查看常见问题'
       },
       {
         tag: 'Content',
         title: '发帖前的草稿与排期',
-        description: '先起草和排期，最终仍由你确认。'
+        description: '先起草和排期，最终仍由你确认。',
+        href: '/agents/rachel/',
+        ctaLabel: '认识 Rachel'
       },
       {
         tag: 'GitHub',
         title: 'Repo 跟进',
-        description: '整理 issue 上下文，推进和代码相关的后续工作。'
+        description: '整理 issue 上下文，推进和代码相关的后续工作。',
+        href: '/solutions/github-issue-automation/',
+        ctaLabel: '查看 GitHub 工作流'
       }
     ]
   },
@@ -471,6 +496,7 @@ const ZH_LANDING_CONTENT = {
     { href: '/terms/', label: '服务条款' },
     { href: '/trust-safety/', label: 'Trust & Safety' },
     { href: '/integrations/', label: '集成' },
+    { href: '/blog/', label: '博客' },
     { href: 'https://www.dowhiz.com/help-center/', label: '帮助中心' },
     { href: '/user-guide/', label: '使用指南' }
   ]

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -2914,6 +2914,29 @@
   padding: 1.05rem;
 }
 
+.example-card-link {
+  color: inherit;
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+.example-card-link:hover,
+.example-card-link:focus-visible {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--brand-primary) 22%, var(--glass-border));
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 22px 42px -34px rgba(28, 28, 30, 0.36);
+}
+
+.example-card-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--brand-primary) 44%, white);
+  outline-offset: 3px;
+}
+
 .example-card-tag {
   display: inline-flex;
   width: fit-content;
@@ -2926,6 +2949,20 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.example-card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.2rem;
+  color: var(--brand-primary);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.example-card-cta::after {
+  content: '->';
 }
 
 .faq-compact {


### PR DESCRIPTION
## Summary
- finish the landing-page SEO/GEO refresh that remained local after #1154 merged
- add crawlable internal links from landing example cards into priority solutions, agents, and support pages
- refresh homepage client-side metadata plus key public page titles and descriptions to match the current site positioning

## Verification
- npm run seo:crawl
- npm run build could not be completed in this workspace because website/node_modules only contains an empty .bin directory and vite is unavailable

Requested-by: @loganye