### PR TITLE
Refine native-feeling landing hero channel stages

### DIFF
--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -203,16 +203,72 @@ const getStageAvatarLabel = (author = '') => {
     .toUpperCase();
 };
 
-function HeroStageMessage({ author, meta, text, tone = 'default' }) {
+function HeroStageAvatarCluster({ items = [], dark = false }) {
+  if (!items.length) {
+    return null;
+  }
+
+  const clusterClasses = ['hero-stage-avatar-cluster'];
+  if (dark) {
+    clusterClasses.push('is-dark');
+  }
+
   return (
-    <div className={`hero-stage-message${tone === 'user' ? ' is-user' : ''}`}>
-      <span className={`hero-stage-avatar${tone === 'user' ? ' is-user' : ''}`} aria-hidden="true">
+    <div className={clusterClasses.join(' ')} aria-hidden="true">
+      {items.map((item, index) => {
+        const label = typeof item === 'string' ? item : item?.name || '';
+        return (
+          <span key={`${label}-${index}`} className="hero-stage-avatar-cluster-item">
+            {getStageAvatarLabel(label)}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function SlackStageMessage({ author, meta, time, text, tone = 'default', reactions = [] }) {
+  return (
+    <div className={`hero-stage-slack-message${tone === 'user' ? ' is-user' : ''}`}>
+      <span className="hero-stage-slack-avatar" aria-hidden="true">
         {getStageAvatarLabel(author)}
       </span>
-      <div className="hero-stage-message-copy">
-        <div className="hero-stage-message-head">
+      <div className="hero-stage-slack-message-main">
+        <div className="hero-stage-slack-message-head">
           <strong>{author}</strong>
-          <span>{meta}</span>
+          {meta ? <span className="hero-stage-slack-message-role">{meta}</span> : null}
+          {time ? <small>{time}</small> : null}
+        </div>
+        <p>{text}</p>
+        {reactions.length ? (
+          <div className="hero-stage-slack-reactions">
+            {reactions.map((reaction) => (
+              <span key={reaction} className="hero-stage-slack-reaction">
+                {reaction}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function DiscordStageMessage({ author, meta, time, text, tone = 'default', accent }) {
+  return (
+    <div className={`hero-stage-discord-message${tone === 'user' ? ' is-user' : ''}`}>
+      <span
+        className="hero-stage-discord-avatar"
+        aria-hidden="true"
+        style={accent ? { '--discord-accent': accent } : undefined}
+      >
+        {getStageAvatarLabel(author)}
+      </span>
+      <div className="hero-stage-discord-message-main">
+        <div className="hero-stage-discord-message-head">
+          <strong style={accent ? { color: accent } : undefined}>{author}</strong>
+          {meta ? <span className="hero-stage-discord-role">{meta}</span> : null}
+          {time ? <small>{time}</small> : null}
         </div>
         <p>{text}</p>
       </div>
@@ -220,11 +276,158 @@ function HeroStageMessage({ author, meta, text, tone = 'default' }) {
   );
 }
 
+function GitHubChecklistItem({ item }) {
+  return (
+    <div className={`hero-stage-github-checklist-item hero-stage-github-checklist-item-${item.state}`}>
+      <span className="hero-stage-github-check" aria-hidden="true">
+        {item.state === 'done' ? '✓' : item.state === 'progress' ? '•' : ''}
+      </span>
+      <div className="hero-stage-github-checklist-copy">
+        <strong>{item.title}</strong>
+        <span>{item.meta}</span>
+      </div>
+    </div>
+  );
+}
+
+function GitHubActivityRow({ item }) {
+  return (
+    <div className="hero-stage-github-activity">
+      <span className="hero-stage-github-activity-dot" aria-hidden="true"></span>
+      <div className="hero-stage-github-activity-copy">
+        <strong>{item.actor}</strong>
+        <p>{item.text}</p>
+      </div>
+      <small>{item.meta}</small>
+    </div>
+  );
+}
+
+function NotionCollaboratorBar({ items = [] }) {
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <div className="hero-stage-notion-collaborators" aria-hidden="true">
+      {items.map((item, index) => (
+        <span key={`${item}-${index}`} className="hero-stage-notion-collaborator">
+          {getStageAvatarLabel(item)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function LarkStageMessage({ author, meta, time, text, badge }) {
+  return (
+    <div className="hero-stage-lark-message">
+      <span className="hero-stage-lark-avatar" aria-hidden="true">
+        {getStageAvatarLabel(author)}
+      </span>
+      <div className="hero-stage-lark-message-main">
+        <div className="hero-stage-lark-message-head">
+          <strong>{author}</strong>
+          {meta ? <span>{meta}</span> : null}
+          {time ? <small>{time}</small> : null}
+          {badge ? <em>{badge}</em> : null}
+        </div>
+        <p>{text}</p>
+      </div>
+    </div>
+  );
+}
+
+function getStageStatusTone(status = '') {
+  const normalized = status.toLowerCase();
+
+  if (normalized.includes('ready') || status.includes('已准备')) {
+    return 'success';
+  }
+
+  if (
+    normalized.includes('progress') ||
+    normalized.includes('active') ||
+    normalized.includes('open') ||
+    status.includes('进行中')
+  ) {
+    return 'progress';
+  }
+
+  if (
+    normalized.includes('queue') ||
+    normalized.includes('next') ||
+    normalized.includes('draft') ||
+    status.includes('待开始') ||
+    status.includes('下一步')
+  ) {
+    return 'queued';
+  }
+
+  return 'neutral';
+}
+
+function HeroStageStatusPill({ label }) {
+  return (
+    <span className={['hero-stage-status-pill', `is-${getStageStatusTone(label)}`].join(' ')}>
+      {label}
+    </span>
+  );
+}
+
+function getNotionBlockMarker(type) {
+  switch (type) {
+    case 'heading':
+      return 'H1';
+    case 'todo':
+      return '[]';
+    case 'callout':
+      return '!';
+    default:
+      return '•';
+  }
+}
+
 function EmailHeroStage({ tool }) {
   const stage = tool.stage;
 
   return (
     <div className="hero-stage-body hero-stage-email-layout">
+      <aside className="hero-stage-email-nav">
+        <div className="hero-stage-email-nav-head">
+          <strong>{stage.appName}</strong>
+          <span>{stage.appMeta}</span>
+        </div>
+
+        <div className="hero-stage-email-folder-list">
+          {stage.folders.map((folder) => (
+            <div
+              key={folder.label}
+              className={`hero-stage-email-folder${folder.active ? ' is-active' : ''}`}
+            >
+              <span>{folder.label}</span>
+              {folder.count ? <small>{folder.count}</small> : null}
+            </div>
+          ))}
+        </div>
+
+        <div className="hero-stage-email-thread-list">
+          {stage.threads.map((thread) => (
+            <article
+              key={`${thread.from}-${thread.subject}`}
+              className={`hero-stage-email-thread${thread.active ? ' is-active' : ''}`}
+            >
+              <div className="hero-stage-email-thread-head">
+                <strong>{thread.from}</strong>
+                <span>{thread.time}</span>
+              </div>
+              <p>{thread.subject}</p>
+              <small>{thread.preview}</small>
+            </article>
+          ))}
+        </div>
+      </aside>
+
       <section className="hero-stage-email-compose">
         <div className="hero-stage-window-bar">
           <div className="hero-stage-window-controls" aria-hidden="true">
@@ -235,10 +438,23 @@ function EmailHeroStage({ tool }) {
           <strong>{stage.composeTitle}</strong>
         </div>
 
+        <div className="hero-stage-email-badges">
+          <span className="hero-stage-email-draft-badge">{stage.draftBadge}</span>
+          {stage.tags.map((tag) => (
+            <span key={tag} className="hero-stage-email-tag">
+              {tag}
+            </span>
+          ))}
+        </div>
+
         <div className="hero-stage-email-fields">
           <div className="hero-stage-email-field">
             <span>{stage.toLabel}</span>
             <strong>{stage.toValue}</strong>
+          </div>
+          <div className="hero-stage-email-field">
+            <span>{stage.ccLabel}</span>
+            <strong>{stage.ccValue}</strong>
           </div>
           <div className="hero-stage-email-field">
             <span>{stage.subjectLabel}</span>
@@ -254,7 +470,7 @@ function EmailHeroStage({ tool }) {
 
         <div className="hero-stage-email-footer">
           <span>{stage.footerNote}</span>
-          <strong>{stage.footerValue}</strong>
+          <span className="hero-stage-mock-button hero-stage-mock-button-dark">{stage.footerValue}</span>
         </div>
       </section>
 
@@ -279,36 +495,103 @@ function SlackHeroStage({ tool }) {
       <aside className="hero-stage-slack-sidebar">
         <div className="hero-stage-slack-workspace">
           <span className="hero-stage-slack-workspace-mark" aria-hidden="true"></span>
-          <strong>{stage.workspace}</strong>
+          <div className="hero-stage-slack-workspace-copy">
+            <strong>{stage.workspace}</strong>
+            <span>{stage.workspaceMeta}</span>
+          </div>
         </div>
-        <div className="hero-stage-slack-channel-list">
-          {stage.channels.map((channel) => (
-            <span key={channel}>{channel}</span>
-          ))}
-        </div>
+
+        {stage.sections.map((section) => (
+          <div key={section.title} className="hero-stage-slack-section">
+            <span className="hero-stage-slack-section-title">{section.title}</span>
+            <div className="hero-stage-slack-section-list">
+              {section.items.map((item) => {
+                const isDirectSection =
+                  section.title.toLowerCase().includes('direct') || section.title.includes('私信');
+                const prefix = isDirectSection ? (item.accent === 'bot' ? '@' : '•') : '#';
+                const label = prefix === '#' ? item.label.replace(/^#\s*/, '') : item.label;
+
+                return (
+                  <div
+                    key={item.label}
+                    className={`hero-stage-slack-item${item.active ? ' is-active' : ''}${
+                      item.accent === 'bot' ? ' is-bot' : ''
+                    }`}
+                  >
+                    <span className="hero-stage-slack-item-marker" aria-hidden="true">
+                      {prefix}
+                    </span>
+                    <span>{label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </aside>
 
       <section className="hero-stage-slack-thread">
         <div className="hero-stage-slack-thread-head">
-          <strong>{stage.room}</strong>
-          <span>{stage.roomMeta}</span>
+          <div className="hero-stage-slack-room-copy">
+            <strong>{stage.room}</strong>
+            <span>{stage.roomMeta}</span>
+          </div>
+          <div className="hero-stage-slack-room-members">
+            <HeroStageAvatarCluster items={stage.roomMembers} />
+            <span>{stage.roomMembers.join(' / ')}</span>
+          </div>
         </div>
-        <div className="hero-stage-message-stack">
+
+        <div className="hero-stage-slack-thread-toolbar">
+          <div className="hero-stage-slack-thread-pills">
+            {(stage.threadPills || []).map((pill) => (
+              <span key={pill} className="hero-stage-slack-thread-pill">
+                {pill}
+              </span>
+            ))}
+          </div>
+          {stage.threadActivity ? (
+            <span className="hero-stage-slack-thread-activity">{stage.threadActivity}</span>
+          ) : null}
+        </div>
+
+        <div className="hero-stage-slack-message-feed">
           {stage.messages.map((message) => (
-            <HeroStageMessage key={`${message.author}-${message.text}`} {...message} />
+            <SlackStageMessage key={`${message.author}-${message.text}`} {...message} />
           ))}
+        </div>
+
+        <div className="hero-stage-slack-summary">
+          <span className="hero-stage-micro-label">{stage.threadLabel}</span>
+          <strong>{stage.threadTitle}</strong>
+          <p>{stage.threadText}</p>
+        </div>
+
+        <div className="hero-stage-slack-composer">
+          <span className="hero-stage-slack-composer-pill">@Oliver</span>
+          <div className="hero-stage-slack-composer-copy">
+            <strong>{stage.composerPlaceholder}</strong>
+            <span>{stage.composerHint}</span>
+          </div>
         </div>
       </section>
 
       <aside className="hero-stage-slack-card">
         <span className="hero-stage-micro-label">{stage.cardLabel}</span>
         <strong>{stage.cardTitle}</strong>
+        <p className="hero-stage-slack-card-summary">{stage.cardSummary}</p>
         <ul className="hero-stage-list">
           {stage.cardItems.map((item) => (
             <li key={item}>{item}</li>
           ))}
         </ul>
-        <div className="hero-stage-inline-note">{stage.cardFooter}</div>
+        <div className="hero-stage-chip-row">
+          {stage.cardActions.map((action) => (
+            <span key={action} className="hero-stage-chip">
+              {action}
+            </span>
+          ))}
+        </div>
       </aside>
     </div>
   );
@@ -331,37 +614,81 @@ function DiscordHeroStage({ tool }) {
           <strong>{stage.server}</strong>
           <span>{stage.onlineLabel}</span>
         </div>
-        <div className="hero-stage-discord-channel-list">
-          {stage.channels.map((channel) => (
-            <span key={channel}># {channel}</span>
-          ))}
+
+        {stage.sections.map((section) => (
+          <div key={section.title} className="hero-stage-discord-section">
+            <span className="hero-stage-discord-section-title">{section.title}</span>
+            <div className="hero-stage-discord-channel-list">
+              {section.items.map((item) => {
+                const label = item.label.replace(/^#\s*/, '');
+                return (
+                  <span key={item.label} className={item.active ? 'is-active' : ''}>
+                    # {label}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+
+        <div className="hero-stage-discord-members-mini">
+          <span>{stage.membersTitle}</span>
+          <HeroStageAvatarCluster items={stage.members} dark />
         </div>
       </aside>
 
       <section className="hero-stage-discord-chat">
         <div className="hero-stage-discord-room-head">
-          <strong>{stage.room}</strong>
+          <div className="hero-stage-discord-room-copy">
+            <strong>{stage.room}</strong>
+            <span>{stage.roomTopic}</span>
+          </div>
         </div>
-        <div className="hero-stage-message-stack is-dense">
+
+        <div className="hero-stage-discord-chat-toolbar">
+          <span className="hero-stage-discord-channel-badge">{stage.room}</span>
+          {stage.roomMeta ? <span className="hero-stage-discord-room-meta">{stage.roomMeta}</span> : null}
+        </div>
+
+        <div className="hero-stage-discord-message-feed">
           {stage.messages.map((message) => (
-            <HeroStageMessage key={`${message.author}-${message.text}`} {...message} />
+            <DiscordStageMessage key={`${message.author}-${message.text}`} {...message} />
           ))}
+        </div>
+
+        <div className="hero-stage-discord-composer">
+          <strong>{stage.composerValue}</strong>
+          <span>{stage.composerHint}</span>
         </div>
       </section>
 
       <aside className="hero-stage-discord-plan">
-        <span className="hero-stage-micro-label">{stage.planLabel}</span>
-        <strong>{stage.planTitle}</strong>
-        <ul className="hero-stage-list">
-          {stage.planItems.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
-        <div className="hero-stage-chip-row">
-          {stage.planActions.map((action) => (
-            <span key={action} className="hero-stage-chip">
-              {action}
-            </span>
+        <span className="hero-stage-micro-label">{stage.botLabel}</span>
+        <strong>{stage.botTitle}</strong>
+        <p className="hero-stage-discord-bot-description">{stage.botDescription}</p>
+
+        <div className="hero-stage-discord-embed">
+          <div className="hero-stage-discord-embed-accent" aria-hidden="true"></div>
+          <div className="hero-stage-discord-field-list">
+            {stage.botFields.map((field) => (
+              <div key={field.label} className="hero-stage-discord-field">
+                <span>{field.label}</span>
+                <strong>{field.value}</strong>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="hero-stage-discord-member-list">
+          <span className="hero-stage-discord-member-title">{stage.membersTitle}</span>
+          {stage.members.map((member) => (
+            <div
+              key={member.name}
+              className={`hero-stage-discord-member${member.accent ? ' is-accent' : ''}`}
+            >
+              <strong>{member.name}</strong>
+              <span>{member.role}</span>
+            </div>
           ))}
         </div>
       </aside>
@@ -387,16 +714,49 @@ function GitHubHeroStage({ tool }) {
           </div>
         </div>
 
+        <div className="hero-stage-github-filter-row">
+          {stage.filters.map((filter) => (
+            <span key={filter} className="hero-stage-github-filter">
+              {filter}
+            </span>
+          ))}
+        </div>
+
+        <div className="hero-stage-github-list-head">
+          <span className="hero-stage-github-list-count is-open">{stage.overview.open}</span>
+          <span className="hero-stage-github-list-count is-closed">{stage.overview.closed}</span>
+        </div>
+
         <div className="hero-stage-github-grid">
           <section className="hero-stage-github-issues">
             {stage.issues.map((issue) => (
-              <article key={issue.id} className="hero-stage-github-issue">
-                <div className="hero-stage-github-issue-head">
-                  <strong>{issue.id}</strong>
-                  <span>{issue.status}</span>
+              <article
+                key={issue.id}
+                className={`hero-stage-github-issue${issue.active ? ' is-active' : ''}`}
+              >
+                <div className="hero-stage-github-issue-title-row">
+                  <div className="hero-stage-github-state">
+                    <span className="hero-stage-github-state-dot" aria-hidden="true"></span>
+                    <strong>{issue.title}</strong>
+                  </div>
+                  <HeroStageStatusPill label={issue.status} />
                 </div>
-                <p>{issue.title}</p>
-                <small>{issue.meta}</small>
+
+                <div className="hero-stage-github-issue-meta-row">
+                  <span>{issue.id}</span>
+                  <span>{issue.meta}</span>
+                </div>
+
+                <div className="hero-stage-github-issue-badges">
+                  <div className="hero-stage-github-issue-labels">
+                    {issue.labels.map((label) => (
+                      <span key={label} className="hero-stage-github-issue-label">
+                        {label}
+                      </span>
+                    ))}
+                  </div>
+                  <span className="hero-stage-github-issue-comments">{issue.comments}</span>
+                </div>
               </article>
             ))}
           </section>
@@ -405,11 +765,33 @@ function GitHubHeroStage({ tool }) {
             <span className="hero-stage-micro-label">{stage.detailLabel}</span>
             <strong>{stage.detailTitle}</strong>
             <p>{stage.detailSummary}</p>
-            <ul className="hero-stage-list">
-              {stage.detailItems.map((item) => (
-                <li key={item}>{item}</li>
+
+            <div className="hero-stage-github-detail-meta">
+              {stage.detailMeta.map((item) => (
+                <span key={item} className="hero-stage-github-detail-chip">
+                  {item}
+                </span>
               ))}
-            </ul>
+            </div>
+
+            <div className="hero-stage-github-checklist">
+              {stage.detailChecklist.map((item) => (
+                <GitHubChecklistItem key={item.title} item={item} />
+              ))}
+            </div>
+
+            <div className="hero-stage-github-detail-comment">
+              <span>{stage.detailCommentTitle}</span>
+              <p>{stage.detailComment}</p>
+            </div>
+
+            <div className="hero-stage-github-activity-list">
+              {stage.detailActivity.map((item) => (
+                <GitHubActivityRow key={`${item.actor}-${item.text}`} item={item} />
+              ))}
+            </div>
+
+            <div className="hero-stage-inline-note">{stage.detailFooter}</div>
           </aside>
         </div>
       </div>
@@ -423,9 +805,27 @@ function NotionHeroStage({ tool }) {
   return (
     <div className="hero-stage-body hero-stage-notion-layout">
       <section className="hero-stage-notion-page">
-        <div className="hero-stage-notion-breadcrumb">{stage.breadcrumb}</div>
-        <h3>{stage.pageTitle}</h3>
-        <p>{stage.pageIntro}</p>
+        <div className="hero-stage-notion-meta-row">
+          <div className="hero-stage-notion-breadcrumb">{stage.breadcrumb}</div>
+          <NotionCollaboratorBar items={stage.collaborators} />
+        </div>
+
+        <div className="hero-stage-notion-page-head">
+          <span className="hero-stage-notion-page-icon">{stage.pageIcon}</span>
+          <div className="hero-stage-notion-title-copy">
+            <h3>{stage.pageTitle}</h3>
+            <p>{stage.pageIntro}</p>
+          </div>
+        </div>
+
+        <div className="hero-stage-notion-properties">
+          {stage.properties.map((property) => (
+            <div key={property.label} className="hero-stage-notion-property">
+              <span>{property.label}</span>
+              <strong>{property.value}</strong>
+            </div>
+          ))}
+        </div>
 
         <div className="hero-stage-notion-blocks">
           {stage.blocks.map((block) => (
@@ -433,20 +833,39 @@ function NotionHeroStage({ tool }) {
               key={`${block.type}-${block.text}`}
               className={`hero-stage-notion-block hero-stage-notion-block-${block.type}`}
             >
-              <span aria-hidden="true">
-                {block.type === 'heading' ? 'H1' : block.type === 'todo' ? '[]' : '-'}
-              </span>
+              <span aria-hidden="true">{getNotionBlockMarker(block.type)}</span>
               <strong>{block.text}</strong>
             </div>
           ))}
         </div>
 
         <div className="hero-stage-notion-table">
-          <span className="hero-stage-micro-label">{stage.databaseLabel}</span>
+          <div className="hero-stage-notion-table-head">
+            <span className="hero-stage-micro-label">{stage.databaseLabel}</span>
+            <div className="hero-stage-notion-tabs">
+              {stage.databaseTabs.map((tab, index) => (
+                <span key={tab} className={index === 0 ? 'is-active' : ''}>
+                  {tab}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {stage.databaseColumns?.length ? (
+            <div className="hero-stage-notion-table-columns">
+              {stage.databaseColumns.map((column) => (
+                <span key={column}>{column}</span>
+              ))}
+            </div>
+          ) : null}
+
           {stage.rows.map((row) => (
             <div key={row.name} className="hero-stage-notion-row">
-              <strong>{row.name}</strong>
-              <span>{row.meta}</span>
+              <div className="hero-stage-notion-row-main">
+                <strong>{row.name}</strong>
+                <span>{row.meta}</span>
+              </div>
+              <HeroStageStatusPill label={row.status} />
             </div>
           ))}
         </div>
@@ -460,6 +879,7 @@ function NotionHeroStage({ tool }) {
             <li key={item}>{item}</li>
           ))}
         </ul>
+        <div className="hero-stage-inline-note">{stage.sideFootnote}</div>
       </aside>
     </div>
   );
@@ -471,19 +891,36 @@ function LarkHeroStage({ tool }) {
   return (
     <div className="hero-stage-body hero-stage-lark-layout">
       <section className="hero-stage-lark-feed">
-        <div className="hero-stage-lark-head">
-          <strong>{stage.chatTitle}</strong>
-          <span>{stage.chatMeta}</span>
+        <div className="hero-stage-lark-toolbar">
+          <div className="hero-stage-lark-head">
+            <strong>{stage.workspace}</strong>
+            <span>{stage.workspaceMeta}</span>
+          </div>
+          <div className="hero-stage-lark-tabs">
+            {stage.tabs.map((tab, index) => (
+              <span key={tab} className={index === 0 ? 'is-active' : ''}>
+                {tab}
+              </span>
+            ))}
+          </div>
         </div>
+
+        {stage.participants?.length ? (
+          <div className="hero-stage-lark-participants">
+            <HeroStageAvatarCluster items={stage.participants} />
+            <span>{stage.participants.join(' / ')}</span>
+          </div>
+        ) : null}
 
         <div className="hero-stage-lark-recap">
           <span className="hero-stage-micro-label">{stage.recapLabel}</span>
+          <strong>{stage.recapTitle}</strong>
           <p>{stage.recapText}</p>
         </div>
 
-        <div className="hero-stage-message-stack">
+        <div className="hero-stage-lark-message-feed">
           {stage.messages.map((message) => (
-            <HeroStageMessage key={`${message.author}-${message.text}`} {...message} />
+            <LarkStageMessage key={`${message.author}-${message.text}`} {...message} />
           ))}
         </div>
       </section>
@@ -491,14 +928,26 @@ function LarkHeroStage({ tool }) {
       <aside className="hero-stage-lark-card">
         <span className="hero-stage-micro-label">{stage.trackerLabel}</span>
         <strong className="hero-stage-lark-title">{stage.trackerTitle}</strong>
+
+        {stage.ownerColumns?.length ? (
+          <div className="hero-stage-lark-owner-head">
+            {stage.ownerColumns.map((column) => (
+              <span key={column}>{column}</span>
+            ))}
+          </div>
+        ) : null}
+
         <div className="hero-stage-lark-owners">
           {stage.owners.map((owner) => (
             <div key={`${owner.owner}-${owner.task}`} className="hero-stage-lark-owner-row">
-              <div>
+              <div className="hero-stage-lark-owner-copy">
                 <strong>{owner.owner}</strong>
                 <span>{owner.task}</span>
               </div>
-              <small>{owner.due}</small>
+              <div className="hero-stage-lark-owner-meta">
+                <small>{owner.due}</small>
+                <HeroStageStatusPill label={owner.status} />
+              </div>
             </div>
           ))}
         </div>
@@ -506,6 +955,14 @@ function LarkHeroStage({ tool }) {
         <div className="hero-stage-lark-update">
           <span>{stage.updateLabel}</span>
           <p>{stage.updateText}</p>
+        </div>
+
+        <div className="hero-stage-chip-row">
+          {stage.updateActions.map((action) => (
+            <span key={action} className="hero-stage-chip">
+              {action}
+            </span>
+          ))}
         </div>
       </aside>
     </div>

--- a/website/src/pages/landingContent.js
+++ b/website/src/pages/landingContent.js
@@ -63,22 +63,55 @@ const EN_LANDING_CONTENT = {
         sampleReply: 'I can draft the reply, tighten the tone, and point out what is still missing',
         accent: '#ff8a3d',
         stage: {
-          composeTitle: 'New request',
+          appName: 'Inbox',
+          appMeta: 'Draft with Oliver',
+          folders: [
+            { label: 'Inbox', count: '12' },
+            { label: 'Drafts', count: '3', active: true },
+            { label: 'Sent', count: '' },
+            { label: 'Archive', count: '' }
+          ],
+          threads: [
+            {
+              from: 'Sage Capital',
+              subject: 'Friday follow-up',
+              preview: 'Loved the conversation today. Could you send the recap by Friday?',
+              time: '2m',
+              active: true
+            },
+            {
+              from: 'Course admin',
+              subject: 'Midterm office hours',
+              preview: 'New time slots are open for next Tuesday.',
+              time: '1h'
+            },
+            {
+              from: 'Mina',
+              subject: 'Launch recap',
+              preview: 'Shared the latest checklist in the ops folder.',
+              time: '3h'
+            }
+          ],
+          composeTitle: 'Draft request',
+          draftBadge: 'Reply',
           toLabel: 'To',
           toValue: 'oliver@dowhiz.com',
-          subjectLabel: 'Subject',
-          subjectValue: 'Follow up after the sponsor call',
+          ccLabel: 'Target',
+          ccValue: 'sponsor@sagecap.com',
+          subjectLabel: 'Request',
+          subjectValue: 'Draft a warm follow-up after the sponsor call',
+          tags: ['Warm tone', 'Friday recap'],
           bodyLines: [
             'Hi Oliver,',
-            'Turn these notes into a warm follow-up email.',
+            'Draft a concise reply for the sponsor.',
             '- thank them for hosting',
             '- mention the Friday recap',
             '- keep the ask light'
           ],
-          footerNote: 'Fastest path',
-          footerValue: 'No login needed',
-          resultLabel: 'Oliver returns',
-          resultTitle: 'Reply draft ready',
+          footerNote: 'Oliver can tighten tone before you send',
+          footerValue: 'Send request',
+          resultLabel: 'Oliver notes',
+          resultTitle: 'Reply ready',
           resultItems: [
             'A tighter subject line',
             'A clean three-paragraph draft',
@@ -100,35 +133,68 @@ const EN_LANDING_CONTENT = {
         accent: '#36c58b',
         stage: {
           workspace: 'product-ops',
+          workspaceMeta: '8 teammates online',
           channels: ['#launch-ops', '#customer-handoffs', '#weekly-plan'],
+          sections: [
+            {
+              title: 'Channels',
+              items: [
+                { label: '#launch-ops', active: true },
+                { label: '#customer-handoffs' },
+                { label: '#weekly-plan' }
+              ]
+            },
+            {
+              title: 'Direct messages',
+              items: [
+                { label: 'Oliver', accent: 'bot' },
+                { label: 'Mina' }
+              ]
+            }
+          ],
           room: '#launch-ops',
-          roomMeta: 'Thread activity',
+          roomMeta: '23 messages today',
+          roomMembers: ['Mina', 'Theo', 'Oliver'],
+          threadPills: ['launch', 'handoff', 'needs owner'],
+          threadActivity: '3 replies in thread',
           messages: [
             {
               author: 'Mina',
               meta: 'Ops',
-              text: 'We still need one clear owner for docs, QA, and launch email.'
+              time: '10:14 AM',
+              text: 'We still need one clear owner for docs, QA, and launch email.',
+              reactions: ['eyes 2', 'check 1']
             },
             {
               author: 'Theo',
               meta: 'Design',
-              text: 'Assets are ready, but the rollout order is not written down.'
+              time: '10:18 AM',
+              text: 'Assets are ready, but the rollout order is not written down.',
+              reactions: ['memo 1']
             },
             {
               author: 'You',
               meta: 'Ask Oliver',
+              time: '10:22 AM',
               text: 'Summarize this thread and give me the next three actions.',
               tone: 'user'
             }
           ],
-          cardLabel: 'Oliver block',
-          cardTitle: 'Next actions',
+          threadLabel: 'Thread summary',
+          threadTitle: 'Launch blockers',
+          threadText: 'Docs owner is still missing. QA order is not final. The launch email needs one clean checklist.',
+          cardLabel: 'Oliver block kit',
+          cardTitle: 'Ready for the channel',
+          cardSummary: 'One clean update and next actions',
           cardItems: [
             'Assign docs owner before 3 PM',
             'Lock QA sign-off order',
             'Post one rollout checklist back to the channel'
           ],
-          cardFooter: 'Ready to paste into Slack'
+          cardFooter: 'One clean update and next actions',
+          cardActions: ['Post summary', 'Open thread'],
+          composerPlaceholder: 'Reply in #launch-ops',
+          composerHint: 'Type a message'
         }
       },
       {
@@ -147,21 +213,39 @@ const EN_LANDING_CONTENT = {
           server: 'study-lab',
           onlineLabel: '18 online',
           channels: ['announcements', 'planning-room', 'resources'],
+          sections: [
+            {
+              title: 'TEXT CHANNELS',
+              items: [
+                { label: 'announcements' },
+                { label: 'planning-room', active: true },
+                { label: 'resources' }
+              ]
+            }
+          ],
           room: '#planning-room',
+          roomTopic: 'Weekly reading coordination',
+          roomMeta: '2 active threads',
           messages: [
             {
               author: 'Lena',
               meta: 'Moderator',
+              time: 'Today at 6:12 PM',
+              accent: '#f2b4ff',
               text: 'We should split the readings and make the check-in deadline obvious.'
             },
             {
               author: 'Marco',
               meta: 'Member',
+              time: 'Today at 6:15 PM',
+              accent: '#8ec5ff',
               text: 'Let us pin one summary so new people stop asking the same thing.'
             },
             {
               author: 'You',
               meta: 'Prompt Oliver',
+              time: 'Today at 6:18 PM',
+              accent: '#9aa4ff',
               text: 'Turn this into a plan for the week.',
               tone: 'user'
             }
@@ -169,11 +253,27 @@ const EN_LANDING_CONTENT = {
           planLabel: 'Oliver bot',
           planTitle: 'Weekly plan',
           planItems: [
-            'Mon: post the reading queue',
-            'Wed: collect open questions',
-            'Fri: pin the recap and next steps'
+            'Mon: Post the reading queue and due dates',
+            'Wed: Collect open questions in one thread',
+            'Fri: Pin the recap and next steps'
           ],
-          planActions: ['Reply with plan', 'Pin summary']
+          planActions: ['Pin plan', 'Open room'],
+          botLabel: 'Oliver bot',
+          botTitle: 'Weekly plan',
+          botDescription: 'Here is a clean plan based on the thread.',
+          botFields: [
+            { label: 'Mon', value: 'Post the reading queue and due dates' },
+            { label: 'Wed', value: 'Collect open questions in one thread' },
+            { label: 'Fri', value: 'Pin the recap and next steps' }
+          ],
+          composerValue: '/oliver turn this into a plan',
+          composerHint: 'Press enter to send',
+          membersTitle: 'Online now',
+          members: [
+            { name: 'Oliver', role: 'Bot', accent: true },
+            { name: 'Lena', role: 'Moderator' },
+            { name: 'Marco', role: 'Member' }
+          ]
         }
       },
       {
@@ -190,36 +290,67 @@ const EN_LANDING_CONTENT = {
         accent: '#2c2c2e',
         stage: {
           repo: 'dowhiz/website',
-          repoMeta: 'Issue triage',
-          tabs: ['Issues', 'Projects', 'Pull requests'],
+          repoMeta: 'main branch',
+          tabs: ['Code', 'Issues', 'Pull requests', 'Actions'],
+          filters: ['is:open', 'label:landing', 'sort:updated-desc'],
+          overview: { open: '18 Open', closed: '128 Closed' },
           issues: [
             {
               id: '#184',
               title: 'Hero states still look too similar',
-              meta: 'landing',
-              status: 'P1'
+              meta: 'shayne opened 2h ago',
+              status: 'Open',
+              labels: ['landing', 'design'],
+              comments: '12',
+              active: true
             },
             {
               id: '#181',
               title: 'Keep no-login CTA behavior intact',
-              meta: 'growth',
-              status: 'Must keep'
+              meta: 'james updated 4h ago',
+              status: 'Open',
+              labels: ['growth', 'routing'],
+              comments: '5'
             },
             {
               id: '#177',
               title: 'Tighten mobile hero spacing',
-              meta: 'ui',
-              status: 'Follow-up'
+              meta: 'yegaoyang updated yesterday',
+              status: 'Open',
+              labels: ['ui'],
+              comments: '3'
             }
           ],
-          detailLabel: 'Oliver triage',
-          detailTitle: 'What matters first',
-          detailSummary: 'Fix the shared hero template first, then polish the supporting details.',
+          detailLabel: 'Selected issue',
+          detailTitle: 'Hero states still look too similar',
+          detailSummary: 'Users still read the hero as one repeated panel with accent swaps instead of six distinct product surfaces.',
+          detailMeta: ['landing', 'design system', 'priority: high'],
           detailItems: [
             'Ship distinct per-channel layouts',
             'Preserve public Slack and Discord entry flows',
             'Treat mobile readability as a release blocker'
-          ]
+          ],
+          detailChecklist: [
+            { title: 'Ship distinct per-channel layouts', meta: 'In progress', state: 'progress' },
+            { title: 'Keep Slack and Discord public entry flows', meta: 'Blocked by regressions', state: 'todo' },
+            { title: 'Treat mobile as release-critical', meta: 'Needs visual QA', state: 'todo' }
+          ],
+          detailCommentTitle: 'Oliver triage note',
+          detailComment:
+            'Ship channel-native structures first. Keep click behavior truthful. Treat smaller screens as part of the release, not a follow-up.',
+          detailActivity: [
+            {
+              actor: 'Oliver',
+              text: 'Split the issue into layout, CTA truthfulness, and mobile follow-up.',
+              meta: 'commented 4m ago'
+            },
+            {
+              actor: 'shayne',
+              text: 'Marked the hero as release-blocking until the channel states stop looking reused.',
+              meta: 'updated 58m ago'
+            }
+          ],
+          detailFooter: 'Ready to post as an issue comment'
         }
       },
       {
@@ -236,23 +367,34 @@ const EN_LANDING_CONTENT = {
         accent: '#6f6b63',
         stage: {
           breadcrumb: 'Personal / Study / Draft',
+          collaborators: ['You', 'Oliver', 'TA'],
+          pageIcon: 'N',
           pageTitle: 'Oliver study outline',
           pageIntro: 'Modern China midterm review',
+          properties: [
+            { label: 'Course', value: 'HIST 242' },
+            { label: 'Status', value: 'Draft' },
+            { label: 'Owner', value: 'You + Oliver' }
+          ],
           blocks: [
             { type: 'heading', text: 'Core questions' },
             { type: 'bullet', text: 'What changed after the reform era' },
             { type: 'bullet', text: 'How the three assigned readings compare' },
-            { type: 'todo', text: 'Add one source for rural policy' }
+            { type: 'todo', text: 'Add one source for rural policy' },
+            { type: 'callout', text: 'Oliver reordered the notes into a better study path' }
           ],
           databaseLabel: 'Next up',
+          databaseTabs: ['Table', 'Board'],
+          databaseColumns: ['Task', 'When', 'Status'],
           rows: [
-            { name: 'Lecture notes cleanup', meta: '20 min' },
-            { name: 'Open questions', meta: '3 gaps' },
-            { name: 'Revision pass', meta: 'Tonight' }
+            { name: 'Lecture notes cleanup', meta: 'Tonight', status: 'In progress' },
+            { name: 'Open questions', meta: '3 gaps', status: 'Queued' },
+            { name: 'Revision pass', meta: 'Tomorrow', status: 'Next' }
           ],
           sideLabel: 'Oliver organized',
           sideTitle: 'From notes to outline',
-          sideItems: ['Cleaner sections', 'A clearer reading order', 'What still needs research']
+          sideItems: ['Cleaner sections', 'A clearer reading order', 'What still needs research'],
+          sideFootnote: 'Ready to paste into your page'
         }
       },
       {
@@ -268,33 +410,42 @@ const EN_LANDING_CONTENT = {
         sampleReply: 'I can turn it into owners, deadlines, and an update you can send',
         accent: '#3f88ff',
         stage: {
+          workspace: 'Growth sync',
+          workspaceMeta: '6 participants',
           chatTitle: 'Growth sync',
           chatMeta: '6 participants',
+          tabs: ['Chat', 'Docs', 'Meetings'],
+          participants: ['Nina', 'Sam', 'Oliver'],
           recapLabel: 'Meeting recap',
-          recapText:
-            'Need a vendor shortlist, a sendable leadership update, and one clear follow-up owner list.',
+          recapTitle: 'Vendor shortlist + leadership update',
+          recapText: 'Need a vendor shortlist, a sendable leadership update, and one clear follow-up owner list.',
           messages: [
             {
               author: 'Nina',
               meta: 'PM',
+              time: '10:02',
               text: 'We have the meeting notes, but not the final owners yet.'
             },
             {
               author: 'Sam',
               meta: 'Ops',
+              time: '10:07',
+              badge: 'Needs send',
               text: 'We also need a clean update card before tomorrow morning.'
             }
           ],
           trackerLabel: 'Oliver follow-up',
           trackerTitle: 'Owners and timing',
+          ownerColumns: ['Owner', 'Task', 'Due'],
           owners: [
-            { owner: 'Nina', task: 'Vendor shortlist', due: 'Thu' },
-            { owner: 'Sam', task: 'Leadership update', due: 'Fri 9 AM' },
-            { owner: 'Oliver', task: 'Draft sendable recap', due: 'Now' }
+            { owner: 'Nina', task: 'Vendor shortlist', due: 'Thu', status: 'In progress' },
+            { owner: 'Sam', task: 'Leadership update', due: 'Fri 9 AM', status: 'Queued' },
+            { owner: 'Oliver', task: 'Draft sendable recap', due: 'Now', status: 'Ready' }
           ],
           updateLabel: 'Sendable update',
           updateText:
-            'Vendor shortlist ships Thursday. Leadership update goes out Friday morning with owners attached.'
+            'Vendor shortlist ships Thursday. Leadership update goes out Friday morning with owners attached.',
+          updateActions: ['Share to chat', 'Open checklist']
         }
       }
     ]
@@ -490,21 +641,54 @@ const ZH_LANDING_CONTENT = {
         sampleReply: '我可以先起草回复、收紧语气，并指出还缺什么信息',
         accent: '#ff8a3d',
         stage: {
-          composeTitle: '新邮件',
+          appName: '收件箱',
+          appMeta: '和 Oliver 一起起草',
+          folders: [
+            { label: '收件箱', count: '12' },
+            { label: '草稿箱', count: '3', active: true },
+            { label: '已发送', count: '' },
+            { label: '归档', count: '' }
+          ],
+          threads: [
+            {
+              from: 'Sage Capital',
+              subject: '周五跟进',
+              preview: '今天沟通很顺利，能否在周五前发一份 recap？',
+              time: '2分',
+              active: true
+            },
+            {
+              from: '课程助教',
+              subject: '期中 office hours',
+              preview: '下周二新开放了一批时间段。',
+              time: '1小时'
+            },
+            {
+              from: 'Mina',
+              subject: 'Launch recap',
+              preview: '我把最新 checklist 放到 ops folder 里了。',
+              time: '3小时'
+            }
+          ],
+          composeTitle: '起草请求',
+          draftBadge: '回复',
           toLabel: '收件人',
           toValue: 'oliver@dowhiz.com',
-          subjectLabel: '主题',
-          subjectValue: '整理赞助方沟通后的跟进邮件',
+          ccLabel: '目标对象',
+          ccValue: 'sponsor@sagecap.com',
+          subjectLabel: '请求内容',
+          subjectValue: '帮我起草一封更自然的赞助方跟进邮件',
+          tags: ['语气温和', '提到周五 recap'],
           bodyLines: [
             '你好 Oliver，',
-            '请把这些要点整理成一封更自然的跟进邮件。',
+            '请帮我起草一封更简洁的赞助方回复。',
             '- 感谢对方今天接待',
             '- 提到周五会发 recap',
             '- 语气保持轻一点'
           ],
-          footerNote: '最快入口',
-          footerValue: '不用先登录',
-          resultLabel: 'Oliver 返回',
+          footerNote: '发送前 Oliver 还可以帮你继续收紧语气',
+          footerValue: '发送请求',
+          resultLabel: 'Oliver 备注',
           resultTitle: '回复草稿已准备好',
           resultItems: ['更清楚的标题', '一版可直接发送的三段式草稿', '还缺哪条信息的提醒']
         }
@@ -523,31 +707,64 @@ const ZH_LANDING_CONTENT = {
         accent: '#36c58b',
         stage: {
           workspace: 'product-ops',
+          workspaceMeta: '8 位同事在线',
           channels: ['#launch-ops', '#customer-handoffs', '#weekly-plan'],
+          sections: [
+            {
+              title: '频道',
+              items: [
+                { label: '#launch-ops', active: true },
+                { label: '#customer-handoffs' },
+                { label: '#weekly-plan' }
+              ]
+            },
+            {
+              title: '私信',
+              items: [
+                { label: 'Oliver', accent: 'bot' },
+                { label: 'Mina' }
+              ]
+            }
+          ],
           room: '#launch-ops',
-          roomMeta: '线程动态',
+          roomMeta: '今天 23 条消息',
+          roomMembers: ['Mina', 'Theo', 'Oliver'],
+          threadPills: ['launch', 'handoff', '缺 owner'],
+          threadActivity: '线程里已有 3 条回复',
           messages: [
             {
               author: 'Mina',
               meta: '运营',
-              text: '文档、QA 和上线邮件还缺一个明确 owner。'
+              time: '10:14',
+              text: '文档、QA 和上线邮件还缺一个明确 owner。',
+              reactions: ['围观 2', '确认 1']
             },
             {
               author: 'Theo',
               meta: '设计',
-              text: '素材已经好了，但 rollout 顺序还没有写清楚。'
+              time: '10:18',
+              text: '素材已经好了，但 rollout 顺序还没有写清楚。',
+              reactions: ['记录 1']
             },
             {
               author: '你',
               meta: '问 Oliver',
+              time: '10:22',
               text: '帮我总结这个线程，并列出接下来三件事。',
               tone: 'user'
             }
           ],
-          cardLabel: 'Oliver 区块',
-          cardTitle: '下一步动作',
+          threadLabel: '线程总结',
+          threadTitle: '上线 blocker',
+          threadText: '文档 owner 还没定，QA 顺序没有锁住，上线邮件也还缺一个干净的 checklist。',
+          cardLabel: 'Oliver Block Kit',
+          cardTitle: '可以直接发回频道',
+          cardSummary: '一段清楚的更新 + 三个动作',
           cardItems: ['下午 3 点前确认文档 owner', '锁定 QA sign-off 顺序', '把 checklist 发回频道'],
-          cardFooter: '可以直接贴回 Slack'
+          cardFooter: '一段清楚的更新 + 三个动作',
+          cardActions: ['发 summary', '打开 thread'],
+          composerPlaceholder: '回复到 #launch-ops',
+          composerHint: '输入消息'
         }
       },
       {
@@ -566,29 +783,67 @@ const ZH_LANDING_CONTENT = {
           server: 'study-lab',
           onlineLabel: '18 人在线',
           channels: ['announcements', 'planning-room', 'resources'],
+          sections: [
+            {
+              title: '文字频道',
+              items: [
+                { label: 'announcements' },
+                { label: 'planning-room', active: true },
+                { label: 'resources' }
+              ]
+            }
+          ],
           room: '#planning-room',
+          roomTopic: '本周阅读安排',
+          roomMeta: '2 个活跃 thread',
           messages: [
             {
               author: 'Lena',
               meta: '管理员',
+              time: '今天 18:12',
+              accent: '#f2b4ff',
               text: '我们应该把阅读任务拆开，也把 check-in 的时间说得更明确。'
             },
             {
               author: 'Marco',
               meta: '成员',
+              time: '今天 18:15',
+              accent: '#8ec5ff',
               text: '还需要一条置顶总结，不然新人会一直重复提问。'
             },
             {
               author: '你',
               meta: '问 Oliver',
+              time: '今天 18:18',
+              accent: '#9aa4ff',
               text: '把这段讨论整理成本周计划。',
               tone: 'user'
             }
           ],
-          planLabel: 'Oliver bot',
+          planLabel: 'Oliver Bot',
           planTitle: '本周计划',
-          planItems: ['周一：发阅读清单', '周三：收集开放问题', '周五：置顶 recap 和下一步'],
-          planActions: ['回复计划', '置顶总结']
+          planItems: [
+            '周一：发阅读清单和截止时间',
+            '周三：把开放问题收集到同一个 thread',
+            '周五：置顶 recap 和下一步'
+          ],
+          planActions: ['置顶计划', '打开频道'],
+          botLabel: 'Oliver Bot',
+          botTitle: '本周计划',
+          botDescription: '我根据这段讨论整理了一份更清楚的节奏。',
+          botFields: [
+            { label: '周一', value: '发阅读清单和截止时间' },
+            { label: '周三', value: '把开放问题收集到同一个 thread' },
+            { label: '周五', value: '置顶 recap 和下一步' }
+          ],
+          composerValue: '/oliver 把这段整理成本周计划',
+          composerHint: '回车发送',
+          membersTitle: '在线成员',
+          members: [
+            { name: 'Oliver', role: 'Bot', accent: true },
+            { name: 'Lena', role: '管理员' },
+            { name: 'Marco', role: '成员' }
+          ]
         }
       },
       {
@@ -605,32 +860,63 @@ const ZH_LANDING_CONTENT = {
         accent: '#2c2c2e',
         stage: {
           repo: 'dowhiz/website',
-          repoMeta: 'Issue 排优先级',
-          tabs: ['Issues', 'Projects', 'Pull requests'],
+          repoMeta: 'main 分支',
+          tabs: ['Code', 'Issues', 'Pull requests', 'Actions'],
+          filters: ['is:open', 'label:landing', 'sort:updated-desc'],
+          overview: { open: '18 个 Open', closed: '128 个 Closed' },
           issues: [
             {
               id: '#184',
               title: 'Hero 状态看起来还是太像了',
-              meta: 'landing',
-              status: 'P1'
+              meta: 'shayne 2 小时前创建',
+              status: 'Open',
+              labels: ['landing', 'design'],
+              comments: '12',
+              active: true
             },
             {
               id: '#181',
               title: '保留无登录 CTA 行为',
-              meta: 'growth',
-              status: '必须保留'
+              meta: 'james 4 小时前更新',
+              status: 'Open',
+              labels: ['growth', 'routing'],
+              comments: '5'
             },
             {
               id: '#177',
               title: '继续收紧移动端 hero 间距',
-              meta: 'ui',
-              status: '待跟进'
+              meta: 'yegaoyang 昨天更新',
+              status: 'Open',
+              labels: ['ui'],
+              comments: '3'
             }
           ],
-          detailLabel: 'Oliver triage',
-          detailTitle: '先做什么',
-          detailSummary: '先解决共享 hero 模板的问题，再继续打磨其他细节。',
-          detailItems: ['先做每个 channel 独立布局', '保留 Slack 和 Discord 的直接入口', '把移动端可读性当成上线门槛']
+          detailLabel: '当前 issue',
+          detailTitle: 'Hero 状态看起来还是太像了',
+          detailSummary: '用户仍然会把 hero 读成“同一个面板只换颜色”，而不是六种不同的软件表面。',
+          detailMeta: ['landing', 'design system', 'priority: high'],
+          detailItems: ['先做每个 channel 独立布局', '保留 Slack 和 Discord 的直接入口', '把移动端可读性当成上线门槛'],
+          detailChecklist: [
+            { title: '先做每个 channel 独立布局', meta: '进行中', state: 'progress' },
+            { title: '保留 Slack 和 Discord 公开入口', meta: '避免回退', state: 'todo' },
+            { title: '把移动端当作上线门槛', meta: '还需要视觉检查', state: 'todo' }
+          ],
+          detailCommentTitle: 'Oliver triage note',
+          detailComment:
+            '先做 channel-native 的结构，再继续打磨局部细节。点击路径必须保持真实，移动端不能当作后续优化。',
+          detailActivity: [
+            {
+              actor: 'Oliver',
+              text: '已拆成布局、入口真实性、移动端三个跟进方向。',
+              meta: '4 分钟前评论'
+            },
+            {
+              actor: 'shayne',
+              text: '在 channel state 停止复用同一骨架前，hero 仍视作 release blocker。',
+              meta: '58 分钟前更新'
+            }
+          ],
+          detailFooter: '可以直接作为 issue comment'
         }
       },
       {
@@ -647,23 +933,34 @@ const ZH_LANDING_CONTENT = {
         accent: '#6f6b63',
         stage: {
           breadcrumb: 'Personal / Study / Draft',
+          collaborators: ['你', 'Oliver', '助教'],
+          pageIcon: 'N',
           pageTitle: 'Oliver 学习提纲',
           pageIntro: '中国近现代史期中复习',
+          properties: [
+            { label: '课程', value: 'HIST 242' },
+            { label: '状态', value: 'Draft' },
+            { label: '协作', value: '你 + Oliver' }
+          ],
           blocks: [
             { type: 'heading', text: '核心问题' },
             { type: 'bullet', text: '改革开放后最关键的变化是什么' },
             { type: 'bullet', text: '三篇阅读材料该怎么对照' },
-            { type: 'todo', text: '补一条关于农村政策的来源' }
+            { type: 'todo', text: '补一条关于农村政策的来源' },
+            { type: 'callout', text: 'Oliver 已经把原始笔记重新整理成更适合复习的顺序' }
           ],
           databaseLabel: '下一步',
+          databaseTabs: ['Table', 'Board'],
+          databaseColumns: ['任务', '时间', '状态'],
           rows: [
-            { name: '整理 lecture notes', meta: '20 分钟' },
-            { name: '补开放问题', meta: '3 个缺口' },
-            { name: '最后 revision', meta: '今晚' }
+            { name: '整理 lecture notes', meta: '今晚', status: '进行中' },
+            { name: '补开放问题', meta: '3 个缺口', status: '待开始' },
+            { name: '最后 revision', meta: '明天', status: '下一步' }
           ],
           sideLabel: 'Oliver 已整理',
           sideTitle: '从笔记到提纲',
-          sideItems: ['章节更清楚', '阅读顺序更明确', '还缺什么研究一眼可见']
+          sideItems: ['章节更清楚', '阅读顺序更明确', '还缺什么研究一眼可见'],
+          sideFootnote: '可以直接贴回你的页面'
         }
       },
       {
@@ -679,31 +976,41 @@ const ZH_LANDING_CONTENT = {
         sampleReply: '我可以把它整理成负责人、时间点和一段可直接发送的更新',
         accent: '#3f88ff',
         stage: {
+          workspace: 'Growth sync',
+          workspaceMeta: '6 位参与者',
           chatTitle: 'Growth sync',
           chatMeta: '6 位参与者',
+          tabs: ['Chat', 'Docs', 'Meetings'],
+          participants: ['Nina', 'Sam', 'Oliver'],
           recapLabel: '会议 recap',
+          recapTitle: 'Vendor shortlist + 领导更新',
           recapText: '需要一份 vendor shortlist、一条可直接发送的领导更新，以及明确的后续 owner 列表。',
           messages: [
             {
               author: 'Nina',
               meta: 'PM',
+              time: '10:02',
               text: '会议纪要有了，但最终 owner 还没定下来。'
             },
             {
               author: 'Sam',
               meta: '运营',
+              time: '10:07',
+              badge: '待发送',
               text: '明天上午前还要有一张干净的更新卡片。'
             }
           ],
           trackerLabel: 'Oliver 跟进',
           trackerTitle: '负责人和时间点',
+          ownerColumns: ['负责人', '事项', '时间'],
           owners: [
-            { owner: 'Nina', task: 'Vendor shortlist', due: '周四' },
-            { owner: 'Sam', task: '领导更新', due: '周五 9:00' },
-            { owner: 'Oliver', task: '起草可发送 recap', due: '现在' }
+            { owner: 'Nina', task: 'Vendor shortlist', due: '周四', status: '进行中' },
+            { owner: 'Sam', task: '领导更新', due: '周五 9:00', status: '待开始' },
+            { owner: 'Oliver', task: '起草可发送 recap', due: '现在', status: '已准备' }
           ],
           updateLabel: '可发送更新',
-          updateText: 'Vendor shortlist 周四完成，周五上午发出领导更新，并附上 owner 分工。'
+          updateText: 'Vendor shortlist 周四完成，周五上午发出领导更新，并附上 owner 分工。',
+          updateActions: ['分享到群聊', '打开 checklist']
         }
       }
     ]

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -2577,6 +2577,38 @@
   font-weight: 600;
 }
 
+.hero-stage-status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.7rem;
+  padding: 0.26rem 0.62rem;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 90%, transparent);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.hero-stage-status-pill.is-progress {
+  border-color: rgba(44, 149, 91, 0.18);
+  background: rgba(231, 252, 239, 0.95);
+  color: #277a49;
+}
+
+.hero-stage-status-pill.is-success {
+  border-color: rgba(63, 136, 255, 0.18);
+  background: rgba(236, 244, 255, 0.95);
+  color: #2f66c8;
+}
+
+.hero-stage-status-pill.is-queued {
+  border-color: rgba(211, 164, 59, 0.2);
+  background: rgba(255, 249, 229, 0.96);
+  color: #996d11;
+}
+
 .hero-stage-message-stack {
   display: grid;
   gap: 0.72rem;
@@ -2598,6 +2630,19 @@
   background: color-mix(in srgb, var(--tool-accent) 9%, #ffffff);
 }
 
+.hero-stage-message.is-flat {
+  padding: 0.8rem 0;
+  border: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--glass-border) 90%, transparent);
+  border-radius: 0;
+  background: transparent;
+}
+
+.hero-stage-message.is-flat:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
 .hero-stage-avatar {
   width: 36px;
   height: 36px;
@@ -2615,6 +2660,37 @@
 
 .hero-stage-avatar.is-user {
   background: color-mix(in srgb, var(--tool-accent) 16%, #ffffff);
+}
+
+.hero-stage-avatar-cluster {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.7rem;
+}
+
+.hero-stage-avatar-cluster-item {
+  width: 28px;
+  height: 28px;
+  margin-left: -0.4rem;
+  border-radius: 0.8rem;
+  border: 2px solid rgba(255, 255, 255, 0.95);
+  background: color-mix(in srgb, var(--tool-accent) 14%, #ffffff);
+  color: color-mix(in srgb, var(--tool-accent) 80%, #111111);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.hero-stage-avatar-cluster-item:first-child {
+  margin-left: 0;
+}
+
+.hero-stage-avatar-cluster.is-dark .hero-stage-avatar-cluster-item {
+  border-color: rgba(24, 25, 34, 0.96);
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(243, 246, 255, 0.94);
 }
 
 .hero-stage-message-copy {
@@ -2675,11 +2751,32 @@
   background: color-mix(in srgb, var(--tool-accent) 26%, white);
 }
 
+.hero-stage-mock-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.1rem;
+  padding: 0.42rem 0.82rem;
+  border-radius: 0.92rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 90%, transparent);
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.hero-stage-mock-button-dark {
+  background: #212127;
+  border-color: #212127;
+  color: rgba(255, 255, 255, 0.96);
+}
+
 .hero-stage-email-layout {
-  grid-template-columns: minmax(0, 1.12fr) minmax(280px, 0.88fr);
+  grid-template-columns: 216px minmax(0, 1.04fr) 288px;
   align-items: stretch;
 }
 
+.hero-stage-email-nav,
 .hero-stage-email-compose,
 .hero-stage-email-result {
   display: grid;
@@ -2688,6 +2785,121 @@
   border-radius: 1.35rem;
   border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
   background: rgba(255, 255, 255, 0.9);
+}
+
+.hero-stage-email-nav {
+  align-content: start;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.97) 0%, rgba(255, 247, 240, 0.95) 100%),
+    radial-gradient(circle at top left, rgba(255, 138, 61, 0.09), transparent 32%);
+}
+
+.hero-stage-email-nav-head {
+  display: grid;
+  gap: 0.16rem;
+}
+
+.hero-stage-email-nav-head strong {
+  font-size: 0.98rem;
+}
+
+.hero-stage-email-nav-head span,
+.hero-stage-email-thread small,
+.hero-stage-email-thread-head span {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.hero-stage-email-folder-list,
+.hero-stage-email-thread-list {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.hero-stage-email-folder {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.9rem;
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.hero-stage-email-folder small {
+  color: inherit;
+  font-size: 0.74rem;
+}
+
+.hero-stage-email-folder.is-active {
+  background: rgba(255, 138, 61, 0.1);
+  color: color-mix(in srgb, var(--tool-accent) 82%, var(--text-primary));
+}
+
+.hero-stage-email-thread {
+  display: grid;
+  gap: 0.26rem;
+  padding: 0.8rem 0.82rem;
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.84);
+}
+
+.hero-stage-email-thread.is-active {
+  border-color: rgba(255, 138, 61, 0.22);
+  background: rgba(255, 250, 245, 0.96);
+  box-shadow: 0 14px 30px -28px rgba(255, 138, 61, 0.28);
+}
+
+.hero-stage-email-thread-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.hero-stage-email-thread-head strong,
+.hero-stage-email-thread p {
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
+.hero-stage-email-thread p {
+  margin: 0;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.hero-stage-email-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.48rem;
+}
+
+.hero-stage-email-draft-badge,
+.hero-stage-email-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.7rem;
+  padding: 0.26rem 0.58rem;
+  border-radius: var(--radius-full);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.hero-stage-email-draft-badge {
+  background: rgba(255, 138, 61, 0.12);
+  color: color-mix(in srgb, var(--tool-accent) 82%, var(--text-primary));
+}
+
+.hero-stage-email-tag {
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-secondary);
 }
 
 .hero-stage-email-fields {
@@ -2729,7 +2941,7 @@
 .hero-stage-email-body {
   display: grid;
   gap: 0.4rem;
-  min-height: 14rem;
+  min-height: 13.2rem;
   padding: 0.1rem 0;
 }
 
@@ -2762,7 +2974,7 @@
 }
 
 .hero-stage-slack-layout {
-  grid-template-columns: 214px minmax(0, 1fr) 300px;
+  grid-template-columns: 228px minmax(0, 1fr) 308px;
   align-items: start;
 }
 
@@ -2788,8 +3000,18 @@
   gap: 0.72rem;
 }
 
+.hero-stage-slack-workspace-copy {
+  display: grid;
+  gap: 0.1rem;
+}
+
 .hero-stage-slack-workspace strong {
   font-size: 0.96rem;
+}
+
+.hero-stage-slack-workspace-copy span {
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 0.74rem;
 }
 
 .hero-stage-slack-workspace-mark {
@@ -2799,22 +3021,51 @@
   background: linear-gradient(135deg, #36c58b, #f25d67 48%, #f8c75d);
 }
 
-.hero-stage-slack-channel-list {
+.hero-stage-slack-section {
   display: grid;
-  gap: 0.52rem;
+  gap: 0.5rem;
 }
 
-.hero-stage-slack-channel-list span {
-  padding: 0.42rem 0.52rem;
-  border-radius: 0.8rem;
+.hero-stage-slack-section-title {
+  color: rgba(255, 255, 255, 0.56);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hero-stage-slack-section-list {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.hero-stage-slack-item {
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+  padding: 0.44rem 0.54rem;
+  border-radius: 0.82rem;
   color: rgba(255, 255, 255, 0.82);
   font-size: 0.84rem;
   line-height: 1.3;
 }
 
-.hero-stage-slack-channel-list span:first-child {
-  background: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.94);
+.hero-stage-slack-item.is-active {
+  background: rgba(255, 255, 255, 0.13);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.hero-stage-slack-item.is-bot {
+  color: #bef1d9;
+}
+
+.hero-stage-slack-item-marker {
+  width: 0.95rem;
+  display: inline-flex;
+  justify-content: center;
+  color: inherit;
+  font-size: 0.74rem;
+  font-weight: 700;
 }
 
 .hero-stage-slack-thread,
@@ -2823,7 +3074,7 @@
   gap: 0.85rem;
   padding: 1rem;
   border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.92);
 }
 
 .hero-stage-slack-thread-head,
@@ -2847,11 +3098,216 @@
   font-size: 0.8rem;
 }
 
+.hero-stage-slack-room-copy {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.hero-stage-slack-room-members {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.hero-stage-slack-thread-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.hero-stage-slack-thread-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.hero-stage-slack-thread-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.65rem;
+  padding: 0.26rem 0.58rem;
+  border-radius: var(--radius-full);
+  background: rgba(74, 21, 75, 0.08);
+  color: #6c2b6b;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.hero-stage-slack-thread-activity {
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+}
+
+.hero-stage-slack-message-feed {
+  display: grid;
+  gap: 0.68rem;
+}
+
+.hero-stage-slack-message {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.72rem;
+  align-items: start;
+}
+
+.hero-stage-slack-message.is-user {
+  padding: 0.78rem 0.82rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(54, 197, 139, 0.16);
+  background: rgba(243, 252, 248, 0.94);
+}
+
+.hero-stage-slack-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 0.95rem;
+  border: 1px solid rgba(74, 21, 75, 0.08);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(243, 246, 249, 0.96));
+  color: #532b55;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.hero-stage-slack-message.is-user .hero-stage-slack-avatar {
+  background: rgba(54, 197, 139, 0.14);
+  color: #1f8e63;
+}
+
+.hero-stage-slack-message-main {
+  display: grid;
+  gap: 0.26rem;
+  min-width: 0;
+}
+
+.hero-stage-slack-message-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.hero-stage-slack-message-head strong {
+  font-size: 0.86rem;
+  line-height: 1.25;
+}
+
+.hero-stage-slack-message-role,
+.hero-stage-slack-message-head small {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  line-height: 1.3;
+}
+
+.hero-stage-slack-message-head small {
+  margin-left: auto;
+}
+
+.hero-stage-slack-message p {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.hero-stage-slack-reactions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.hero-stage-slack-reaction {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.55rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 90%, transparent);
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.hero-stage-slack-summary {
+  display: grid;
+  gap: 0.48rem;
+  padding: 0.9rem;
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(247, 250, 255, 0.9);
+}
+
+.hero-stage-slack-summary strong,
+.hero-stage-lark-recap strong {
+  font-size: 0.96rem;
+  line-height: 1.25;
+}
+
+.hero-stage-slack-summary p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.hero-stage-slack-composer {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.72rem 0.8rem;
+  border-radius: 0.95rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.hero-stage-slack-composer-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.8rem;
+  padding: 0.3rem 0.62rem;
+  border-radius: var(--radius-full);
+  background: rgba(54, 197, 139, 0.12);
+  color: #1f8e63;
+  font-size: 0.74rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.hero-stage-slack-composer-copy {
+  display: grid;
+  gap: 0.08rem;
+}
+
+.hero-stage-slack-composer-copy strong {
+  font-size: 0.84rem;
+  line-height: 1.3;
+}
+
+.hero-stage-slack-composer-copy span {
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+}
+
 .hero-stage-slack-card {
   align-content: start;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(246, 255, 251, 0.96) 100%),
     radial-gradient(circle at top left, rgba(54, 197, 139, 0.12), transparent 36%);
+}
+
+.hero-stage-slack-card-summary {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.55;
 }
 
 .hero-stage-discord-layout {
@@ -2918,20 +3374,141 @@
   gap: 0.5rem;
 }
 
+.hero-stage-discord-section {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.hero-stage-discord-section-title,
+.hero-stage-discord-members-mini span:first-child {
+  color: rgba(227, 232, 255, 0.5);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
 .hero-stage-discord-channel-list span {
   padding: 0.42rem 0.52rem;
   border-radius: 0.8rem;
   font-size: 0.84rem;
 }
 
-.hero-stage-discord-channel-list span:nth-child(2) {
+.hero-stage-discord-channel-list span.is-active {
   background: rgba(255, 255, 255, 0.08);
   color: rgba(243, 246, 255, 0.96);
+}
+
+.hero-stage-discord-members-mini {
+  display: grid;
+  gap: 0.46rem;
 }
 
 .hero-stage-discord-room-head {
   padding-bottom: 0.8rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hero-stage-discord-room-copy {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.hero-stage-discord-room-copy span {
+  color: rgba(227, 232, 255, 0.7);
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.hero-stage-discord-chat-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.hero-stage-discord-channel-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.7rem;
+  padding: 0.26rem 0.58rem;
+  border-radius: 0.78rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(243, 246, 255, 0.94);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.hero-stage-discord-room-meta {
+  color: rgba(227, 232, 255, 0.7);
+  font-size: 0.72rem;
+}
+
+.hero-stage-discord-message-feed {
+  display: grid;
+  gap: 0.72rem;
+}
+
+.hero-stage-discord-message {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.72rem;
+  align-items: start;
+}
+
+.hero-stage-discord-message.is-user {
+  padding: 0.74rem 0.82rem;
+  border-radius: 1rem;
+  background: rgba(108, 120, 255, 0.12);
+}
+
+.hero-stage-discord-avatar {
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--discord-accent, #6c78ff) 92%, #ffffff 8%),
+    color-mix(in srgb, var(--discord-accent, #6c78ff) 58%, #0e1223 42%)
+  );
+  color: rgba(255, 255, 255, 0.96);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  box-shadow: 0 10px 24px -18px rgba(108, 120, 255, 0.9);
+}
+
+.hero-stage-discord-message-main {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.hero-stage-discord-message-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.hero-stage-discord-message-head strong {
+  font-size: 0.86rem;
+  line-height: 1.2;
+}
+
+.hero-stage-discord-role,
+.hero-stage-discord-message-head small {
+  color: rgba(227, 232, 255, 0.72);
+  font-size: 0.72rem;
+}
+
+.hero-stage-discord-message p {
+  margin: 0;
+  color: rgba(243, 246, 255, 0.92);
+  font-size: 0.86rem;
+  line-height: 1.55;
 }
 
 .hero-stage-message-stack.is-dense {
@@ -2953,10 +3530,79 @@
   color: rgba(255, 255, 255, 0.94);
 }
 
+.hero-stage-discord-composer {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.82rem 0.9rem;
+  border-radius: 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.hero-stage-discord-composer strong,
+.hero-stage-discord-field strong,
+.hero-stage-discord-member strong {
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
+.hero-stage-discord-composer span,
+.hero-stage-discord-field span,
+.hero-stage-discord-member span {
+  color: rgba(227, 232, 255, 0.74);
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
 .hero-stage-discord-plan {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(108, 120, 255, 0.12) 100%),
     rgba(255, 255, 255, 0.04);
+}
+
+.hero-stage-discord-bot-description {
+  margin: 0;
+  color: rgba(227, 232, 255, 0.78);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+.hero-stage-discord-embed {
+  display: grid;
+  grid-template-columns: 4px minmax(0, 1fr);
+  gap: 0.8rem;
+  padding: 0.2rem 0;
+}
+
+.hero-stage-discord-embed-accent {
+  border-radius: var(--radius-full);
+  background: linear-gradient(180deg, rgba(108, 120, 255, 0.98), rgba(144, 136, 255, 0.92));
+}
+
+.hero-stage-discord-field-list,
+.hero-stage-discord-member-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.hero-stage-discord-field,
+.hero-stage-discord-member {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.72rem 0.82rem;
+  border-radius: 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.hero-stage-discord-member-title {
+  color: rgba(243, 246, 255, 0.88);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.hero-stage-discord-member.is-accent {
+  background: rgba(108, 120, 255, 0.14);
 }
 
 .hero-stage-discord-plan .hero-stage-micro-label {
@@ -3022,6 +3668,55 @@
   font-weight: 600;
 }
 
+.hero-stage-github-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.hero-stage-github-filter,
+.hero-stage-github-detail-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.7rem;
+  padding: 0.28rem 0.58rem;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(247, 249, 252, 0.96);
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.hero-stage-github-list-head {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.hero-stage-github-list-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.38rem;
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.hero-stage-github-list-count::before {
+  content: '';
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: var(--radius-full);
+  background: rgba(110, 118, 129, 0.54);
+}
+
+.hero-stage-github-list-count.is-open::before {
+  background: #2da44e;
+}
+
 .hero-stage-github-grid {
   display: grid;
   grid-template-columns: minmax(280px, 0.96fr) minmax(0, 1.04fr);
@@ -3042,30 +3737,87 @@
   background: rgba(255, 255, 255, 0.92);
 }
 
-.hero-stage-github-issue-head {
+.hero-stage-github-issue.is-active {
+  border-color: rgba(63, 136, 255, 0.2);
+  box-shadow: 0 18px 34px -28px rgba(63, 136, 255, 0.22);
+}
+
+.hero-stage-github-issue-title-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.8rem;
 }
 
-.hero-stage-github-issue-head strong {
-  font-size: 0.84rem;
-  line-height: 1.2;
+.hero-stage-github-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
 }
 
-.hero-stage-github-issue-head span {
+.hero-stage-github-state strong {
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+
+.hero-stage-github-state-dot {
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: var(--radius-full);
+  background: #2da44e;
+  box-shadow: 0 0 0 4px rgba(45, 164, 78, 0.12);
+}
+
+.hero-stage-github-issue-meta-row,
+.hero-stage-github-issue-comments,
+.hero-stage-github-detail-comment span {
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
+.hero-stage-github-issue-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.hero-stage-github-issue-badges {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.hero-stage-github-issue-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.hero-stage-github-issue-label {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 1.7rem;
-  padding: 0.28rem 0.58rem;
+  min-height: 1.55rem;
+  padding: 0.22rem 0.52rem;
   border-radius: var(--radius-full);
-  border: 1px solid color-mix(in srgb, var(--glass-border) 88%, transparent);
-  background: color-mix(in srgb, var(--tool-accent) 8%, #ffffff);
-  color: color-mix(in srgb, var(--tool-accent) 68%, var(--text-secondary));
-  font-size: 0.72rem;
+  background: rgba(229, 236, 245, 0.9);
+  color: #51606f;
+  font-size: 0.7rem;
   font-weight: 700;
+}
+
+.hero-stage-github-issue-comments {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.34rem;
+  white-space: nowrap;
+}
+
+.hero-stage-github-issue-comments::before {
+  content: '💬';
+  font-size: 0.78rem;
 }
 
 .hero-stage-github-issue p,
@@ -3089,6 +3841,117 @@
     radial-gradient(circle at top left, rgba(63, 136, 255, 0.08), transparent 36%);
 }
 
+.hero-stage-github-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.48rem;
+}
+
+.hero-stage-github-checklist {
+  display: grid;
+  gap: 0.52rem;
+}
+
+.hero-stage-github-checklist-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.72rem;
+  padding: 0.74rem 0.84rem;
+  border-radius: 0.98rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.hero-stage-github-checklist-item-progress {
+  border-color: rgba(63, 136, 255, 0.18);
+  background: rgba(244, 248, 255, 0.96);
+}
+
+.hero-stage-github-check {
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(110, 118, 129, 0.24);
+  background: rgba(255, 255, 255, 0.94);
+  color: #6e7681;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.hero-stage-github-checklist-item-progress .hero-stage-github-check {
+  border-color: rgba(63, 136, 255, 0.24);
+  background: rgba(236, 244, 255, 0.96);
+  color: #2f66c8;
+}
+
+.hero-stage-github-checklist-copy {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.hero-stage-github-checklist-copy strong {
+  font-size: 0.86rem;
+  line-height: 1.3;
+}
+
+.hero-stage-github-checklist-copy span {
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+}
+
+.hero-stage-github-detail-comment {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.9rem;
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.hero-stage-github-activity-list {
+  display: grid;
+  gap: 0.62rem;
+}
+
+.hero-stage-github-activity {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.72rem;
+  align-items: start;
+}
+
+.hero-stage-github-activity-dot {
+  width: 0.72rem;
+  height: 0.72rem;
+  margin-top: 0.24rem;
+  border-radius: var(--radius-full);
+  background: rgba(110, 118, 129, 0.58);
+}
+
+.hero-stage-github-activity-copy {
+  display: grid;
+  gap: 0.14rem;
+}
+
+.hero-stage-github-activity-copy strong {
+  font-size: 0.82rem;
+  line-height: 1.3;
+}
+
+.hero-stage-github-activity-copy p,
+.hero-stage-github-activity small {
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
+.hero-stage-github-activity small {
+  white-space: nowrap;
+}
+
 .hero-stage-notion-layout {
   grid-template-columns: minmax(0, 1.12fr) minmax(280px, 0.88fr);
   align-items: start;
@@ -3107,24 +3970,110 @@
   background: rgba(255, 252, 247, 0.9);
 }
 
+.hero-stage-notion-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
 .hero-stage-notion-breadcrumb {
   color: #8f8577;
   font-size: 0.78rem;
   line-height: 1.2;
 }
 
-.hero-stage-notion-page h3 {
+.hero-stage-notion-collaborators {
+  display: inline-flex;
+  align-items: center;
+}
+
+.hero-stage-notion-collaborator {
+  width: 30px;
+  height: 30px;
+  margin-left: -0.4rem;
+  border-radius: 0.85rem;
+  border: 2px solid rgba(255, 252, 247, 0.96);
+  background: rgba(255, 255, 255, 0.96);
+  color: #5f594f;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.hero-stage-notion-collaborator:first-child {
+  margin-left: 0;
+}
+
+.hero-stage-notion-page-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.88rem;
+}
+
+.hero-stage-notion-page-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(143, 133, 119, 0.2);
+  background: rgba(255, 255, 255, 0.94);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.96rem;
+  font-weight: 700;
+  color: #5f594f;
+}
+
+.hero-stage-notion-title-copy {
+  display: grid;
+  gap: 0.28rem;
+}
+
+.hero-stage-notion-page h3,
+.hero-stage-notion-title-copy h3 {
   margin: 0;
   font-size: 1.5rem;
   line-height: 1.04;
   letter-spacing: -0.04em;
 }
 
-.hero-stage-notion-page > p {
+.hero-stage-notion-title-copy p {
   margin: 0;
   color: #5f594f;
   font-size: 0.94rem;
   line-height: 1.55;
+}
+
+.hero-stage-notion-properties {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.hero-stage-notion-property {
+  display: grid;
+  gap: 0.14rem;
+  padding: 0.72rem 0.82rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(143, 133, 119, 0.14);
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.hero-stage-notion-property span,
+.hero-stage-notion-row-main span {
+  color: #8f8577;
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
+.hero-stage-notion-property strong,
+.hero-stage-notion-row-main strong {
+  font-size: 0.86rem;
+  line-height: 1.35;
 }
 
 .hero-stage-notion-blocks {
@@ -3163,6 +4112,10 @@
   background: rgba(247, 252, 247, 0.94);
 }
 
+.hero-stage-notion-block-callout {
+  background: rgba(250, 246, 234, 0.96);
+}
+
 .hero-stage-notion-table {
   display: grid;
   gap: 0.32rem;
@@ -3170,6 +4123,45 @@
   border-radius: 1.05rem;
   border: 1px solid rgba(143, 133, 119, 0.14);
   background: rgba(250, 248, 244, 0.95);
+}
+
+.hero-stage-notion-table-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-stage-notion-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+}
+
+.hero-stage-notion-tabs span {
+  padding: 0.34rem 0.62rem;
+  border-radius: 0.82rem;
+  color: #8f8577;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.hero-stage-notion-tabs span.is-active {
+  background: rgba(255, 255, 255, 0.94);
+  color: #5f594f;
+}
+
+.hero-stage-notion-table-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 88px 96px;
+  gap: 0.8rem;
+  padding: 0.14rem 0 0.24rem;
+  color: #8f8577;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .hero-stage-notion-row {
@@ -3185,13 +4177,9 @@
   border-top: 0;
 }
 
-.hero-stage-notion-row strong {
-  font-size: 0.88rem;
-}
-
-.hero-stage-notion-row span {
-  color: #8f8577;
-  font-size: 0.78rem;
+.hero-stage-notion-row-main {
+  display: grid;
+  gap: 0.14rem;
 }
 
 .hero-stage-notion-sidecard {
@@ -3221,6 +4209,43 @@
     radial-gradient(circle at top left, rgba(63, 136, 255, 0.1), transparent 34%);
 }
 
+.hero-stage-lark-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-stage-lark-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.hero-stage-lark-tabs span {
+  padding: 0.34rem 0.62rem;
+  border-radius: 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.hero-stage-lark-tabs span.is-active {
+  border-color: rgba(63, 136, 255, 0.2);
+  background: rgba(237, 247, 255, 0.96);
+  color: #2f66c8;
+}
+
+.hero-stage-lark-participants {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
 .hero-stage-lark-recap,
 .hero-stage-lark-update {
   padding: 0.9rem;
@@ -3244,6 +4269,90 @@
     radial-gradient(circle at top left, rgba(63, 136, 255, 0.12), transparent 34%);
 }
 
+.hero-stage-lark-message-feed {
+  display: grid;
+  gap: 0.62rem;
+}
+
+.hero-stage-lark-message {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.72rem;
+  padding: 0.78rem 0.82rem;
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.hero-stage-lark-avatar {
+  width: 38px;
+  height: 38px;
+  border-radius: 1rem;
+  background: rgba(63, 136, 255, 0.14);
+  color: #2f66c8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.hero-stage-lark-message-main {
+  display: grid;
+  gap: 0.22rem;
+  min-width: 0;
+}
+
+.hero-stage-lark-message-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.hero-stage-lark-message-head strong {
+  font-size: 0.86rem;
+  line-height: 1.25;
+}
+
+.hero-stage-lark-message-head span,
+.hero-stage-lark-message-head small {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+}
+
+.hero-stage-lark-message-head em {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.45rem;
+  padding: 0.18rem 0.46rem;
+  border-radius: var(--radius-full);
+  background: rgba(63, 136, 255, 0.12);
+  color: #2f66c8;
+  font-size: 0.68rem;
+  font-style: normal;
+  font-weight: 700;
+}
+
+.hero-stage-lark-message p {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 0.88rem;
+  line-height: 1.52;
+}
+
+.hero-stage-lark-owner-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 1rem;
+  padding: 0 0.2rem;
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .hero-stage-lark-owners {
   display: grid;
   gap: 0.62rem;
@@ -3263,6 +4372,17 @@
 .hero-stage-lark-owner-row div {
   display: grid;
   gap: 0.14rem;
+}
+
+.hero-stage-lark-owner-copy {
+  display: grid;
+  gap: 0.14rem;
+}
+
+.hero-stage-lark-owner-meta {
+  display: grid;
+  justify-items: end;
+  gap: 0.35rem;
 }
 
 .hero-stage-lark-owner-row strong {


### PR DESCRIPTION
## Summary
- rebuild the landing hero showcase into more channel-native mock surfaces instead of one repeated card template
- differentiate Slack, Discord, GitHub, Notion, Lark, and Email with their own interaction grammar while preserving current real CTA wiring
- expand localized landing content so English and Chinese hero states stay aligned with the richer native-feeling structures

## Testing
- `cd website && npm run build`
- `cd website && npm run lint`
- manually checked `/` and `/cn`
- manually checked desktop and mobile hero readability
- manually confirmed the hero still uses the existing `handleHeroToolAction` flow wiring

## Notes
- this keeps the current truthful direct-use paths intact; the hero surfaces are mocked presentation components only
- screenshots were validated locally during implementation
