### PR TITLE
Normalize outbound email shell rendering

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -213,9 +213,9 @@ Do not pretend the job has been done without actually doing it."#
             _ => {
                 // Default to email (HTML)
                 if prefer_fast_completion {
-                    "2. Recovery-mode override for email replies: write a useful HTML email draft in reply_email_draft.html as soon as you have enough information to help the user. In this recovery run, a concise but honest email reply is preferable to timing out while trying to rebuild the entire original project. Do NOT start new PDFs, slide decks, LaTeX reports, or other large attachments unless the user explicitly required that format and it is already nearly complete. If the original task is blocked or cannot be fully completed within this run, explain what you were able to verify, what remains uncertain, and what next step or source would be needed."
+                    "2. Recovery-mode override for email replies: write a useful HTML email draft in reply_email_draft.html as soon as you have enough information to help the user. In this recovery run, a concise but honest email reply is preferable to timing out while trying to rebuild the entire original project. Keep the HTML content-focused: use semantic blocks like paragraphs, lists, tables, headings, and links, and avoid hard-coding narrow outer containers, oversized side margins, or overflow-prone layouts because DoWhiz applies a shared responsive email shell at send time. Do NOT start new PDFs, slide decks, LaTeX reports, or other large attachments unless the user explicitly required that format and it is already nearly complete. If the original task is blocked or cannot be fully completed within this run, explain what you were able to verify, what remains uncertain, and what next step or source would be needed."
                 } else {
-                    "2. After finishing the task (step one), make sure you write a proper HTML email draft in reply_email_draft.html in the workspace root. If there are files to attach, put them in reply_email_attachments/ and reference them in the email draft. Do not pretend the job has been done without actually doing it, and do not write the email draft until the task is done. If you are not sure about the task, send another email to ask for clarification (and if any, attach information about why did you fail to get the task done, what is the exact error you encountered)."
+                    "2. After finishing the task (step one), make sure you write a proper HTML email draft in reply_email_draft.html in the workspace root. Keep the HTML content-focused: use semantic blocks like paragraphs, lists, tables, headings, and links, and avoid hard-coding narrow outer containers, oversized side margins, or overflow-prone layouts because DoWhiz applies a shared responsive email shell at send time. If there are files to attach, put them in reply_email_attachments/ and reference them in the email draft. Do not pretend the job has been done without actually doing it, and do not write the email draft until the task is done. If you are not sure about the task, send another email to ask for clarification (and if any, attach information about why did you fail to get the task done, what is the exact error you encountered)."
                 }
             }
         }
@@ -730,7 +730,7 @@ Identifier format per channel:
 - lark: Lark open_id (e.g., "ou_xxxxxxxxxxxxxxxxx")
 
 IMPORTANT: When using cross-channel routing, write the reply in the TARGET channel's format:
-- email target: reply_email_draft.html (HTML), attachments in reply_email_attachments/
+- email target: reply_email_draft.html (HTML content only; DoWhiz adds the responsive shell at send time), attachments in reply_email_attachments/
 - slack target: reply_message.txt (Slack mrkdwn: *bold*, _italic_, `code`)
 - discord target: reply_message.txt (Discord markdown: **bold**, *italic*, `code`)
 - telegram target: reply_message.txt (MarkdownV2)
@@ -1421,6 +1421,8 @@ mod tests {
             zoom_user_ids: vec![],
             github_usernames: vec![],
             allowed_user_ids: vec![],
+            organization_id: None,
+            organization_name: None,
         };
         let section = build_user_identities_section(&identities);
 
@@ -1678,6 +1680,8 @@ mod tests {
             zoom_user_ids: vec![],
             github_usernames: vec![],
             allowed_user_ids: vec![],
+            organization_id: None,
+            organization_name: None,
         };
 
         let prompt = build_prompt(
@@ -1720,6 +1724,8 @@ mod tests {
             zoom_user_ids: vec![],
             github_usernames: vec![],
             allowed_user_ids: vec![user_uuid.to_string()],
+            organization_id: None,
+            organization_name: None,
         };
 
         let prompt = build_prompt(
@@ -1771,6 +1777,8 @@ mod tests {
                 slack_uuid.to_string(),
                 discord_uuid.to_string(),
             ],
+            organization_id: None,
+            organization_name: None,
         };
 
         let prompt = build_prompt(
@@ -1814,6 +1822,8 @@ mod tests {
             zoom_user_ids: vec![],
             github_usernames: vec![],
             allowed_user_ids: vec![], // Empty even though account exists
+            organization_id: None,
+            organization_name: None,
         };
 
         let prompt = build_prompt(
@@ -1952,6 +1962,8 @@ mod tests {
             zoom_user_ids: vec![],
             github_usernames: vec![],
             allowed_user_ids: vec!["uuid-email-alice".to_string()],
+            organization_id: None,
+            organization_name: None,
         };
 
         let prompt = build_prompt(
@@ -2003,6 +2015,8 @@ mod tests {
                 "uuid-discord-bob".to_string(),
                 "uuid-phone-bob".to_string(),
             ],
+            organization_id: None,
+            organization_name: None,
         };
 
         let prompt = build_prompt(
@@ -2058,6 +2072,8 @@ mod tests {
             // In production, identifiers_to_user_identities deduplicates
             // So if email and slack both map to same user_id, only one entry
             allowed_user_ids: vec!["uuid-charlie-shared".to_string()],
+            organization_id: None,
+            organization_name: None,
         };
 
         let prompt = build_prompt(
@@ -2101,6 +2117,8 @@ mod tests {
             zoom_user_ids: vec![],
             github_usernames: vec![],
             allowed_user_ids: vec!["uuid-email-dave".to_string(), "uuid-slack-dave".to_string()],
+            organization_id: None,
+            organization_name: None,
         };
 
         let prompt = build_prompt(

--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
@@ -944,7 +944,10 @@ fn resolve_wechat_mp_passive_reply_text() -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-fn build_wechat_mp_passive_text_response(message: &InboundMessage, reply_text: &str) -> Option<Response> {
+fn build_wechat_mp_passive_text_response(
+    message: &InboundMessage,
+    reply_text: &str,
+) -> Option<Response> {
     let to_user = message
         .metadata
         .wechat_mp_open_id
@@ -971,12 +974,14 @@ fn build_wechat_mp_passive_text_response(message: &InboundMessage, reply_text: &
         content = cdata_safe(reply_text),
     );
 
-    Some((
-        StatusCode::OK,
-        [(CONTENT_TYPE, "application/xml; charset=utf-8")],
-        xml,
+    Some(
+        (
+            StatusCode::OK,
+            [(CONTENT_TYPE, "application/xml; charset=utf-8")],
+            xml,
+        )
+            .into_response(),
     )
-        .into_response())
 }
 
 /// Handle Lark inbound messages (POST request)

--- a/DoWhiz_service/scheduler_module/src/bin/tpm_cli.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/tpm_cli.rs
@@ -1168,7 +1168,11 @@ fn cmd_setup_tpm_cron(args: &[String]) -> ExitCode {
         "$setOnInsert": { "retry_count": 0i32 },
     };
 
-    match tasks.update_one(filter, update, UpdateOptions::builder().upsert(true).build()) {
+    match tasks.update_one(
+        filter,
+        update,
+        UpdateOptions::builder().upsert(true).build(),
+    ) {
         Ok(result) => {
             let output = json!({
                 "success": true,
@@ -1476,8 +1480,8 @@ mod tests {
         // Set required env var for the test
         env::set_var("EMPLOYEE_ID", "test_employee");
 
-        let client = NotionApiClient::from_env("test_employee")
-            .expect("failed to create Notion client");
+        let client =
+            NotionApiClient::from_env("test_employee").expect("failed to create Notion client");
 
         // Build database schema
         let properties = json!({
@@ -1505,12 +1509,7 @@ mod tests {
 
         // Create database
         let db = client
-            .create_database(
-                "default",
-                &parent_page_id,
-                "TPM CLI Test Board",
-                properties,
-            )
+            .create_database("default", &parent_page_id, "TPM CLI Test Board", properties)
             .expect("failed to create database");
 
         assert!(!db.id.is_empty());
@@ -1544,8 +1543,8 @@ mod tests {
         env::set_var("EMPLOYEE_ID", "test_employee");
 
         let store = DevTaskStore::new(TEST_ORG).expect("failed to create store");
-        let client = NotionApiClient::from_env("test_employee")
-            .expect("failed to create Notion client");
+        let client =
+            NotionApiClient::from_env("test_employee").expect("failed to create Notion client");
 
         // 1. Create task in MongoDB
         let task = DevTask::new(

--- a/DoWhiz_service/scheduler_module/src/dev_task_store.rs
+++ b/DoWhiz_service/scheduler_module/src/dev_task_store.rs
@@ -147,7 +147,12 @@ pub struct DevTask {
 }
 
 impl DevTask {
-    pub fn new(organization: String, title: String, description: String, source: TaskSource) -> Self {
+    pub fn new(
+        organization: String,
+        title: String,
+        description: String,
+        source: TaskSource,
+    ) -> Self {
         let now = Utc::now();
         Self {
             id: None,
@@ -257,7 +262,9 @@ impl DevTaskStore {
         let result = self.tasks.insert_one(doc, None)?;
         match result.inserted_id {
             Bson::ObjectId(id) => Ok(id),
-            _ => Err(DevTaskStoreError::NotFound("failed to get inserted id".into())),
+            _ => Err(DevTaskStoreError::NotFound(
+                "failed to get inserted id".into(),
+            )),
         }
     }
 
@@ -299,9 +306,7 @@ impl DevTaskStore {
             "organization": &self.organization,
             "status": status.as_str(),
         };
-        let options = FindOptions::builder()
-            .sort(doc! { "priority": 1 })
-            .build();
+        let options = FindOptions::builder().sort(doc! { "priority": 1 }).build();
         let cursor = self.tasks.find(filter, options)?;
         let mut tasks = Vec::new();
         for doc in cursor {
@@ -319,9 +324,7 @@ impl DevTaskStore {
             "organization": &self.organization,
             "assignee": assignee,
         };
-        let options = FindOptions::builder()
-            .sort(doc! { "priority": 1 })
-            .build();
+        let options = FindOptions::builder().sort(doc! { "priority": 1 }).build();
         let cursor = self.tasks.find(filter, options)?;
         let mut tasks = Vec::new();
         for doc in cursor {

--- a/DoWhiz_service/scheduler_module/src/lib.rs
+++ b/DoWhiz_service/scheduler_module/src/lib.rs
@@ -48,4 +48,6 @@ pub use scheduler::{
     SchedulerError, SendReplyTask, TaskExecution, TaskExecutor, TaskKind, TaskStatusSummary,
 };
 
-pub use dev_task_store::{DevTask, DevTaskStore, DevTaskStoreError, Priority, TaskSource, TaskStatus};
+pub use dev_task_store::{
+    DevTask, DevTaskStore, DevTaskStoreError, Priority, TaskSource, TaskStatus,
+};

--- a/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
@@ -13,10 +13,10 @@ use crate::account_store::{
 };
 use crate::blob_store::get_blob_store;
 use crate::channel::Channel;
-use crate::grocery_store::sync_grocery_preferences_to_workspace;
 use crate::github_inbound::{
     extract_github_sender_login_from_postmark_payload, is_github_notifications_postmark_payload,
 };
+use crate::grocery_store::sync_grocery_preferences_to_workspace;
 use crate::memory_diff::compute_memory_diff;
 use crate::memory_queue::{global_memory_queue, MemoryWriteRequest};
 use crate::memory_store::{

--- a/DoWhiz_service/scheduler_module/src/scheduler/outbound.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/outbound.rs
@@ -12,6 +12,9 @@ use super::types::{SchedulerError, SendReplyTask};
 
 /// Execute a SendReplyTask via email (Postmark).
 pub(crate) fn execute_email_send(task: &SendReplyTask) -> Result<(), SchedulerError> {
+    send_emails_module::normalize_email_html_file(&task.subject, &task.html_path)
+        .map_err(|err| SchedulerError::TaskFailed(err.to_string()))?;
+
     let params = send_emails_module::SendEmailParams {
         subject: task.subject.clone(),
         html_path: task.html_path.clone(),
@@ -1032,9 +1035,44 @@ pub(crate) fn execute_notion_send(task: &SendReplyTask) -> Result<(), SchedulerE
 #[cfg(test)]
 mod tests {
     use super::{
-        is_discord_unknown_message_reference, split_discord_message_chunks,
+        execute_email_send, is_discord_unknown_message_reference, split_discord_message_chunks,
         DISCORD_MAX_CONTENT_CHARS,
     };
+    use crate::channel::Channel;
+    use crate::scheduler::types::SendReplyTask;
+    use mockito::{Matcher, Server};
+    use send_emails_module::normalize_email_html;
+    use serde_json::json;
+    use std::env;
+    use std::ffi::OsString;
+    use std::fs;
+    use tempfile::TempDir;
+
+    struct EnvGuard {
+        saved: Vec<(String, Option<OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn set(vars: &[(&str, &str)]) -> Self {
+            let mut saved = Vec::with_capacity(vars.len());
+            for (key, value) in vars {
+                saved.push((key.to_string(), env::var_os(key)));
+                env::set_var(key, value);
+            }
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.saved.drain(..) {
+                match value {
+                    Some(prev) => env::set_var(&key, prev),
+                    None => env::remove_var(&key),
+                }
+            }
+        }
+    }
 
     #[test]
     fn split_discord_message_keeps_short_text() {
@@ -1075,8 +1113,7 @@ mod tests {
 
     #[test]
     fn notion_send_skips_when_api_replied_marker_exists() {
-        use super::{execute_notion_send, SendReplyTask};
-        use crate::channel::Channel;
+        use super::execute_notion_send;
         use std::fs;
 
         // Create a temp workspace directory
@@ -1116,5 +1153,78 @@ mod tests {
 
         // Clean up
         let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn execute_email_send_normalizes_html_before_postmark_send(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut server = Server::new();
+        let raw_html = r#"<div style="max-width: 520px; margin: 0 auto;"><p>你好，这里有一个超长字符串用于检查自动换行：LONGTOKENLONGTOKENLONGTOKENLONGTOKENLONGTOKEN</p></div>"#;
+        let expected_html = normalize_email_html("Project update", raw_html);
+        let expected_payload = json!({
+            "From": "sender@example.com",
+            "To": "user@example.com",
+            "Bcc": "sender@example.com",
+            "Subject": "Project update",
+            "TextBody": "你好，这里有一个超长字符串用于检查自动换行：LONGTOKENLONGTOKENLONGTOKENLONGTOKENLONGTOKEN",
+            "HtmlBody": expected_html,
+        });
+
+        let email_mock = server
+            .mock("POST", "/email")
+            .match_header("x-postmark-server-token", "test-token")
+            .match_header("accept", "application/json")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::Json(expected_payload))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "To": "user@example.com",
+                    "SubmittedAt": "2024-01-01T00:00:00Z",
+                    "MessageID": "test-message-id",
+                    "ErrorCode": 0,
+                    "Message": "OK",
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create();
+
+        let _env = EnvGuard::set(&[
+            ("POSTMARK_SERVER_TOKEN", "test-token"),
+            ("POSTMARK_API_BASE_URL", server.url().as_str()),
+        ]);
+
+        let temp = TempDir::new()?;
+        let html_path = temp.path().join("reply_email_draft.html");
+        fs::write(&html_path, raw_html)?;
+        let attachments_dir = temp.path().join("reply_email_attachments");
+        fs::create_dir_all(&attachments_dir)?;
+
+        let task = SendReplyTask {
+            channel: Channel::Email,
+            subject: "Project update".to_string(),
+            html_path: html_path.clone(),
+            attachments_dir,
+            from: Some("sender@example.com".to_string()),
+            to: vec!["user@example.com".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            in_reply_to: None,
+            references: None,
+            archive_root: None,
+            thread_epoch: None,
+            thread_state_path: None,
+            employee_id: None,
+            channel_metadata: Default::default(),
+        };
+
+        execute_email_send(&task)?;
+
+        let normalized_file = fs::read_to_string(&html_path)?;
+        assert_eq!(normalized_file, expected_html);
+        email_mock.assert();
+        Ok(())
     }
 }

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -1450,8 +1450,14 @@ mod tests {
 
     #[test]
     fn strip_discord_mentions_preserves_non_mention_content() {
-        assert_eq!(strip_discord_mentions("no mentions here"), "no mentions here");
-        assert_eq!(strip_discord_mentions("email@example.com"), "email@example.com");
+        assert_eq!(
+            strip_discord_mentions("no mentions here"),
+            "no mentions here"
+        );
+        assert_eq!(
+            strip_discord_mentions("email@example.com"),
+            "email@example.com"
+        );
         assert_eq!(strip_discord_mentions("<not a mention>"), "<not a mention>");
     }
 

--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -1616,12 +1616,13 @@ pub async fn set_account_organization(
     let account_id = account.id;
     let org_name = payload.organization_name.clone();
 
-    let result = task::spawn_blocking(move || store.set_account_organization(account_id, &org_name))
-        .await
-        .map_err(|e| {
-            error!("spawn_blocking panicked: {}", e);
-            json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal error")
-        });
+    let result =
+        task::spawn_blocking(move || store.set_account_organization(account_id, &org_name))
+            .await
+            .map_err(|e| {
+                error!("spawn_blocking panicked: {}", e);
+                json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal error")
+            });
 
     match result {
         Ok(Ok(updated_account)) => (
@@ -6423,7 +6424,10 @@ pub fn auth_router(state: AuthState) -> Router {
     Router::new()
         .route("/auth/signup", post(signup))
         .route("/auth/account", get(get_account).delete(delete_account))
-        .route("/auth/account/organization", put(set_account_organization).delete(clear_account_organization))
+        .route(
+            "/auth/account/organization",
+            put(set_account_organization).delete(clear_account_organization),
+        )
         .route("/auth/organization", post(create_organization))
         .route("/auth/organizations", get(list_organizations))
         .route("/auth/link", post(link_identifier))

--- a/DoWhiz_service/scheduler_module/tests/send_reply_outbound_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/send_reply_outbound_e2e.rs
@@ -5,8 +5,11 @@ use scheduler_module::{
     channel::{Channel, ChannelMetadata},
     ModuleExecutor, Scheduler, SendReplyTask, TaskKind,
 };
+use send_emails_module::normalize_email_html;
+use serde_json::json;
 use std::env;
 use std::fs;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -34,6 +37,46 @@ impl Drop for EnvGuard {
             None => env::remove_var(self.key),
         }
     }
+}
+
+fn require_mongodb_uri(test_name: &str) -> Option<String> {
+    dotenvy::dotenv().ok();
+    match env::var("MONGODB_URI") {
+        Ok(value) if !value.trim().is_empty() => {
+            if let Some(address) = extract_mongodb_socket_addr(&value) {
+                if TcpStream::connect_timeout(&address, Duration::from_millis(250)).is_err() {
+                    eprintln!("Skipping {test_name}; MongoDB at {address} is not reachable.");
+                    return None;
+                }
+            }
+            Some(value)
+        }
+        _ => {
+            eprintln!("Skipping {test_name}; MONGODB_URI not set.");
+            None
+        }
+    }
+}
+
+fn extract_mongodb_socket_addr(uri: &str) -> Option<std::net::SocketAddr> {
+    let remainder = uri.trim().strip_prefix("mongodb://")?;
+    let authority = remainder.split('/').next()?.split('?').next()?.trim();
+    if authority.is_empty() {
+        return None;
+    }
+
+    let host_port = authority.rsplit('@').next()?.split(',').next()?.trim();
+    if host_port.is_empty() {
+        return None;
+    }
+
+    let normalized = if host_port.contains(':') {
+        host_port.to_string()
+    } else {
+        format!("{host_port}:27017")
+    };
+
+    normalized.to_socket_addrs().ok()?.next()
 }
 
 fn write_text_file(
@@ -75,6 +118,9 @@ fn base_send_task(channel: Channel, html_path: PathBuf, attachments_dir: PathBuf
 #[test]
 fn send_reply_slack_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(_mongo_uri) = require_mongodb_uri("send_reply_slack_uses_mock") else {
+        return Ok(());
+    };
     let Some(mut server) = test_support::start_mockito_server("send_reply_slack_uses_mock") else {
         return Ok(());
     };
@@ -113,6 +159,10 @@ fn send_reply_slack_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn send_reply_slack_includes_thread_ts_when_present() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(_mongo_uri) = require_mongodb_uri("send_reply_slack_includes_thread_ts_when_present")
+    else {
+        return Ok(());
+    };
     let Some(mut server) =
         test_support::start_mockito_server("send_reply_slack_includes_thread_ts_when_present")
     else {
@@ -157,6 +207,11 @@ fn send_reply_slack_includes_thread_ts_when_present() -> Result<(), Box<dyn std:
 fn send_reply_slack_team_scoped_prefers_employee_token_over_global(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(_mongo_uri) =
+        require_mongodb_uri("send_reply_slack_team_scoped_prefers_employee_token_over_global")
+    else {
+        return Ok(());
+    };
     let Some(mut server) = test_support::start_mockito_server(
         "send_reply_slack_team_scoped_prefers_employee_token_over_global",
     ) else {
@@ -207,6 +262,9 @@ fn send_reply_slack_team_scoped_prefers_employee_token_over_global(
 #[test]
 fn send_reply_discord_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(_mongo_uri) = require_mongodb_uri("send_reply_discord_uses_mock") else {
+        return Ok(());
+    };
     let Some(mut server) = test_support::start_mockito_server("send_reply_discord_uses_mock")
     else {
         return Ok(());
@@ -246,6 +304,11 @@ fn send_reply_discord_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
 fn send_reply_discord_uploads_attachments_and_includes_blob_links(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(_mongo_uri) =
+        require_mongodb_uri("send_reply_discord_uploads_attachments_and_includes_blob_links")
+    else {
+        return Ok(());
+    };
     let Some(mut server) = test_support::start_mockito_server(
         "send_reply_discord_uploads_attachments_and_includes_blob_links",
     ) else {
@@ -317,6 +380,9 @@ fn send_reply_discord_uploads_attachments_and_includes_blob_links(
 #[test]
 fn send_reply_sms_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(_mongo_uri) = require_mongodb_uri("send_reply_sms_uses_mock") else {
+        return Ok(());
+    };
     let Some(mut server) = test_support::start_mockito_server("send_reply_sms_uses_mock") else {
         return Ok(());
     };
@@ -353,5 +419,75 @@ fn send_reply_sms_uses_mock() -> Result<(), Box<dyn std::error::Error>> {
     scheduler.tick()?;
 
     sms_mock.assert();
+    Ok(())
+}
+
+#[test]
+fn send_reply_email_applies_branded_shell_before_send() -> Result<(), Box<dyn std::error::Error>> {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(_mongo_uri) =
+        require_mongodb_uri("send_reply_email_applies_branded_shell_before_send")
+    else {
+        return Ok(());
+    };
+    let Some(mut server) =
+        test_support::start_mockito_server("send_reply_email_applies_branded_shell_before_send")
+    else {
+        return Ok(());
+    };
+
+    let raw_html = r#"<div style="max-width: 520px; margin: 0 auto;"><p>你好，这里有一个超长字符串用于检查自动换行：LONGTOKENLONGTOKENLONGTOKENLONGTOKENLONGTOKEN</p></div>"#;
+    let expected_html = normalize_email_html("Project update", raw_html);
+    let expected_payload = json!({
+        "From": "sender@example.com",
+        "To": "user@example.com",
+        "Bcc": "sender@example.com",
+        "Subject": "Project update",
+        "TextBody": "你好，这里有一个超长字符串用于检查自动换行：LONGTOKENLONGTOKENLONGTOKENLONGTOKENLONGTOKEN",
+        "HtmlBody": expected_html,
+    });
+
+    let email_mock = server
+        .mock("POST", "/email")
+        .match_header("x-postmark-server-token", "test-token")
+        .match_header("accept", "application/json")
+        .match_header("content-type", "application/json")
+        .match_body(Matcher::Json(expected_payload))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "To": "user@example.com",
+                "SubmittedAt": "2024-01-01T00:00:00Z",
+                "MessageID": "test-message-id",
+                "ErrorCode": 0,
+                "Message": "OK",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let _guard_token = EnvGuard::set("POSTMARK_SERVER_TOKEN", "test-token");
+    let _guard_api = EnvGuard::set("POSTMARK_API_BASE_URL", server.url());
+
+    let temp = TempDir::new()?;
+    let html_path = write_text_file(&temp, "reply_email_draft.html", raw_html)?;
+    let attachments_dir = create_attachments_dir(&temp)?;
+
+    let mut task = base_send_task(Channel::Email, html_path.clone(), attachments_dir);
+    task.subject = "Project update".to_string();
+    task.from = Some("sender@example.com".to_string());
+    task.to = vec!["user@example.com".to_string()];
+
+    let db_path = temp.path().join("tasks.db");
+    let mut scheduler = Scheduler::load(&db_path, ModuleExecutor::default())?;
+    scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::SendReply(task))?;
+    scheduler.tick()?;
+
+    let normalized_file = fs::read_to_string(&html_path)?;
+    assert_eq!(normalized_file, expected_html);
+
+    email_mock.assert();
     Ok(())
 }

--- a/DoWhiz_service/send_emails_module/README.md
+++ b/DoWhiz_service/send_emails_module/README.md
@@ -5,6 +5,7 @@ Postmark outbound email sender used by scheduler `SendReply` tasks.
 ## Features
 
 - send HTML email from file (`html_path`)
+- wrap outbound HTML in a responsive DoWhiz-branded shell that uses the shared website light-theme colors
 - send attachments from flat directory (`attachments_dir`)
 - supports To/Cc/Bcc + threading headers (`In-Reply-To`, `References`)
 
@@ -37,6 +38,10 @@ let params = SendEmailParams {
 let resp = send_email(&params)?;
 println!("message id: {}", resp.message_id);
 ```
+
+`send_email` expects the draft file to contain the email content itself (paragraphs, headings,
+lists, tables, links). The module applies the shared DoWhiz shell at send time so replies stay
+responsive and avoid overly narrow centered layouts.
 
 ## Tests
 

--- a/DoWhiz_service/send_emails_module/src/lib.rs
+++ b/DoWhiz_service/send_emails_module/src/lib.rs
@@ -87,6 +87,299 @@ struct PostmarkHeader {
     value: String,
 }
 
+const DOWHIZ_EMAIL_SHELL_MARKER: &str = r#"data-dowhiz-email-shell="true""#;
+const DOWHIZ_EMAIL_CONTENT_START: &str = "<!-- dowhiz-email-content:start -->";
+const DOWHIZ_EMAIL_CONTENT_END: &str = "<!-- dowhiz-email-content:end -->";
+const DEFAULT_EMAIL_SUBJECT: &str = "DoWhiz update";
+const EMAIL_PREHEADER_MAX_CHARS: usize = 140;
+
+pub fn normalize_email_html(subject: &str, raw_html: &str) -> String {
+    if is_already_normalized_email(raw_html) {
+        return raw_html.to_string();
+    }
+
+    let normalized_subject = normalized_email_subject(subject);
+    let escaped_subject = html_escape(&normalized_subject);
+    let extra_styles = extract_style_blocks(raw_html);
+    let body_source = extract_html_body(raw_html).trim();
+    let content_html = if body_source.is_empty() {
+        "<p>(no content)</p>".to_string()
+    } else if looks_like_html_fragment(body_source) {
+        body_source.to_string()
+    } else {
+        wrap_plain_text_body(body_source)
+    };
+    let preheader = html_escape(&build_preheader(&normalized_subject, &content_html));
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{escaped_subject}</title>
+    <style>
+      body,
+      table,
+      td,
+      a {{
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }}
+
+      table,
+      td {{
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }}
+
+      img {{
+        border: 0;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }}
+
+      body {{
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 100% !important;
+        min-width: 100% !important;
+        background-color: #f6f8fb;
+        color: #1f1f22;
+      }}
+
+      a {{
+        color: #8d3b16;
+      }}
+
+      a[x-apple-data-detectors] {{
+        color: inherit !important;
+        text-decoration: none !important;
+      }}
+
+      .dw-preheader {{
+        display: none !important;
+        visibility: hidden;
+        opacity: 0;
+        color: transparent;
+        height: 0;
+        width: 0;
+        overflow: hidden;
+        mso-hide: all;
+        font-size: 1px;
+        line-height: 1px;
+      }}
+
+      .dw-card {{
+        width: 100%;
+        max-width: 780px;
+      }}
+
+      .dw-card-shell {{
+        width: 100%;
+        background-color: #ffffff;
+        border: 1px solid rgba(16, 18, 22, 0.10);
+        border-radius: 16px;
+        overflow: hidden;
+      }}
+
+      .dw-content,
+      .dw-content p,
+      .dw-content li,
+      .dw-content div,
+      .dw-content span,
+      .dw-content td,
+      .dw-content th,
+      .dw-content blockquote,
+      .dw-content a,
+      .dw-content code,
+      .dw-content pre {{
+        word-break: break-word;
+        word-wrap: break-word;
+        overflow-wrap: anywhere;
+      }}
+
+      .dw-content > div,
+      .dw-content > section,
+      .dw-content > article,
+      .dw-content > table {{
+        width: 100% !important;
+        max-width: 100% !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+      }}
+
+      .dw-content p {{
+        margin: 0 0 1.15em;
+      }}
+
+      .dw-content ul,
+      .dw-content ol {{
+        margin: 0 0 1.25em 1.25em;
+        padding: 0;
+      }}
+
+      .dw-content li {{
+        margin: 0 0 0.65em;
+      }}
+
+      .dw-content h1,
+      .dw-content h2,
+      .dw-content h3,
+      .dw-content h4,
+      .dw-content h5,
+      .dw-content h6 {{
+        margin: 0 0 0.7em;
+        color: #1f1f22;
+        line-height: 1.22;
+      }}
+
+      .dw-content blockquote {{
+        margin: 0 0 1.25em;
+        padding: 0 0 0 16px;
+        border-left: 3px solid #d7dde6;
+        color: #5b616d;
+      }}
+
+      .dw-content pre {{
+        margin: 0 0 1.25em;
+        padding: 16px;
+        border: 1px solid #e4e8ee;
+        border-radius: 12px;
+        background-color: #f8fafc;
+        color: #1f1f22;
+        white-space: pre-wrap !important;
+        font-size: 14px;
+        line-height: 1.6;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      }}
+
+      .dw-content code {{
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      }}
+
+      .dw-content img {{
+        display: block;
+        max-width: 100% !important;
+        height: auto !important;
+        border-radius: 12px;
+      }}
+
+      .dw-content table {{
+        width: 100% !important;
+        max-width: 100% !important;
+        border-collapse: collapse;
+      }}
+
+      .dw-content th,
+      .dw-content td {{
+        border: 1px solid #e4e8ee;
+        padding: 10px 12px;
+        vertical-align: top;
+      }}
+
+      .dw-content hr {{
+        margin: 1.5em 0;
+        border: 0;
+        border-top: 1px solid #e4e8ee;
+      }}
+
+      @media screen and (max-width: 640px) {{
+        .dw-shell-pad {{
+          padding: 10px !important;
+        }}
+
+        .dw-card-hero {{
+          padding: 20px 18px 16px !important;
+        }}
+
+        .dw-card-body {{
+          padding: 24px 18px 20px !important;
+          font-size: 15px !important;
+          line-height: 1.72 !important;
+        }}
+
+        .dw-card-footer {{
+          padding: 0 18px 18px !important;
+        }}
+
+        .dw-subject {{
+          font-size: 28px !important;
+        }}
+      }}
+    </style>
+{extra_styles}
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #f6f8fb;">
+    <div class="dw-preheader">{preheader}</div>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="width: 100%; background-color: #f6f8fb;">
+      <tr>
+        <td align="center" class="dw-shell-pad" style="padding: 20px 12px 36px;">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="dw-card" {marker} style="width: 100%; max-width: 780px;">
+            <tr>
+              <td style="padding: 0;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="dw-card-shell" style="width: 100%; background-color: #ffffff; border: 1px solid rgba(16, 18, 22, 0.10); border-radius: 16px; overflow: hidden;">
+                  <tr>
+                    <td class="dw-card-hero" style="padding: 24px 32px 18px; background-color: #ffffff; border-bottom: 1px solid #e4e8ee;">
+                      <p style="margin: 0 0 16px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Noto Sans SC', 'Microsoft YaHei', sans-serif;">
+                        <span style="display: inline-block; padding: 8px 14px; border-radius: 999px; border: 1px solid rgba(141, 59, 22, 0.12); background-color: #fff7ee; font-size: 13px; line-height: 1; font-weight: 600; color: #8d3b16;">
+                          DoWhiz digital employee
+                        </span>
+                      </p>
+                      <h1 class="dw-subject" style="margin: 0 0 10px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Noto Sans SC', 'Microsoft YaHei', sans-serif; font-size: 34px; line-height: 1.12; font-weight: 700; letter-spacing: -0.01em; color: #1f1f22;">
+                        {escaped_subject}
+                      </h1>
+                      <p style="margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Noto Sans SC', 'Microsoft YaHei', sans-serif; font-size: 15px; line-height: 1.6; color: #5b616d;">
+                        Reply directly to continue this thread with DoWhiz.
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="dw-card-body" style="padding: 28px 32px 20px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Noto Sans SC', 'Microsoft YaHei', sans-serif; font-size: 16px; line-height: 1.76; color: #1f1f22;">
+                      <div class="dw-content" style="font-size: 16px; line-height: 1.76; color: #1f1f22;">
+                        {content_start}{content_html}{content_end}
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="dw-card-footer" style="padding: 0 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Noto Sans SC', 'Microsoft YaHei', sans-serif; font-size: 13px; line-height: 1.6; color: #838a96;">
+                      Sent by DoWhiz. If you reply, the same task thread will continue.
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+"#,
+        escaped_subject = escaped_subject,
+        preheader = preheader,
+        extra_styles = if extra_styles.trim().is_empty() {
+            String::new()
+        } else {
+            format!("    {}\n", extra_styles.trim())
+        },
+        marker = DOWHIZ_EMAIL_SHELL_MARKER,
+        content_start = DOWHIZ_EMAIL_CONTENT_START,
+        content_html = content_html,
+        content_end = DOWHIZ_EMAIL_CONTENT_END,
+    )
+}
+
+pub fn normalize_email_html_file(subject: &str, html_path: &Path) -> Result<(), std::io::Error> {
+    let raw_html = fs::read_to_string(html_path)?;
+    let normalized = normalize_email_html(subject, &raw_html);
+    if normalized != raw_html {
+        fs::write(html_path, normalized)?;
+    }
+    Ok(())
+}
+
 pub fn send_email(params: &SendEmailParams) -> Result<PostmarkSendResponse, SendEmailError> {
     dotenvy::dotenv().ok();
 
@@ -114,8 +407,9 @@ pub fn send_email(params: &SendEmailParams) -> Result<PostmarkSendResponse, Send
     }
     let bcc = join_recipients(&bcc_list);
 
-    let html_body = fs::read_to_string(&params.html_path)?;
-    let mut text_body = strip_html_tags(&html_body);
+    let raw_html_body = fs::read_to_string(&params.html_path)?;
+    let html_body = normalize_email_html(&params.subject, &raw_html_body);
+    let mut text_body = plain_text_body_from_html(&html_body);
     if text_body.trim().is_empty() {
         text_body = "(no content)".to_string();
     }
@@ -251,6 +545,169 @@ fn clean_header_value(value: &Option<String>) -> Option<String> {
         .map(|trimmed| trimmed.to_string())
 }
 
+fn plain_text_body_from_html(html: &str) -> String {
+    let source = extract_shell_content_html(html).unwrap_or(html);
+    let text = decode_basic_html_entities(&strip_html_tags(source));
+    if text.trim().is_empty() {
+        "(no content)".to_string()
+    } else {
+        text
+    }
+}
+
+fn build_preheader(subject: &str, content_html: &str) -> String {
+    let preview_body = decode_basic_html_entities(&strip_html_tags(content_html));
+    let compact_body = compact_whitespace(&preview_body);
+    let combined = if compact_body.is_empty() {
+        subject.trim().to_string()
+    } else if subject.trim().is_empty() {
+        compact_body
+    } else {
+        format!("{} | {}", subject.trim(), compact_body)
+    };
+    truncate_chars(&combined, EMAIL_PREHEADER_MAX_CHARS)
+}
+
+fn normalized_email_subject(subject: &str) -> String {
+    let trimmed = subject.trim();
+    if trimmed.is_empty() {
+        DEFAULT_EMAIL_SUBJECT.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn is_already_normalized_email(html: &str) -> bool {
+    html.contains(DOWHIZ_EMAIL_SHELL_MARKER)
+}
+
+fn extract_shell_content_html(html: &str) -> Option<&str> {
+    let start = html.find(DOWHIZ_EMAIL_CONTENT_START)?;
+    let content_start = start + DOWHIZ_EMAIL_CONTENT_START.len();
+    let end_rel = html[content_start..].find(DOWHIZ_EMAIL_CONTENT_END)?;
+    Some(&html[content_start..content_start + end_rel])
+}
+
+fn extract_html_body(raw_html: &str) -> &str {
+    let lower = raw_html.to_ascii_lowercase();
+    let Some(body_start) = lower.find("<body") else {
+        return raw_html;
+    };
+    let Some(open_end_rel) = lower[body_start..].find('>') else {
+        return raw_html;
+    };
+    let content_start = body_start + open_end_rel + 1;
+    let Some(close_rel) = lower[content_start..].rfind("</body>") else {
+        return &raw_html[content_start..];
+    };
+    &raw_html[content_start..content_start + close_rel]
+}
+
+fn extract_style_blocks(raw_html: &str) -> String {
+    let lower = raw_html.to_ascii_lowercase();
+    let mut search_start = 0;
+    let mut styles = Vec::new();
+
+    while let Some(open_rel) = lower[search_start..].find("<style") {
+        let open = search_start + open_rel;
+        let Some(tag_end_rel) = lower[open..].find('>') else {
+            break;
+        };
+        let content_start = open + tag_end_rel + 1;
+        let Some(close_rel) = lower[content_start..].find("</style>") else {
+            break;
+        };
+        let close = content_start + close_rel + "</style>".len();
+        styles.push(raw_html[open..close].to_string());
+        search_start = close;
+    }
+
+    styles.join("\n")
+}
+
+fn looks_like_html_fragment(value: &str) -> bool {
+    let lower = value.trim().to_ascii_lowercase();
+    lower.contains("<p")
+        || lower.contains("<div")
+        || lower.contains("<span")
+        || lower.contains("<table")
+        || lower.contains("<tbody")
+        || lower.contains("<tr")
+        || lower.contains("<td")
+        || lower.contains("<th")
+        || lower.contains("<br")
+        || lower.contains("<ul")
+        || lower.contains("<ol")
+        || lower.contains("<li")
+        || lower.contains("<a ")
+        || lower.contains("<img")
+        || lower.contains("<h1")
+        || lower.contains("<h2")
+        || lower.contains("<h3")
+        || lower.contains("<blockquote")
+        || lower.contains("</")
+}
+
+fn wrap_plain_text_body(raw: &str) -> String {
+    let normalized = raw.replace("\r\n", "\n").replace('\r', "\n");
+    let paragraphs = normalized
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| {
+            let lines = segment
+                .lines()
+                .map(|line| html_escape(line.trim_end()))
+                .collect::<Vec<_>>()
+                .join("<br />");
+            format!("<p>{}</p>", lines)
+        })
+        .collect::<Vec<_>>();
+
+    if paragraphs.is_empty() {
+        "<p>(no content)</p>".to_string()
+    } else {
+        paragraphs.join("\n")
+    }
+}
+
+fn html_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn decode_basic_html_entities(value: &str) -> String {
+    value
+        .replace("&nbsp;", " ")
+        .replace("&#39;", "'")
+        .replace("&quot;", "\"")
+        .replace("&gt;", ">")
+        .replace("&lt;", "<")
+        .replace("&amp;", "&")
+}
+
+fn compact_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let total_chars = value.chars().count();
+    if total_chars <= max_chars {
+        return value.to_string();
+    }
+
+    let mut out = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    out.push('…');
+    out
+}
+
 fn strip_html_tags(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let mut in_tag = false;
@@ -374,4 +831,49 @@ fn load_attachments(dir: &Path) -> Result<Vec<PostmarkAttachment>, std::io::Erro
     }
 
     Ok(attachments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_email_html_wraps_fragment_with_branded_responsive_shell() {
+        let normalized = normalize_email_html(
+            "Status update",
+            r#"<div style="max-width: 520px; margin: 0 auto;"><p>Hello team</p></div>"#,
+        );
+
+        assert!(normalized.contains(DOWHIZ_EMAIL_SHELL_MARKER));
+        assert!(normalized.contains("max-width: 780px"));
+        assert!(normalized.contains("overflow-wrap: anywhere"));
+        assert!(normalized.contains("DoWhiz digital employee"));
+        assert!(normalized.contains("Status update"));
+        assert!(normalized
+            .contains(r#"<div style="max-width: 520px; margin: 0 auto;"><p>Hello team</p></div>"#));
+    }
+
+    #[test]
+    fn normalize_email_html_is_idempotent() {
+        let once = normalize_email_html("Status update", "<p>Hello team</p>");
+        let twice = normalize_email_html("Status update", &once);
+
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn normalize_email_html_wraps_plain_text_into_paragraphs() {
+        let normalized = normalize_email_html("Plain text", "First line\n\nSecond line");
+
+        assert!(normalized.contains("<p>First line</p>"));
+        assert!(normalized.contains("<p>Second line</p>"));
+    }
+
+    #[test]
+    fn plain_text_body_from_html_uses_shell_content_only() {
+        let normalized =
+            normalize_email_html("Status update", "<p>Hello <strong>team</strong></p>");
+
+        assert_eq!(plain_text_body_from_html(&normalized), "Hello team");
+    }
 }

--- a/DoWhiz_service/send_emails_module/tests/live_postmark.rs
+++ b/DoWhiz_service/send_emails_module/tests/live_postmark.rs
@@ -32,6 +32,10 @@ fn require_live_config() -> (String, String) {
     (token, recipient)
 }
 
+fn should_run_live_tests() -> bool {
+    env::var("POSTMARK_LIVE_TEST").unwrap_or_default() == "1"
+}
+
 fn unique_subject(prefix: &str) -> String {
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -173,6 +177,10 @@ fn build_html_file(dir: &Path, name: &str) -> PathBuf {
 #[test]
 fn send_email_with_attachments_and_delivery() {
     load_env_from_repo();
+    if !should_run_live_tests() {
+        eprintln!("Skipping live Postmark test. Set POSTMARK_LIVE_TEST=1 to run.");
+        return;
+    }
     let (token, recipient) = require_live_config();
     let from = env::var("POSTMARK_TEST_FROM").unwrap_or_else(|_| "oliver@dowhiz.com".to_string());
 
@@ -220,6 +228,10 @@ fn send_email_with_attachments_and_delivery() {
 #[test]
 fn send_multiple_emails_batch() {
     load_env_from_repo();
+    if !should_run_live_tests() {
+        eprintln!("Skipping live Postmark batch test. Set POSTMARK_LIVE_TEST=1 to run.");
+        return;
+    }
     let (token, recipient) = require_live_config();
     let from = env::var("POSTMARK_TEST_FROM").unwrap_or_else(|_| "oliver@dowhiz.com".to_string());
 

--- a/DoWhiz_service/send_emails_module/tests/send_emails_integration.rs
+++ b/DoWhiz_service/send_emails_module/tests/send_emails_integration.rs
@@ -1,6 +1,6 @@
 use base64::{engine::general_purpose, Engine as _};
 use mockito::{Matcher, Server};
-use send_emails_module::{send_email, SendEmailParams};
+use send_emails_module::{normalize_email_html, send_email, SendEmailParams};
 use serde_json::json;
 use std::env;
 use std::ffi::OsString;
@@ -164,7 +164,7 @@ fn send_payload_includes_recipients_and_attachments() -> Result<(), Box<dyn std:
         "Bcc": "bcc@example.com, sender@example.com",
         "Subject": "Test subject",
         "TextBody": "Hello",
-        "HtmlBody": "<p>Hello</p>",
+        "HtmlBody": normalize_email_html("Test subject", "<p>Hello</p>"),
         "Attachments": expected_attachments,
     });
 
@@ -266,7 +266,7 @@ fn send_payload_sanitizes_attachment_names_to_ascii() -> Result<(), Box<dyn std:
         "Bcc": "sender@example.com",
         "Subject": "Unicode attachment test",
         "TextBody": "Hello",
-        "HtmlBody": "<p>Hello</p>",
+        "HtmlBody": normalize_email_html("Unicode attachment test", "<p>Hello</p>"),
         "Attachments": expected_attachments,
     });
 


### PR DESCRIPTION
## Summary
- normalize outbound HTML replies through a shared DoWhiz email shell before Postmark send
- refresh the shell to a flatter, Google-inspired layout with better responsive spacing and overflow handling
- update scheduler/run-task guidance and tests so normalized email output is applied and validated end to end

## Testing
- POSTMARK_LIVE_TEST=0 cargo test -p send_emails_module
- cargo test -p scheduler_module execute_email_send_normalizes_html_before_postmark_send --lib
- cargo test -p scheduler_module --test send_reply_outbound_e2e
- cargo test -p run_task_module
