### PR TITLE
ci: reduce Rust workflow disk pressure

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -108,6 +108,9 @@ jobs:
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            DoWhiz_service -> target
 
       - name: Run tests (scheduler_module)
         run: cargo test --locked -p scheduler_module
@@ -139,6 +142,9 @@ jobs:
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            DoWhiz_service -> target
 
       - name: Remove cached debug artifacts before release build
         run: rm -rf target/debug

--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -150,7 +150,22 @@ jobs:
         run: rm -rf target/debug
 
       - name: Build release binaries
-        run: cargo build --locked -p scheduler_module --bins --release
+        run: |
+          cargo build --locked -p scheduler_module --release \
+            --bin rust_service \
+            --bin inbound_fanout \
+            --bin inbound_gateway \
+            --bin google-docs \
+            --bin google-sheets \
+            --bin google-slides \
+            --bin set_postmark_inbound_hook \
+            --bin notion_api_cli \
+            --bin tpm_cli \
+            --bin slack_cli \
+            --bin discord_cli \
+            --bin lark_cli \
+            --bin identity_lookup_cli \
+            --bin grocery_cli
 
       - name: Archive rust binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -17,7 +17,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  prepare:
     runs-on: ubuntu-latest
     environment: production
     if: |
@@ -27,10 +27,6 @@ jobs:
       CARGO_INCREMENTAL: 0
     outputs:
       deploy_sha: ${{ steps.auto_bump_base.outputs.deploy_sha }}
-
-    defaults:
-      run:
-        working-directory: DoWhiz_service
 
     steps:
       - name: Checkout code
@@ -92,6 +88,24 @@ jobs:
             echo "Base Dockerfile unchanged: keep version_base.txt at $current_version"
           fi
 
+  test:
+    runs-on: ubuntu-latest
+    needs: prepare
+    environment: production
+    env:
+      CARGO_INCREMENTAL: 0
+
+    defaults:
+      run:
+        working-directory: DoWhiz_service
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.deploy_sha }}
+
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -102,6 +116,29 @@ jobs:
       - name: Run tests (run_task_module)
         run: cargo test --locked -p run_task_module
         continue-on-error: true
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - test
+    environment: production
+    env:
+      CARGO_INCREMENTAL: 0
+
+    defaults:
+      run:
+        working-directory: DoWhiz_service
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.deploy_sha }}
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build release binaries
         run: cargo build --locked -p scheduler_module --bins --release
@@ -130,7 +167,9 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - prepare
+      - build
     environment: production
     if: |
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
@@ -141,7 +180,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.build.outputs.deploy_sha }}
+          ref: ${{ needs.prepare.outputs.deploy_sha }}
 
       - name: Download rust binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -140,6 +140,9 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Remove cached debug artifacts before release build
+        run: rm -rf target/debug
+
       - name: Build release binaries
         run: cargo build --locked -p scheduler_module --bins --release
 

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -108,6 +108,9 @@ jobs:
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            DoWhiz_service -> target
 
       - name: Run tests (scheduler_module)
         run: cargo test --locked -p scheduler_module
@@ -139,6 +142,9 @@ jobs:
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            DoWhiz_service -> target
 
       - name: Remove cached debug artifacts before release build
         run: rm -rf target/debug

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -22,7 +22,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  prepare:
     runs-on: ubuntu-latest
     environment: staging
     if: |
@@ -32,10 +32,6 @@ jobs:
       CARGO_INCREMENTAL: 0
     outputs:
       deploy_sha: ${{ steps.auto_bump_base.outputs.deploy_sha }}
-
-    defaults:
-      run:
-        working-directory: DoWhiz_service
 
     steps:
       - name: Checkout code
@@ -92,6 +88,24 @@ jobs:
             echo "Base Dockerfile unchanged: keep version_base.txt at $current_version"
           fi
 
+  test:
+    runs-on: ubuntu-latest
+    needs: prepare
+    environment: staging
+    env:
+      CARGO_INCREMENTAL: 0
+
+    defaults:
+      run:
+        working-directory: DoWhiz_service
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.deploy_sha }}
+
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -102,6 +116,29 @@ jobs:
       - name: Run tests (run_task_module)
         run: cargo test --locked -p run_task_module
         continue-on-error: true
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - test
+    environment: staging
+    env:
+      CARGO_INCREMENTAL: 0
+
+    defaults:
+      run:
+        working-directory: DoWhiz_service
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.deploy_sha }}
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build release binaries
         run: cargo build --locked -p scheduler_module --bins --release
@@ -130,7 +167,9 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - prepare
+      - build
     environment: staging
     if: |
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
@@ -141,7 +180,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.build.outputs.deploy_sha }}
+          ref: ${{ needs.prepare.outputs.deploy_sha }}
 
       - name: Download rust binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -150,7 +150,22 @@ jobs:
         run: rm -rf target/debug
 
       - name: Build release binaries
-        run: cargo build --locked -p scheduler_module --bins --release
+        run: |
+          cargo build --locked -p scheduler_module --release \
+            --bin rust_service \
+            --bin inbound_fanout \
+            --bin inbound_gateway \
+            --bin google-docs \
+            --bin google-sheets \
+            --bin google-slides \
+            --bin set_postmark_inbound_hook \
+            --bin notion_api_cli \
+            --bin tpm_cli \
+            --bin slack_cli \
+            --bin discord_cli \
+            --bin lark_cli \
+            --bin identity_lookup_cli \
+            --bin grocery_cli
 
       - name: Archive rust binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -140,6 +140,9 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Remove cached debug artifacts before release build
+        run: rm -rf target/debug
+
       - name: Build release binaries
         run: cargo build --locked -p scheduler_module --bins --release
 


### PR DESCRIPTION
## Summary
- split test and release compilation into separate GitHub Actions jobs
- remove cached debug artifacts before release builds
- point rust-cache at the nested DoWhiz_service workspace
- build only the deployed release binaries instead of all bins

## Included PRs
- #1382
- #1383
- #1384
- #1385

## Testing
- each change was landed to dev in its own PR with YAML validation and targeted workflow consistency checks