### PR TITLE
Upgrade stock investment skill v1 contract

### DIFF
--- a/.agents/skills/us-equity-daily-monitor/SKILL.md
+++ b/.agents/skills/us-equity-daily-monitor/SKILL.md
@@ -1,42 +1,81 @@
 ---
 name: us-equity-daily-monitor
-description: Daily monitoring and email-ready trading notes for U.S. stocks and ETFs. Use this skill whenever the user asks to track or watch a ticker, follow BE or INTC or any other U.S. equity, prepare a daily trading rating, explain what changed versus yesterday, summarize public news or filings, review insider or major-holder activity, or analyze price action, support or resistance, moving averages, momentum, volume, sentiment, event impact, key levels, or risk or reward for a trade decision. Also use it for Buy or Hold or Sell style ratings and for Buy or Wait or Trim or Sell action calls. Separate facts from interpretation, use current market data before making market claims, and do not present this as personalized investment advice or autonomous execution.
+description: One-off investment research for a single U.S. stock or single U.S. ETF. Use this skill whenever the user asks to analyze a ticker, do deep research on one stock or ETF, ask whether it is worth buying now, request an investment view, or wants a structured Buy / Wait / Sell answer grounded in public information. Keep the scope to one U.S. stock or one U.S. ETF, use current public sources, separate facts from interpretation, and do not present personalized investment advice, auto-execution, portfolio construction, recurring automation, or dashboard behavior.
 ---
 
-# U.S. Equity Daily Monitor
+# Stock Investment Skill
 
-Use this skill to produce a disciplined daily note for one U.S. equity or ETF.
+This is the first-version stock investment research workflow for one U.S. public-market asset.
 
-This skill is for research, monitoring, and communication quality. It is not a scheduler and it is not an execution engine.
+Use it for one-off analysis of:
+
+- one U.S. stock
+- one U.S. ETF
+
+This skill is for public-information-based research only. It is not a broker, auto-trader, scheduler, dashboard, or delivery system.
 
 ## Core job
 
-Produce one clear daily view that:
+Produce one clear investment research answer that:
 
-- explains what happened
-- explains what matters now
-- translates professional trading logic into plain language
-- states uncertainty honestly
-- gives an action-oriented but non-hyped conclusion
+- identifies the asset correctly
+- explains the current setup in plain language
+- separates facts from interpretation
+- weighs bullish and bearish evidence honestly
+- returns exactly one rating: `Buy`, `Wait`, or `Sell`
+- stays usable for both quick analysis and deeper one-off research
 
-## Boundaries
+## Hard boundaries
 
 - Use only public information.
 - Do not imply access to non-public information, channel checks, or privileged order flow.
-- Do not present yourself as a licensed investment adviser or promise returns.
+- Do not present yourself as a licensed investment adviser or as giving personalized regulated advice.
 - Do not place trades or imply that a trade will be placed automatically.
-- Do not overstate conviction when the signal set is mixed.
+- Do not expand into options, crypto, global equities, portfolio allocation, or multi-asset comparison.
+- Do not invent unavailable price levels, holdings data, filing details, or "changed vs yesterday" baselines.
+- Do not add scheduler, automation, channel-delivery, or dashboard logic to the analysis.
 
 ## Source hierarchy
 
 Prefer sources in this order:
 
-1. Official company releases, SEC filings, exchange notices, and earnings materials
-2. Reliable market data and chart data for price, volume, and trend context
+1. Official company or fund materials, SEC filings, exchange notices, earnings materials, and fund sponsor or index-provider documents
+2. Reliable market data and chart data for price, volume, trend, and session context
 3. Reputable financial news coverage
-4. Consensus analyst or sector commentary as context, not as the thesis by itself
+4. Consensus analyst or sector commentary as context, never as the thesis by itself
 
-If a source is stale, ambiguous, or inaccessible, say so plainly.
+If a source is stale, gated, ambiguous, or inaccessible, say so plainly and reduce conviction.
+
+## Asset identification
+
+Start by confirming:
+
+- ticker
+- issuer or fund name
+- whether it is a stock or ETF
+- whether the user wants a quick analysis or deep research answer
+
+If the prompt is ambiguous or could map to multiple tickers, resolve the ambiguity before making claims.
+
+## Research workflow
+
+Work in this order:
+
+1. Confirm the asset and whether it is a stock or ETF.
+2. Determine market context: pre-market, intraday, post-close, or market-closed day.
+3. Gather current public facts:
+   - latest relevant news, earnings, guidance, contracts, policy, sector, or fund updates
+   - price action, volume, trend, moving averages, momentum, and key levels when available
+   - ownership or insider filings if relevant
+   - for ETFs, objective, major exposures, concentration, sector or factor sensitivity, and rate sensitivity when relevant
+4. Separate facts from interpretation.
+5. Build the case for both sides:
+   - bullish factors
+   - bearish factors
+   - near-term risks and thesis-break conditions
+6. Assign exactly one rating: `Buy`, `Wait`, or `Sell`.
+7. Write the answer in the required structure.
+8. Name or cite the public sources behind the main claims.
 
 ## Interpret filings correctly
 
@@ -51,113 +90,98 @@ When a filing is material but lagged, say both things:
 1. what the filing shows
 2. why it may not reflect today's live positioning
 
+Do not turn one filing into the whole thesis without broader context.
+
 ## Handle time of day correctly
 
-Before writing the note, determine which market context applies:
+Before writing the answer, determine which market context applies:
 
 - **Pre-market**: before the regular session opens. Use the prior close plus pre-market context if available.
 - **Intraday**: during the regular session. Do not describe the current daily candle as a confirmed end-of-day close.
 - **Post-close**: after the regular session ends. You may discuss the completed daily candle and close.
 - **Market closed day**: weekend or holiday. Do not fabricate a live session; give a carry-forward watchlist view instead.
 
-If the user says "9:00 AM America/Los_Angeles", treat that as a market-status check first, not a fixed assumption that the market is still closed.
-
-## Required thinking process
-
-Build the note in this order:
-
-1. Confirm the ticker and company.
-2. Gather current public facts:
-   - latest relevant news
-   - earnings, guidance, policy, contracts, or sector updates
-   - ownership or insider filings if any
-   - current price action and volume context
-3. Separate **facts** from **interpretation**.
-4. Build the technical view:
-   - trend
-   - support and resistance
-   - relative volume
-   - candlestick context
-   - moving averages
-   - momentum
-5. Build the event view:
-   - catalyst
-   - sentiment
-   - event impact
-   - risk or reward asymmetry
-6. Compare with the prior note if one exists.
-7. Assign rating, confidence, and final action.
-8. Write the note in plain language.
+If the user says "9:00 AM America/Los_Angeles", treat that as a market-status check first, not as a fixed assumption that the market is still closed.
 
 ## If prior-day context is missing
 
 Never invent "what changed vs yesterday."
 
-If no prior report, prior close summary, or prior stored note is available, say:
+If the user asks for a yesterday comparison and no reliable prior report, prior close summary, or stored note is available, say:
 
 - that there is no reliable prior-note baseline
-- what changed versus the latest available public facts instead
+- what changed versus the latest accessible public baseline instead
 
-## Rating rubric
+## Rating semantics
 
-Use these labels consistently:
+Use only these labels:
 
-- `Strong Buy`: multiple aligned bullish signals, favorable risk or reward, and no major near-term contradiction
-- `Buy`: positive setup with some risks or less-than-perfect alignment
-- `Hold`: mixed or balanced setup; evidence does not justify a directional call
-- `Sell`: bearish setup or deteriorating thesis, but not a panic scenario
-- `Strong Sell`: strongly negative setup with multiple aligned bearish signals or major thesis break
+- `Buy`: evidence is sufficiently favorable for a constructive stance right now, even if risks remain
+- `Wait`: setup is mixed, incomplete, extended, or not attractive enough for action right now
+- `Sell`: evidence suggests avoiding, reducing, or exiting because the setup or thesis is deteriorating or broken
 
-Do not force a bullish or bearish rating when `Hold` is the honest answer.
+If signals are mixed, `Wait` is often the honest answer.
 
-## Confidence rubric
+Do not mix these labels with `Strong Buy`, `Hold`, `Trim`, `No action`, `Strong Sell`, or any second action taxonomy.
 
-- `High`: several independent signals align and the main uncertainty is modest
-- `Medium`: the thesis is plausible but key signals are mixed or incomplete
-- `Low`: the setup is noisy, event-driven, or too uncertain for conviction
+Do not introduce a second formal confidence scale by default. Express uncertainty in the summary, why-now explanation, and risks instead.
 
-Confidence is about signal quality, not about sounding authoritative.
+## Quick analysis versus deep research
 
-## Output format
+- For a quick request such as "Analyze NVDA", keep each section concise and decision-useful.
+- For a deep-research request such as "Deep research BE", use the same section order but provide broader synthesis across filings, news, price action, and risks.
+- Deep research should go deeper than a headline recap, but it should still stay readable and structured.
 
-When the user wants an email-ready daily note, use this structure:
+## Required output format
 
-**Subject**
+Always use this section order:
 
-`[TICKER] Daily Trading Rating - [DATE]`
+## Asset identified
+- `Ticker`: ...
+- `Name`: ...
+- `Type`: `Stock` or `ETF`
+- `Market context`: `Pre-market`, `Intraday`, `Post-close`, or `Market closed`
+- `Research mode`: `Quick analysis` or `Deep research`
 
-**Body**
+## Summary
+- `Facts`: 2 to 4 sentences on the most relevant current public facts
+- `Interpretation`: 1 to 3 sentences on what those facts mean now
 
-1. `Rating`: one of the five rating labels
-2. `Confidence`: High, Medium, or Low
-3. `One-sentence reason`
-4. `What happened`
-5. `Top 3 bullish factors`
-6. `Top 3 bearish factors`
-7. `Key price levels to watch`
-8. `What changed vs yesterday`
-9. `Risks`
-10. `Final action`: Buy, Wait, Trim, Sell, or No action
-11. `Key sources`
+## Rating
+`Buy` or `Wait` or `Sell`
+
+## Why now
+Explain why the current timing, catalyst path, valuation backdrop, fund-exposure backdrop, or technical setup supports the rating now.
+
+## Bullish factors
+- 2 to 5 concise bullets
+
+## Bearish factors
+- 2 to 5 concise bullets
+
+## Risks
+- 2 to 5 concise bullets, including what could break the thesis or invalidate the rating
+
+## Key levels to watch
+- Include support, resistance, trend, or trigger levels when relevant and supported by accessible market data
+- If levels are not available or not meaningful, say so instead of inventing them
+
+## Sources
+- Name the main public sources used
+- Put official and primary sources first
+
+## Disclaimer
+`Public-information-based research only, not personalized investment advice or trade execution.`
 
 ## Writing style
 
 - Sound precise, calm, and evidence-based.
-- Explain jargon in plain English.
-- Keep the conclusion concise enough for email.
-- Use short sentences for the final recommendation.
-- If there is little new news, say that and still provide a technical update.
+- Explain jargon in plain language.
+- Keep the answer structured and easy to scan.
+- Avoid hype, memes, and certainty theater.
+- For ETFs, do not write as though the fund were an operating company.
+- For stocks, do not let analyst price targets or a single headline dominate the thesis.
 
-## What to avoid
+## Out of scope
 
-- Do not confuse a lagged 13F with same-day live buying.
-- Do not describe an intraday candle as a fully confirmed daily close.
-- Do not let analyst price targets dominate the conclusion.
-- Do not present every insider buy as bullish or every insider sale as bearish without context.
-- Do not hide uncertainty.
-
-## Automation handoff
-
-This skill drafts the analysis and the email-ready content.
-
-Scheduling, recurring execution, and actual email delivery belong to the automation or scheduler layer. If used inside an automated workflow, return content that is ready to send, but do not mix scheduling rules into the analytical conclusion.
+Automation, recurring execution, channel delivery, dashboards, and broker actions belong to other layers. This skill returns the research answer only.

--- a/.agents/skills/us-equity-daily-monitor/SKILL.md
+++ b/.agents/skills/us-equity-daily-monitor/SKILL.md
@@ -7,6 +7,8 @@ description: One-off investment research for a single U.S. stock or single U.S. 
 
 This is the first-version stock investment research workflow for one U.S. public-market asset.
 
+Technical compatibility note: the skill id remains `us-equity-daily-monitor` in this round to avoid broader rename churn. A path or id cleanup can happen later as a dedicated follow-up.
+
 Use it for one-off analysis of:
 
 - one U.S. stock
@@ -122,9 +124,13 @@ Use only these labels:
 
 If signals are mixed, `Wait` is often the honest answer.
 
-Do not mix these labels with `Strong Buy`, `Hold`, `Trim`, `No action`, `Strong Sell`, or any second action taxonomy.
+The formal `## Rating` section must contain exactly one standalone label: `Buy`, `Wait`, or `Sell`.
 
-Do not introduce a second formal confidence scale by default. Express uncertainty in the summary, why-now explanation, and risks instead.
+Never reintroduce legacy formal labels such as `Strong Buy`, `Hold`, `Trim`, `No action`, or `Strong Sell`.
+
+Do not add a second formal action taxonomy such as `Action`, `Final action`, `Trade plan`, or similar.
+
+Do not output a formal `Confidence` label or section by default unless a future version explicitly adds it back. Express uncertainty in the summary, why-now explanation, and risks instead.
 
 ## Quick analysis versus deep research
 
@@ -135,6 +141,8 @@ Do not introduce a second formal confidence scale by default. Express uncertaint
 ## Required output format
 
 Always use this section order:
+
+Use these headers as written. Do not add formal sections such as `Confidence`, `Action`, or `Final action`.
 
 ## Asset identified
 - `Ticker`: ...

--- a/.agents/skills/us-equity-daily-monitor/agents/openai.yaml
+++ b/.agents/skills/us-equity-daily-monitor/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "US Equity Daily Monitor"
-  short_description: "Track U.S. stocks with daily ratings"
-  default_prompt: "Use $us-equity-daily-monitor to prepare today's email-ready note for a U.S. stock."
+  display_name: "Stock Investment Research"
+  short_description: "Analyze one U.S. stock or ETF with a Buy/Wait/Sell view"
+  default_prompt: "Use $us-equity-daily-monitor to analyze a single U.S. stock or ETF and return a structured Buy/Wait/Sell investment research answer."

--- a/.agents/skills/us-equity-daily-monitor/evals/evals.json
+++ b/.agents/skills/us-equity-daily-monitor/evals/evals.json
@@ -3,65 +3,81 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Track BE - Bloom Energy. It is 9:00 AM America/Los_Angeles on a normal U.S. trading day. Use public web sources to prepare today's email-ready trading note. Include Rating, Confidence, one-sentence reason, top 3 bullish factors, top 3 bearish factors, key price levels, what changed vs yesterday, risks, and final action. If the market is already open at that time, treat this as an intraday update rather than a pre-market note.",
-      "expected_output": "A concise, evidence-based BE note that uses current public information, correctly handles 9:00 AM PT market status, and avoids inventing missing prior-day context.",
+      "prompt": "Analyze VRT and tell me if it is worth buying now. It is 9:00 AM America/Los_Angeles on a normal U.S. trading day. Use current public web sources and return the stock investment research format with Asset identified, Summary, Rating, Why now, Bullish factors, Bearish factors, Risks, Key levels to watch, Sources, and Disclaimer. If the market is already open at that time, treat the price action as intraday rather than a completed close.",
+      "expected_output": "A structured single-stock research answer for VRT that handles 9:00 AM PT market timing correctly, keeps facts separate from interpretation, and ends with exactly one Buy, Wait, or Sell rating.",
       "files": [],
       "expectations": [
-        "The note explicitly handles market timing correctly and does not call a 9:00 AM PT note a pre-market report if the regular session is already open.",
-        "The note separates factual developments from interpretation or judgment.",
-        "The note includes both bullish and bearish factors instead of presenting a one-sided thesis.",
-        "The note includes concrete price levels and explains why they matter.",
-        "The note cites or clearly names the public sources behind the main claims.",
-        "If no prior report is available, the note says the yesterday comparison baseline is missing instead of inventing a change."
+        "The answer identifies VRT correctly as a U.S. stock and does not describe it as an ETF.",
+        "The answer treats 9:00 AM America/Los_Angeles on a normal trading day as an intraday context and does not describe the current session as a completed daily close.",
+        "The answer uses the required section structure and includes exactly one rating from Buy, Wait, or Sell.",
+        "The answer keeps facts separate from interpretation inside the summary or surrounding explanation.",
+        "The answer names or cites the main public sources behind the key claims.",
+        "The answer includes a research-only disclaimer and does not imply trade execution or personalized regulated advice."
       ]
     },
     {
       "id": 2,
-      "prompt": "Track INTC - Intel and write a daily rating note for email delivery. Focus on current public news, sector and macro context, recent price action, support or resistance, volume, moving averages, momentum, sentiment, and event impact. Be rigorous but explain the result for a non-expert. If signals are mixed, say so clearly.",
-      "expected_output": "A balanced INTC note that weighs technical and event-driven evidence, communicates uncertainty clearly, and avoids overconfident language.",
+      "prompt": "Give me an investment view on XLU. Keep it concise but evidence-based, use public information only, and return the same stock investment research format with exactly one rating: Buy, Wait, or Sell.",
+      "expected_output": "A structured ETF research answer for XLU that evaluates the fund as an ETF, uses the stable output contract, and does not drift into operating-company analysis.",
       "files": [],
       "expectations": [
-        "The note includes a rating, a confidence label, and a final action.",
-        "The note explicitly acknowledges mixed signals when the evidence does not point in one direction.",
-        "The note includes trend, price action, and event context rather than relying only on news headlines.",
-        "The explanation is plain-language enough for a non-expert reader without dropping the analytical substance.",
-        "The conclusion does not exaggerate certainty or imply guaranteed upside or downside."
+        "The answer identifies XLU correctly as an ETF rather than as an operating company.",
+        "The answer discusses ETF-relevant context such as fund objective, exposure, concentration, sector or rate sensitivity, or related public fund information when relevant.",
+        "The answer uses the required section structure and includes exactly one rating from Buy, Wait, or Sell.",
+        "The answer does not invent holdings weights, exposures, or other unavailable fund details.",
+        "The answer stays within the public-information research boundary and includes a disclaimer."
       ]
     },
     {
       "id": 3,
-      "prompt": "Prepare a daily note for a U.S. equity where the user asks you to monitor major shareholder, insider, and institutional buying or selling. Use public filings if relevant. Explain what each filing means in plain English and say which signals are timely versus lagged.",
-      "expected_output": "A note that correctly distinguishes insider activity, large-holder disclosures, and lagged institutional holdings, instead of blending them into one generic ownership signal.",
+      "prompt": "A single U.S. stock has strong recent momentum and bullish price action, but the latest public headlines are negative and event risk is elevated. Produce the stock investment research answer and choose Buy, Wait, or Sell.",
+      "expected_output": "A mixed-signal research answer that acknowledges the conflict between technical strength and event risk, uses the stable structure, and chooses Wait rather than forcing a directional action.",
       "files": [],
       "expectations": [
-        "The note distinguishes Form 4 insider activity from Schedule 13D or 13G large-holder filings and from Form 13F institutional holdings.",
-        "The note explains that some ownership disclosures can be materially lagged and should not be presented as today's live positioning.",
-        "The note avoids turning any single filing into a directional conclusion without context.",
-        "The note translates the filing categories into plain language for a non-expert reader."
+        "The answer identifies the conflict between bullish technicals and negative or risky event context.",
+        "The answer selects Wait as the honest rating for the mixed-signal setup instead of forcing a bullish or bearish call.",
+        "The answer explains why the current evidence is not clean enough for Buy or Sell.",
+        "The answer includes explicit risks and thesis-break conditions.",
+        "The answer avoids hype, certainty theater, and any implication of auto-execution."
       ]
     },
     {
       "id": 4,
-      "prompt": "It is a U.S. market holiday. The user still wants today's daily rating email for one stock. Produce the note without pretending the market is open. Include what the user should watch next and what remains unchanged from the last active session.",
-      "expected_output": "A market-closed note that is still useful, avoids fabricating live price action, and carries forward a clear watchlist view.",
+      "prompt": "Deep research BE and include any relevant ownership or insider angle from public filings. If you mention Form 4, Schedule 13D or 13G, or Form 13F, explain in plain English what each filing means and which signals are timely versus lagged. Return the same structured stock investment answer with exactly one Buy, Wait, or Sell rating.",
+      "expected_output": "A deep-research answer on BE that correctly interprets ownership filings, distinguishes timely versus lagged signals, and keeps the final view grounded in broader evidence rather than filing labels alone.",
       "files": [],
       "expectations": [
-        "The note explicitly states that the market is closed or not in a live regular session.",
-        "The note does not fabricate intraday movement, a live candlestick, or new session volume.",
-        "The note still provides actionable next-watch items such as levels, upcoming catalysts, or risks.",
-        "The note clearly separates unchanged background context from genuinely new information."
+        "The answer distinguishes Form 4 insider activity from Schedule 13D or 13G major-holder disclosures and from Form 13F institutional holdings.",
+        "The answer explains that Form 13F data is materially lagged and should not be framed as live same-day positioning.",
+        "The answer does not turn a single filing into the entire thesis without broader context.",
+        "The answer uses the required section structure and includes exactly one rating from Buy, Wait, or Sell.",
+        "The answer stays within the public-information boundary and names or cites the relevant sources."
       ]
     },
     {
       "id": 5,
-      "prompt": "A stock has strong recent momentum and bullish price action, but the latest public headlines are negative and event risk is elevated. Produce the daily rating email and decide whether the right action is Buy, Wait, Trim, Sell, or No action.",
-      "expected_output": "A note that handles conflicting signals honestly, ties the final action to risk management, and does not force a strong directional call when the setup is mixed.",
+      "prompt": "It is a U.S. market holiday. Analyze NVDA in the stock investment research format without pretending the market is open. Tell me what matters next and keep the response grounded in public information.",
+      "expected_output": "A market-closed stock research answer for NVDA that avoids fabricating live trading context, still provides a useful carry-forward view, and preserves the structured output contract.",
       "files": [],
       "expectations": [
-        "The note identifies the conflict between technical strength and event-driven risk.",
-        "The final action is tied to the mixed-signal setup rather than defaulting to a bullish call.",
-        "The note includes a risks section that explains what could break the thesis.",
-        "The note uses uncertainty-aware language and avoids hype."
+        "The answer explicitly states that the market is closed or not in a live regular session.",
+        "The answer does not fabricate intraday movement, live volume, or a completed session that did not happen.",
+        "The answer still provides useful next-watch items such as catalysts, risks, or key levels where relevant.",
+        "The answer uses the required section structure and includes exactly one rating from Buy, Wait, or Sell.",
+        "The answer avoids implying that an order will be placed or that the response is personalized investment advice."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Deep research BE. I want more than a quick note, but keep it usable. Synthesize current public information into a structured investment view rather than just listing headlines. Return Asset identified, Summary, Rating, Why now, Bullish factors, Bearish factors, Risks, Key levels to watch, Sources, and Disclaimer.",
+      "expected_output": "A deeper but still usable BE research answer that preserves the stable structure, goes beyond a headline recap, and ends with exactly one Buy, Wait, or Sell rating.",
+      "files": [],
+      "expectations": [
+        "The answer uses the same stable section structure as the quick-analysis cases rather than switching to an unstructured essay.",
+        "The answer goes deeper than a headline summary by synthesizing public facts, interpretation, and current setup.",
+        "The answer remains concise enough to be usable rather than turning into a bloated long-form report.",
+        "The answer includes exactly one rating from Buy, Wait, or Sell and does not reintroduce old rating labels.",
+        "The answer stays evidence-based, non-hyped, and inside the research-only boundary."
       ]
     }
   ]

--- a/.agents/skills/us-equity-daily-monitor/evals/evals.json
+++ b/.agents/skills/us-equity-daily-monitor/evals/evals.json
@@ -9,7 +9,9 @@
       "expectations": [
         "The answer identifies VRT correctly as a U.S. stock and does not describe it as an ETF.",
         "The answer treats 9:00 AM America/Los_Angeles on a normal trading day as an intraday context and does not describe the current session as a completed daily close.",
-        "The answer uses the required section structure and includes exactly one rating from Buy, Wait, or Sell.",
+        "The answer uses the required section structure with Asset identified, Summary, Rating, Why now, Bullish factors, Bearish factors, Risks, Key levels to watch, Sources, and Disclaimer.",
+        "The answer includes exactly one formal rating from Buy, Wait, or Sell and does not use legacy labels such as Strong Buy, Hold, Trim, No action, or Strong Sell.",
+        "The answer does not add a second formal action taxonomy such as Action or Final action and does not include a formal Confidence label by default.",
         "The answer keeps facts separate from interpretation inside the summary or surrounding explanation.",
         "The answer names or cites the main public sources behind the key claims.",
         "The answer includes a research-only disclaimer and does not imply trade execution or personalized regulated advice."
@@ -23,7 +25,9 @@
       "expectations": [
         "The answer identifies XLU correctly as an ETF rather than as an operating company.",
         "The answer discusses ETF-relevant context such as fund objective, exposure, concentration, sector or rate sensitivity, or related public fund information when relevant.",
-        "The answer uses the required section structure and includes exactly one rating from Buy, Wait, or Sell.",
+        "The answer uses the required section structure with Asset identified, Summary, Rating, Why now, Bullish factors, Bearish factors, Risks, Key levels to watch, Sources, and Disclaimer.",
+        "The answer includes exactly one formal rating from Buy, Wait, or Sell and does not use legacy labels such as Strong Buy, Hold, Trim, No action, or Strong Sell.",
+        "The answer does not add a second formal action taxonomy such as Action or Final action and does not include a formal Confidence label by default.",
         "The answer does not invent holdings weights, exposures, or other unavailable fund details.",
         "The answer stays within the public-information research boundary and includes a disclaimer."
       ]
@@ -36,6 +40,9 @@
       "expectations": [
         "The answer identifies the conflict between bullish technicals and negative or risky event context.",
         "The answer selects Wait as the honest rating for the mixed-signal setup instead of forcing a bullish or bearish call.",
+        "The answer uses the required section structure with Asset identified, Summary, Rating, Why now, Bullish factors, Bearish factors, Risks, Key levels to watch, Sources, and Disclaimer.",
+        "The answer does not use legacy labels such as Strong Buy, Hold, Trim, No action, or Strong Sell.",
+        "The answer does not add a second formal action taxonomy such as Action or Final action and does not include a formal Confidence label by default.",
         "The answer explains why the current evidence is not clean enough for Buy or Sell.",
         "The answer includes explicit risks and thesis-break conditions.",
         "The answer avoids hype, certainty theater, and any implication of auto-execution."
@@ -50,7 +57,9 @@
         "The answer distinguishes Form 4 insider activity from Schedule 13D or 13G major-holder disclosures and from Form 13F institutional holdings.",
         "The answer explains that Form 13F data is materially lagged and should not be framed as live same-day positioning.",
         "The answer does not turn a single filing into the entire thesis without broader context.",
-        "The answer uses the required section structure and includes exactly one rating from Buy, Wait, or Sell.",
+        "The answer uses the required section structure with Asset identified, Summary, Rating, Why now, Bullish factors, Bearish factors, Risks, Key levels to watch, Sources, and Disclaimer.",
+        "The answer includes exactly one formal rating from Buy, Wait, or Sell and does not use legacy labels such as Strong Buy, Hold, Trim, No action, or Strong Sell.",
+        "The answer does not add a second formal action taxonomy such as Action or Final action and does not include a formal Confidence label by default.",
         "The answer stays within the public-information boundary and names or cites the relevant sources."
       ]
     },
@@ -63,7 +72,9 @@
         "The answer explicitly states that the market is closed or not in a live regular session.",
         "The answer does not fabricate intraday movement, live volume, or a completed session that did not happen.",
         "The answer still provides useful next-watch items such as catalysts, risks, or key levels where relevant.",
-        "The answer uses the required section structure and includes exactly one rating from Buy, Wait, or Sell.",
+        "The answer uses the required section structure with Asset identified, Summary, Rating, Why now, Bullish factors, Bearish factors, Risks, Key levels to watch, Sources, and Disclaimer.",
+        "The answer includes exactly one formal rating from Buy, Wait, or Sell and does not use legacy labels such as Strong Buy, Hold, Trim, No action, or Strong Sell.",
+        "The answer does not add a second formal action taxonomy such as Action or Final action and does not include a formal Confidence label by default.",
         "The answer avoids implying that an order will be placed or that the response is personalized investment advice."
       ]
     },
@@ -73,10 +84,11 @@
       "expected_output": "A deeper but still usable BE research answer that preserves the stable structure, goes beyond a headline recap, and ends with exactly one Buy, Wait, or Sell rating.",
       "files": [],
       "expectations": [
-        "The answer uses the same stable section structure as the quick-analysis cases rather than switching to an unstructured essay.",
+        "The answer uses the required section structure with Asset identified, Summary, Rating, Why now, Bullish factors, Bearish factors, Risks, Key levels to watch, Sources, and Disclaimer.",
         "The answer goes deeper than a headline summary by synthesizing public facts, interpretation, and current setup.",
         "The answer remains concise enough to be usable rather than turning into a bloated long-form report.",
-        "The answer includes exactly one rating from Buy, Wait, or Sell and does not reintroduce old rating labels.",
+        "The answer includes exactly one formal rating from Buy, Wait, or Sell and does not use legacy labels such as Strong Buy, Hold, Trim, No action, or Strong Sell.",
+        "The answer does not add a second formal action taxonomy such as Action or Final action and does not include a formal Confidence label by default.",
         "The answer stays evidence-based, non-hyped, and inside the research-only boundary."
       ]
     }


### PR DESCRIPTION
## Summary
- upgrade the existing `us-equity-daily-monitor` skill in place into a first-version single-asset stock/ETF investment research skill
- replace the old daily-note and multi-label rating flow with a stable structured response and a single formal `Buy / Wait / Sell` rating system
- harden the skill instructions and evals against regressions to legacy labels, secondary action taxonomies, confidence-label drift, and section-structure drift

## Testing
- `jq empty .agents/skills/us-equity-daily-monitor/evals/evals.json`
- `git diff --check -- .agents/skills/us-equity-daily-monitor/SKILL.md .agents/skills/us-equity-daily-monitor/agents/openai.yaml .agents/skills/us-equity-daily-monitor/evals/evals.json`

## Config / Env Changes
- none

## Notes
- no UI changes
- benchmark or live output review has not been run yet in this PR and should be the next check before merge