### PR TITLE
Fix inbound dedupe and dashboard refresh behavior

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -141,6 +141,23 @@ impl<E: TaskExecutor> Scheduler<E> {
         Ok(())
     }
 
+    /// Add a one-shot task with a specific task ID unless it already exists.
+    ///
+    /// Returns `true` when a new task is inserted and `false` when an existing
+    /// task with the same ID is already present in this scheduler.
+    pub fn add_one_shot_in_if_absent_with_id(
+        &mut self,
+        id: Uuid,
+        delay: Duration,
+        kind: TaskKind,
+    ) -> Result<bool, SchedulerError> {
+        if self.tasks.iter().any(|task| task.id == id) {
+            return Ok(false);
+        }
+        self.add_one_shot_in_with_id(id, delay, kind)?;
+        Ok(true)
+    }
+
     pub fn add_one_shot_at(
         &mut self,
         run_at: DateTime<Utc>,

--- a/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
@@ -29,19 +29,31 @@ const ROUTINE_ONE_SHOT_DELAY_THRESHOLD_MINUTES: i64 = 5;
 /// Load task status summaries for the owner scope derived from `tasks_db_path`.
 /// Returns an empty vector if the storage backend can't be reached.
 pub fn load_tasks_with_status(tasks_db_path: &Path) -> Vec<TaskStatusSummary> {
-    match store::SchedulerStore::new(tasks_db_path.to_path_buf()) {
-        Ok(store) => store.list_tasks_with_status().unwrap_or_default(),
-        Err(_) => Vec::new(),
-    }
+    try_load_tasks_with_status(tasks_db_path).unwrap_or_default()
+}
+
+/// Load task status summaries for the owner scope derived from `tasks_db_path`.
+/// Returns a storage error if the backend can't be reached.
+pub fn try_load_tasks_with_status(
+    tasks_db_path: &Path,
+) -> Result<Vec<TaskStatusSummary>, SchedulerError> {
+    let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
+    store.list_tasks_with_status()
 }
 
 /// Load account/user-visible routine summaries for the owner scope derived from `tasks_db_path`.
 /// Returns an empty vector if the storage backend can't be reached.
 pub fn load_routines_with_status(tasks_db_path: &Path) -> Vec<RoutineSummary> {
-    match store::SchedulerStore::new(tasks_db_path.to_path_buf()) {
-        Ok(store) => store.list_routines_with_status().unwrap_or_default(),
-        Err(_) => Vec::new(),
-    }
+    try_load_routines_with_status(tasks_db_path).unwrap_or_default()
+}
+
+/// Load account/user-visible routine summaries for the owner scope derived from `tasks_db_path`.
+/// Returns a storage error if the backend can't be reached.
+pub fn try_load_routines_with_status(
+    tasks_db_path: &Path,
+) -> Result<Vec<RoutineSummary>, SchedulerError> {
+    let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
+    store.list_routines_with_status()
 }
 
 /// Load a single scheduled task by ID from the owner scope derived from `tasks_db_path`.

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -623,6 +623,34 @@ fn add_one_shot_in_with_id_persists_to_database() {
 }
 
 #[test]
+fn add_one_shot_in_if_absent_with_id_skips_existing_task() {
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = temp.path().join("tasks.db");
+    let specific_id = Uuid::new_v4();
+
+    {
+        let mut scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("load");
+        let inserted = scheduler
+            .add_one_shot_in_if_absent_with_id(specific_id, Duration::from_secs(0), TaskKind::Noop)
+            .expect("insert first task");
+        assert!(inserted, "first insertion should create the task");
+
+        let inserted_again = scheduler
+            .add_one_shot_in_if_absent_with_id(specific_id, Duration::from_secs(0), TaskKind::Noop)
+            .expect("second insert should not fail");
+        assert!(
+            !inserted_again,
+            "duplicate insertion should be skipped for the same task id"
+        );
+        assert_eq!(scheduler.tasks().len(), 1);
+    }
+
+    let scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("reload");
+    assert_eq!(scheduler.tasks().len(), 1);
+    assert_eq!(scheduler.tasks()[0].id, specific_id);
+}
+
+#[test]
 fn execution_status_can_be_recorded_for_task() {
     let temp = TempDir::new().expect("tempdir");
     let tasks_db = temp.path().join("tasks.db");

--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -16,16 +16,17 @@ use tokio::task;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use crate::index_store::IndexStore;
 use crate::account_store::{
     AccountStore, AccountStoreError, AnalyticsEventInsert, ChannelInstallOnboardingState,
 };
 use crate::blob_store::BlobStore;
 use crate::google_auth::GoogleAuthConfig;
+use crate::index_store::IndexStore;
 use crate::notion_store::{NotionCredential, NotionStore};
 use crate::scheduler::{
-    is_user_visible_routine_task, load_routines_with_status, load_scheduled_task,
-    persist_scheduled_task, prepare_task_for_resume, RoutineSummary, ScheduledTask,
+    is_user_visible_routine_task, load_scheduled_task, persist_scheduled_task,
+    prepare_task_for_resume, try_load_routines_with_status, try_load_tasks_with_status,
+    RoutineSummary, ScheduledTask,
 };
 use crate::slack_store::{SlackInstallation, SlackStore};
 use crate::user_store::UserStore;
@@ -870,6 +871,34 @@ async fn try_load_unified_account_tasks(
     tasks
 }
 
+fn load_task_statuses_or_response(
+    tasks_db_path: &std::path::Path,
+    scope_label: &str,
+) -> Result<Vec<TaskStatusSummary>, Response> {
+    try_load_tasks_with_status(tasks_db_path).map_err(|err| {
+        error!(
+            "Failed to load {scope_label} tasks from {}: {}",
+            tasks_db_path.display(),
+            err
+        );
+        json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load tasks")
+    })
+}
+
+fn load_routine_summaries_or_response(
+    tasks_db_path: &std::path::Path,
+    scope_label: &str,
+) -> Result<Vec<RoutineSummary>, Response> {
+    try_load_routines_with_status(tasks_db_path).map_err(|err| {
+        error!(
+            "Failed to load {scope_label} routines from {}: {}",
+            tasks_db_path.display(),
+            err
+        );
+        json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load routines")
+    })
+}
+
 async fn load_authenticated_account_from_headers(
     state: &AuthState,
     headers: &HeaderMap,
@@ -1030,7 +1059,8 @@ async fn try_load_unified_account_routines(
     let task_paths = load_unified_account_task_paths(state, account_id).await?;
     let mut routines = Vec::new();
     for task_path in task_paths {
-        routines = merge_routine_summaries(routines, load_routines_with_status(&task_path));
+        let loaded = load_routine_summaries_or_response(&task_path, "account-scoped")?;
+        routines = merge_routine_summaries(routines, loaded);
     }
     Ok(partition_routines(routines))
 }
@@ -1625,7 +1655,11 @@ pub async fn list_organizations(
                     })
                 })
                 .collect();
-            (StatusCode::OK, Json(serde_json::json!({ "organizations": items }))).into_response()
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "organizations": items })),
+            )
+                .into_response()
         }
         Ok(Err(e)) => {
             error!("Failed to list organizations: {}", e);
@@ -1665,9 +1699,10 @@ pub async fn get_organization_member_count(
             })),
         )
             .into_response(),
-        Ok(Err(AccountStoreError::NotFound)) => {
-            json_error_response(StatusCode::NOT_FOUND, &format!("Organization '{}' not found", org_name))
-        }
+        Ok(Err(AccountStoreError::NotFound)) => json_error_response(
+            StatusCode::NOT_FOUND,
+            &format!("Organization '{}' not found", org_name),
+        ),
         Ok(Err(e)) => {
             error!("Failed to get organization member count: {}", e);
             json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Database error")
@@ -1751,7 +1786,14 @@ pub async fn setup_tpm_cron(
     let cron_result = task::spawn_blocking(move || {
         let index_store = IndexStore::new("/tmp/task_index.db")
             .map_err(|e| crate::tpm_cron::TpmCronError::IndexStoreSync(e.to_string()))?;
-        crate::tpm_cron::setup_tpm_cron(&store_clone, &user_store, &index_store, account_id, &org_name_for_cron, None)
+        crate::tpm_cron::setup_tpm_cron(
+            &store_clone,
+            &user_store,
+            &index_store,
+            account_id,
+            &org_name_for_cron,
+            None,
+        )
     })
     .await
     .map_err(|e| {
@@ -1846,7 +1888,13 @@ pub async fn trigger_tpm_sync_endpoint(
     let sync_result = task::spawn_blocking(move || {
         let index_store = IndexStore::new("/tmp/task_index.db")
             .map_err(|e| crate::tpm_cron::TpmCronError::IndexStoreSync(e.to_string()))?;
-        crate::tpm_cron::trigger_tpm_sync(&store_clone, &user_store, &index_store, account_id, &org_name_for_sync)
+        crate::tpm_cron::trigger_tpm_sync(
+            &store_clone,
+            &user_store,
+            &index_store,
+            account_id,
+            &org_name_for_sync,
+        )
     })
     .await
     .map_err(|e| {
@@ -6352,7 +6400,10 @@ pub async fn get_tasks(
 
     // Load tasks for this user
     let paths = user_store.user_paths(&users_root, &user_record.user_id);
-    let tasks = load_tasks_with_status(&paths.tasks_db_path);
+    let tasks = match load_task_statuses_or_response(&paths.tasks_db_path, "channel-scoped") {
+        Ok(tasks) => tasks,
+        Err(response) => return response,
+    };
 
     (StatusCode::OK, Json(TasksResponse { tasks })).into_response()
 }
@@ -6442,7 +6493,10 @@ pub async fn get_account_tasks(
         .join("state")
         .join("tasks.db");
 
-    let mut tasks = load_tasks_with_status(&account_tasks_db_path);
+    let mut tasks = match load_task_statuses_or_response(&account_tasks_db_path, "account-scoped") {
+        Ok(tasks) => tasks,
+        Err(response) => return response,
+    };
 
     // For Slack, also fetch from legacy user storage (where status updates go)
     // Get linked Slack identifiers for this account
@@ -6471,7 +6525,18 @@ pub async fn get_account_tasks(
                     if let Ok(Ok(Some(user_record))) = user_result {
                         // Load tasks from legacy user storage
                         let user_paths = user_store.user_paths(&users_root, &user_record.user_id);
-                        let legacy_tasks = load_tasks_with_status(&user_paths.tasks_db_path);
+                        let legacy_tasks =
+                            match try_load_tasks_with_status(&user_paths.tasks_db_path) {
+                                Ok(tasks) => tasks,
+                                Err(err) => {
+                                    warn!(
+                                        "failed to load legacy Slack tasks from {}: {}",
+                                        user_paths.tasks_db_path.display(),
+                                        err
+                                    );
+                                    continue;
+                                }
+                            };
 
                         // Merge legacy tasks, preferring ones with execution_status set
                         // (legacy storage has the updated status for Slack tasks)
@@ -6696,7 +6761,10 @@ pub fn auth_router(state: AuthState) -> Router {
         )
         .route("/auth/organization", post(create_organization))
         .route("/auth/organizations", get(list_organizations))
-        .route("/auth/organization/:name/member-count", get(get_organization_member_count))
+        .route(
+            "/auth/organization/:name/member-count",
+            get(get_organization_member_count),
+        )
         .route("/api/tpm/setup-cron", post(setup_tpm_cron))
         .route("/api/tpm/trigger-sync", post(trigger_tpm_sync_endpoint))
         .route("/auth/link", post(link_identifier))

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -410,15 +410,43 @@ pub fn process_inbound_payload(
             err
         );
     }
-    let task_id = scheduler
-        .add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))
-        .map_err(|err| {
-            io::Error::other(format!(
-                "scheduler_add_one_shot_in failed tasks_db_path={} error={}",
-                user_paths.tasks_db_path.display(),
-                err
-            ))
-        })?;
+    let task_id = if let Some(stable_task_id) =
+        email_message_task_id(&thread_key, message_id.as_deref())
+    {
+        let inserted = scheduler
+            .add_one_shot_in_if_absent_with_id(
+                stable_task_id,
+                Duration::from_secs(0),
+                TaskKind::RunTask(run_task),
+            )
+            .map_err(|err| {
+                io::Error::other(format!(
+                    "scheduler_add_one_shot_in_if_absent_with_id failed tasks_db_path={} task_id={} error={}",
+                    user_paths.tasks_db_path.display(),
+                    stable_task_id,
+                    err
+                ))
+            })?;
+        if !inserted {
+            info!(
+                "skipping duplicate email full-task enqueue user_id={} task_id={} message_id={}",
+                user.user_id,
+                stable_task_id,
+                message_id.as_deref().unwrap_or("-")
+            );
+        }
+        stable_task_id
+    } else {
+        scheduler
+            .add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))
+            .map_err(|err| {
+                io::Error::other(format!(
+                    "scheduler_add_one_shot_in failed tasks_db_path={} error={}",
+                    user_paths.tasks_db_path.display(),
+                    err
+                ))
+            })?
+    };
     index_store
         .sync_user_tasks(&user.user_id, scheduler.tasks())
         .map_err(|err| {
@@ -460,14 +488,20 @@ pub fn process_inbound_payload(
             match Scheduler::load(&account_tasks_db_path, ModuleExecutor::default()) {
                 Ok(mut account_scheduler) => {
                     // Use the same task_id so we can update status at completion
-                    match account_scheduler.add_one_shot_in_with_id(
+                    match account_scheduler.add_one_shot_in_if_absent_with_id(
                         task_id,
                         Duration::from_secs(0),
                         TaskKind::RunTask(run_task_for_account),
                     ) {
-                        Ok(()) => {
+                        Ok(true) => {
                             info!(
                                 "also enqueued task to account-level storage account={} task_id={}",
+                                acct_id, task_id
+                            );
+                        }
+                        Ok(false) => {
+                            info!(
+                                "skipping duplicate email account-level enqueue account={} task_id={}",
                                 acct_id, task_id
                             );
                         }
@@ -490,6 +524,17 @@ pub fn process_inbound_payload(
     }
 
     Ok(())
+}
+
+fn email_message_task_id(thread_key: &str, message_id: Option<&str>) -> Option<Uuid> {
+    let thread_key = thread_key.trim();
+    let message_id = message_id?.trim();
+    if thread_key.is_empty() || message_id.is_empty() {
+        return None;
+    }
+
+    let dedupe_key = format!("email:{thread_key}:{message_id}");
+    Some(Uuid::from_bytes(md5::compute(dedupe_key.as_bytes()).0))
 }
 
 pub(super) fn is_blacklisted_sender(sender: &str, service_addresses: &HashSet<String>) -> bool {
@@ -1085,6 +1130,22 @@ mod tests {
                 identifier: "alice@example.com".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn email_message_task_id_is_stable_for_duplicate_delivery() {
+        let first = email_message_task_id("thread:abc", Some("<msg-1@example.com>"));
+        let duplicate = email_message_task_id("thread:abc", Some("<msg-1@example.com>"));
+
+        assert_eq!(first, duplicate);
+    }
+
+    #[test]
+    fn email_message_task_id_changes_for_distinct_messages() {
+        let first = email_message_task_id("thread:abc", Some("<msg-1@example.com>"));
+        let second = email_message_task_id("thread:abc", Some("<msg-2@example.com>"));
+
+        assert_ne!(first, second);
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use crate::account_store::AccountStore;
 use crate::channel::Channel;
@@ -237,7 +238,22 @@ pub(crate) fn process_discord_inbound_message(
             err
         );
     }
-    let task_id = scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?;
+    let task_id = if let Some(stable_task_id) = discord_message_task_id(message) {
+        let inserted = scheduler.add_one_shot_in_if_absent_with_id(
+            stable_task_id,
+            Duration::from_secs(0),
+            TaskKind::RunTask(run_task),
+        )?;
+        if !inserted {
+            info!(
+                "skipping duplicate discord full-task enqueue user_id={} task_id={} message_id={:?}",
+                user.user_id, stable_task_id, message.message_id
+            );
+        }
+        stable_task_id
+    } else {
+        scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?
+    };
 
     index_store.sync_user_tasks(&user.user_id, scheduler.tasks())?;
 
@@ -265,14 +281,20 @@ pub(crate) fn process_discord_inbound_message(
             match Scheduler::load(&user_tasks_db_path, ModuleExecutor::default()) {
                 Ok(mut user_scheduler) => {
                     // Use the same task_id so we can update status at completion
-                    match user_scheduler.add_one_shot_in_with_id(
+                    match user_scheduler.add_one_shot_in_if_absent_with_id(
                         task_id,
                         Duration::from_secs(0),
                         TaskKind::RunTask(run_task_for_account),
                     ) {
-                        Ok(()) => {
+                        Ok(true) => {
                             info!(
                                 "also enqueued task to account-level storage account={} task_id={}",
+                                account.id, task_id
+                            );
+                        }
+                        Ok(false) => {
+                            info!(
+                                "skipping duplicate discord account-level enqueue account={} task_id={}",
                                 account.id, task_id
                             );
                         }
@@ -295,6 +317,27 @@ pub(crate) fn process_discord_inbound_message(
     }
 
     Ok(())
+}
+
+fn discord_message_task_id(message: &crate::channel::InboundMessage) -> Option<Uuid> {
+    let channel_id = message.metadata.discord_channel_id?.to_string();
+    let message_id = message
+        .message_id
+        .as_deref()
+        .or(message.metadata.discord_message_id.as_deref())?
+        .trim();
+    let thread_id = message.thread_id.trim();
+    if message_id.is_empty() || thread_id.is_empty() {
+        return None;
+    }
+
+    let guild_id = message
+        .metadata
+        .discord_guild_id
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "dm".to_string());
+    let dedupe_key = format!("discord:{guild_id}:{channel_id}:{thread_id}:{message_id}");
+    Some(Uuid::from_bytes(md5::compute(dedupe_key.as_bytes()).0))
 }
 
 pub(super) fn append_discord_message_payload(
@@ -768,5 +811,76 @@ mod tests {
         assert_eq!(fs::read(archived_attachment)?, attachment_bytes);
 
         Ok(())
+    }
+
+    #[test]
+    fn discord_message_task_id_is_stable_for_duplicate_delivery() {
+        let channel_id = 67890u64;
+        let mut first = InboundMessage {
+            channel: Channel::Discord,
+            sender: "12345".to_string(),
+            sender_name: Some("test-user".to_string()),
+            recipient: channel_id.to_string(),
+            subject: None,
+            text_body: Some("Hello".to_string()),
+            html_body: None,
+            thread_id: "thread-abc".to_string(),
+            message_id: Some("msg-1".to_string()),
+            attachments: Vec::new(),
+            reply_to: vec!["12345".to_string(), channel_id.to_string()],
+            raw_payload: br#"{"event_id":"evt-1"}"#.to_vec(),
+            metadata: ChannelMetadata {
+                discord_guild_id: Some(111u64),
+                discord_channel_id: Some(channel_id),
+                discord_message_id: Some("msg-1".to_string()),
+                ..Default::default()
+            },
+        };
+
+        let mut duplicate = first.clone();
+        duplicate.raw_payload = br#"{"event_id":"evt-2"}"#.to_vec();
+
+        assert_eq!(
+            discord_message_task_id(&first),
+            discord_message_task_id(&duplicate)
+        );
+
+        first.raw_payload = br#"{"event_id":"evt-3"}"#.to_vec();
+        assert_eq!(
+            discord_message_task_id(&first),
+            discord_message_task_id(&duplicate)
+        );
+    }
+
+    #[test]
+    fn discord_message_task_id_changes_for_distinct_messages() {
+        let first = InboundMessage {
+            channel: Channel::Discord,
+            sender: "12345".to_string(),
+            sender_name: Some("test-user".to_string()),
+            recipient: "67890".to_string(),
+            subject: None,
+            text_body: Some("Hello".to_string()),
+            html_body: None,
+            thread_id: "thread-abc".to_string(),
+            message_id: Some("msg-1".to_string()),
+            attachments: Vec::new(),
+            reply_to: vec!["12345".to_string(), "67890".to_string()],
+            raw_payload: br#"{"event_id":"evt-1"}"#.to_vec(),
+            metadata: ChannelMetadata {
+                discord_guild_id: Some(111u64),
+                discord_channel_id: Some(67890u64),
+                discord_message_id: Some("msg-1".to_string()),
+                ..Default::default()
+            },
+        };
+        let mut second = first.clone();
+        second.message_id = Some("msg-2".to_string());
+        second.metadata.discord_message_id = Some("msg-2".to_string());
+
+        assert_ne!(
+            discord_message_task_id(&first),
+            discord_message_task_id(&second)
+        );
     }
 }

--- a/DoWhiz_service/scheduler_module/src/service/inbound/lark.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/lark.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use crate::account_store::AccountStore;
 use crate::channel::Channel;
@@ -121,7 +122,22 @@ pub(crate) fn process_lark_event(
             err
         );
     }
-    let task_id = scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?;
+    let task_id = if let Some(stable_task_id) = lark_message_task_id(message) {
+        let inserted = scheduler.add_one_shot_in_if_absent_with_id(
+            stable_task_id,
+            Duration::from_secs(0),
+            TaskKind::RunTask(run_task),
+        )?;
+        if !inserted {
+            info!(
+                "skipping duplicate lark full-task enqueue user_id={} task_id={} message_id={:?}",
+                user.user_id, stable_task_id, message.message_id
+            );
+        }
+        stable_task_id
+    } else {
+        scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?
+    };
     index_store.sync_user_tasks(&user.user_id, scheduler.tasks())?;
 
     info!(
@@ -147,14 +163,20 @@ pub(crate) fn process_lark_event(
             match Scheduler::load(&account_tasks_db_path, ModuleExecutor::default()) {
                 Ok(mut account_scheduler) => {
                     // Use the same task_id so we can update status at completion
-                    match account_scheduler.add_one_shot_in_with_id(
+                    match account_scheduler.add_one_shot_in_if_absent_with_id(
                         task_id,
                         Duration::from_secs(0),
                         TaskKind::RunTask(run_task_for_account),
                     ) {
-                        Ok(()) => {
+                        Ok(true) => {
                             info!(
                                 "also enqueued task to account-level storage account={} task_id={}",
+                                account.id, task_id
+                            );
+                        }
+                        Ok(false) => {
+                            info!(
+                                "skipping duplicate lark account-level enqueue account={} task_id={}",
                                 account.id, task_id
                             );
                         }
@@ -177,6 +199,29 @@ pub(crate) fn process_lark_event(
     }
 
     Ok(())
+}
+
+fn lark_message_task_id(message: &crate::channel::InboundMessage) -> Option<Uuid> {
+    let chat_id = message.metadata.lark_chat_id.as_deref()?.trim();
+    let message_id = message
+        .message_id
+        .as_deref()
+        .or(message.metadata.lark_message_id.as_deref())?
+        .trim();
+    let thread_id = message.thread_id.trim();
+    if chat_id.is_empty() || message_id.is_empty() || thread_id.is_empty() {
+        return None;
+    }
+
+    let tenant_key = message
+        .metadata
+        .lark_tenant_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown");
+    let dedupe_key = format!("lark:{tenant_key}:{chat_id}:{thread_id}:{message_id}");
+    Some(Uuid::from_bytes(md5::compute(dedupe_key.as_bytes()).0))
 }
 
 /// Append a Lark message to the workspace inbox.
@@ -322,5 +367,29 @@ mod tests {
 
         assert!(workspace.join("incoming_email/9999_lark.json").exists());
         assert!(workspace.join("incoming_email/9999_lark.txt").exists());
+    }
+
+    #[test]
+    fn lark_message_task_id_is_stable_for_duplicate_delivery() {
+        let mut first = make_test_message("ou_sender", Some("Hello"));
+        first.raw_payload = br#"{"event_id":"evt-1"}"#.to_vec();
+
+        let mut duplicate = make_test_message("ou_sender", Some("Hello"));
+        duplicate.raw_payload = br#"{"event_id":"evt-2"}"#.to_vec();
+
+        assert_eq!(
+            lark_message_task_id(&first),
+            lark_message_task_id(&duplicate)
+        );
+    }
+
+    #[test]
+    fn lark_message_task_id_changes_for_distinct_messages() {
+        let first = make_test_message("ou_sender", Some("Hello"));
+        let mut second = make_test_message("ou_sender", Some("Hello again"));
+        second.message_id = Some("msg_456".to_string());
+        second.metadata.lark_message_id = Some("msg_456".to_string());
+
+        assert_ne!(lark_message_task_id(&first), lark_message_task_id(&second));
     }
 }

--- a/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use crate::account_store::AccountStore;
 use crate::channel::Channel;
@@ -228,7 +229,22 @@ pub(crate) fn process_notion_message(
 
     // Schedule the task
     let mut scheduler = Scheduler::load(&user_paths.tasks_db_path, ModuleExecutor::default())?;
-    let task_id = scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?;
+    let task_id = if let Some(stable_task_id) = notion_message_task_id(message) {
+        let inserted = scheduler.add_one_shot_in_if_absent_with_id(
+            stable_task_id,
+            Duration::from_secs(0),
+            TaskKind::RunTask(run_task),
+        )?;
+        if !inserted {
+            info!(
+                "skipping duplicate notion full-task enqueue user_id={} task_id={} message_id={:?}",
+                user.user_id, stable_task_id, message.message_id
+            );
+        }
+        stable_task_id
+    } else {
+        scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?
+    };
     index_store.sync_user_tasks(&user.user_id, scheduler.tasks())?;
 
     info!(
@@ -272,14 +288,20 @@ pub(crate) fn process_notion_message(
             let account_tasks_db_path = account_tasks_dir.join("tasks.db");
             match Scheduler::load(&account_tasks_db_path, ModuleExecutor::default()) {
                 Ok(mut account_scheduler) => {
-                    match account_scheduler.add_one_shot_in_with_id(
+                    match account_scheduler.add_one_shot_in_if_absent_with_id(
                         task_id,
                         Duration::from_secs(0),
                         TaskKind::RunTask(run_task_for_account),
                     ) {
-                        Ok(()) => {
+                        Ok(true) => {
                             info!(
                                 "also enqueued task to account-level storage account={} task_id={} channel=Notion",
+                                account.id, task_id
+                            );
+                        }
+                        Ok(false) => {
+                            info!(
+                                "skipping duplicate notion account-level enqueue account={} task_id={}",
                                 account.id, task_id
                             );
                         }
@@ -307,6 +329,23 @@ pub(crate) fn process_notion_message(
     }
 
     Ok(())
+}
+
+fn notion_message_task_id(message: &crate::channel::InboundMessage) -> Option<Uuid> {
+    let workspace_id = message.metadata.notion_workspace_id.as_deref()?.trim();
+    let page_id = message.metadata.notion_page_id.as_deref()?.trim();
+    let message_id = message.message_id.as_deref()?.trim();
+    let thread_id = message.thread_id.trim();
+    if workspace_id.is_empty()
+        || page_id.is_empty()
+        || message_id.is_empty()
+        || thread_id.is_empty()
+    {
+        return None;
+    }
+
+    let dedupe_key = format!("notion:{workspace_id}:{page_id}:{thread_id}:{message_id}");
+    Some(Uuid::from_bytes(md5::compute(dedupe_key.as_bytes()).0))
 }
 
 /// Write Notion context file for agent to understand how to reply.
@@ -436,4 +475,57 @@ fn append_workspace_notion_comment(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::{Channel, ChannelMetadata, InboundMessage};
+
+    fn build_message(message_id: &str) -> InboundMessage {
+        InboundMessage {
+            channel: Channel::Notion,
+            sender: "notion-user".to_string(),
+            sender_name: Some("Notion User".to_string()),
+            recipient: "integration".to_string(),
+            subject: Some("Notion comment".to_string()),
+            text_body: Some("Please take a look".to_string()),
+            html_body: None,
+            thread_id: "notion:workspace-1:discussion-1".to_string(),
+            message_id: Some(message_id.to_string()),
+            attachments: Vec::new(),
+            reply_to: Vec::new(),
+            raw_payload: Vec::new(),
+            metadata: ChannelMetadata {
+                notion_workspace_id: Some("workspace-1".to_string()),
+                notion_page_id: Some("page-1".to_string()),
+                notion_comment_id: Some("comment-1".to_string()),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn notion_message_task_id_is_stable_for_duplicate_delivery() {
+        let mut first = build_message("notion-comment-comment-1");
+        first.raw_payload = br#"{"id":"notification-1"}"#.to_vec();
+        let mut duplicate = build_message("notion-comment-comment-1");
+        duplicate.raw_payload = br#"{"id":"notification-2"}"#.to_vec();
+
+        assert_eq!(
+            notion_message_task_id(&first),
+            notion_message_task_id(&duplicate)
+        );
+    }
+
+    #[test]
+    fn notion_message_task_id_changes_for_distinct_messages() {
+        let first = build_message("notion-comment-comment-1");
+        let second = build_message("notion-comment-comment-2");
+
+        assert_ne!(
+            notion_message_task_id(&first),
+            notion_message_task_id(&second)
+        );
+    }
 }

--- a/DoWhiz_service/scheduler_module/src/service/inbound/quick_responses.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/quick_responses.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
-use std::path::Path;
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
@@ -30,12 +30,9 @@ use super::discord_context::build_discord_router_context;
 use super::persist_discord_ingest_context;
 use super::slack::{build_slack_router_context, persist_slack_ingest_context};
 
-const DISCORD_QUICK_RESPONSE_DEDUPE_FILE: &str = "discord_quick_response_dedupe.json";
-const DISCORD_QUICK_RESPONSE_MAX_THREADS: usize = 512;
-const DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD: usize = 256;
-const SLACK_QUICK_RESPONSE_DEDUPE_FILE: &str = "slack_quick_response_dedupe.json";
-const SLACK_QUICK_RESPONSE_MAX_THREADS: usize = 512;
-const SLACK_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD: usize = 256;
+const QUICK_RESPONSE_CLAIMS_DIR: &str = "quick_response_claims";
+const QUICK_RESPONSE_INFLIGHT_STALE_SECS: i64 = 5 * 60;
+const QUICK_RESPONSE_SENT_TTL_SECS: i64 = 30 * 24 * 60 * 60;
 const WECHAT_MP_QUICK_RESPONSE_MAX_BYTES: usize = 1800;
 const WECHAT_MP_QUICK_RESPONSE_TRUNCATED_SUFFIX: &str = "\n\n[truncated]";
 const WECHAT_MP_QUICK_FALLBACK_RESPONSE: &str =
@@ -43,32 +40,40 @@ const WECHAT_MP_QUICK_FALLBACK_RESPONSE: &str =
 const WECHAT_MP_PROFILE_QUICK_RESPONSE: &str =
     "我是 DoWhiz 助手，可以帮你快速解答问题、梳理任务、制定执行计划，并持续跟进你的进展。你可以直接告诉我你现在想解决什么。";
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct SlackQuickResponseDedupeStore {
-    #[serde(default)]
-    threads: HashMap<String, SlackQuickResponseThreadStore>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum QuickResponseClaimStatus {
+    InFlight,
+    Sent,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct SlackQuickResponseThreadStore {
-    #[serde(default)]
-    message_ids: Vec<String>,
-    #[serde(default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct QuickResponseClaimRecord {
+    scope_key: String,
+    message_id: String,
+    status: QuickResponseClaimStatus,
     updated_at_unix_secs: i64,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct DiscordQuickResponseDedupeStore {
-    #[serde(default)]
-    threads: HashMap<String, DiscordQuickResponseThreadStore>,
+#[derive(Debug)]
+struct QuickResponseClaim {
+    path: PathBuf,
+    scope_dir: PathBuf,
+    record: QuickResponseClaimRecord,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct DiscordQuickResponseThreadStore {
-    #[serde(default)]
-    message_ids: Vec<String>,
-    #[serde(default)]
-    updated_at_unix_secs: i64,
+#[derive(Debug)]
+enum QuickResponseClaimResult {
+    Acquired(QuickResponseClaim),
+    AlreadySent,
+    InFlight,
+}
+
+#[derive(Debug)]
+enum QuickResponseSendGate {
+    Untracked,
+    Acquired(QuickResponseClaim),
+    Suppressed,
 }
 
 /// Read memo.md from a user's memory directory (local file)
@@ -133,8 +138,268 @@ fn write_memory_update(
         .map_err(|e| e.to_string())
 }
 
-fn slack_quick_response_dedupe_path(state_dir: &Path) -> std::path::PathBuf {
-    state_dir.join(SLACK_QUICK_RESPONSE_DEDUPE_FILE)
+fn quick_response_claims_root(state_dir: &Path) -> PathBuf {
+    state_dir.join(QUICK_RESPONSE_CLAIMS_DIR)
+}
+
+fn quick_response_claim_hash(input: &str) -> String {
+    format!("{:x}", md5::compute(input.as_bytes()))
+}
+
+fn quick_response_scope_dir(state_dir: &Path, scope_key: &str) -> PathBuf {
+    quick_response_claims_root(state_dir).join(quick_response_claim_hash(scope_key))
+}
+
+fn quick_response_claim_path(state_dir: &Path, scope_key: &str, message_id: &str) -> PathBuf {
+    quick_response_scope_dir(state_dir, scope_key)
+        .join(format!("{}.json", quick_response_claim_hash(message_id)))
+}
+
+fn quick_response_claim_record(
+    scope_key: &str,
+    message_id: &str,
+    status: QuickResponseClaimStatus,
+) -> QuickResponseClaimRecord {
+    QuickResponseClaimRecord {
+        scope_key: scope_key.to_string(),
+        message_id: message_id.to_string(),
+        status,
+        updated_at_unix_secs: now_unix_secs(),
+    }
+}
+
+fn quick_response_claim_file_age_secs(path: &Path, now_unix_secs: i64) -> Option<i64> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let modified_unix_secs = modified
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs() as i64;
+    Some(now_unix_secs.saturating_sub(modified_unix_secs))
+}
+
+fn quick_response_claim_record_expired(
+    record: &QuickResponseClaimRecord,
+    now_unix_secs: i64,
+) -> bool {
+    let age_secs = now_unix_secs.saturating_sub(record.updated_at_unix_secs);
+    match record.status {
+        QuickResponseClaimStatus::InFlight => age_secs > QUICK_RESPONSE_INFLIGHT_STALE_SECS,
+        QuickResponseClaimStatus::Sent => age_secs > QUICK_RESPONSE_SENT_TTL_SECS,
+    }
+}
+
+fn load_quick_response_claim_record(
+    path: &Path,
+) -> Result<Option<QuickResponseClaimRecord>, BoxError> {
+    match std::fs::read(path) {
+        Ok(raw) => Ok(Some(serde_json::from_slice::<QuickResponseClaimRecord>(
+            &raw,
+        )?)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn try_create_quick_response_claim(
+    path: &Path,
+    record: &QuickResponseClaimRecord,
+) -> Result<bool, BoxError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let serialized = serde_json::to_vec_pretty(record)?;
+    match std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+    {
+        Ok(mut file) => {
+            if let Err(err) = file.write_all(&serialized) {
+                let _ = std::fs::remove_file(path);
+                return Err(err.into());
+            }
+            Ok(true)
+        }
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn write_quick_response_claim_record(
+    path: &Path,
+    record: &QuickResponseClaimRecord,
+) -> Result<(), BoxError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
+    let serialized = serde_json::to_vec_pretty(record)?;
+    std::fs::write(&tmp, serialized)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+fn remove_quick_response_claim_file(path: &Path) -> Result<(), BoxError> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn prune_quick_response_scope_dir(scope_dir: &Path, now_unix_secs: i64) -> Result<(), BoxError> {
+    let entries = match std::fs::read_dir(scope_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                warn!(
+                    "failed to enumerate quick response scope dir {}: {}",
+                    scope_dir.display(),
+                    err
+                );
+                continue;
+            }
+        };
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let should_remove = match load_quick_response_claim_record(&path) {
+            Ok(Some(record)) => quick_response_claim_record_expired(&record, now_unix_secs),
+            Ok(None) => false,
+            Err(err) => {
+                warn!(
+                    "failed to inspect quick response claim {} during prune: {}",
+                    path.display(),
+                    err
+                );
+                quick_response_claim_file_age_secs(&path, now_unix_secs)
+                    .map(|age_secs| age_secs > QUICK_RESPONSE_INFLIGHT_STALE_SECS)
+                    .unwrap_or(false)
+            }
+        };
+
+        if should_remove {
+            remove_quick_response_claim_file(&path)?;
+        }
+    }
+
+    if let Ok(mut remaining) = std::fs::read_dir(scope_dir) {
+        if remaining.next().is_none() {
+            let _ = std::fs::remove_dir(scope_dir);
+        }
+    }
+
+    Ok(())
+}
+
+fn claim_quick_response_send(
+    state_dir: &Path,
+    scope_key: &str,
+    message_id: &str,
+) -> Result<QuickResponseClaimResult, BoxError> {
+    let scope_dir = quick_response_scope_dir(state_dir, scope_key);
+    let path = quick_response_claim_path(state_dir, scope_key, message_id);
+    let record =
+        quick_response_claim_record(scope_key, message_id, QuickResponseClaimStatus::InFlight);
+
+    loop {
+        let now = now_unix_secs();
+        prune_quick_response_scope_dir(&scope_dir, now)?;
+
+        if try_create_quick_response_claim(&path, &record)? {
+            return Ok(QuickResponseClaimResult::Acquired(QuickResponseClaim {
+                path,
+                scope_dir,
+                record,
+            }));
+        }
+
+        match load_quick_response_claim_record(&path) {
+            Ok(Some(existing)) => {
+                if quick_response_claim_record_expired(&existing, now) {
+                    remove_quick_response_claim_file(&path)?;
+                    continue;
+                }
+                return Ok(match existing.status {
+                    QuickResponseClaimStatus::Sent => QuickResponseClaimResult::AlreadySent,
+                    QuickResponseClaimStatus::InFlight => QuickResponseClaimResult::InFlight,
+                });
+            }
+            Ok(None) => continue,
+            Err(err) => {
+                warn!(
+                    "failed to read quick response claim {}: {}",
+                    path.display(),
+                    err
+                );
+                if quick_response_claim_file_age_secs(&path, now)
+                    .map(|age_secs| age_secs > QUICK_RESPONSE_INFLIGHT_STALE_SECS)
+                    .unwrap_or(false)
+                {
+                    remove_quick_response_claim_file(&path)?;
+                    continue;
+                }
+                return Ok(QuickResponseClaimResult::InFlight);
+            }
+        }
+    }
+}
+
+fn mark_quick_response_sent(claim: &QuickResponseClaim) -> Result<(), BoxError> {
+    let record = quick_response_claim_record(
+        &claim.record.scope_key,
+        &claim.record.message_id,
+        QuickResponseClaimStatus::Sent,
+    );
+    write_quick_response_claim_record(&claim.path, &record)?;
+    prune_quick_response_scope_dir(&claim.scope_dir, record.updated_at_unix_secs)?;
+    Ok(())
+}
+
+fn release_quick_response_claim(claim: &QuickResponseClaim) -> Result<(), BoxError> {
+    remove_quick_response_claim_file(&claim.path)?;
+    prune_quick_response_scope_dir(&claim.scope_dir, now_unix_secs())?;
+    Ok(())
+}
+
+fn start_quick_response_send(
+    state_dir: &Path,
+    scope_key: Option<&str>,
+    message_id: Option<&str>,
+    channel_label: &str,
+    employee_id: &str,
+    sender: &str,
+) -> Result<QuickResponseSendGate, BoxError> {
+    let (Some(scope_key), Some(message_id)) = (scope_key, message_id) else {
+        return Ok(QuickResponseSendGate::Untracked);
+    };
+
+    match claim_quick_response_send(state_dir, scope_key, message_id)? {
+        QuickResponseClaimResult::Acquired(claim) => Ok(QuickResponseSendGate::Acquired(claim)),
+        QuickResponseClaimResult::AlreadySent => {
+            info!(
+                "{} quick response dedupe hit employee={} sender={} scope={} message_id={}",
+                channel_label, employee_id, sender, scope_key, message_id
+            );
+            Ok(QuickResponseSendGate::Suppressed)
+        }
+        QuickResponseClaimResult::InFlight => {
+            info!(
+                "{} quick response send already in flight employee={} sender={} scope={} message_id={}",
+                channel_label, employee_id, sender, scope_key, message_id
+            );
+            Ok(QuickResponseSendGate::Suppressed)
+        }
+    }
 }
 
 fn slack_quick_response_scope_key(message: &crate::channel::InboundMessage) -> Option<String> {
@@ -152,96 +417,6 @@ fn slack_quick_response_scope_key(message: &crate::channel::InboundMessage) -> O
 
 fn slack_inbound_message_id(message: &crate::channel::InboundMessage) -> Option<&str> {
     message.message_id.as_deref()
-}
-
-fn slack_quick_response_already_sent(state_dir: &Path, scope_key: &str, message_id: &str) -> bool {
-    let path = slack_quick_response_dedupe_path(state_dir);
-    let store = load_slack_quick_response_dedupe_store(&path);
-    store
-        .threads
-        .get(scope_key)
-        .map(|thread| thread.message_ids.iter().any(|entry| entry == message_id))
-        .unwrap_or(false)
-}
-
-fn record_slack_quick_response_sent(
-    state_dir: &Path,
-    scope_key: &str,
-    message_id: &str,
-) -> Result<(), BoxError> {
-    let path = slack_quick_response_dedupe_path(state_dir);
-    let mut store = load_slack_quick_response_dedupe_store(&path);
-
-    let thread = store.threads.entry(scope_key.to_string()).or_default();
-    if !thread.message_ids.iter().any(|entry| entry == message_id) {
-        thread.message_ids.push(message_id.to_string());
-    }
-    let overflow = thread
-        .message_ids
-        .len()
-        .saturating_sub(SLACK_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD);
-    if overflow > 0 {
-        thread.message_ids.drain(0..overflow);
-    }
-    thread.updated_at_unix_secs = now_unix_secs();
-
-    prune_slack_quick_response_store(&mut store);
-    write_slack_quick_response_dedupe_store(&path, &store)?;
-    Ok(())
-}
-
-fn load_slack_quick_response_dedupe_store(path: &Path) -> SlackQuickResponseDedupeStore {
-    let Ok(raw) = std::fs::read(path) else {
-        return SlackQuickResponseDedupeStore::default();
-    };
-    match serde_json::from_slice::<SlackQuickResponseDedupeStore>(&raw) {
-        Ok(store) => store,
-        Err(err) => {
-            warn!(
-                "failed to parse slack quick response dedupe store at {}: {}",
-                path.display(),
-                err
-            );
-            SlackQuickResponseDedupeStore::default()
-        }
-    }
-}
-
-fn write_slack_quick_response_dedupe_store(
-    path: &Path,
-    store: &SlackQuickResponseDedupeStore,
-) -> Result<(), BoxError> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let tmp = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
-    let serialized = serde_json::to_vec_pretty(store)?;
-    std::fs::write(&tmp, serialized)?;
-    std::fs::rename(&tmp, path)?;
-    Ok(())
-}
-
-fn prune_slack_quick_response_store(store: &mut SlackQuickResponseDedupeStore) {
-    if store.threads.len() <= SLACK_QUICK_RESPONSE_MAX_THREADS {
-        return;
-    }
-    let mut thread_by_age = store
-        .threads
-        .iter()
-        .map(|(key, value)| (key.clone(), value.updated_at_unix_secs))
-        .collect::<Vec<_>>();
-    thread_by_age.sort_by_key(|(_, updated_at)| *updated_at);
-    let overflow = store
-        .threads
-        .len()
-        .saturating_sub(SLACK_QUICK_RESPONSE_MAX_THREADS);
-    for (key, _) in thread_by_age.into_iter().take(overflow) {
-        store.threads.remove(&key);
-    }
-}
-
-fn discord_quick_response_dedupe_path(state_dir: &Path) -> std::path::PathBuf {
-    state_dir.join(DISCORD_QUICK_RESPONSE_DEDUPE_FILE)
 }
 
 fn discord_quick_response_scope_key(message: &crate::channel::InboundMessage) -> Option<String> {
@@ -264,94 +439,33 @@ fn discord_inbound_message_id(message: &crate::channel::InboundMessage) -> Optio
         .or(message.metadata.discord_message_id.as_deref())
 }
 
-fn discord_quick_response_already_sent(
-    state_dir: &Path,
-    scope_key: &str,
-    message_id: &str,
-) -> bool {
-    let path = discord_quick_response_dedupe_path(state_dir);
-    let store = load_discord_quick_response_dedupe_store(&path);
-    store
-        .threads
-        .get(scope_key)
-        .map(|thread| thread.message_ids.iter().any(|entry| entry == message_id))
-        .unwrap_or(false)
+fn lark_quick_response_scope_key(message: &crate::channel::InboundMessage) -> Option<String> {
+    let chat_id = message.metadata.lark_chat_id.as_deref()?;
+    let tenant_key = message
+        .metadata
+        .lark_tenant_key
+        .as_deref()
+        .unwrap_or("unknown");
+    Some(format!(
+        "lark:{}:{}:{}",
+        tenant_key, chat_id, message.thread_id
+    ))
 }
 
-fn record_discord_quick_response_sent(
-    state_dir: &Path,
-    scope_key: &str,
-    message_id: &str,
-) -> Result<(), BoxError> {
-    let path = discord_quick_response_dedupe_path(state_dir);
-    let mut store = load_discord_quick_response_dedupe_store(&path);
-
-    let thread = store.threads.entry(scope_key.to_string()).or_default();
-    if !thread.message_ids.iter().any(|entry| entry == message_id) {
-        thread.message_ids.push(message_id.to_string());
-    }
-    let overflow = thread
-        .message_ids
-        .len()
-        .saturating_sub(DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD);
-    if overflow > 0 {
-        thread.message_ids.drain(0..overflow);
-    }
-    thread.updated_at_unix_secs = now_unix_secs();
-
-    prune_discord_quick_response_store(&mut store);
-    write_discord_quick_response_dedupe_store(&path, &store)?;
-    Ok(())
+fn lark_inbound_message_id(message: &crate::channel::InboundMessage) -> Option<&str> {
+    message
+        .message_id
+        .as_deref()
+        .or(message.metadata.lark_message_id.as_deref())
 }
 
-fn load_discord_quick_response_dedupe_store(path: &Path) -> DiscordQuickResponseDedupeStore {
-    let Ok(raw) = std::fs::read(path) else {
-        return DiscordQuickResponseDedupeStore::default();
-    };
-    match serde_json::from_slice::<DiscordQuickResponseDedupeStore>(&raw) {
-        Ok(store) => store,
-        Err(err) => {
-            warn!(
-                "failed to parse discord quick response dedupe store at {}: {}",
-                path.display(),
-                err
-            );
-            DiscordQuickResponseDedupeStore::default()
-        }
-    }
+fn wechat_quick_response_scope_key(message: &crate::channel::InboundMessage) -> Option<String> {
+    let corp_id = message.metadata.wechat_corp_id.as_deref()?;
+    Some(format!("wechat:{}:{}", corp_id, message.thread_id))
 }
 
-fn write_discord_quick_response_dedupe_store(
-    path: &Path,
-    store: &DiscordQuickResponseDedupeStore,
-) -> Result<(), BoxError> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let tmp = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
-    let serialized = serde_json::to_vec_pretty(store)?;
-    std::fs::write(&tmp, serialized)?;
-    std::fs::rename(&tmp, path)?;
-    Ok(())
-}
-
-fn prune_discord_quick_response_store(store: &mut DiscordQuickResponseDedupeStore) {
-    if store.threads.len() <= DISCORD_QUICK_RESPONSE_MAX_THREADS {
-        return;
-    }
-    let mut thread_by_age = store
-        .threads
-        .iter()
-        .map(|(key, value)| (key.clone(), value.updated_at_unix_secs))
-        .collect::<Vec<_>>();
-    thread_by_age.sort_by_key(|(_, updated_at)| *updated_at);
-    let overflow = store
-        .threads
-        .len()
-        .saturating_sub(DISCORD_QUICK_RESPONSE_MAX_THREADS);
-    for (key, _) in thread_by_age.into_iter().take(overflow) {
-        store.threads.remove(&key);
-    }
+fn wechat_inbound_message_id(message: &crate::channel::InboundMessage) -> Option<&str> {
+    message.message_id.as_deref()
 }
 
 fn now_unix_secs() -> i64 {
@@ -385,16 +499,6 @@ pub(crate) fn try_quick_response_slack(
     let dedupe_scope = slack_quick_response_scope_key(message);
     let inbound_message_id = slack_inbound_message_id(message);
 
-    if let (Some(scope), Some(inbound_id)) = (dedupe_scope.as_deref(), inbound_message_id) {
-        if slack_quick_response_already_sent(&user_paths.state_dir, scope, inbound_id) {
-            info!(
-                "slack quick response dedupe hit employee={} sender={} scope={} message_id={}",
-                config.employee_profile.id, message.sender, scope, inbound_id
-            );
-            return Ok(true);
-        }
-    }
-
     let cleaned_text = text
         .split_whitespace()
         .filter(|word| !(word.starts_with("<@") && word.ends_with(">")))
@@ -420,6 +524,19 @@ pub(crate) fn try_quick_response_slack(
             response,
             memory_update,
         } => {
+            let quick_response_claim = match start_quick_response_send(
+                &user_paths.state_dir,
+                dedupe_scope.as_deref(),
+                inbound_message_id,
+                "slack",
+                &config.employee_profile.id,
+                &message.sender,
+            )? {
+                QuickResponseSendGate::Untracked => None,
+                QuickResponseSendGate::Acquired(claim) => Some(claim),
+                QuickResponseSendGate::Suppressed => return Ok(true),
+            };
+
             // Write memory update if present (to blob storage if account linked)
             if let Some(update) = memory_update {
                 if let Err(e) =
@@ -438,9 +555,9 @@ pub(crate) fn try_quick_response_slack(
                 slack_store,
                 message.metadata.slack_team_id.as_deref(),
             );
-            if let Some(token) = token {
+            let sent = if let Some(token) = token {
                 let thread_ts = Some(message.thread_id.as_str());
-                if runtime
+                runtime
                     .block_on(send_quick_slack_response(
                         &token,
                         channel_id,
@@ -450,30 +567,33 @@ pub(crate) fn try_quick_response_slack(
                         &response,
                     ))
                     .is_ok()
+            } else {
+                false
+            };
+
+            if sent {
+                if let Some(claim) = quick_response_claim.as_ref() {
+                    if let Err(err) = mark_quick_response_sent(claim) {
+                        warn!(
+                            "failed to mark slack quick response claim sent scope={} message_id={}: {}",
+                            claim.record.scope_key, claim.record.message_id, err
+                        );
+                    }
+                }
+                if let Err(err) =
+                    persist_slack_ingest_context(config, user_store, message, &message.raw_payload)
                 {
-                    if let Err(err) = persist_slack_ingest_context(
-                        config,
-                        user_store,
-                        message,
-                        &message.raw_payload,
-                    ) {
-                        warn!("Failed to persist Slack context after quick reply: {}", err);
-                    }
-                    if let (Some(scope), Some(inbound_id)) =
-                        (dedupe_scope.as_deref(), inbound_message_id)
-                    {
-                        if let Err(err) = record_slack_quick_response_sent(
-                            &user_paths.state_dir,
-                            scope,
-                            inbound_id,
-                        ) {
-                            warn!(
-                                "failed to record slack quick response dedupe key scope={} message_id={}: {}",
-                                scope, inbound_id, err
-                            );
-                        }
-                    }
-                    return Ok(true);
+                    warn!("Failed to persist Slack context after quick reply: {}", err);
+                }
+                return Ok(true);
+            }
+
+            if let Some(claim) = quick_response_claim.as_ref() {
+                if let Err(err) = release_quick_response_claim(claim) {
+                    warn!(
+                        "failed to release slack quick response claim scope={} message_id={}: {}",
+                        claim.record.scope_key, claim.record.message_id, err
+                    );
                 }
             }
             Ok(false)
@@ -624,16 +744,6 @@ pub(crate) fn try_quick_response_discord(
     let dedupe_scope = discord_quick_response_scope_key(message);
     let inbound_message_id = discord_inbound_message_id(message);
 
-    if let (Some(scope), Some(inbound_id)) = (dedupe_scope.as_deref(), inbound_message_id) {
-        if discord_quick_response_already_sent(&user_paths.state_dir, scope, inbound_id) {
-            info!(
-                "discord quick response dedupe hit employee={} sender={} scope={} message_id={}",
-                config.employee_profile.id, message.sender, scope, inbound_id
-            );
-            return Ok(true);
-        }
-    }
-
     let router_context = match build_discord_router_context(config, message, raw_payload) {
         Ok(context) => Some(context),
         Err(err) => {
@@ -661,6 +771,19 @@ pub(crate) fn try_quick_response_discord(
             response,
             memory_update,
         } => {
+            let quick_response_claim = match start_quick_response_send(
+                &user_paths.state_dir,
+                dedupe_scope.as_deref(),
+                inbound_message_id,
+                "discord",
+                &config.employee_profile.id,
+                &message.sender,
+            )? {
+                QuickResponseSendGate::Untracked => None,
+                QuickResponseSendGate::Acquired(claim) => Some(claim),
+                QuickResponseSendGate::Suppressed => return Ok(true),
+            };
+
             // Write memory update if present (to blob storage if account linked)
             if let Some(update) = memory_update {
                 if let Err(e) =
@@ -678,15 +801,11 @@ pub(crate) fn try_quick_response_discord(
                 send_quick_discord_response_simple(&token, channel_id, message_id, &response)
                     .is_ok();
             if sent {
-                if let (Some(scope), Some(inbound_id)) =
-                    (dedupe_scope.as_deref(), inbound_message_id)
-                {
-                    if let Err(err) =
-                        record_discord_quick_response_sent(&user_paths.state_dir, scope, inbound_id)
-                    {
+                if let Some(claim) = quick_response_claim.as_ref() {
+                    if let Err(err) = mark_quick_response_sent(claim) {
                         warn!(
-                            "failed to record discord quick response dedupe key scope={} message_id={}: {}",
-                            scope, inbound_id, err
+                            "failed to mark discord quick response claim sent scope={} message_id={}: {}",
+                            claim.record.scope_key, claim.record.message_id, err
                         );
                     }
                 }
@@ -703,6 +822,14 @@ pub(crate) fn try_quick_response_discord(
                     );
                 }
                 return Ok(true);
+            }
+            if let Some(claim) = quick_response_claim.as_ref() {
+                if let Err(err) = release_quick_response_claim(claim) {
+                    warn!(
+                        "failed to release discord quick response claim scope={} message_id={}: {}",
+                        claim.record.scope_key, claim.record.message_id, err
+                    );
+                }
             }
             Ok(false)
         }
@@ -1069,6 +1196,8 @@ pub(crate) fn try_quick_response_wechat(
     let user = user_store.get_or_create_user("wechat", user_id)?;
     let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
     let memory = read_user_memo(runtime, account_id, &user_paths.memory_dir);
+    let dedupe_scope = wechat_quick_response_scope_key(message);
+    let inbound_message_id = wechat_inbound_message_id(message);
 
     let employee_name = config.employee_profile.display_name.as_deref();
     let decision =
@@ -1079,6 +1208,19 @@ pub(crate) fn try_quick_response_wechat(
             response,
             memory_update,
         } => {
+            let quick_response_claim = match start_quick_response_send(
+                &user_paths.state_dir,
+                dedupe_scope.as_deref(),
+                inbound_message_id,
+                "wechat",
+                &config.employee_profile.id,
+                user_id,
+            )? {
+                QuickResponseSendGate::Untracked => None,
+                QuickResponseSendGate::Acquired(claim) => Some(claim),
+                QuickResponseSendGate::Suppressed => return Ok(true),
+            };
+
             // Write memory update if present
             if let Some(update) = memory_update {
                 if let Err(e) =
@@ -1090,8 +1232,24 @@ pub(crate) fn try_quick_response_wechat(
 
             // Send quick response via WeChat API
             if send_quick_wechat_response(user_id, &response).is_ok() {
+                if let Some(claim) = quick_response_claim.as_ref() {
+                    if let Err(err) = mark_quick_response_sent(claim) {
+                        warn!(
+                            "failed to mark wechat quick response claim sent scope={} message_id={}: {}",
+                            claim.record.scope_key, claim.record.message_id, err
+                        );
+                    }
+                }
                 info!("wechat quick response sent: user_id={}", user_id);
                 return Ok(true);
+            }
+            if let Some(claim) = quick_response_claim.as_ref() {
+                if let Err(err) = release_quick_response_claim(claim) {
+                    warn!(
+                        "failed to release wechat quick response claim scope={} message_id={}: {}",
+                        claim.record.scope_key, claim.record.message_id, err
+                    );
+                }
             }
             Ok(false)
         }
@@ -1336,6 +1494,8 @@ pub(crate) fn try_quick_response_lark(
     let user = user_store.get_or_create_user("lark", open_id)?;
     let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
     let memory = read_user_memo(runtime, account_id, &user_paths.memory_dir);
+    let dedupe_scope = lark_quick_response_scope_key(message);
+    let inbound_message_id = lark_inbound_message_id(message);
 
     let employee_name = config.employee_profile.display_name.as_deref();
     let decision =
@@ -1346,6 +1506,19 @@ pub(crate) fn try_quick_response_lark(
             response,
             memory_update,
         } => {
+            let quick_response_claim = match start_quick_response_send(
+                &user_paths.state_dir,
+                dedupe_scope.as_deref(),
+                inbound_message_id,
+                "lark",
+                &config.employee_profile.id,
+                open_id,
+            )? {
+                QuickResponseSendGate::Untracked => None,
+                QuickResponseSendGate::Acquired(claim) => Some(claim),
+                QuickResponseSendGate::Suppressed => return Ok(true),
+            };
+
             // Write memory update if present
             if let Some(update) = memory_update {
                 if let Err(e) =
@@ -1361,8 +1534,24 @@ pub(crate) fn try_quick_response_lark(
 
             // Send quick response via Lark API
             if send_quick_lark_response(open_id, &response).is_ok() {
+                if let Some(claim) = quick_response_claim.as_ref() {
+                    if let Err(err) = mark_quick_response_sent(claim) {
+                        warn!(
+                            "failed to mark lark quick response claim sent scope={} message_id={}: {}",
+                            claim.record.scope_key, claim.record.message_id, err
+                        );
+                    }
+                }
                 info!("lark quick response sent: open_id={}", open_id);
                 return Ok(true);
+            }
+            if let Some(claim) = quick_response_claim.as_ref() {
+                if let Err(err) = release_quick_response_claim(claim) {
+                    warn!(
+                        "failed to release lark quick response claim scope={} message_id={}: {}",
+                        claim.record.scope_key, claim.record.message_id, err
+                    );
+                }
             }
             Ok(false)
         }
@@ -1466,57 +1655,168 @@ mod tests {
         }
     }
 
+    fn build_lark_message(
+        thread_id: &str,
+        message_id: Option<&str>,
+        metadata_message_id: Option<&str>,
+        tenant_key: Option<&str>,
+        chat_id: Option<&str>,
+    ) -> InboundMessage {
+        InboundMessage {
+            channel: Channel::Lark,
+            sender: "ou_test_user".to_string(),
+            sender_name: Some("Bingran".to_string()),
+            recipient: "oc_test_chat".to_string(),
+            subject: None,
+            text_body: Some("Hi".to_string()),
+            html_body: None,
+            thread_id: thread_id.to_string(),
+            message_id: message_id.map(str::to_string),
+            attachments: Vec::new(),
+            reply_to: Vec::new(),
+            raw_payload: Vec::new(),
+            metadata: ChannelMetadata {
+                lark_tenant_key: tenant_key.map(str::to_string),
+                lark_chat_id: chat_id.map(str::to_string),
+                lark_message_id: metadata_message_id.map(str::to_string),
+                ..Default::default()
+            },
+        }
+    }
+
+    fn build_wechat_scope_message(
+        thread_id: &str,
+        message_id: Option<&str>,
+        corp_id: Option<&str>,
+    ) -> InboundMessage {
+        InboundMessage {
+            channel: Channel::WeChat,
+            sender: "zhangsan".to_string(),
+            sender_name: Some("张三".to_string()),
+            recipient: "wwcorp".to_string(),
+            subject: None,
+            text_body: Some("你好".to_string()),
+            html_body: None,
+            thread_id: thread_id.to_string(),
+            message_id: message_id.map(str::to_string),
+            attachments: Vec::new(),
+            reply_to: Vec::new(),
+            raw_payload: Vec::new(),
+            metadata: ChannelMetadata {
+                wechat_corp_id: corp_id.map(str::to_string),
+                ..Default::default()
+            },
+        }
+    }
+
+    fn write_test_quick_response_claim_record(
+        path: &Path,
+        scope_key: &str,
+        message_id: &str,
+        status: QuickResponseClaimStatus,
+        updated_at_unix_secs: i64,
+    ) -> Result<(), BoxError> {
+        let record = QuickResponseClaimRecord {
+            scope_key: scope_key.to_string(),
+            message_id: message_id.to_string(),
+            status,
+            updated_at_unix_secs,
+        };
+        write_quick_response_claim_record(path, &record)
+    }
+
     #[test]
-    fn discord_quick_response_dedupe_records_and_matches() -> Result<(), BoxError> {
+    fn quick_response_claim_transitions_from_inflight_to_sent() -> Result<(), BoxError> {
         let temp = TempDir::new()?;
         let state_dir = temp.path().join("state");
         let scope = "discord:guild-1:42:thread-1";
         let message_id = "msg-1";
 
-        assert!(!discord_quick_response_already_sent(
-            &state_dir, scope, message_id
+        let claim = match claim_quick_response_send(&state_dir, scope, message_id)? {
+            QuickResponseClaimResult::Acquired(claim) => claim,
+            other => panic!("expected acquired claim, got {:?}", other),
+        };
+
+        assert!(matches!(
+            claim_quick_response_send(&state_dir, scope, message_id)?,
+            QuickResponseClaimResult::InFlight
         ));
 
-        record_discord_quick_response_sent(&state_dir, scope, message_id)?;
+        mark_quick_response_sent(&claim)?;
 
-        assert!(discord_quick_response_already_sent(
-            &state_dir, scope, message_id
+        assert!(matches!(
+            claim_quick_response_send(&state_dir, scope, message_id)?,
+            QuickResponseClaimResult::AlreadySent
         ));
 
-        let path = discord_quick_response_dedupe_path(&state_dir);
-        let store = load_discord_quick_response_dedupe_store(&path);
-        let entries = &store.threads.get(scope).expect("thread entry").message_ids;
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0], "msg-1");
+        let path = quick_response_claim_path(&state_dir, scope, message_id);
+        let record = load_quick_response_claim_record(&path)?
+            .expect("quick response claim record should exist");
+        assert_eq!(record.status, QuickResponseClaimStatus::Sent);
 
         Ok(())
     }
 
     #[test]
-    fn discord_quick_response_dedupe_prunes_old_message_ids() -> Result<(), BoxError> {
+    fn quick_response_claim_release_allows_retry() -> Result<(), BoxError> {
         let temp = TempDir::new()?;
         let state_dir = temp.path().join("state");
         let scope = "discord:guild-1:42:thread-1";
+        let message_id = "msg-2";
 
-        for index in 0..(DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD + 5) {
-            let message_id = format!("msg-{}", index);
-            record_discord_quick_response_sent(&state_dir, scope, &message_id)?;
-        }
+        let claim = match claim_quick_response_send(&state_dir, scope, message_id)? {
+            QuickResponseClaimResult::Acquired(claim) => claim,
+            other => panic!("expected acquired claim, got {:?}", other),
+        };
 
-        let path = discord_quick_response_dedupe_path(&state_dir);
-        let store = load_discord_quick_response_dedupe_store(&path);
-        let entries = &store.threads.get(scope).expect("thread entry").message_ids;
+        assert!(matches!(
+            claim_quick_response_send(&state_dir, scope, message_id)?,
+            QuickResponseClaimResult::InFlight
+        ));
 
-        assert_eq!(
-            entries.len(),
-            DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD
-        );
-        assert!(!entries.iter().any(|entry| entry == "msg-0"));
-        assert!(entries.iter().any(|entry| entry
-            == &format!(
-                "msg-{}",
-                DISCORD_QUICK_RESPONSE_MAX_MESSAGE_IDS_PER_THREAD + 4
-            )));
+        release_quick_response_claim(&claim)?;
+
+        assert!(matches!(
+            claim_quick_response_send(&state_dir, scope, message_id)?,
+            QuickResponseClaimResult::Acquired(_)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn quick_response_claim_reclaims_expired_records() -> Result<(), BoxError> {
+        let temp = TempDir::new()?;
+        let state_dir = temp.path().join("state");
+        let scope = "slack:T123:C123:thread-1";
+
+        let stale_inflight_path = quick_response_claim_path(&state_dir, scope, "msg-stale");
+        write_test_quick_response_claim_record(
+            &stale_inflight_path,
+            scope,
+            "msg-stale",
+            QuickResponseClaimStatus::InFlight,
+            now_unix_secs() - QUICK_RESPONSE_INFLIGHT_STALE_SECS - 1,
+        )?;
+
+        assert!(matches!(
+            claim_quick_response_send(&state_dir, scope, "msg-stale")?,
+            QuickResponseClaimResult::Acquired(_)
+        ));
+
+        let expired_sent_path = quick_response_claim_path(&state_dir, scope, "msg-sent");
+        write_test_quick_response_claim_record(
+            &expired_sent_path,
+            scope,
+            "msg-sent",
+            QuickResponseClaimStatus::Sent,
+            now_unix_secs() - QUICK_RESPONSE_SENT_TTL_SECS - 1,
+        )?;
+
+        assert!(matches!(
+            claim_quick_response_send(&state_dir, scope, "msg-sent")?,
+            QuickResponseClaimResult::Acquired(_)
+        ));
 
         Ok(())
     }
@@ -1533,26 +1833,6 @@ mod tests {
     }
 
     #[test]
-    fn slack_quick_response_dedupe_records_and_matches() -> Result<(), BoxError> {
-        let temp = TempDir::new()?;
-        let state_dir = temp.path().join("state");
-        let scope = "slack:T123:C123:thread-1";
-        let message_id = "1712345678.000100";
-
-        assert!(!slack_quick_response_already_sent(
-            &state_dir, scope, message_id
-        ));
-
-        record_slack_quick_response_sent(&state_dir, scope, message_id)?;
-
-        assert!(slack_quick_response_already_sent(
-            &state_dir, scope, message_id
-        ));
-
-        Ok(())
-    }
-
-    #[test]
     fn slack_scope_key_uses_team_channel_thread() {
         let message = build_slack_message(
             "1712345678.000100",
@@ -1566,6 +1846,41 @@ mod tests {
 
         let message_id = slack_inbound_message_id(&message).expect("message id");
         assert_eq!(message_id, "1712345678.000100");
+    }
+
+    #[test]
+    fn lark_scope_key_and_message_id_fallback_work() {
+        let message = build_lark_message(
+            "lark:oc_test_chat:ou_test_user",
+            None,
+            Some("om_message"),
+            Some("tenant-1"),
+            Some("oc_test_chat"),
+        );
+
+        let scope = lark_quick_response_scope_key(&message).expect("scope key");
+        assert_eq!(
+            scope,
+            "lark:tenant-1:oc_test_chat:lark:oc_test_chat:ou_test_user"
+        );
+
+        let message_id = lark_inbound_message_id(&message).expect("message id");
+        assert_eq!(message_id, "om_message");
+    }
+
+    #[test]
+    fn wechat_scope_key_and_message_id_work() {
+        let message = build_wechat_scope_message(
+            "wechat:wwcorp:zhangsan",
+            Some("wechat-msg-1"),
+            Some("wwcorp"),
+        );
+
+        let scope = wechat_quick_response_scope_key(&message).expect("scope key");
+        assert_eq!(scope, "wechat:wwcorp:wechat:wwcorp:zhangsan");
+
+        let message_id = wechat_inbound_message_id(&message).expect("message id");
+        assert_eq!(message_id, "wechat-msg-1");
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use crate::account_store::AccountStore;
 use crate::adapters::slack::SlackEventWrapper;
@@ -154,7 +155,24 @@ pub(crate) fn process_slack_event(
             err
         );
     }
-    let task_id = scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?;
+    let task_id = if let Some(stable_task_id) = slack_message_task_id(&message) {
+        // Use a deterministic task id and skip re-inserting when the same Slack
+        // message is delivered again.
+        let inserted = scheduler.add_one_shot_in_if_absent_with_id(
+            stable_task_id,
+            Duration::from_secs(0),
+            TaskKind::RunTask(run_task),
+        )?;
+        if !inserted {
+            info!(
+                "skipping duplicate slack full-task enqueue user_id={} task_id={} message_id={:?}",
+                user.user_id, stable_task_id, message.message_id
+            );
+        }
+        stable_task_id
+    } else {
+        scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?
+    };
     index_store.sync_user_tasks(&user.user_id, scheduler.tasks())?;
 
     info!(
@@ -180,14 +198,20 @@ pub(crate) fn process_slack_event(
             match Scheduler::load(&account_tasks_db_path, ModuleExecutor::default()) {
                 Ok(mut account_scheduler) => {
                     // Use the same task_id so we can update status at completion
-                    match account_scheduler.add_one_shot_in_with_id(
+                    match account_scheduler.add_one_shot_in_if_absent_with_id(
                         task_id,
                         Duration::from_secs(0),
                         TaskKind::RunTask(run_task_for_account),
                     ) {
-                        Ok(()) => {
+                        Ok(true) => {
                             info!(
                                 "also enqueued task to account-level storage account={} task_id={}",
+                                account.id, task_id
+                            );
+                        }
+                        Ok(false) => {
+                            info!(
+                                "skipping duplicate slack account-level enqueue account={} task_id={}",
                                 account.id, task_id
                             );
                         }
@@ -236,6 +260,25 @@ fn ensure_slack_workspace(
     )?;
 
     Ok((user, user_paths, workspace, thread_key))
+}
+
+fn slack_message_task_id(message: &crate::channel::InboundMessage) -> Option<Uuid> {
+    let channel_id = message.metadata.slack_channel_id.as_deref()?.trim();
+    let message_id = message.message_id.as_deref()?.trim();
+    let thread_id = message.thread_id.trim();
+    if channel_id.is_empty() || message_id.is_empty() || thread_id.is_empty() {
+        return None;
+    }
+
+    let team_id = message
+        .metadata
+        .slack_team_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown");
+    let dedupe_key = format!("slack:{team_id}:{channel_id}:{thread_id}:{message_id}");
+    Some(Uuid::from_bytes(md5::compute(dedupe_key.as_bytes()).0))
 }
 
 pub(crate) fn persist_slack_ingest_context(
@@ -550,5 +593,30 @@ mod tests {
         assert!(rendered.contains("First context"));
         assert!(rendered.contains("Second context"));
         assert!(rendered.contains("Bingran"));
+    }
+
+    #[test]
+    fn slack_message_task_id_is_stable_for_duplicate_delivery() {
+        let mut first = build_message("Root ask", "1700.1", "1700.1");
+        first.raw_payload = br#"{"event_id":"Ev1"}"#.to_vec();
+
+        let mut duplicate = build_message("Root ask", "1700.1", "1700.1");
+        duplicate.raw_payload = br#"{"event_id":"Ev2"}"#.to_vec();
+
+        assert_eq!(
+            slack_message_task_id(&first),
+            slack_message_task_id(&duplicate)
+        );
+    }
+
+    #[test]
+    fn slack_message_task_id_changes_for_distinct_messages() {
+        let first = build_message("Root ask", "1700.1", "1700.1");
+        let second = build_message("Follow-up detail", "1700.1", "1700.2");
+
+        assert_ne!(
+            slack_message_task_id(&first),
+            slack_message_task_id(&second)
+        );
     }
 }

--- a/DoWhiz_service/scheduler_module/src/service/inbound/wechat.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/wechat.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use crate::account_store::AccountStore;
 use crate::channel::Channel;
@@ -128,7 +129,22 @@ pub(crate) fn process_wechat_event(
             err
         );
     }
-    let task_id = scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?;
+    let task_id = if let Some(stable_task_id) = wechat_message_task_id(message) {
+        let inserted = scheduler.add_one_shot_in_if_absent_with_id(
+            stable_task_id,
+            Duration::from_secs(0),
+            TaskKind::RunTask(run_task),
+        )?;
+        if !inserted {
+            info!(
+                "skipping duplicate wechat full-task enqueue user_id={} task_id={} message_id={:?}",
+                user.user_id, stable_task_id, message.message_id
+            );
+        }
+        stable_task_id
+    } else {
+        scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))?
+    };
     index_store.sync_user_tasks(&user.user_id, scheduler.tasks())?;
 
     info!(
@@ -156,14 +172,20 @@ pub(crate) fn process_wechat_event(
             match Scheduler::load(&account_tasks_db_path, ModuleExecutor::default()) {
                 Ok(mut account_scheduler) => {
                     // Use the same task_id so we can update status at completion
-                    match account_scheduler.add_one_shot_in_with_id(
+                    match account_scheduler.add_one_shot_in_if_absent_with_id(
                         task_id,
                         Duration::from_secs(0),
                         TaskKind::RunTask(run_task_for_account),
                     ) {
-                        Ok(()) => {
+                        Ok(true) => {
                             info!(
                                 "also enqueued task to account-level storage account={} task_id={}",
+                                account.id, task_id
+                            );
+                        }
+                        Ok(false) => {
+                            info!(
+                                "skipping duplicate wechat account-level enqueue account={} task_id={}",
                                 account.id, task_id
                             );
                         }
@@ -186,6 +208,18 @@ pub(crate) fn process_wechat_event(
     }
 
     Ok(())
+}
+
+fn wechat_message_task_id(message: &crate::channel::InboundMessage) -> Option<Uuid> {
+    let corp_id = message.metadata.wechat_corp_id.as_deref()?.trim();
+    let message_id = message.message_id.as_deref()?.trim();
+    let thread_id = message.thread_id.trim();
+    if corp_id.is_empty() || message_id.is_empty() || thread_id.is_empty() {
+        return None;
+    }
+
+    let dedupe_key = format!("wechat:{corp_id}:{thread_id}:{message_id}");
+    Some(Uuid::from_bytes(md5::compute(dedupe_key.as_bytes()).0))
 }
 
 /// Append a WeChat message to the workspace inbox.
@@ -215,4 +249,56 @@ pub(super) fn append_wechat_message(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::{Channel, ChannelMetadata, InboundMessage};
+
+    fn build_message(message_id: &str) -> InboundMessage {
+        InboundMessage {
+            channel: Channel::WeChat,
+            sender: "wechat-user".to_string(),
+            sender_name: None,
+            recipient: "corp-1".to_string(),
+            subject: None,
+            text_body: Some("hello".to_string()),
+            html_body: None,
+            thread_id: "wechat:corp-1:wechat-user".to_string(),
+            message_id: Some(message_id.to_string()),
+            attachments: Vec::new(),
+            reply_to: vec!["wechat-user".to_string()],
+            raw_payload: Vec::new(),
+            metadata: ChannelMetadata {
+                wechat_corp_id: Some("corp-1".to_string()),
+                wechat_user_id: Some("wechat-user".to_string()),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn wechat_message_task_id_is_stable_for_duplicate_delivery() {
+        let mut first = build_message("msg-1");
+        first.raw_payload = br#"<xml><MsgId>msg-1</MsgId></xml>"#.to_vec();
+        let mut duplicate = build_message("msg-1");
+        duplicate.raw_payload = br#"<xml><MsgId>msg-1</MsgId><Retry>1</Retry></xml>"#.to_vec();
+
+        assert_eq!(
+            wechat_message_task_id(&first),
+            wechat_message_task_id(&duplicate)
+        );
+    }
+
+    #[test]
+    fn wechat_message_task_id_changes_for_distinct_messages() {
+        let first = build_message("msg-1");
+        let second = build_message("msg-2");
+
+        assert_ne!(
+            wechat_message_task_id(&first),
+            wechat_message_task_id(&second)
+        );
+    }
 }

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -2853,6 +2853,8 @@
       let workspaceRecommendationLastFetchedAt = null;
       let workspaceRecommendationDismissedForDay = false;
       let taskPollingInterval = null;
+      let taskLoadRequestNonce = 0;
+      let routineLoadRequestNonce = 0;
       let cachedIdentifiers = [];
       let cachedTasks = [];
       let cachedRoutines = { active: [], history: [] };
@@ -6763,12 +6765,18 @@
         const { refreshRecommendation = false } = options;
         const taskList = document.getElementById('task-list');
         const tasksStatus = document.getElementById('tasks-status');
+        const hadExistingData = Array.isArray(cachedTasks) && cachedTasks.length > 0;
+        const requestNonce = ++taskLoadRequestNonce;
 
         try {
           // Fetch all tasks for this account (aggregated from all channels)
           const res = await fetch(`${DOWHIZ_API_URL}/api/account/tasks`, {
             headers: { 'Authorization': `Bearer ${accessToken}` }
           });
+
+          if (requestNonce !== taskLoadRequestNonce) {
+            return;
+          }
 
           if (!res.ok) {
             if (res.status === 404) {
@@ -6778,15 +6786,20 @@
                 className: 'task-item work-item',
                 message: 'No tasks yet. Send Oliver one request from a connected app and it will show up here.'
               });
+              tasksStatus.textContent = `Updated ${new Date().toLocaleTimeString()}`;
               loadWorkspaceSummaryFromStorage();
               renderNextSteps(cachedIdentifiers);
               return;
             }
-            throw new Error(`HTTP ${res.status}`);
+            throw new Error(await readApiErrorMessage(res, `Failed to load tasks (HTTP ${res.status}).`));
           }
 
           const data = await res.json();
-          const allTasks = data.tasks || [];
+          if (requestNonce !== taskLoadRequestNonce) {
+            return;
+          }
+
+          const allTasks = Array.isArray(data.tasks) ? [...data.tasks] : [];
           cachedTasks = allTasks;
 
           // Sort by created_at descending (newest first)
@@ -6836,19 +6849,25 @@
           loadWorkspaceSummaryFromStorage();
           renderNextSteps(cachedIdentifiers);
         } catch (err) {
+          if (requestNonce !== taskLoadRequestNonce) {
+            return;
+          }
           const displayMessage = normalizeApiFetchError(err);
           console.error('Failed to load tasks:', err);
-          cachedTasks = [];
-          taskList.innerHTML = renderWorkListState({
-            tagName: 'li',
-            className: 'task-item work-item',
-            message: `Error loading tasks: ${displayMessage}`,
-            tone: 'danger'
-          });
+          if (!hadExistingData) {
+            cachedTasks = [];
+            taskList.innerHTML = renderWorkListState({
+              tagName: 'li',
+              className: 'task-item work-item',
+              message: `Error loading tasks: ${displayMessage}`,
+              tone: 'danger'
+            });
+          }
+          tasksStatus.textContent = `Error: ${displayMessage}`;
           loadWorkspaceSummaryFromStorage();
           renderNextSteps(cachedIdentifiers);
         } finally {
-          if (refreshRecommendation) {
+          if (refreshRecommendation && requestNonce === taskLoadRequestNonce) {
             await loadWorkspaceRecommendation(accessToken, { force: true });
           }
         }
@@ -7278,17 +7297,26 @@
           (Array.isArray(cachedRoutines.active) && cachedRoutines.active.length > 0) ||
           (Array.isArray(cachedRoutines.history) && cachedRoutines.history.length > 0)
         );
+        const requestNonce = ++routineLoadRequestNonce;
 
         try {
           const res = await fetch(`${DOWHIZ_API_URL}/api/account/routines`, {
             headers: { 'Authorization': `Bearer ${accessToken}` }
           });
 
+          if (requestNonce !== routineLoadRequestNonce) {
+            return;
+          }
+
           if (!res.ok) {
             throw new Error(await readApiErrorMessage(res, `Failed to load routines (HTTP ${res.status}).`));
           }
 
           const data = await res.json();
+          if (requestNonce !== routineLoadRequestNonce) {
+            return;
+          }
+
           cachedRoutines = {
             active: Array.isArray(data.active) ? data.active : [],
             history: Array.isArray(data.history) ? data.history : []
@@ -7305,6 +7333,9 @@
           renderRoutineList();
           routinesStatus.textContent = `Updated ${new Date().toLocaleTimeString()}`;
         } catch (err) {
+          if (requestNonce !== routineLoadRequestNonce) {
+            return;
+          }
           const displayMessage = normalizeApiFetchError(err);
           console.error('Failed to load routines:', err);
           setRoutineTabState();


### PR DESCRIPTION
## Summary
- make quick-response dedupe atomic with per-message claim files so repeated Slack deliveries cannot race into duplicate replies
- add deterministic duplicate suppression for inbound task scheduling across Slack, Lark, WeChat, Discord, and Notion paths, and fix the personal dashboard refresh disappearance bug
- merge the latest `origin/dev` into this branch so the fix is ready to review against current `dev`

## Testing
- `cargo test -p scheduler_module --lib quick_response -- --nocapture`
- `cargo test -p scheduler_module --lib message_task_id -- --nocapture`
- staging duplicate-delivery validation run `24597703271`
  - Slack: `slack quick response dedupe hit`
  - Lark: `skipping duplicate lark full-task enqueue`
  - WeChat: `skipping duplicate wechat full-task enqueue`
