### PR TITLE
Clarify inbound dedupe boundaries

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -113,8 +113,11 @@ impl<E: TaskExecutor> Scheduler<E> {
         Ok(self.tasks.last().unwrap().id)
     }
 
-    /// Add a one-shot task with a specific task ID.
-    /// Used when syncing a task to user storage with the same ID as the workspace task.
+    /// Add a one-shot task with a caller-provided task ID.
+    ///
+    /// This is used when the caller needs a stable scheduler task identity, for
+    /// example to mirror the same task across workspace/account storage or to
+    /// reuse a transport-derived ID for full-task duplicate-delivery handling.
     pub fn add_one_shot_in_with_id(
         &mut self,
         id: Uuid,
@@ -141,10 +144,15 @@ impl<E: TaskExecutor> Scheduler<E> {
         Ok(())
     }
 
-    /// Add a one-shot task with a specific task ID unless it already exists.
+    /// Add a one-shot task with a caller-provided task ID unless it already exists.
     ///
     /// Returns `true` when a new task is inserted and `false` when an existing
     /// task with the same ID is already present in this scheduler.
+    ///
+    /// This is intended for full `RunTask` duplicate-delivery suppression when
+    /// callers derive a stable task ID from message identity. It is separate
+    /// from quick-response dedupe, which uses claim files instead of scheduler
+    /// task IDs.
     pub fn add_one_shot_in_if_absent_with_id(
         &mut self,
         id: Uuid,

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -413,6 +413,9 @@ pub fn process_inbound_payload(
     let task_id = if let Some(stable_task_id) =
         email_message_task_id(&thread_key, message_id.as_deref())
     {
+        // This stable task id is only for full RunTask duplicate-delivery
+        // suppression. Quick-response dedupe is handled separately from
+        // scheduler task IDs.
         let inserted = scheduler
             .add_one_shot_in_if_absent_with_id(
                 stable_task_id,

--- a/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
@@ -239,6 +239,9 @@ pub(crate) fn process_discord_inbound_message(
         );
     }
     let task_id = if let Some(stable_task_id) = discord_message_task_id(message) {
+        // This stable task id is only for full RunTask duplicate-delivery
+        // suppression. Quick responses are deduped separately via
+        // service/inbound/quick_responses.rs claim files.
         let inserted = scheduler.add_one_shot_in_if_absent_with_id(
             stable_task_id,
             Duration::from_secs(0),

--- a/DoWhiz_service/scheduler_module/src/service/inbound/lark.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/lark.rs
@@ -123,6 +123,9 @@ pub(crate) fn process_lark_event(
         );
     }
     let task_id = if let Some(stable_task_id) = lark_message_task_id(message) {
+        // This stable task id is only for full RunTask duplicate-delivery
+        // suppression. Quick responses are deduped separately via
+        // service/inbound/quick_responses.rs claim files.
         let inserted = scheduler.add_one_shot_in_if_absent_with_id(
             stable_task_id,
             Duration::from_secs(0),

--- a/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
@@ -230,6 +230,9 @@ pub(crate) fn process_notion_message(
     // Schedule the task
     let mut scheduler = Scheduler::load(&user_paths.tasks_db_path, ModuleExecutor::default())?;
     let task_id = if let Some(stable_task_id) = notion_message_task_id(message) {
+        // This stable task id is only for full RunTask duplicate-delivery
+        // suppression. Quick responses are deduped separately via
+        // service/inbound/quick_responses.rs claim files.
         let inserted = scheduler.add_one_shot_in_if_absent_with_id(
             stable_task_id,
             Duration::from_secs(0),

--- a/DoWhiz_service/scheduler_module/src/service/inbound/quick_responses.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/quick_responses.rs
@@ -76,6 +76,11 @@ enum QuickResponseSendGate {
     Suppressed,
 }
 
+// Quick-response dedupe is handled outside the scheduler via claim files keyed
+// by (scope_key, message_id). This keeps "send Working on it" suppression
+// separate from the stable scheduler task IDs used for full RunTask
+// duplicate-delivery handling.
+
 /// Read memo.md from a user's memory directory (local file)
 fn read_user_memo_local(memory_dir: &Path) -> Option<String> {
     let memo_path = memory_dir.join("memo.md");

--- a/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
@@ -156,8 +156,9 @@ pub(crate) fn process_slack_event(
         );
     }
     let task_id = if let Some(stable_task_id) = slack_message_task_id(&message) {
-        // Use a deterministic task id and skip re-inserting when the same Slack
-        // message is delivered again.
+        // This stable task id is only for full RunTask duplicate-delivery
+        // suppression. Quick responses are deduped separately via
+        // service/inbound/quick_responses.rs claim files.
         let inserted = scheduler.add_one_shot_in_if_absent_with_id(
             stable_task_id,
             Duration::from_secs(0),

--- a/DoWhiz_service/scheduler_module/src/service/inbound/wechat.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/wechat.rs
@@ -130,6 +130,9 @@ pub(crate) fn process_wechat_event(
         );
     }
     let task_id = if let Some(stable_task_id) = wechat_message_task_id(message) {
+        // This stable task id is only for full RunTask duplicate-delivery
+        // suppression. Quick responses are deduped separately via
+        // service/inbound/quick_responses.rs claim files.
         let inserted = scheduler.add_one_shot_in_if_absent_with_id(
             stable_task_id,
             Duration::from_secs(0),


### PR DESCRIPTION
## Summary
- clarify that quick-response dedupe uses claim files keyed by scope/message rather than scheduler task IDs
- document that caller-provided task IDs are for full RunTask duplicate-delivery handling and mirrored task identity
- add channel-local comments on the stable task-id path to reduce confusion in inbound handlers

## Validation
- `rustfmt --edition 2021 --check` on the 8 touched files
- `cargo test -p scheduler_module --lib quick_response_claim_transitions_from_inflight_to_sent --manifest-path DoWhiz_service/Cargo.toml`
- `cargo test -p scheduler_module --lib slack_message_task_id_is_stable_for_duplicate_delivery --manifest-path DoWhiz_service/Cargo.toml`
- attempted `cargo test -p scheduler_module --lib add_one_shot_in_if_absent_with_id_skips_existing_task --manifest-path DoWhiz_service/Cargo.toml`, but it requires a reachable local MongoDB (`127.0.0.1:27017` in the current env) and fails before exercising the assertion