### PR TITLE
Add U.S. equity daily monitor skill

### DIFF
--- a/.agents/skills/us-equity-daily-monitor/SKILL.md
+++ b/.agents/skills/us-equity-daily-monitor/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: us-equity-daily-monitor
+description: Daily monitoring and email-ready trading notes for U.S. stocks and ETFs. Use this skill whenever the user asks to track or watch a ticker, follow BE or INTC or any other U.S. equity, prepare a daily trading rating, explain what changed versus yesterday, summarize public news or filings, review insider or major-holder activity, or analyze price action, support or resistance, moving averages, momentum, volume, sentiment, event impact, key levels, or risk or reward for a trade decision. Also use it for Buy or Hold or Sell style ratings and for Buy or Wait or Trim or Sell action calls. Separate facts from interpretation, use current market data before making market claims, and do not present this as personalized investment advice or autonomous execution.
+---
+
+# U.S. Equity Daily Monitor
+
+Use this skill to produce a disciplined daily note for one U.S. equity or ETF.
+
+This skill is for research, monitoring, and communication quality. It is not a scheduler and it is not an execution engine.
+
+## Core job
+
+Produce one clear daily view that:
+
+- explains what happened
+- explains what matters now
+- translates professional trading logic into plain language
+- states uncertainty honestly
+- gives an action-oriented but non-hyped conclusion
+
+## Boundaries
+
+- Use only public information.
+- Do not imply access to non-public information, channel checks, or privileged order flow.
+- Do not present yourself as a licensed investment adviser or promise returns.
+- Do not place trades or imply that a trade will be placed automatically.
+- Do not overstate conviction when the signal set is mixed.
+
+## Source hierarchy
+
+Prefer sources in this order:
+
+1. Official company releases, SEC filings, exchange notices, and earnings materials
+2. Reliable market data and chart data for price, volume, and trend context
+3. Reputable financial news coverage
+4. Consensus analyst or sector commentary as context, not as the thesis by itself
+
+If a source is stale, ambiguous, or inaccessible, say so plainly.
+
+## Interpret filings correctly
+
+Do not collapse all ownership signals into one bucket.
+
+- `Form 4`: insider ownership changes. Treat this as insider activity, not institutional positioning.
+- `Schedule 13D` or `13G`: beneficial ownership disclosures for large holders. Treat these as major-holder positioning or control-relevant updates.
+- `Form 13F`: lagged quarterly institutional holdings disclosure. Do not frame this as same-day active buying or selling.
+
+When a filing is material but lagged, say both things:
+
+1. what the filing shows
+2. why it may not reflect today's live positioning
+
+## Handle time of day correctly
+
+Before writing the note, determine which market context applies:
+
+- **Pre-market**: before the regular session opens. Use the prior close plus pre-market context if available.
+- **Intraday**: during the regular session. Do not describe the current daily candle as a confirmed end-of-day close.
+- **Post-close**: after the regular session ends. You may discuss the completed daily candle and close.
+- **Market closed day**: weekend or holiday. Do not fabricate a live session; give a carry-forward watchlist view instead.
+
+If the user says "9:00 AM America/Los_Angeles", treat that as a market-status check first, not a fixed assumption that the market is still closed.
+
+## Required thinking process
+
+Build the note in this order:
+
+1. Confirm the ticker and company.
+2. Gather current public facts:
+   - latest relevant news
+   - earnings, guidance, policy, contracts, or sector updates
+   - ownership or insider filings if any
+   - current price action and volume context
+3. Separate **facts** from **interpretation**.
+4. Build the technical view:
+   - trend
+   - support and resistance
+   - relative volume
+   - candlestick context
+   - moving averages
+   - momentum
+5. Build the event view:
+   - catalyst
+   - sentiment
+   - event impact
+   - risk or reward asymmetry
+6. Compare with the prior note if one exists.
+7. Assign rating, confidence, and final action.
+8. Write the note in plain language.
+
+## If prior-day context is missing
+
+Never invent "what changed vs yesterday."
+
+If no prior report, prior close summary, or prior stored note is available, say:
+
+- that there is no reliable prior-note baseline
+- what changed versus the latest available public facts instead
+
+## Rating rubric
+
+Use these labels consistently:
+
+- `Strong Buy`: multiple aligned bullish signals, favorable risk or reward, and no major near-term contradiction
+- `Buy`: positive setup with some risks or less-than-perfect alignment
+- `Hold`: mixed or balanced setup; evidence does not justify a directional call
+- `Sell`: bearish setup or deteriorating thesis, but not a panic scenario
+- `Strong Sell`: strongly negative setup with multiple aligned bearish signals or major thesis break
+
+Do not force a bullish or bearish rating when `Hold` is the honest answer.
+
+## Confidence rubric
+
+- `High`: several independent signals align and the main uncertainty is modest
+- `Medium`: the thesis is plausible but key signals are mixed or incomplete
+- `Low`: the setup is noisy, event-driven, or too uncertain for conviction
+
+Confidence is about signal quality, not about sounding authoritative.
+
+## Output format
+
+When the user wants an email-ready daily note, use this structure:
+
+**Subject**
+
+`[TICKER] Daily Trading Rating - [DATE]`
+
+**Body**
+
+1. `Rating`: one of the five rating labels
+2. `Confidence`: High, Medium, or Low
+3. `One-sentence reason`
+4. `What happened`
+5. `Top 3 bullish factors`
+6. `Top 3 bearish factors`
+7. `Key price levels to watch`
+8. `What changed vs yesterday`
+9. `Risks`
+10. `Final action`: Buy, Wait, Trim, Sell, or No action
+11. `Key sources`
+
+## Writing style
+
+- Sound precise, calm, and evidence-based.
+- Explain jargon in plain English.
+- Keep the conclusion concise enough for email.
+- Use short sentences for the final recommendation.
+- If there is little new news, say that and still provide a technical update.
+
+## What to avoid
+
+- Do not confuse a lagged 13F with same-day live buying.
+- Do not describe an intraday candle as a fully confirmed daily close.
+- Do not let analyst price targets dominate the conclusion.
+- Do not present every insider buy as bullish or every insider sale as bearish without context.
+- Do not hide uncertainty.
+
+## Automation handoff
+
+This skill drafts the analysis and the email-ready content.
+
+Scheduling, recurring execution, and actual email delivery belong to the automation or scheduler layer. If used inside an automated workflow, return content that is ready to send, but do not mix scheduling rules into the analytical conclusion.

--- a/.agents/skills/us-equity-daily-monitor/agents/openai.yaml
+++ b/.agents/skills/us-equity-daily-monitor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "US Equity Daily Monitor"
+  short_description: "Track U.S. stocks with daily ratings"
+  default_prompt: "Use $us-equity-daily-monitor to prepare today's email-ready note for a U.S. stock."

--- a/.agents/skills/us-equity-daily-monitor/evals/evals.json
+++ b/.agents/skills/us-equity-daily-monitor/evals/evals.json
@@ -1,0 +1,68 @@
+{
+  "skill_name": "us-equity-daily-monitor",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Track BE - Bloom Energy. It is 9:00 AM America/Los_Angeles on a normal U.S. trading day. Use public web sources to prepare today's email-ready trading note. Include Rating, Confidence, one-sentence reason, top 3 bullish factors, top 3 bearish factors, key price levels, what changed vs yesterday, risks, and final action. If the market is already open at that time, treat this as an intraday update rather than a pre-market note.",
+      "expected_output": "A concise, evidence-based BE note that uses current public information, correctly handles 9:00 AM PT market status, and avoids inventing missing prior-day context.",
+      "files": [],
+      "expectations": [
+        "The note explicitly handles market timing correctly and does not call a 9:00 AM PT note a pre-market report if the regular session is already open.",
+        "The note separates factual developments from interpretation or judgment.",
+        "The note includes both bullish and bearish factors instead of presenting a one-sided thesis.",
+        "The note includes concrete price levels and explains why they matter.",
+        "The note cites or clearly names the public sources behind the main claims.",
+        "If no prior report is available, the note says the yesterday comparison baseline is missing instead of inventing a change."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Track INTC - Intel and write a daily rating note for email delivery. Focus on current public news, sector and macro context, recent price action, support or resistance, volume, moving averages, momentum, sentiment, and event impact. Be rigorous but explain the result for a non-expert. If signals are mixed, say so clearly.",
+      "expected_output": "A balanced INTC note that weighs technical and event-driven evidence, communicates uncertainty clearly, and avoids overconfident language.",
+      "files": [],
+      "expectations": [
+        "The note includes a rating, a confidence label, and a final action.",
+        "The note explicitly acknowledges mixed signals when the evidence does not point in one direction.",
+        "The note includes trend, price action, and event context rather than relying only on news headlines.",
+        "The explanation is plain-language enough for a non-expert reader without dropping the analytical substance.",
+        "The conclusion does not exaggerate certainty or imply guaranteed upside or downside."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Prepare a daily note for a U.S. equity where the user asks you to monitor major shareholder, insider, and institutional buying or selling. Use public filings if relevant. Explain what each filing means in plain English and say which signals are timely versus lagged.",
+      "expected_output": "A note that correctly distinguishes insider activity, large-holder disclosures, and lagged institutional holdings, instead of blending them into one generic ownership signal.",
+      "files": [],
+      "expectations": [
+        "The note distinguishes Form 4 insider activity from Schedule 13D or 13G large-holder filings and from Form 13F institutional holdings.",
+        "The note explains that some ownership disclosures can be materially lagged and should not be presented as today's live positioning.",
+        "The note avoids turning any single filing into a directional conclusion without context.",
+        "The note translates the filing categories into plain language for a non-expert reader."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "It is a U.S. market holiday. The user still wants today's daily rating email for one stock. Produce the note without pretending the market is open. Include what the user should watch next and what remains unchanged from the last active session.",
+      "expected_output": "A market-closed note that is still useful, avoids fabricating live price action, and carries forward a clear watchlist view.",
+      "files": [],
+      "expectations": [
+        "The note explicitly states that the market is closed or not in a live regular session.",
+        "The note does not fabricate intraday movement, a live candlestick, or new session volume.",
+        "The note still provides actionable next-watch items such as levels, upcoming catalysts, or risks.",
+        "The note clearly separates unchanged background context from genuinely new information."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "A stock has strong recent momentum and bullish price action, but the latest public headlines are negative and event risk is elevated. Produce the daily rating email and decide whether the right action is Buy, Wait, Trim, Sell, or No action.",
+      "expected_output": "A note that handles conflicting signals honestly, ties the final action to risk management, and does not force a strong directional call when the setup is mixed.",
+      "files": [],
+      "expectations": [
+        "The note identifies the conflict between technical strength and event-driven risk.",
+        "The final action is tied to the mixed-signal setup rather than defaulting to a bullish call.",
+        "The note includes a risks section that explains what could break the thesis.",
+        "The note uses uncertainty-aware language and avoids hype."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a new `us-equity-daily-monitor` skill under `.agents/skills/`
- define the skill workflow for daily U.S. stock/ETF monitoring, ratings, market-session handling, and ownership-filing interpretation
- add UI metadata and an eval pack with representative prompts and expectations

## Testing
- `PYTHONPATH=/tmp/codex-skill-validate python3 /Users/yegaoyang/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/yegaoyang/Desktop/workspace/DoWhiz/.agents/skills/us-equity-daily-monitor`
- `python3 -m json.tool /Users/yegaoyang/Desktop/workspace/DoWhiz/.agents/skills/us-equity-daily-monitor/evals/evals.json >/dev/null`

## Notes
- exploratory trigger smoke tests showed the description is still conservative for implicit invocation, so automation prompts should invoke `$us-equity-daily-monitor` explicitly when we wire this into scheduled stock-monitor emails
