### PR TITLE
feat(onboarding): add quick start templates and /students landing page

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -359,6 +359,9 @@ Do NOT use browser automation for GitHub - the CLI is faster and more reliable.
 Identity Lookup - for inviting Discord guild members to shared resources:
 - When you need to share Google Docs/GitHub repos with Discord guild members, read `skills/identity-lookup/SKILL.md` for the `identity_lookup_cli` commands.
 
+Group Project Coordination:
+- When coordinating team workspaces or shared resources for multiple people, read `skills/group-project-coordination/SKILL.md` for the workflow.
+
 Security: Only access files the CURRENT USER has shared. Never access other users' files.
 See `.agents/skills/google-*/SKILL.md` for detailed command references.
 

--- a/DoWhiz_service/skills/group-project-coordination/SKILL.md
+++ b/DoWhiz_service/skills/group-project-coordination/SKILL.md
@@ -1,0 +1,48 @@
+# Group Project Coordination
+
+Use this skill when users ask to set up or coordinate a group project, team workspace, or shared resources.
+
+## Core Principle
+
+When coordinating multiple people, you often need contact info (email, GitHub) that you don't have. **Don't stop and report "I don't have their email" - proactively collect it.**
+
+## Workflow
+
+1. **Identify team members**: Ask the user who's in the group (Discord @mentions, names, etc.)
+
+2. **Look up known identities**: 
+   ```bash
+   # Check if team members have DoWhiz accounts with linked identities
+   identity_lookup_cli guild-identities <guild_id> --type email,github
+   ```
+
+3. **Collect missing info**: For members without linked accounts, reach out directly:
+   ```bash
+   # DM the person to ask for their email/GitHub
+   discord_cli send-dm <user_id> "Hi! [Organizer] is setting up a shared workspace for [project]. Could you reply with your email so I can invite you to the Google Drive folder?"
+   ```
+
+4. **Create shared resources**:
+   - Google Drive folder: `google-docs create-folder "Project Name" && google-docs share <folder_id> <email> editor`
+   - GitHub repo: `gh repo create <org>/<name> --private && gh api repos/<org>/<name>/collaborators/<username> -X PUT`
+
+5. **Report back** with links and who still needs to respond
+
+## Key Commands
+
+| Task | Command |
+|------|---------|
+| List guild members | `discord_cli list-guild-members <guild_id>` |
+| Look up linked email | `identity_lookup_cli discord-to-email <discord_user_id>` |
+| Look up linked GitHub | `identity_lookup_cli discord-to-github <discord_user_id>` |
+| Batch lookup | `identity_lookup_cli guild-identities <guild_id>` |
+| Send DM | `discord_cli send-dm <user_id> "<message>"` |
+| Create Drive folder | `google-docs create-folder "<name>"` |
+| Share with user | `google-docs share <file_id> <email> editor` |
+
+## Tips
+
+- **Don't wait for everyone**: Create resources as soon as you have some emails, then add others as they respond
+- **Track who's missing**: Keep a list in your reply of who you're still waiting on
+- **Follow up**: If someone doesn't respond to DM, mention it to the organizer so they can nudge
+- **Remember for next time**: Once you learn someone's email, save it to memory for future tasks


### PR DESCRIPTION
## Summary
- **Quick Start Templates**: 6 pre-filled task templates on landing page (email/Discord) to lower first-message barrier
- **/students page**: Dedicated landing page with student-focused copy, examples, and FAQ
- **Progressive Discovery**: Agent suggests related capabilities after completing tasks

## Changes
- `landingContent.js` - Added quickStart templates (EN + CN) and STUDENTS_CONTENT_OVERRIDES
- `LandingPage.jsx` - Render quickStart section, accept audience prop
- `AppRouter.jsx` - Added /students route
- `landing.css` - Styles for quick-start-card grid
- `prompt.rs` - Added "Progressive Discovery" guidance

## How to test locally
```bash
cd website && npm run dev
```
- http://localhost:5173 → Main page (scroll to "Try one of these")
- http://localhost:5173/students → Student landing page

## Screenshots
| Main page Quick Start | /students page |
|----------------------|----------------|
| "Try one of these" with 6 template buttons | "Your AI study assistant" hero |

🤖 Generated with [Claude Code](https://claude.com/claude-code)