### PR TITLE
Update $PATH used for login shell to include /local/cargo

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -1908,7 +1908,7 @@ fn run_azure_aci_execution(
 
     let script = format!(
         "set -euo pipefail\n\
-export PATH=/app/bin:$PATH\n\
+export PATH=/app/bin:/usr/local/cargo/bin:$PATH\n\
 export PLAYWRIGHT_BROWSERS_PATH=\"${{PLAYWRIGHT_BROWSERS_PATH:-/app/.cache/ms-playwright}}\"\n\
 export XDG_CACHE_HOME=\"${{XDG_CACHE_HOME:-/tmp/.cache}}\"\n\
 export NPM_CONFIG_CACHE=\"${{NPM_CONFIG_CACHE:-/tmp/.npm}}\"\n\


### PR DESCRIPTION
Dockerfile.base (ENV PATH=...) (build time)

Used during RUN commands at build time (installing packages, etc.)
Sets default container environment

codex.rs (export PATH=...) (spin up container)

Needed because we use /bin/bash -lc (login shell)
Login shell resets PATH via profile files, so we have to re-establish it in the script