### PR TITLE
Release ACI Codex timeout fallback to production

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -204,6 +204,9 @@ For the operational lookup/download/debugging flow, see:
   - otherwise local
 - `TASK_TIMEOUT_SECS` controls scheduler watchdog stale-task detection (default: `600`).
 - `RUN_TASK_TIMEOUT_SECS` (optional) controls command timeout for run_task; runtime caps it below `TASK_TIMEOUT_SECS` to avoid stale-task retry loops (default effective value: `TASK_TIMEOUT_SECS - 30s`).
+- `RUN_TASK_CODEX_TIMEOUT_SECS` (optional) caps primary Codex runtime before Claude fallback is
+  considered; if unset, Azure ACI Codex runs default to a 900-second primary budget while local
+  Codex keeps the overall `RUN_TASK_TIMEOUT_SECS` budget.
 
 In staging/production targets, local codex execution is blocked unless you explicitly avoid that policy.
 
@@ -213,6 +216,9 @@ Docker execution path (local worker):
 - optional `RUN_TASK_DOCKER_REQUIRED=1`
 - Codex-specific failures automatically retry with the Claude runner, including warm-pool
   executions
+- Azure ACI timeout errors (`az container create` / `az container show`) are treated as
+  fallback-eligible primary Codex failures, so long-running or stuck remote Codex attempts can
+  hand off to Claude instead of waiting for the full scheduler timeout window
 - optional `RUN_TASK_CODEX_FALLBACK_CLAUDE_MODEL=<model>` to force the Claude model used by that fallback
 - optional `RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS=<seconds>` to cap Claude fallback runtime; the
   default fallback cap is 900 seconds and it is still bounded by the overall watchdog budget

--- a/DoWhiz_service/run_task_module/README.md
+++ b/DoWhiz_service/run_task_module/README.md
@@ -34,6 +34,9 @@ Late-finalization recovery:
 - when scheduler warm-pool mode is enabled and a warm-pool run still fails, the scheduler now
   retries once through the normal direct `run_task` path so the Codex -> Claude fallback remains
   available for those jobs too
+- optional `RUN_TASK_CODEX_TIMEOUT_SECS=<seconds>` caps the primary Codex runtime; by default
+  Azure ACI Codex runs are time-boxed to 900 seconds so Claude fallback can still fire within a
+  much larger overall `RUN_TASK_TIMEOUT_SECS` window
 - optional `RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS=<seconds>` caps Claude fallback runtime; by
   default the fallback is bounded to 900 seconds and never exceeds the overall run_task timeout
 - recovered runs surface a `recovery_note` in `RunTaskOutput` and write
@@ -64,6 +67,7 @@ Minimum practical requirement:
 Common optional controls:
 - `CODEX_MODEL`, `CLAUDE_MODEL`
 - `RUN_TASK_TIMEOUT_SECS`
+- optional `RUN_TASK_CODEX_TIMEOUT_SECS=<seconds>` to cap the primary Codex runtime
 - `CODEX_SANDBOX_MODE`, `CODEX_BYPASS_SANDBOX`
 - Codex-specific failures automatically retry with the Claude runner, including warm-pool
   executions

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -106,6 +106,7 @@ const REMOTE_EXIT_CODE_FILENAME: &str = ".codex_remote_exit_code";
 const HAG_MCP_CONFIG_START_MARKER: &str = "# BEGIN DOWHIZ HUMAN APPROVAL GATE MCP";
 const HAG_MCP_CONFIG_END_MARKER: &str = "# END DOWHIZ HUMAN APPROVAL GATE MCP";
 const EPHEMERAL_SHARE_PREFIX: &str = "task-";
+const DEFAULT_AZURE_ACI_CODEX_TIMEOUT_SECS: u64 = 900;
 static ACI_CONTAINER_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Deserialize)]
@@ -561,7 +562,7 @@ pub(super) fn run_codex_task(
         trace_env_overrides.push((key.clone(), value.clone()));
     }
 
-    let timeout = run_task_timeout();
+    let timeout = codex_command_timeout(ExecutionBackend::Local);
     let mut trace = RunTaskTraceRecorder::new(
         request.workspace_dir,
         runner,
@@ -1016,6 +1017,28 @@ fn resolve_execution_backend() -> ExecutionBackend {
     }
 }
 
+fn codex_command_timeout(backend: ExecutionBackend) -> Duration {
+    let overall_timeout = run_task_timeout();
+    let configured_timeout = read_env_trimmed("RUN_TASK_CODEX_TIMEOUT_SECS")
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .map(Duration::from_secs);
+
+    let default_timeout = match backend {
+        // Azure ACI primary Codex runs need a shorter budget so Claude fallback can fire before
+        // the overall run_task watchdog window is exhausted.
+        ExecutionBackend::AzureAci => {
+            Some(Duration::from_secs(DEFAULT_AZURE_ACI_CODEX_TIMEOUT_SECS))
+        }
+        ExecutionBackend::Local => None,
+    };
+
+    configured_timeout
+        .or(default_timeout)
+        .map(|timeout| timeout.min(overall_timeout))
+        .unwrap_or(overall_timeout)
+}
+
 fn normalized_deploy_target() -> String {
     env::var("DEPLOY_TARGET")
         .unwrap_or_else(|_| "local".to_string())
@@ -1218,7 +1241,7 @@ fn run_codex_task_azure_aci(
     let container_name = build_aci_container_name();
     timing.set_task_id(&container_name);
     timing.end_setup();
-    let timeout = run_task_timeout();
+    let timeout = codex_command_timeout(ExecutionBackend::AzureAci);
     let mut trace = RunTaskTraceRecorder::new(
         request.workspace_dir,
         runner,
@@ -4614,6 +4637,51 @@ addresses = ["dowhiz@deep-tutor.com"]
             EnvVarGuard::set("RUN_TASK_EXECUTION_BACKEND", "azure_aci"),
         ];
         assert_eq!(resolve_execution_backend(), ExecutionBackend::AzureAci);
+    }
+
+    #[test]
+    fn test_codex_command_timeout_defaults_to_overall_budget_locally() {
+        let _lock = env_lock();
+        let _guards = vec![
+            EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "1200"),
+            EnvVarGuard::unset("RUN_TASK_CODEX_TIMEOUT_SECS"),
+            EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
+        ];
+
+        assert_eq!(
+            codex_command_timeout(ExecutionBackend::Local),
+            Duration::from_secs(1200)
+        );
+    }
+
+    #[test]
+    fn test_codex_command_timeout_caps_azure_aci_by_default() {
+        let _lock = env_lock();
+        let _guards = vec![
+            EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "36000"),
+            EnvVarGuard::unset("RUN_TASK_CODEX_TIMEOUT_SECS"),
+            EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
+        ];
+
+        assert_eq!(
+            codex_command_timeout(ExecutionBackend::AzureAci),
+            Duration::from_secs(DEFAULT_AZURE_ACI_CODEX_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn test_codex_command_timeout_respects_explicit_override_and_budget() {
+        let _lock = env_lock();
+        let _guards = vec![
+            EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "300"),
+            EnvVarGuard::set("RUN_TASK_CODEX_TIMEOUT_SECS", "900"),
+            EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
+        ];
+
+        assert_eq!(
+            codex_command_timeout(ExecutionBackend::AzureAci),
+            Duration::from_secs(300)
+        );
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/src/run_task/core.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/core.rs
@@ -118,6 +118,13 @@ fn normalize_runner(raw: &str) -> String {
     }
 }
 
+fn is_codex_timeout_eligible_for_fallback(command: &str) -> bool {
+    matches!(
+        command,
+        "codex" | "docker" | "docker run" | "az container create" | "az container show"
+    )
+}
+
 fn build_request<'a>(
     workspace_dir: &'a Path,
     params: &'a RunTaskParams,
@@ -145,23 +152,18 @@ fn should_fallback_to_claude(primary_runner: &str, err: &RunTaskError) -> bool {
         return false;
     }
 
-    matches!(
-        err,
+    match err {
         RunTaskError::CodexNotFound
-            | RunTaskError::CodexFailed { .. }
-            | RunTaskError::DockerNotFound
-            | RunTaskError::DockerFailed { .. }
-            | RunTaskError::AzureCliNotFound
-            | RunTaskError::OutputMissing { .. }
-            | RunTaskError::CommandTimeout {
-                command: "codex",
-                ..
-            }
-            | RunTaskError::CommandTimeout {
-                command: "docker",
-                ..
-            }
-    )
+        | RunTaskError::CodexFailed { .. }
+        | RunTaskError::DockerNotFound
+        | RunTaskError::DockerFailed { .. }
+        | RunTaskError::AzureCliNotFound
+        | RunTaskError::OutputMissing { .. } => true,
+        RunTaskError::CommandTimeout { command, .. } => {
+            is_codex_timeout_eligible_for_fallback(command)
+        }
+        _ => false,
+    }
 }
 
 fn resolve_claude_fallback_model(primary_model_name: &str) -> String {
@@ -233,12 +235,17 @@ fn primary_error_summary(err: &RunTaskError) -> &'static str {
         RunTaskError::DockerNotFound => "Docker not found for Codex execution",
         RunTaskError::DockerFailed { .. } => "Docker-wrapped Codex execution failed",
         RunTaskError::AzureCliNotFound => "Azure CLI unavailable for Codex execution",
-        RunTaskError::CommandTimeout {
-            command: "codex", ..
-        } => "Codex timed out",
-        RunTaskError::CommandTimeout {
-            command: "docker", ..
-        } => "Docker-wrapped Codex timed out",
+        RunTaskError::CommandTimeout { command, .. } if *command == "codex" => "Codex timed out",
+        RunTaskError::CommandTimeout { command, .. }
+            if *command == "docker" || *command == "docker run" =>
+        {
+            "Docker-wrapped Codex timed out"
+        }
+        RunTaskError::CommandTimeout { command, .. }
+            if *command == "az container create" || *command == "az container show" =>
+        {
+            "Azure ACI Codex timed out"
+        }
         RunTaskError::OutputMissing { .. } => {
             "Codex finished without writing the expected reply artifact"
         }
@@ -275,4 +282,20 @@ fn write_fallback_note(
     }
     fs::write(recovery_dir.join("codex_to_claude_fallback.txt"), body)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_codex_timeout_eligible_for_fallback;
+
+    #[test]
+    fn codex_timeout_fallback_covers_remote_and_docker_commands() {
+        assert!(is_codex_timeout_eligible_for_fallback("codex"));
+        assert!(is_codex_timeout_eligible_for_fallback("docker run"));
+        assert!(is_codex_timeout_eligible_for_fallback(
+            "az container create"
+        ));
+        assert!(is_codex_timeout_eligible_for_fallback("az container show"));
+        assert!(!is_codex_timeout_eligible_for_fallback("az container logs"));
+    }
 }

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -472,6 +472,51 @@ fn warm_pool_codex_failure_falls_back_to_claude_by_default() {
 
 #[test]
 #[cfg(unix)]
+fn azure_aci_timeout_error_falls_back_to_claude() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("azure_aci_timeout_fallback_to_claude").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_claude(&bin_dir, FakeClaudeMode::EnsureModel).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("EXPECTED_CLAUDE_MODEL", "claude-sonnet-4-5"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let params = build_params(&workspace);
+    let result = run_claude_fallback_after_codex_failure(
+        &params,
+        RunTaskError::CommandTimeout {
+            command: "az container show",
+            timeout_secs: 900,
+            output: "container did not reach terminal state before timeout".to_string(),
+        },
+    )
+    .expect("azure aci timeout should fall back to Claude");
+
+    let html = fs::read_to_string(&result.reply_html_path).unwrap();
+    assert!(html.contains("Claude fallback reply"));
+    assert_eq!(
+        result.recovery_note.as_deref(),
+        Some(
+            "Recovered via Claude fallback after primary Codex failure (Azure ACI Codex timed out) using Claude model claude-sonnet-4-5"
+        )
+    );
+}
+
+#[test]
+#[cfg(unix)]
 fn run_task_recovers_ready_reply_after_claude_fallback_timeout() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_claude_timeout_recovery").unwrap();


### PR DESCRIPTION
## Summary
- release the Azure ACI Codex primary timebox so stuck remote runs can fall back to Claude
- release the broader fallback eligibility for Azure ACI and docker-run timeout errors
- carry the regression tests and README updates for the new Codex timeout control

## Testing
- cargo test -p run_task_module --manifest-path DoWhiz_service/Cargo.toml

## Notes
- Relevant AUTO suites: AUTO-RUN-01 PASS
- Relevant LIVE/MANUAL suites: SKIP (not executed in release PR validation)