### PR TITLE
Resolve origin/main -> dev merge conflicts for recovery updates

### DIFF
--- a/DoWhiz_service/README.md
+++ b/DoWhiz_service/README.md
@@ -206,10 +206,10 @@ For the operational lookup/download/debugging flow, see:
   allows two full `RUN_TASK_TIMEOUT_SECS` windows plus 30 seconds of headroom so a timed-out
   Codex primary can still hand off to Claude fallback.
 - `RUN_TASK_TIMEOUT_SECS` (optional) controls each runner command timeout for run_task (default:
-  `36000`). When `TASK_TIMEOUT_SECS` is explicitly set, runtime caps each runner below that
-  watchdog budget to avoid stale-task retry loops.
+  `36000`). Runtime caps it below the effective watchdog budget to avoid stale-task retry loops.
 - `RUN_TASK_CODEX_TIMEOUT_SECS` (optional) caps primary Codex runtime before Claude fallback is
-  considered; if unset, Codex keeps the overall `RUN_TASK_TIMEOUT_SECS` budget.
+  considered; if unset, Azure ACI Codex runs default to a 900-second primary budget while local
+  Codex keeps the overall `RUN_TASK_TIMEOUT_SECS` budget.
 
 In staging/production targets, local codex execution is blocked unless you explicitly avoid that policy.
 
@@ -221,10 +221,14 @@ Docker execution path (local worker):
   executions
 - Azure ACI timeout errors (`az container create` / `az container show`) are treated as
   fallback-eligible primary Codex failures, so long-running or stuck remote Codex attempts can
-  hand off to Claude
+  hand off to Claude instead of waiting for the full scheduler timeout window
 - optional `RUN_TASK_CODEX_FALLBACK_CLAUDE_MODEL=<model>` to force the Claude model used by that fallback
-- optional `RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS=<seconds>` to cap Claude fallback runtime; if
-  unset, the fallback keeps the overall `RUN_TASK_TIMEOUT_SECS` budget
+- optional `RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS=<seconds>` to cap Claude fallback runtime; the
+  default fallback cap is 900 seconds and it is still bounded by the effective overall
+  `RUN_TASK_TIMEOUT_SECS` budget
+- Claude fallback recovery mode now prioritizes writing a useful in-channel reply before starting
+  new PDFs or other large deliverables, and it reuses `.codex_remote_output.log` plus
+  `.run_task_trace_codex_primary/` when the primary Codex attempt already gathered evidence
 - Codex success still requires the expected reply artifact to be present and non-empty; warm-pool
   completion queue exit codes are validated before the scheduler records success
 - when scheduler warm-pool mode is enabled, a warm-pool failure automatically retries through the

--- a/DoWhiz_service/run_task_module/README.md
+++ b/DoWhiz_service/run_task_module/README.md
@@ -34,10 +34,14 @@ Late-finalization recovery:
 - when scheduler warm-pool mode is enabled and a warm-pool run still fails, the scheduler now
   retries once through the normal direct `run_task` path so the Codex -> Claude fallback remains
   available for those jobs too
-- optional `RUN_TASK_CODEX_TIMEOUT_SECS=<seconds>` caps the primary Codex runtime; if unset,
-  Codex keeps the overall `RUN_TASK_TIMEOUT_SECS` budget
-- optional `RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS=<seconds>` caps Claude fallback runtime; if
-  unset, Claude fallback also keeps the overall `RUN_TASK_TIMEOUT_SECS` budget
+- optional `RUN_TASK_CODEX_TIMEOUT_SECS=<seconds>` caps the primary Codex runtime; by default
+  Azure ACI Codex runs are time-boxed to 900 seconds so Claude fallback can still fire within a
+  much larger overall `RUN_TASK_TIMEOUT_SECS` window
+- optional `RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS=<seconds>` caps Claude fallback runtime; by
+  default the fallback is bounded to 900 seconds and never exceeds the overall run_task timeout
+- Claude fallback recovery mode now prioritizes a useful in-channel reply over rebuilding large
+  multi-file deliverables from scratch, and it reuses `.codex_remote_output.log` plus
+  `.run_task_trace_codex_primary/` when the primary run already gathered evidence
 - recovered runs surface a `recovery_note` in `RunTaskOutput` and write
   `.run_task_trace/logs/recovery_note.txt` for debugging
 
@@ -71,6 +75,8 @@ Common optional controls:
 - Codex-specific failures automatically retry with the Claude runner, including warm-pool
   executions
 - optional `RUN_TASK_CODEX_FALLBACK_CLAUDE_MODEL=<model>` to force the Claude model used by that fallback
+- Claude fallback runs allow the built-in `WebSearch`, `WebFetch`, and `TodoWrite` tools in
+  addition to the existing file-editing / shell toolset
 - Bright Data social scraping:
   - `BRIGHT_DATA_API_KEY`
   - optional `BRIGHT_DATA_XIAOHONGSHU_COLLECTOR`

--- a/DoWhiz_service/run_task_module/src/run_task/claude.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/claude.rs
@@ -57,6 +57,8 @@ use super::utils::{
     run_command_with_timeout_and_cancel, run_task_timeout, tail_string, ThreadSupersedeMonitor,
 };
 
+const DEFAULT_CLAUDE_FALLBACK_TIMEOUT_SECS: u64 = 900;
+const CLAUDE_ALLOWED_TOOLS: &str = "Read,Glob,Grep,Bash,Write,Edit,WebSearch,WebFetch,TodoWrite";
 pub(super) fn run_claude_task(
     request: RunTaskRequest<'_>,
     runner: &str,
@@ -228,12 +230,12 @@ fn claude_task_timeout(is_codex_fallback: bool) -> std::time::Duration {
         return default_timeout;
     }
 
-    read_env_trimmed("RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS")
+    let fallback_timeout_secs = read_env_trimmed("RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS")
         .and_then(|value| value.parse::<u64>().ok())
         .filter(|value| *value > 0)
-        .map(std::time::Duration::from_secs)
-        .map(|timeout| default_timeout.min(timeout))
-        .unwrap_or(default_timeout)
+        .unwrap_or(DEFAULT_CLAUDE_FALLBACK_TIMEOUT_SECS);
+
+    default_timeout.min(std::time::Duration::from_secs(fallback_timeout_secs))
 }
 
 fn prepare_claude_env(
@@ -441,7 +443,7 @@ fn build_claude_command(
         .arg("--model")
         .arg(model_name)
         .arg("--allowedTools")
-        .arg("Read,Glob,Grep,Bash,Write,Edit")
+        .arg(CLAUDE_ALLOWED_TOOLS)
         .arg("--max-turns")
         .arg(max_turns.to_string())
         .arg("--dangerously-skip-permissions")
@@ -578,8 +580,12 @@ fn extract_claude_fragment(event: &serde_json::Value) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::claude_task_timeout;
+    use super::{
+        build_claude_command, claude_task_timeout, CLAUDE_ALLOWED_TOOLS,
+        DEFAULT_CLAUDE_FALLBACK_TIMEOUT_SECS,
+    };
     use std::env;
+    use std::path::Path;
     use std::sync::{Mutex, OnceLock};
     use std::time::Duration;
 
@@ -617,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_fallback_timeout_defaults_to_run_task_timeout() {
+    fn claude_fallback_timeout_defaults_to_recovery_cap() {
         let _lock = env_lock();
         let _guards = vec![
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "1200"),
@@ -625,7 +631,10 @@ mod tests {
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
         ];
 
-        assert_eq!(claude_task_timeout(true), Duration::from_secs(1200));
+        assert_eq!(
+            claude_task_timeout(true),
+            Duration::from_secs(DEFAULT_CLAUDE_FALLBACK_TIMEOUT_SECS)
+        );
     }
 
     #[test]
@@ -638,5 +647,20 @@ mod tests {
         ];
 
         assert_eq!(claude_task_timeout(true), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn build_claude_command_includes_web_and_todo_tools() {
+        let cmd = build_claude_command(Path::new("."), "hello", "claude-sonnet-4-5", &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        let allowed_tools_idx = args
+            .iter()
+            .position(|arg| arg == "--allowedTools")
+            .expect("allowedTools flag should be present");
+
+        assert_eq!(args[allowed_tools_idx + 1], CLAUDE_ALLOWED_TOOLS);
     }
 }

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -106,6 +106,7 @@ const REMOTE_EXIT_CODE_FILENAME: &str = ".codex_remote_exit_code";
 const HAG_MCP_CONFIG_START_MARKER: &str = "# BEGIN DOWHIZ HUMAN APPROVAL GATE MCP";
 const HAG_MCP_CONFIG_END_MARKER: &str = "# END DOWHIZ HUMAN APPROVAL GATE MCP";
 const EPHEMERAL_SHARE_PREFIX: &str = "task-";
+const DEFAULT_AZURE_ACI_CODEX_TIMEOUT_SECS: u64 = 900;
 static ACI_CONTAINER_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Deserialize)]
@@ -561,7 +562,7 @@ pub(super) fn run_codex_task(
         trace_env_overrides.push((key.clone(), value.clone()));
     }
 
-    let timeout = codex_command_timeout();
+    let timeout = codex_command_timeout(ExecutionBackend::Local);
     let mut trace = RunTaskTraceRecorder::new(
         request.workspace_dir,
         runner,
@@ -1016,14 +1017,24 @@ fn resolve_execution_backend() -> ExecutionBackend {
     }
 }
 
-fn codex_command_timeout() -> Duration {
+fn codex_command_timeout(backend: ExecutionBackend) -> Duration {
     let overall_timeout = run_task_timeout();
     let configured_timeout = read_env_trimmed("RUN_TASK_CODEX_TIMEOUT_SECS")
         .and_then(|value| value.parse::<u64>().ok())
         .filter(|value| *value > 0)
         .map(Duration::from_secs);
 
+    let default_timeout = match backend {
+        // Azure ACI primary Codex runs need a shorter budget so Claude fallback can fire before
+        // the overall run_task watchdog window is exhausted.
+        ExecutionBackend::AzureAci => {
+            Some(Duration::from_secs(DEFAULT_AZURE_ACI_CODEX_TIMEOUT_SECS))
+        }
+        ExecutionBackend::Local => None,
+    };
+
     configured_timeout
+        .or(default_timeout)
         .map(|timeout| timeout.min(overall_timeout))
         .unwrap_or(overall_timeout)
 }
@@ -1230,7 +1241,7 @@ fn run_codex_task_azure_aci(
     let container_name = build_aci_container_name();
     timing.set_task_id(&container_name);
     timing.end_setup();
-    let timeout = codex_command_timeout();
+    let timeout = codex_command_timeout(ExecutionBackend::AzureAci);
     let mut trace = RunTaskTraceRecorder::new(
         request.workspace_dir,
         runner,
@@ -4647,7 +4658,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     }
 
     #[test]
-    fn test_codex_command_timeout_defaults_to_overall_budget_when_unset() {
+    fn test_codex_command_timeout_defaults_to_overall_budget_locally() {
         let _lock = env_lock();
         let _guards = vec![
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "1200"),
@@ -4655,7 +4666,25 @@ addresses = ["dowhiz@deep-tutor.com"]
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
         ];
 
-        assert_eq!(codex_command_timeout(), Duration::from_secs(1200));
+        assert_eq!(
+            codex_command_timeout(ExecutionBackend::Local),
+            Duration::from_secs(1200)
+        );
+    }
+
+    #[test]
+    fn test_codex_command_timeout_caps_azure_aci_by_default() {
+        let _lock = env_lock();
+        let _guards = vec![
+            EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "36000"),
+            EnvVarGuard::unset("RUN_TASK_CODEX_TIMEOUT_SECS"),
+            EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
+        ];
+
+        assert_eq!(
+            codex_command_timeout(ExecutionBackend::AzureAci),
+            Duration::from_secs(DEFAULT_AZURE_ACI_CODEX_TIMEOUT_SECS)
+        );
     }
 
     #[test]
@@ -4667,7 +4696,10 @@ addresses = ["dowhiz@deep-tutor.com"]
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
         ];
 
-        assert_eq!(codex_command_timeout(), Duration::from_secs(300));
+        assert_eq!(
+            codex_command_timeout(ExecutionBackend::AzureAci),
+            Duration::from_secs(300)
+        );
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -191,7 +191,11 @@ Keep your reply concise. Use the API only - no browser automation."#
             }
             _ => {
                 // Default to email (HTML)
-                "2. After finishing the task (step one), make sure you write a proper HTML email draft in reply_email_draft.html in the workspace root. If there are files to attach, put them in reply_email_attachments/ and reference them in the email draft. Do not pretend the job has been done without actually doing it, and do not write the email draft until the task is done. If you are not sure about the task, send another email to ask for clarification (and if any, attach information about why did you fail to get the task done, what is the exact error you encountered)."
+                if prefer_fast_completion {
+                    "2. Recovery-mode override for email replies: write a useful HTML email draft in reply_email_draft.html as soon as you have enough information to help the user. In this recovery run, a concise but honest email reply is preferable to timing out while trying to rebuild the entire original project. Do NOT start new PDFs, slide decks, LaTeX reports, or other large attachments unless the user explicitly required that format and it is already nearly complete. If the original task is blocked or cannot be fully completed within this run, explain what you were able to verify, what remains uncertain, and what next step or source would be needed."
+                } else {
+                    "2. After finishing the task (step one), make sure you write a proper HTML email draft in reply_email_draft.html in the workspace root. If there are files to attach, put them in reply_email_attachments/ and reference them in the email draft. Do not pretend the job has been done without actually doing it, and do not write the email draft until the task is done. If you are not sure about the task, send another email to ask for clarification (and if any, attach information about why did you fail to get the task done, what is the exact error you encountered)."
+                }
             }
         }
     };
@@ -211,10 +215,15 @@ Keep your reply concise. Use the API only - no browser automation."#
         build_chat_history_capabilities_section(workspace_dir, channel);
     let fast_completion_section = if prefer_fast_completion {
         r#"Claude fallback execution guidance:
-- This run is a recovery path after the primary runner failed, so prioritize delivering a useful reply over exhaustive research.
+- This run is a recovery path after the primary runner failed. These recovery instructions take precedence over conflicting planning or artifact-building advice elsewhere in this prompt.
+- Prioritize delivering a useful reply within the recovery budget over rebuilding the entire original project from scratch.
+- Before starting new research, inspect any existing artifacts from the primary runner, especially `.codex_remote_output.log` and `.run_task_trace_codex_primary/`, and reuse any facts, sources, filenames, or failure context already gathered there.
 - For long research or writing tasks, begin updating the final reply artifact early and keep it current as sections become ready.
 - If you are still gathering evidence, clearly mark the draft as a working draft near the top, and remove or replace that note before you finish if the reply becomes complete.
-- Keep web research focused. Reuse evidence already gathered, avoid repeating similar searches, and stop searching once you have enough support to answer the user's questions coherently.
+- Prefer a concise in-email deliverable over new PDFs, slide decks, LaTeX reports, or other multi-file attachments unless the user explicitly required that format and it is already almost complete.
+- Keep any new web research focused. Reuse evidence already gathered, avoid repeating similar searches, and stop searching once you have enough support to answer the user's questions coherently.
+- If authoritative evidence is missing or the research path is blocked, send an honest limitation / next-steps reply instead of timing out with no reply.
+- If you can finish only part of the task, state what is completed, what remains uncertain, and what sources or follow-up would be needed to finish the rest.
 
 "#
     } else {
@@ -1255,6 +1264,32 @@ mod tests {
         assert!(prompt.contains("Never include raw credentials"));
         assert!(prompt.contains("persistent remote browser context"));
         assert!(prompt.contains("single browser tab"));
+    }
+
+    #[test]
+    fn build_prompt_with_fast_completion_prioritizes_recovery_reply() {
+        let temp = TempDir::new().expect("tempdir");
+
+        let prompt = build_prompt_with_fast_completion(
+            Path::new("incoming_email"),
+            Path::new("incoming_attachments"),
+            Path::new("memory"),
+            Path::new("references"),
+            temp.path(),
+            "claude",
+            "",
+            true,
+            "email",
+            true,
+            &UserIdentities::default(),
+            true,
+        );
+
+        assert!(prompt.contains("Recovery-mode override for email replies"));
+        assert!(prompt.contains(".codex_remote_output.log"));
+        assert!(prompt.contains(".run_task_trace_codex_primary/"));
+        assert!(prompt.contains("Do NOT start new PDFs"));
+        assert!(prompt.contains("send an honest limitation / next-steps reply"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- merge `origin/main` into `dev` on top of the existing routines merge
- keep the recovery prompt guidance and Claude tool allowlist from `main`
- preserve `dev`'s warm-pool container cleanup path while adopting the 900s Azure ACI primary Codex and Claude fallback default caps
- reconcile the RunTask docs to match the merged timeout/watchdog behavior

## Tests
- `cargo test --manifest-path DoWhiz_service/Cargo.toml -p run_task_module claude_fallback_timeout`
- `cargo test --manifest-path DoWhiz_service/Cargo.toml -p run_task_module build_claude_command_includes_web_and_todo_tools`
- `cargo test --manifest-path DoWhiz_service/Cargo.toml -p run_task_module codex_command_timeout`
- `cargo test --manifest-path DoWhiz_service/Cargo.toml -p run_task_module task_completion`

## Notes
- No frontend/manual smoke check was needed in this cut because the merge only touched backend run_task/docs files.