### PR TITLE
fix(ci): use prepare deploy sha in deploy jobs

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Update repo on Azure VM
         run: |
           ssh -F ~/.ssh/config azureproduction << 'EOF'
-          TARGET_SHA="${{ needs.build.outputs.deploy_sha }}"
+          TARGET_SHA="${{ needs.prepare.outputs.deploy_sha }}"
           [[ -n "$TARGET_SHA" ]] || {
             echo "Missing TARGET_SHA" >&2
             exit 1

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -249,7 +249,7 @@ jobs:
         id: update_repo
         run: |
           result=$(ssh -F ~/.ssh/config azureproduction << 'EOF'
-          TARGET_SHA="${{ needs.build.outputs.deploy_sha }}"
+          TARGET_SHA="${{ needs.prepare.outputs.deploy_sha }}"
           [[ -n "$TARGET_SHA" ]] || {
             echo "Missing TARGET_SHA" >&2
             exit 1


### PR DESCRIPTION
## Summary
- fix staging deploy job to use the existing prepare job deploy SHA output
- fix production deploy job to use the existing prepare job deploy SHA output
- unblock mainline merge/deployment flows that were failing with Missing TARGET_SHA

## Testing
- git diff --check
- inspected failing staging workflow log for Missing TARGET_SHA root cause