### PR TITLE
Merge dev into main

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
@@ -12,7 +12,7 @@ mod utils;
 
 pub use core::Scheduler;
 pub use executor::{ModuleExecutor, TaskExecutor};
-pub use store::{RoutineSummary, TaskStatusSummary};
+pub use store::{RoutineSummary, TaskExecutionSummary, TaskStatusSummary};
 pub use types::{
     RunTaskTask, Schedule, ScheduledTask, SchedulerError, SendReplyTask, TaskExecution, TaskKind,
 };
@@ -39,6 +39,37 @@ pub fn try_load_tasks_with_status(
 ) -> Result<Vec<TaskStatusSummary>, SchedulerError> {
     let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
     store.list_tasks_with_status()
+}
+
+/// Load a single task status summary by ID from the owner scope derived from `tasks_db_path`.
+pub fn try_load_task_with_status(
+    tasks_db_path: &Path,
+    task_id: &str,
+) -> Result<Option<TaskStatusSummary>, SchedulerError> {
+    let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
+    store.load_task_with_status(task_id)
+}
+
+/// Load execution history for a single task from the owner scope derived from `tasks_db_path`.
+pub fn try_load_task_executions(
+    tasks_db_path: &Path,
+    task_id: &str,
+) -> Result<Vec<TaskExecutionSummary>, SchedulerError> {
+    let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
+    store.list_task_executions(task_id)
+}
+
+/// Append a synthetic execution history event for a task.
+pub fn append_task_execution_event(
+    tasks_db_path: &Path,
+    task_id: &str,
+    started_at: DateTime<Utc>,
+    finished_at: Option<DateTime<Utc>>,
+    status: &str,
+    error_message: Option<&str>,
+) -> Result<(), SchedulerError> {
+    let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
+    store.append_execution_event(task_id, started_at, finished_at, status, error_message)
 }
 
 /// Load account/user-visible routine summaries for the owner scope derived from `tasks_db_path`.
@@ -72,6 +103,15 @@ pub fn persist_scheduled_task(
 ) -> Result<(), SchedulerError> {
     let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
     store.update_task(task)
+}
+
+/// Insert a new scheduled task into scheduler storage.
+pub fn insert_scheduled_task(
+    tasks_db_path: &Path,
+    task: &ScheduledTask,
+) -> Result<(), SchedulerError> {
+    let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
+    store.insert_task(task)
 }
 
 /// MVP routine heuristic for the dashboard.

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
@@ -136,8 +136,34 @@ impl SchedulerStore {
         Ok(())
     }
 
+    pub(crate) fn append_execution_event(
+        &self,
+        task_id: &str,
+        started_at: DateTime<Utc>,
+        finished_at: Option<DateTime<Utc>>,
+        status: &str,
+        error_message: Option<&str>,
+    ) -> Result<(), SchedulerError> {
+        self.mongo
+            .append_execution_event(task_id, started_at, finished_at, status, error_message)
+    }
+
     pub fn list_tasks_with_status(&self) -> Result<Vec<TaskStatusSummary>, SchedulerError> {
         self.mongo.list_tasks_with_status()
+    }
+
+    pub fn load_task_with_status(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<TaskStatusSummary>, SchedulerError> {
+        self.mongo.load_task_with_status(task_id)
+    }
+
+    pub fn list_task_executions(
+        &self,
+        task_id: &str,
+    ) -> Result<Vec<TaskExecutionSummary>, SchedulerError> {
+        self.mongo.list_task_executions(task_id)
     }
 
     pub fn list_routines_with_status(&self) -> Result<Vec<RoutineSummary>, SchedulerError> {
@@ -164,6 +190,20 @@ pub struct TaskStatusSummary {
     pub execution_status: Option<String>,
     pub error_message: Option<String>,
     pub execution_started_at: Option<String>,
+    /// User-facing task state derived from schedule, enabled flag, and execution history.
+    pub status: String,
+    /// Optional explanation for the current task state.
+    pub status_reason: Option<String>,
+    /// When the current user-facing state last changed.
+    pub status_changed_at: Option<String>,
+    /// Current retry counter persisted with the task.
+    pub retry_count: u32,
+    /// Whether the task has been running long enough to warn that it may be stuck.
+    pub is_running_long: bool,
+    /// Whether the dashboard should offer a cancel action for this task.
+    pub can_cancel: bool,
+    /// Whether the dashboard should offer a resubmit action for this task.
+    pub can_resubmit: bool,
 }
 
 /// Summary of a user-visible scheduled run_task surfaced as a dashboard routine.
@@ -182,6 +222,17 @@ pub struct RoutineSummary {
     pub error_message: Option<String>,
     pub created_at: String,
     pub is_recurring: bool,
+}
+
+/// Execution history row for a task detail view.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TaskExecutionSummary {
+    pub execution_id: i64,
+    pub status: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub error_message: Option<String>,
+    pub duration_seconds: Option<i64>,
 }
 
 #[derive(Debug, Clone)]

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -13,23 +13,26 @@ use crate::mongo_store::{
     create_client_from_env, database_from_env, ensure_index_compatible, retry_mongo_write,
 };
 
-use super::super::types::{Schedule, ScheduledTask, SchedulerError};
+use super::super::types::{Schedule, ScheduledTask, SchedulerError, TaskKind};
 use super::super::utils::{task_kind_channel, task_kind_label};
 use super::super::{is_user_visible_routine_task, maybe_repair_legacy_weekday_cron_task};
 use super::{
     ExecutionReconciliationSummary, ExecutionRecordHandle, RoutineSummary, TaskDebugArchiveRecord,
-    TaskStatusSummary,
+    TaskExecutionSummary, TaskStatusSummary,
 };
 
 static EXECUTION_SEQ: AtomicI64 = AtomicI64::new(0);
 const REQUEST_SUMMARY_MAX_CHARS: usize = 72;
+const LONG_RUNNING_WARNING_SECS: i64 = 3600;
 
 #[derive(Debug, Clone)]
 struct ExecutionRow {
     doc_id: Bson,
+    execution_id: i64,
     started_at: chrono::DateTime<Utc>,
     finished_at: Option<chrono::DateTime<Utc>>,
     status: String,
+    error_message: Option<String>,
 }
 
 fn next_execution_id(started_at: chrono::DateTime<Utc>) -> i64 {
@@ -493,6 +496,31 @@ impl MongoSchedulerStore {
         Ok(())
     }
 
+    pub(crate) fn append_execution_event(
+        &self,
+        task_id: &str,
+        started_at: chrono::DateTime<Utc>,
+        finished_at: Option<chrono::DateTime<Utc>>,
+        status: &str,
+        error_message: Option<&str>,
+    ) -> Result<(), SchedulerError> {
+        self.executions
+            .insert_one(
+                doc! {
+                    "owner_scope": self.owner_scope_doc(),
+                    "execution_id": next_execution_id(started_at),
+                    "task_id": task_id,
+                    "started_at": BsonDateTime::from_chrono(started_at),
+                    "finished_at": finished_at.map(BsonDateTime::from_chrono).map(Bson::DateTime).unwrap_or(Bson::Null),
+                    "status": status,
+                    "error_message": error_message.map(Bson::from).unwrap_or(Bson::Null),
+                },
+                None,
+            )
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
     fn load_execution_rows_for_task(
         &self,
         task_id: &str,
@@ -613,7 +641,8 @@ impl MongoSchedulerStore {
                 self.update_task(&task)?;
             }
             let request_summary = derive_request_summary(&task_doc);
-            let execution = self.latest_execution_for_task(task_id)?;
+            let executions = self.load_execution_rows_for_task(task_id)?;
+            let retry_count = numeric_field_to_u32(&task_doc, "retry_count").unwrap_or(0);
             let (schedule_type, next_run, run_at) = match &task.schedule {
                 Schedule::Cron { next_run, .. } => {
                     ("cron".to_string(), Some(next_run.to_rfc3339()), None)
@@ -622,32 +651,92 @@ impl MongoSchedulerStore {
                     ("one_shot".to_string(), None, Some(run_at.to_rfc3339()))
                 }
             };
-            summaries.push(TaskStatusSummary {
-                id: task_id.to_string(),
-                kind: task_doc.get_str("kind").unwrap_or("unknown").to_string(),
-                channel: task_doc.get_str("channel").unwrap_or("email").to_string(),
+            summaries.push(build_task_status_summary(
+                task_id,
+                task_doc.get_str("kind").unwrap_or("unknown"),
+                task_doc.get_str("channel").unwrap_or("email"),
                 request_summary,
-                enabled: task.enabled,
-                created_at: task.created_at.to_rfc3339(),
-                last_run: task.last_run.map(|value| value.to_rfc3339()),
+                &task,
                 schedule_type,
                 next_run,
                 run_at,
-                execution_status: execution
-                    .as_ref()
-                    .and_then(|doc| doc.get_str("status").ok())
-                    .map(|value| value.to_string()),
-                error_message: execution.as_ref().and_then(|doc| {
-                    doc.get_str("error_message")
-                        .ok()
-                        .map(|value| value.to_string())
-                }),
-                execution_started_at: execution
-                    .as_ref()
-                    .and_then(|doc| datetime_field_to_rfc3339(doc, "started_at")),
-            });
+                &executions,
+                retry_count,
+                now,
+            ));
         }
         Ok(summaries)
+    }
+
+    pub fn load_task_with_status(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<TaskStatusSummary>, SchedulerError> {
+        let Some(task_doc) = self
+            .tasks
+            .find_one(
+                doc! {
+                    "owner_scope.kind": &self.owner_kind,
+                    "owner_scope.id": &self.owner_id,
+                    "task_id": task_id,
+                },
+                None,
+            )
+            .map_err(mongo_err)?
+        else {
+            return Ok(None);
+        };
+
+        let now = Utc::now();
+        let mut task = deserialize_task_document(&task_doc)?;
+        if maybe_repair_legacy_weekday_cron_task(&mut task, now)? {
+            self.update_task(&task)?;
+        }
+        let request_summary = derive_request_summary(&task_doc);
+        let executions = self.load_execution_rows_for_task(task_id)?;
+        let retry_count = numeric_field_to_u32(&task_doc, "retry_count").unwrap_or(0);
+        let (schedule_type, next_run, run_at) = match &task.schedule {
+            Schedule::Cron { next_run, .. } => {
+                ("cron".to_string(), Some(next_run.to_rfc3339()), None)
+            }
+            Schedule::OneShot { run_at } => {
+                ("one_shot".to_string(), None, Some(run_at.to_rfc3339()))
+            }
+        };
+
+        Ok(Some(build_task_status_summary(
+            task_id,
+            task_doc.get_str("kind").unwrap_or("unknown"),
+            task_doc.get_str("channel").unwrap_or("email"),
+            request_summary,
+            &task,
+            schedule_type,
+            next_run,
+            run_at,
+            &executions,
+            retry_count,
+            now,
+        )))
+    }
+
+    pub fn list_task_executions(
+        &self,
+        task_id: &str,
+    ) -> Result<Vec<TaskExecutionSummary>, SchedulerError> {
+        let rows = self.load_execution_rows_for_task(task_id)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| TaskExecutionSummary {
+                execution_id: row.execution_id,
+                status: row.status,
+                started_at: row.started_at.to_rfc3339(),
+                finished_at: row.finished_at.map(|value| value.to_rfc3339()),
+                error_message: row.error_message,
+                duration_seconds: row
+                    .finished_at
+                    .map(|value| value.signed_duration_since(row.started_at).num_seconds()),
+            })
+            .collect())
     }
 
     pub(crate) fn list_routines_with_status(&self) -> Result<Vec<RoutineSummary>, SchedulerError> {
@@ -758,7 +847,7 @@ fn parse_execution_row(document: Document) -> Result<ExecutionRow, SchedulerErro
         .get("_id")
         .cloned()
         .ok_or_else(|| SchedulerError::Storage("missing _id for execution row".to_string()))?;
-    bson_i64(document.get("execution_id"), "execution_id")?;
+    let execution_id = bson_i64(document.get("execution_id"), "execution_id")?;
     document.get_str("task_id").map_err(|err| {
         SchedulerError::Storage(format!("missing task_id for execution row: {err}"))
     })?;
@@ -776,13 +865,210 @@ fn parse_execution_row(document: Document) -> Result<ExecutionRow, SchedulerErro
         .get_str("status")
         .map_err(|err| SchedulerError::Storage(format!("missing status for execution row: {err}")))?
         .to_string();
+    let error_message = document
+        .get_str("error_message")
+        .ok()
+        .map(|value| value.to_string());
 
     Ok(ExecutionRow {
         doc_id,
+        execution_id,
         started_at,
         finished_at,
         status,
+        error_message,
     })
+}
+
+fn build_task_status_summary(
+    task_id: &str,
+    kind: &str,
+    channel: &str,
+    request_summary: Option<String>,
+    task: &ScheduledTask,
+    schedule_type: String,
+    next_run: Option<String>,
+    run_at: Option<String>,
+    executions: &[ExecutionRow],
+    retry_count: u32,
+    now: chrono::DateTime<Utc>,
+) -> TaskStatusSummary {
+    let latest_execution = executions.first();
+    let derived_status = derive_user_task_status(task, latest_execution, retry_count, now);
+
+    TaskStatusSummary {
+        id: task_id.to_string(),
+        kind: kind.to_string(),
+        channel: channel.to_string(),
+        request_summary,
+        enabled: task.enabled,
+        created_at: task.created_at.to_rfc3339(),
+        last_run: task.last_run.map(|value| value.to_rfc3339()),
+        schedule_type,
+        next_run,
+        run_at,
+        execution_status: latest_execution.map(|row| row.status.clone()),
+        error_message: latest_execution.and_then(|row| row.error_message.clone()),
+        execution_started_at: latest_execution.map(|row| row.started_at.to_rfc3339()),
+        status: derived_status.status.to_string(),
+        status_reason: derived_status.status_reason,
+        status_changed_at: derived_status.status_changed_at,
+        retry_count,
+        is_running_long: derived_status.is_running_long,
+        can_cancel: derived_status.can_cancel,
+        can_resubmit: derived_status.can_resubmit,
+    }
+}
+
+#[derive(Debug)]
+struct DerivedTaskStatus {
+    status: &'static str,
+    status_reason: Option<String>,
+    status_changed_at: Option<String>,
+    is_running_long: bool,
+    can_cancel: bool,
+    can_resubmit: bool,
+}
+
+fn derive_user_task_status(
+    task: &ScheduledTask,
+    latest_execution: Option<&ExecutionRow>,
+    retry_count: u32,
+    now: chrono::DateTime<Utc>,
+) -> DerivedTaskStatus {
+    let is_one_shot = matches!(&task.schedule, Schedule::OneShot { .. });
+    let is_run_task = matches!(&task.kind, TaskKind::RunTask(_));
+
+    let mut status_reason = None;
+    let mut is_running_long = false;
+    let (status, status_changed_at) = if let Some(row) = latest_execution {
+        let mut status = "scheduled";
+        let status_changed_at = Some(row.finished_at.unwrap_or(row.started_at).to_rfc3339());
+        match row.status.as_str() {
+            "running" => {
+                let running_secs = now.signed_duration_since(row.started_at).num_seconds();
+                is_running_long = running_secs >= LONG_RUNNING_WARNING_SECS;
+                if task.enabled {
+                    status = "running";
+                    if is_running_long {
+                        status_reason = Some(
+                            "Running for over an hour. It may be waiting on a worker or external tool."
+                                .to_string(),
+                        );
+                    }
+                } else {
+                    status = "cancellation_requested";
+                    status_reason = Some(
+                        "Cancellation requested. Waiting for the running worker to stop."
+                            .to_string(),
+                    );
+                }
+            }
+            "failed" => {
+                if task.enabled && is_one_shot {
+                    match &task.schedule {
+                        Schedule::OneShot { run_at } if *run_at > now => {
+                            status = "retry_scheduled";
+                            let retry_prefix = if retry_count > 0 {
+                                format!("Retry {retry_count} scheduled")
+                            } else {
+                                "Retry scheduled".to_string()
+                            };
+                            status_reason =
+                                Some(format!("{retry_prefix} for {}", run_at.to_rfc3339()));
+                        }
+                        Schedule::OneShot { .. } => {
+                            status = "queued";
+                            status_reason = Some(
+                                "Retry is due and waiting for a worker to pick it up.".to_string(),
+                            );
+                        }
+                        Schedule::Cron { .. } => {
+                            status = "failed";
+                        }
+                    }
+                } else {
+                    status = "failed";
+                }
+            }
+            "success" => {
+                status = "success";
+            }
+            "superseded" => {
+                status = "superseded";
+            }
+            "cancelled" => {
+                status = "cancelled";
+                status_reason = row
+                    .error_message
+                    .clone()
+                    .or_else(|| Some("Cancelled from the dashboard.".to_string()));
+            }
+            other => {
+                status = match other {
+                    "" => "scheduled",
+                    _ => "scheduled",
+                };
+            }
+        }
+        (status, status_changed_at)
+    } else {
+        let status;
+        let status_changed_at;
+        match &task.schedule {
+            Schedule::OneShot { run_at } => {
+                if task.enabled {
+                    if *run_at <= now {
+                        status = "queued";
+                        status_reason =
+                            Some("Waiting for a worker to pick up this task.".to_string());
+                        status_changed_at = Some(run_at.to_rfc3339());
+                    } else {
+                        status = "scheduled";
+                        status_changed_at = Some(task.created_at.to_rfc3339());
+                    }
+                } else if *run_at <= now {
+                    status = "expired";
+                    status_reason = Some(
+                        "This one-time task passed its scheduled run time without completing."
+                            .to_string(),
+                    );
+                    status_changed_at = Some(run_at.to_rfc3339());
+                } else {
+                    status = "cancelled";
+                    status_reason = Some("Cancelled before the task started running.".to_string());
+                    status_changed_at = Some(task.created_at.to_rfc3339());
+                }
+            }
+            Schedule::Cron { next_run, .. } => {
+                if task.enabled {
+                    status = "scheduled";
+                    status_changed_at = Some(next_run.to_rfc3339());
+                } else {
+                    status = "paused";
+                    status_reason = Some("This recurring task is paused.".to_string());
+                    status_changed_at = Some(task.created_at.to_rfc3339());
+                }
+            }
+        }
+        (status, status_changed_at)
+    };
+
+    let can_cancel = match status {
+        "scheduled" | "queued" | "retry_scheduled" => is_one_shot,
+        "running" => is_one_shot && is_run_task,
+        _ => false,
+    };
+    let can_resubmit = is_run_task && is_one_shot && matches!(status, "failed" | "expired");
+
+    DerivedTaskStatus {
+        status,
+        status_reason,
+        status_changed_at,
+        is_running_long,
+        can_cancel,
+        can_resubmit,
+    }
 }
 
 fn bson_i64(value: Option<&Bson>, field: &str) -> Result<i64, SchedulerError> {
@@ -1227,13 +1513,54 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
+    use chrono::{Duration as ChronoDuration, TimeZone, Utc};
     use mongodb::bson::doc;
+    use mongodb::bson::Bson;
     use tempfile::TempDir;
 
     use super::{
-        derive_request_summary, normalize_discord_summary_text, resolve_owner_scope,
-        strip_discord_mentions,
+        build_task_status_summary, derive_request_summary, normalize_discord_summary_text,
+        resolve_owner_scope, strip_discord_mentions, ExecutionRow,
     };
+    use crate::channel::Channel;
+    use crate::{RunTaskTask, Schedule, ScheduledTask, TaskKind};
+
+    fn sample_run_task_task() -> RunTaskTask {
+        RunTaskTask {
+            workspace_dir: PathBuf::from("/tmp/task-workspace"),
+            input_email_dir: PathBuf::from("incoming_email"),
+            input_attachments_dir: PathBuf::from("incoming_attachments"),
+            memory_dir: PathBuf::from("memory"),
+            reference_dir: PathBuf::from("references"),
+            model_name: "gpt-test".to_string(),
+            runner: "codex".to_string(),
+            codex_disabled: false,
+            reply_to: vec!["thread".to_string()],
+            reply_from: None,
+            archive_root: None,
+            thread_id: Some("slack:C123:1234.5678".to_string()),
+            thread_epoch: Some(1),
+            thread_state_path: None,
+            channel: Channel::Slack,
+            slack_team_id: Some("T123".to_string()),
+            employee_id: None,
+            requester_identifier_type: None,
+            requester_identifier: None,
+            account_id: None,
+            channel_metadata: Default::default(),
+        }
+    }
+
+    fn sample_one_shot_task(run_at: chrono::DateTime<Utc>) -> ScheduledTask {
+        ScheduledTask {
+            id: uuid::Uuid::new_v4(),
+            kind: TaskKind::RunTask(sample_run_task_task()),
+            schedule: Schedule::OneShot { run_at },
+            enabled: true,
+            created_at: run_at - ChronoDuration::minutes(30),
+            last_run: None,
+        }
+    }
 
     #[test]
     fn resolve_owner_scope_extracts_user_id() {
@@ -1298,6 +1625,100 @@ mod tests {
             summary.as_deref(),
             Some("Please draft a concise project update for the team.")
         );
+    }
+
+    #[test]
+    fn task_status_summary_marks_future_one_shot_as_scheduled_not_running() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 12, 0, 0).unwrap();
+        let task = sample_one_shot_task(now + ChronoDuration::minutes(15));
+
+        let summary = build_task_status_summary(
+            &task.id.to_string(),
+            "run_task",
+            "slack",
+            Some("Review launch checklist".to_string()),
+            &task,
+            "one_shot".to_string(),
+            None,
+            Some((now + ChronoDuration::minutes(15)).to_rfc3339()),
+            &[],
+            0,
+            now,
+        );
+
+        assert_eq!(summary.execution_status, None);
+        assert_eq!(summary.status, "scheduled");
+        assert!(summary.can_cancel);
+        assert!(!summary.can_resubmit);
+    }
+
+    #[test]
+    fn task_status_summary_marks_long_running_task_and_allows_cancel() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 12, 0, 0).unwrap();
+        let started_at = now - ChronoDuration::hours(2);
+        let task = sample_one_shot_task(started_at - ChronoDuration::minutes(5));
+        let execution = ExecutionRow {
+            doc_id: Bson::Null,
+            execution_id: 42,
+            started_at,
+            finished_at: None,
+            status: "running".to_string(),
+            error_message: None,
+        };
+
+        let summary = build_task_status_summary(
+            &task.id.to_string(),
+            "run_task",
+            "slack",
+            Some("Review launch checklist".to_string()),
+            &task,
+            "one_shot".to_string(),
+            None,
+            Some((started_at - ChronoDuration::minutes(5)).to_rfc3339()),
+            &[execution],
+            0,
+            now,
+        );
+
+        assert_eq!(summary.status, "running");
+        assert!(summary.is_running_long);
+        assert!(summary.can_cancel);
+        assert_eq!(summary.execution_status.as_deref(), Some("running"));
+    }
+
+    #[test]
+    fn task_status_summary_marks_disabled_failed_run_task_as_resubmittable() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 12, 0, 0).unwrap();
+        let started_at = now - ChronoDuration::minutes(10);
+        let mut task = sample_one_shot_task(started_at - ChronoDuration::minutes(5));
+        task.enabled = false;
+        task.last_run = Some(now - ChronoDuration::minutes(9));
+        let execution = ExecutionRow {
+            doc_id: Bson::Null,
+            execution_id: 7,
+            started_at,
+            finished_at: Some(now - ChronoDuration::minutes(9)),
+            status: "failed".to_string(),
+            error_message: Some("worker died".to_string()),
+        };
+
+        let summary = build_task_status_summary(
+            &task.id.to_string(),
+            "run_task",
+            "slack",
+            Some("Review launch checklist".to_string()),
+            &task,
+            "one_shot".to_string(),
+            None,
+            Some((started_at - ChronoDuration::minutes(5)).to_rfc3339()),
+            &[execution],
+            3,
+            now,
+        );
+
+        assert_eq!(summary.status, "failed");
+        assert!(!summary.can_cancel);
+        assert!(summary.can_resubmit);
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -4,7 +4,7 @@ use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::{delete, get, post, put};
 use axum::{Json, Router};
 use base64::Engine;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -24,11 +24,16 @@ use crate::google_auth::GoogleAuthConfig;
 use crate::index_store::IndexStore;
 use crate::notion_store::{NotionCredential, NotionStore};
 use crate::scheduler::{
-    is_user_visible_routine_task, load_scheduled_task, persist_scheduled_task,
-    prepare_task_for_resume, try_load_routines_with_status, try_load_tasks_with_status,
-    RoutineSummary, ScheduledTask,
+    append_task_execution_event, insert_scheduled_task, is_user_visible_routine_task,
+    load_scheduled_task, persist_scheduled_task, prepare_task_for_resume,
+    try_load_routines_with_status, try_load_task_executions, try_load_task_with_status,
+    try_load_tasks_with_status, RoutineSummary, Schedule, ScheduledTask, TaskExecutionSummary,
+    TaskKind,
 };
 use crate::slack_store::{SlackInstallation, SlackStore};
+use crate::thread_state::{
+    default_thread_state_path, load_thread_state, write_thread_state, ThreadState,
+};
 use crate::user_store::UserStore;
 use crate::{load_tasks_with_status, TaskStatusSummary};
 
@@ -806,69 +811,77 @@ async fn try_load_unified_account_tasks(
     state: &AuthState,
     account_id: Uuid,
 ) -> Vec<TaskStatusSummary> {
-    let (Some(user_store), Some(users_root)) = (&state.user_store, &state.users_root) else {
-        return Vec::new();
+    let task_paths = match load_unified_account_task_paths(state, account_id).await {
+        Ok(paths) => paths,
+        Err(_) => return Vec::new(),
     };
 
-    let account_tasks_db_path = users_root
-        .join(account_id.to_string())
-        .join("state")
-        .join("tasks.db");
+    let mut tasks = Vec::new();
+    for task_path in task_paths {
+        tasks = merge_task_summaries(tasks, load_tasks_with_status(&task_path));
+    }
+    sort_task_summaries(&mut tasks);
+    tasks
+}
 
-    let mut tasks = load_tasks_with_status(&account_tasks_db_path);
+fn sort_task_summaries(tasks: &mut [TaskStatusSummary]) {
+    tasks.sort_by(|left, right| {
+        parse_rfc3339_utc(Some(right.created_at.as_str()))
+            .cmp(&parse_rfc3339_utc(Some(left.created_at.as_str())))
+            .then_with(|| task_latest_activity_at(right).cmp(&task_latest_activity_at(left)))
+    });
+}
 
-    let store_for_identifiers = state.account_store.clone();
-    let identifiers_result =
-        task::spawn_blocking(move || store_for_identifiers.list_identifiers(account_id)).await;
-
-    if let Ok(Ok(identifiers)) = identifiers_result {
-        let slack_identifiers: Vec<_> = identifiers
-            .iter()
-            .filter(|id| id.identifier_type == "slack" && id.verified)
-            .collect();
-
-        for slack_identifier in slack_identifiers {
-            let user_store_clone = user_store.clone();
-            let identifier = slack_identifier.identifier.clone();
-            let user_result = task::spawn_blocking(move || {
-                user_store_clone.get_user_by_identifier("slack", &identifier)
-            })
-            .await;
-
-            if let Ok(Ok(Some(user_record))) = user_result {
-                let user_paths = user_store.user_paths(users_root, &user_record.user_id);
-                let legacy_tasks = load_tasks_with_status(&user_paths.tasks_db_path);
-
-                for legacy_task in legacy_tasks {
-                    if let Some(existing_idx) =
-                        tasks.iter().position(|task| task.id == legacy_task.id)
-                    {
-                        if legacy_task.execution_status.is_some()
-                            && tasks[existing_idx].execution_status.is_none()
-                        {
-                            tasks[existing_idx] = legacy_task;
-                        } else if legacy_task.execution_status.is_some() {
-                            let legacy_status =
-                                legacy_task.execution_status.as_deref().unwrap_or("");
-                            let existing_status = tasks[existing_idx]
-                                .execution_status
-                                .as_deref()
-                                .unwrap_or("");
-                            if (existing_status == "pending" || existing_status == "running")
-                                && (legacy_status == "success" || legacy_status == "failed")
-                            {
-                                tasks[existing_idx] = legacy_task;
-                            }
-                        }
-                    } else {
-                        tasks.push(legacy_task);
-                    }
-                }
+fn merge_task_summaries(
+    mut base: Vec<TaskStatusSummary>,
+    incoming: Vec<TaskStatusSummary>,
+) -> Vec<TaskStatusSummary> {
+    for candidate in incoming {
+        if let Some(existing_idx) = base.iter().position(|task| task.id == candidate.id) {
+            if should_prefer_task_summary(&candidate, &base[existing_idx]) {
+                base[existing_idx] = candidate;
             }
+        } else {
+            base.push(candidate);
         }
     }
+    base
+}
 
-    tasks
+fn should_prefer_task_summary(candidate: &TaskStatusSummary, existing: &TaskStatusSummary) -> bool {
+    let candidate_rank = task_status_rank(candidate.status.as_str());
+    let existing_rank = task_status_rank(existing.status.as_str());
+    if candidate_rank != existing_rank {
+        return candidate_rank > existing_rank;
+    }
+
+    let candidate_error = candidate.error_message.as_deref().unwrap_or("").trim();
+    let existing_error = existing.error_message.as_deref().unwrap_or("").trim();
+    if !candidate_error.is_empty() && existing_error.is_empty() {
+        return true;
+    }
+
+    task_latest_activity_at(candidate) > task_latest_activity_at(existing)
+}
+
+fn task_status_rank(status: &str) -> i32 {
+    match status {
+        "failed" | "success" | "cancelled" | "expired" | "superseded" => 5,
+        "cancellation_requested" => 4,
+        "running" | "retry_scheduled" => 3,
+        "queued" => 2,
+        "scheduled" | "paused" => 1,
+        _ => 0,
+    }
+}
+
+fn task_latest_activity_at(task: &TaskStatusSummary) -> Option<DateTime<Utc>> {
+    parse_rfc3339_utc(task.status_changed_at.as_deref())
+        .or_else(|| parse_rfc3339_utc(task.execution_started_at.as_deref()))
+        .or_else(|| parse_rfc3339_utc(task.last_run.as_deref()))
+        .or_else(|| parse_rfc3339_utc(task.run_at.as_deref()))
+        .or_else(|| parse_rfc3339_utc(task.next_run.as_deref()))
+        .or_else(|| parse_rfc3339_utc(Some(task.created_at.as_str())))
 }
 
 fn load_task_statuses_or_response(
@@ -6308,6 +6321,33 @@ struct RoutineMutationResponse {
     task_id: String,
 }
 
+#[derive(Debug, Serialize)]
+struct TaskDetailResponse {
+    task: TaskStatusSummary,
+    executions: Vec<TaskExecutionSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct TaskMutationResponse {
+    ok: bool,
+    task_id: String,
+    resubmitted_task_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TaskStorageMatch {
+    path: PathBuf,
+    task: ScheduledTask,
+    summary: TaskStatusSummary,
+    executions: Vec<TaskExecutionSummary>,
+}
+
+#[derive(Debug, Clone)]
+struct TaskMutationOutcome {
+    task_id: String,
+    resubmitted_task_id: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct TasksQuery {
     pub channel: Option<String>,
@@ -6417,166 +6457,466 @@ pub async fn get_account_tasks(
     State(state): State<AuthState>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
-    // Validate auth token
-    let token = match extract_bearer_token(&headers) {
-        Some(t) => t,
-        None => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({
-                    "error": "Missing Authorization header"
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let auth_user_id = match validate_supabase_token(&state.supabase_url, &token).await {
-        Ok(user) => user.id,
-        Err((status, msg)) => {
-            return (status, Json(serde_json::json!({ "error": msg }))).into_response();
-        }
-    };
-
-    // Check if users_root is configured
-    let users_root = match &state.users_root {
-        Some(root) => root.clone(),
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({
-                    "error": "Task storage not configured"
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    // Get account by auth_user_id
-    let account_id_for_identifiers = {
-        let store_clone = state.account_store.clone();
-        let account_result =
-            task::spawn_blocking(move || store_clone.get_account_by_auth_user(auth_user_id))
-                .await
-                .map_err(|e| {
-                    error!("spawn_blocking panicked: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(serde_json::json!({ "error": "Internal error" })),
-                    )
-                });
-
-        match account_result {
-            Ok(Ok(Some(acc))) => acc.id,
-            Ok(Ok(None)) => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({ "error": "Account not found" })),
-                )
-                    .into_response();
-            }
-            Ok(Err(e)) => {
-                error!("Failed to get account: {}", e);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": "Failed to get account" })),
-                )
-                    .into_response();
-            }
-            Err(resp) => return resp.into_response(),
-        }
-    };
-
-    // Load tasks from account-level tasks.db
-    let account_tasks_db_path = users_root
-        .join(account_id_for_identifiers.to_string())
-        .join("state")
-        .join("tasks.db");
-
-    let mut tasks = match load_task_statuses_or_response(&account_tasks_db_path, "account-scoped") {
-        Ok(tasks) => tasks,
+    let account = match load_authenticated_account_from_headers(&state, &headers).await {
+        Ok(account) => account,
         Err(response) => return response,
     };
 
-    // For Slack, also fetch from legacy user storage (where status updates go)
-    // Get linked Slack identifiers for this account
-    let account_id = account_id_for_identifiers;
-    let store_for_identifiers = state.account_store.clone();
-    let identifiers_result =
-        task::spawn_blocking(move || store_for_identifiers.list_identifiers(account_id)).await;
+    let task_paths = match load_unified_account_task_paths(&state, account.id).await {
+        Ok(paths) => paths,
+        Err(response) => return response,
+    };
 
-    if let Ok(Ok(identifiers)) = identifiers_result {
-        let slack_identifiers: Vec<_> = identifiers
-            .iter()
-            .filter(|id| id.identifier_type == "slack" && id.verified)
-            .collect();
+    let mut tasks = Vec::new();
+    for task_path in task_paths {
+        let loaded = match load_task_statuses_or_response(&task_path, "account-scoped") {
+            Ok(tasks) => tasks,
+            Err(response) => return response,
+        };
+        tasks = merge_task_summaries(tasks, loaded);
+    }
+    sort_task_summaries(&mut tasks);
 
-        if !slack_identifiers.is_empty() {
-            if let Some(user_store) = &state.user_store {
-                for slack_id in slack_identifiers {
-                    // Look up the legacy user for this Slack identifier
-                    let user_store_clone = user_store.clone();
-                    let identifier = slack_id.identifier.clone();
-                    let user_result = task::spawn_blocking(move || {
-                        user_store_clone.get_user_by_identifier("slack", &identifier)
-                    })
-                    .await;
+    (StatusCode::OK, Json(TasksResponse { tasks })).into_response()
+}
 
-                    if let Ok(Ok(Some(user_record))) = user_result {
-                        // Load tasks from legacy user storage
-                        let user_paths = user_store.user_paths(&users_root, &user_record.user_id);
-                        let legacy_tasks =
-                            match try_load_tasks_with_status(&user_paths.tasks_db_path) {
-                                Ok(tasks) => tasks,
-                                Err(err) => {
-                                    warn!(
-                                        "failed to load legacy Slack tasks from {}: {}",
-                                        user_paths.tasks_db_path.display(),
-                                        err
-                                    );
-                                    continue;
-                                }
-                            };
+/// GET /api/account/tasks/:task_id
+/// Returns the current task summary together with execution history for one task.
+pub async fn get_account_task_detail(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Path(task_id): Path<String>,
+) -> impl IntoResponse {
+    let account = match load_authenticated_account_from_headers(&state, &headers).await {
+        Ok(account) => account,
+        Err(response) => return response,
+    };
 
-                        // Merge legacy tasks, preferring ones with execution_status set
-                        // (legacy storage has the updated status for Slack tasks)
-                        for legacy_task in legacy_tasks {
-                            if let Some(existing_idx) =
-                                tasks.iter().position(|t| t.id == legacy_task.id)
-                            {
-                                // If legacy task has status and existing doesn't, use legacy
-                                if legacy_task.execution_status.is_some()
-                                    && tasks[existing_idx].execution_status.is_none()
-                                {
-                                    tasks[existing_idx] = legacy_task;
-                                }
-                                // If both have status, prefer the one that's not "pending"/"running"
-                                else if legacy_task.execution_status.is_some() {
-                                    let legacy_status =
-                                        legacy_task.execution_status.as_deref().unwrap_or("");
-                                    let existing_status = tasks[existing_idx]
-                                        .execution_status
-                                        .as_deref()
-                                        .unwrap_or("");
-                                    if (existing_status == "pending"
-                                        || existing_status == "running")
-                                        && (legacy_status == "success" || legacy_status == "failed")
-                                    {
-                                        tasks[existing_idx] = legacy_task;
-                                    }
-                                }
-                            } else {
-                                // Task only exists in legacy storage, add it
-                                tasks.push(legacy_task);
-                            }
-                        }
-                    }
-                }
+    let task_paths = match load_unified_account_task_paths(&state, account.id).await {
+        Ok(paths) => paths,
+        Err(response) => return response,
+    };
+    let task_id_for_log = task_id.clone();
+
+    let detail_result =
+        task::spawn_blocking(move || load_account_task_detail_blocking(&task_paths, &task_id))
+            .await;
+
+    match detail_result {
+        Ok(Ok(Some(detail))) => (StatusCode::OK, Json(detail)).into_response(),
+        Ok(Ok(None)) => json_error_response(StatusCode::NOT_FOUND, "Task not found"),
+        Ok(Err(response)) => response,
+        Err(err) => {
+            error!(
+                "spawn_blocking panicked while loading task detail {}: {}",
+                task_id_for_log, err
+            );
+            json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal error")
+        }
+    }
+}
+
+/// POST /api/account/tasks/:task_id/cancel
+pub async fn cancel_account_task(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Path(task_id): Path<String>,
+) -> impl IntoResponse {
+    mutate_account_task_endpoint(state, headers, task_id, TaskMutationAction::Cancel).await
+}
+
+/// POST /api/account/tasks/:task_id/resubmit
+pub async fn resubmit_account_task(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Path(task_id): Path<String>,
+) -> impl IntoResponse {
+    mutate_account_task_endpoint(state, headers, task_id, TaskMutationAction::Resubmit).await
+}
+
+fn load_account_task_detail_blocking(
+    task_paths: &[PathBuf],
+    task_id: &str,
+) -> Result<Option<TaskDetailResponse>, Response> {
+    let matches = load_task_storage_matches_blocking(task_paths, task_id)?;
+    let Some(selected_idx) = preferred_task_match_index(&matches) else {
+        return Ok(None);
+    };
+    let executions = merge_task_execution_summaries(&matches);
+    let selected = matches[selected_idx].clone();
+    Ok(Some(TaskDetailResponse {
+        task: selected.summary,
+        executions,
+    }))
+}
+
+fn load_task_storage_matches_blocking(
+    task_paths: &[PathBuf],
+    task_id: &str,
+) -> Result<Vec<TaskStorageMatch>, Response> {
+    let mut matches = Vec::new();
+    for task_path in task_paths {
+        let task = load_scheduled_task(task_path, task_id).map_err(|err| {
+            error!(
+                "failed to load task {} from {}: {}",
+                task_id,
+                task_path.display(),
+                err
+            );
+            json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load task")
+        })?;
+        let Some(task) = task else {
+            continue;
+        };
+
+        let summary = try_load_task_with_status(task_path, task_id)
+            .map_err(|err| {
+                error!(
+                    "failed to load task status {} from {}: {}",
+                    task_id,
+                    task_path.display(),
+                    err
+                );
+                json_error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to load task status",
+                )
+            })?
+            .ok_or_else(|| {
+                json_error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to load task status",
+                )
+            })?;
+
+        let executions = try_load_task_executions(task_path, task_id).map_err(|err| {
+            error!(
+                "failed to load task executions {} from {}: {}",
+                task_id,
+                task_path.display(),
+                err
+            );
+            json_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to load task history",
+            )
+        })?;
+
+        matches.push(TaskStorageMatch {
+            path: task_path.clone(),
+            task,
+            summary,
+            executions,
+        });
+    }
+    Ok(matches)
+}
+
+fn preferred_task_match_index(matches: &[TaskStorageMatch]) -> Option<usize> {
+    let mut best_idx = 0usize;
+    let mut found = false;
+    for (idx, candidate) in matches.iter().enumerate() {
+        if !found {
+            best_idx = idx;
+            found = true;
+            continue;
+        }
+        if should_prefer_task_summary(&candidate.summary, &matches[best_idx].summary) {
+            best_idx = idx;
+        }
+    }
+    found.then_some(best_idx)
+}
+
+fn merge_task_execution_summaries(matches: &[TaskStorageMatch]) -> Vec<TaskExecutionSummary> {
+    let mut seen = HashSet::new();
+    let mut executions = Vec::new();
+
+    for task_match in matches {
+        for execution in &task_match.executions {
+            let dedupe_key = format!(
+                "{}|{}|{}|{}|{}",
+                execution.status,
+                execution.started_at,
+                execution.finished_at.as_deref().unwrap_or(""),
+                execution.error_message.as_deref().unwrap_or(""),
+                execution.duration_seconds.unwrap_or_default()
+            );
+            if seen.insert(dedupe_key) {
+                executions.push(execution.clone());
             }
         }
     }
 
-    (StatusCode::OK, Json(TasksResponse { tasks })).into_response()
+    executions.sort_by(|left, right| {
+        parse_rfc3339_utc(Some(right.started_at.as_str()))
+            .cmp(&parse_rfc3339_utc(Some(left.started_at.as_str())))
+            .then_with(|| right.execution_id.cmp(&left.execution_id))
+    });
+    executions
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TaskMutationAction {
+    Cancel,
+    Resubmit,
+}
+
+async fn mutate_account_task_endpoint(
+    state: AuthState,
+    headers: HeaderMap,
+    task_id: String,
+    action: TaskMutationAction,
+) -> Response {
+    let account = match load_authenticated_account_from_headers(&state, &headers).await {
+        Ok(account) => account,
+        Err(response) => return response,
+    };
+
+    match mutate_unified_account_task(&state, account.id, &task_id, action).await {
+        Ok(Some(outcome)) => (
+            StatusCode::OK,
+            Json(TaskMutationResponse {
+                ok: true,
+                task_id: outcome.task_id,
+                resubmitted_task_id: outcome.resubmitted_task_id,
+            }),
+        )
+            .into_response(),
+        Ok(None) => json_error_response(StatusCode::NOT_FOUND, "Task not found"),
+        Err(response) => response,
+    }
+}
+
+async fn mutate_unified_account_task(
+    state: &AuthState,
+    account_id: Uuid,
+    task_id: &str,
+    action: TaskMutationAction,
+) -> Result<Option<TaskMutationOutcome>, Response> {
+    let task_paths = load_unified_account_task_paths(state, account_id).await?;
+    let task_id = task_id.to_string();
+    let action_name = match action {
+        TaskMutationAction::Cancel => "cancel",
+        TaskMutationAction::Resubmit => "resubmit",
+    }
+    .to_string();
+    let task_id_for_log = task_id.clone();
+    let action_name_for_log = action_name.clone();
+
+    task::spawn_blocking(move || {
+        mutate_unified_account_task_blocking(&task_paths, &task_id, action, &action_name)
+    })
+    .await
+    .map_err(|err| {
+        error!(
+            "spawn_blocking panicked while applying task action {} to {}: {}",
+            action_name_for_log, task_id_for_log, err
+        );
+        json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal error")
+    })?
+}
+
+fn mutate_unified_account_task_blocking(
+    task_paths: &[PathBuf],
+    task_id: &str,
+    action: TaskMutationAction,
+    action_name: &str,
+) -> Result<Option<TaskMutationOutcome>, Response> {
+    let matches = load_task_storage_matches_blocking(task_paths, task_id)?;
+    let Some(selected_idx) = preferred_task_match_index(&matches) else {
+        return Ok(None);
+    };
+    let selected = matches[selected_idx].clone();
+
+    match action {
+        TaskMutationAction::Cancel => {
+            cancel_task_matches(&matches, &selected, action_name)?;
+            Ok(Some(TaskMutationOutcome {
+                task_id: task_id.to_string(),
+                resubmitted_task_id: None,
+            }))
+        }
+        TaskMutationAction::Resubmit => {
+            if !selected.summary.can_resubmit {
+                return Err(json_error_response(
+                    StatusCode::CONFLICT,
+                    "Only failed or expired workflow tasks can be resubmitted safely.",
+                ));
+            }
+            let resubmitted_task = build_resubmitted_task(&selected.task, Utc::now())
+                .map_err(|message| json_error_response(StatusCode::CONFLICT, &message))?;
+            insert_scheduled_task(&selected.path, &resubmitted_task).map_err(|err| {
+                error!(
+                    "failed to insert resubmitted task {} into {}: {}",
+                    resubmitted_task.id,
+                    selected.path.display(),
+                    err
+                );
+                json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to resubmit task")
+            })?;
+            Ok(Some(TaskMutationOutcome {
+                task_id: task_id.to_string(),
+                resubmitted_task_id: Some(resubmitted_task.id.to_string()),
+            }))
+        }
+    }
+}
+
+fn cancel_task_matches(
+    matches: &[TaskStorageMatch],
+    selected: &TaskStorageMatch,
+    action_name: &str,
+) -> Result<(), Response> {
+    if !selected.summary.can_cancel {
+        return Err(json_error_response(
+            StatusCode::CONFLICT,
+            "Task cannot be cancelled in its current state.",
+        ));
+    }
+
+    if selected.summary.status == "running" {
+        let TaskKind::RunTask(run_task) = &selected.task.kind else {
+            return Err(json_error_response(
+                StatusCode::CONFLICT,
+                "Only running workflow tasks support cancellation right now.",
+            ));
+        };
+        request_running_task_cancellation(run_task)
+            .map_err(|message| json_error_response(StatusCode::CONFLICT, &message))?;
+    }
+
+    let cancelled_at = Utc::now();
+    for task_match in matches {
+        let mut updated_task = task_match.task.clone();
+        updated_task.enabled = false;
+        persist_scheduled_task(&task_match.path, &updated_task).map_err(|err| {
+            error!(
+                "failed to persist task {} to {} during {}: {}",
+                updated_task.id,
+                task_match.path.display(),
+                action_name,
+                err
+            );
+            json_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to update task")
+        })?;
+
+        if selected.summary.status != "running" {
+            append_task_execution_event(
+                &task_match.path,
+                &updated_task.id.to_string(),
+                cancelled_at,
+                Some(cancelled_at),
+                "cancelled",
+                Some("Cancelled from the dashboard."),
+            )
+            .map_err(|err| {
+                error!(
+                    "failed to append cancelled event for task {} in {}: {}",
+                    updated_task.id,
+                    task_match.path.display(),
+                    err
+                );
+                json_error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to record task cancellation",
+                )
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn request_running_task_cancellation(task: &crate::RunTaskTask) -> Result<(), String> {
+    let state_path = task
+        .thread_state_path
+        .clone()
+        .unwrap_or_else(|| default_thread_state_path(&task.workspace_dir));
+    let expected_epoch = task.thread_epoch.unwrap_or(0);
+    let now = Utc::now().to_rfc3339();
+
+    if let Some(mut state) = load_thread_state(&state_path) {
+        if state.epoch <= expected_epoch {
+            let next_epoch = state.epoch.max(expected_epoch).saturating_add(1).max(1);
+            state.epoch = next_epoch;
+            state.last_email_seq = state.last_email_seq.max(next_epoch);
+            state.updated_at = now;
+            write_thread_state(&state_path, &state).map_err(|err| {
+                format!(
+                    "Failed to write thread state for cancellation at {}: {}",
+                    state_path.display(),
+                    err
+                )
+            })?;
+        }
+        return Ok(());
+    }
+
+    let Some(thread_id) = task
+        .thread_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Err(
+            "Task is already running, but its thread state is unavailable for cancellation."
+                .to_string(),
+        );
+    };
+
+    let next_epoch = expected_epoch.saturating_add(1).max(1);
+    let state = ThreadState {
+        thread_id: thread_id.to_string(),
+        epoch: next_epoch,
+        last_email_seq: next_epoch,
+        last_message_id: None,
+        updated_at: now,
+    };
+    write_thread_state(&state_path, &state).map_err(|err| {
+        format!(
+            "Failed to create thread state for cancellation at {}: {}",
+            state_path.display(),
+            err
+        )
+    })
+}
+
+fn build_resubmitted_task(
+    task: &ScheduledTask,
+    now: DateTime<Utc>,
+) -> Result<ScheduledTask, String> {
+    let TaskKind::RunTask(run_task) = &task.kind else {
+        return Err("Only workflow tasks can be resubmitted safely.".to_string());
+    };
+    if !matches!(&task.schedule, Schedule::OneShot { .. }) {
+        return Err("Recurring tasks should be managed from the routines dashboard.".to_string());
+    }
+
+    if let Some(expected_epoch) = run_task.thread_epoch {
+        let state_path = run_task
+            .thread_state_path
+            .clone()
+            .unwrap_or_else(|| default_thread_state_path(&run_task.workspace_dir));
+        if let Some(state) = load_thread_state(&state_path) {
+            if state.epoch > expected_epoch {
+                return Err(
+                    "This task belongs to an older thread state. Send a fresh message instead of resubmitting it."
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    let mut resubmitted = task.clone();
+    resubmitted.id = Uuid::new_v4();
+    resubmitted.enabled = true;
+    resubmitted.created_at = now;
+    resubmitted.last_run = None;
+    resubmitted.schedule = Schedule::OneShot {
+        run_at: now + ChronoDuration::seconds(1),
+    };
+    Ok(resubmitted)
 }
 
 /// GET /api/account/routines
@@ -6813,6 +7153,15 @@ pub fn auth_router(state: AuthState) -> Router {
         )
         .route("/api/tasks", get(get_tasks))
         .route("/api/account/tasks", get(get_account_tasks))
+        .route("/api/account/tasks/:task_id", get(get_account_task_detail))
+        .route(
+            "/api/account/tasks/:task_id/cancel",
+            post(cancel_account_task),
+        )
+        .route(
+            "/api/account/tasks/:task_id/resubmit",
+            post(resubmit_account_task),
+        )
         .route("/api/account/routines", get(get_account_routines))
         .route(
             "/api/account/routines/:task_id/pause",
@@ -6838,8 +7187,10 @@ mod tests {
     use super::*;
     use chrono::{Duration as ChronoDuration, TimeZone};
     use std::path::PathBuf;
+    use tempfile::TempDir;
 
     use crate::channel::Channel;
+    use crate::thread_state::{write_thread_state, ThreadState};
     use crate::{RunTaskTask, Schedule, ScheduledTask, TaskKind};
 
     // Unit tests for GitHub OAuth structs and encoding logic
@@ -7485,6 +7836,67 @@ mod tests {
         let error = mutate_routine_task(&task, RoutineMutationAction::Resume, now)
             .expect_err("stale one-shot");
         assert!(error.contains("run_at is in the past"));
+    }
+
+    #[test]
+    fn task_resubmit_clones_failed_workflow_safely() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 1, 12, 0, 0).unwrap();
+        let task = ScheduledTask {
+            id: Uuid::new_v4(),
+            kind: TaskKind::RunTask(sample_run_task_task()),
+            schedule: Schedule::OneShot {
+                run_at: now - ChronoDuration::minutes(5),
+            },
+            enabled: false,
+            created_at: now - ChronoDuration::hours(1),
+            last_run: Some(now - ChronoDuration::minutes(4)),
+        };
+
+        let resubmitted = build_resubmitted_task(&task, now).expect("resubmit task");
+        assert_ne!(resubmitted.id, task.id);
+        assert!(resubmitted.enabled);
+        assert_eq!(resubmitted.created_at, now);
+        assert_eq!(resubmitted.last_run, None);
+        match resubmitted.schedule {
+            Schedule::OneShot { run_at } => {
+                assert_eq!(run_at, now + ChronoDuration::seconds(1));
+            }
+            _ => panic!("expected one-shot schedule"),
+        }
+    }
+
+    #[test]
+    fn task_resubmit_rejects_stale_thread_epoch() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 1, 12, 0, 0).unwrap();
+        let temp = TempDir::new().expect("tempdir");
+        let thread_state_path = temp.path().join("thread_state.json");
+        let thread_state = ThreadState {
+            thread_id: "slack:C123:1234.5678".to_string(),
+            epoch: 2,
+            last_email_seq: 2,
+            last_message_id: None,
+            updated_at: now.to_rfc3339(),
+        };
+        write_thread_state(&thread_state_path, &thread_state).expect("write thread state");
+
+        let mut run_task = sample_run_task_task();
+        run_task.workspace_dir = temp.path().to_path_buf();
+        run_task.thread_state_path = Some(thread_state_path);
+        run_task.thread_epoch = Some(1);
+
+        let task = ScheduledTask {
+            id: Uuid::new_v4(),
+            kind: TaskKind::RunTask(run_task),
+            schedule: Schedule::OneShot {
+                run_at: now - ChronoDuration::minutes(5),
+            },
+            enabled: false,
+            created_at: now - ChronoDuration::hours(1),
+            last_run: Some(now - ChronoDuration::minutes(4)),
+        };
+
+        let error = build_resubmitted_task(&task, now).expect_err("stale thread epoch");
+        assert!(error.contains("older thread state"));
     }
 
     // ==================== WeCom OAuth Tests ====================

--- a/DoWhiz_service/scheduler_module/src/service/startup_workspace/recommendation.rs
+++ b/DoWhiz_service/scheduler_module/src/service/startup_workspace/recommendation.rs
@@ -596,6 +596,7 @@ mod tests {
         execution_status: Option<&str>,
         request_summary: Option<&str>,
     ) -> TaskStatusSummary {
+        let status = execution_status.unwrap_or("scheduled");
         TaskStatusSummary {
             id: id.to_string(),
             kind: "run_task".to_string(),
@@ -610,6 +611,13 @@ mod tests {
             execution_status: execution_status.map(|value| value.to_string()),
             error_message: None,
             execution_started_at: Some(Utc::now().to_rfc3339()),
+            status: status.to_string(),
+            status_reason: None,
+            status_changed_at: Some(Utc::now().to_rfc3339()),
+            retry_count: 0,
+            is_running_long: false,
+            can_cancel: false,
+            can_resubmit: matches!(status, "failed" | "expired"),
         }
     }
 

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -496,6 +496,26 @@
         background: rgba(156, 163, 175, 0.2);
         color: #9ca3af;
       }
+      .task-badge.scheduled,
+      .task-badge.queued {
+        background: rgba(148, 163, 184, 0.18);
+        color: #cbd5f5;
+      }
+      .task-badge.retry_scheduled,
+      .task-badge.cancellation_requested {
+        background: rgba(251, 191, 36, 0.18);
+        color: #fbbf24;
+      }
+      .task-badge.cancelled,
+      .task-badge.superseded,
+      .task-badge.paused {
+        background: rgba(148, 163, 184, 0.18);
+        color: #d1d5db;
+      }
+      .task-badge.expired {
+        background: rgba(249, 115, 22, 0.18);
+        color: #fb923c;
+      }
       .work-item-meta-flow,
       .task-details {
         display: flex;
@@ -774,6 +794,81 @@
         text-align: right;
         word-break: break-all;
         max-width: 60%;
+      }
+      .task-modal-section + .task-modal-section {
+        margin-top: 1.25rem;
+      }
+      .task-modal-section-title {
+        margin: 0 0 0.75rem;
+        font-size: 0.92rem;
+        font-weight: 600;
+        color: var(--text, #fff);
+      }
+      .task-modal-note {
+        margin: 0 0 0.75rem;
+        padding: 0.75rem 0.9rem;
+        border-radius: 0.85rem;
+        background: rgba(59, 130, 246, 0.12);
+        border: 1px solid rgba(59, 130, 246, 0.24);
+        color: #dbeafe;
+        font-size: 0.88rem;
+        line-height: 1.45;
+      }
+      .task-modal-empty {
+        padding: 0.9rem;
+        border: 1px dashed var(--border, #333);
+        border-radius: 0.9rem;
+        color: var(--text-muted, #888);
+        text-align: center;
+        font-size: 0.88rem;
+      }
+      .task-timeline {
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+      }
+      .task-timeline-item {
+        padding: 0.9rem;
+        border-radius: 0.95rem;
+        border: 1px solid color-mix(in srgb, var(--text, #fff) 8%, var(--border, #333));
+        background: color-mix(in srgb, var(--surface-secondary, #17191d) 84%, transparent);
+      }
+      .task-timeline-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        margin-bottom: 0.55rem;
+      }
+      .task-timeline-meta {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.6rem 0.8rem;
+      }
+      .task-timeline-meta-item {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+      }
+      .task-timeline-meta-label {
+        font-size: 0.74rem;
+        color: var(--text-muted, #888);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .task-timeline-meta-value {
+        font-size: 0.88rem;
+        color: var(--text, #fff);
+        word-break: break-word;
+      }
+      .task-timeline-error {
+        margin-top: 0.7rem;
+        padding-top: 0.7rem;
+        border-top: 1px solid rgba(239, 68, 68, 0.16);
+        color: #fca5a5;
+        font-size: 0.88rem;
+        line-height: 1.45;
+        word-break: break-word;
       }
 
       #refresh-tasks-btn {
@@ -2860,6 +2955,9 @@
       let cachedRoutines = { active: [], history: [] };
       let activeWorkView = 'tasks';
       let activeRoutineTab = 'active';
+      let taskActionBusyIds = new Set();
+      let taskActionErrors = {};
+      let openTaskModalTaskId = null;
       let routineActionBusyIds = new Set();
       let routineActionErrors = {};
       let cachedMemoContent = '';
@@ -3553,7 +3651,7 @@
       }
 
       function taskExecutionStatus(task) {
-        return String(task?.execution_status || '').trim().toLowerCase();
+        return taskStatusKey(task);
       }
 
       function countSuccessfulTasks(tasks = cachedTasks) {
@@ -3561,7 +3659,7 @@
       }
 
       function countReviewableTasks(tasks = cachedTasks) {
-        const terminalStatuses = new Set(['success', 'failed', 'failure', 'error', 'complete', 'completed', 'cancelled']);
+        const terminalStatuses = new Set(['success', 'failed', 'failure', 'error', 'complete', 'completed', 'cancelled', 'expired', 'superseded']);
         return (Array.isArray(tasks) ? tasks : []).filter((task) => terminalStatuses.has(taskExecutionStatus(task))).length;
       }
 
@@ -5325,6 +5423,9 @@
         cachedRoutines = { active: [], history: [] };
         activeWorkView = 'tasks';
         activeRoutineTab = 'active';
+        taskActionBusyIds = new Set();
+        taskActionErrors = {};
+        openTaskModalTaskId = null;
         routineActionBusyIds = new Set();
         routineActionErrors = {};
         cachedMemoContent = '';
@@ -6766,6 +6867,7 @@
         const taskList = document.getElementById('task-list');
         const tasksStatus = document.getElementById('tasks-status');
         const hadExistingData = Array.isArray(cachedTasks) && cachedTasks.length > 0;
+        const previousTasks = Array.isArray(cachedTasks) ? [...cachedTasks] : [];
         const requestNonce = ++taskLoadRequestNonce;
 
         try {
@@ -6800,16 +6902,20 @@
           }
 
           const allTasks = Array.isArray(data.tasks) ? [...data.tasks] : [];
-          cachedTasks = allTasks;
+          const visibleIds = new Set(allTasks.map((task) => task.id));
+          taskActionErrors = Object.fromEntries(
+            Object.entries(taskActionErrors).filter(([taskId]) => visibleIds.has(taskId))
+          );
 
           // Sort by created_at descending (newest first)
           allTasks.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+          cachedTasks = allTasks;
 
           // Auto-complete "Get Started" when a new "Create Workspace Brief" task completes
           const briefStatus = localStorage.getItem('workspace_brief_status');
           const completedCount = allTasks.filter(t =>
             (t.request_summary || '').toLowerCase().includes('workspace brief') &&
-            t.execution_status === 'success'
+            taskStatusKey(t) === 'success'
           ).length;
           const consumedCount = Number(localStorage.getItem('workspace_brief_consumed_count') || 0);
           console.log('[workspace_brief] status:', briefStatus, 'completedCount:', completedCount, 'consumedCount:', consumedCount);
@@ -6824,7 +6930,7 @@
           const planStatus = localStorage.getItem('workspace_plan_status');
           const planCompletedCount = allTasks.filter(t =>
             (t.request_summary || '').toLowerCase().includes('-day plan') &&
-            t.execution_status === 'success'
+            taskStatusKey(t) === 'success'
           ).length;
           const planConsumedCount = Number(localStorage.getItem('workspace_plan_consumed_count') || 0);
           console.log('[workspace_plan] status:', planStatus, 'completedCount:', planCompletedCount, 'consumedCount:', planConsumedCount);
@@ -6845,9 +6951,13 @@
             taskList.innerHTML = allTasks.map(task => renderTask(task)).join('');
           }
 
+          notifyTaskStatusChanges(previousTasks, allTasks);
           tasksStatus.textContent = `Updated ${new Date().toLocaleTimeString()}`;
           loadWorkspaceSummaryFromStorage();
           renderNextSteps(cachedIdentifiers);
+          if (openTaskModalTaskId && allTasks.some((task) => task.id === openTaskModalTaskId)) {
+            await showTaskModal(openTaskModalTaskId, { silent: true });
+          }
         } catch (err) {
           if (requestNonce !== taskLoadRequestNonce) {
             return;
@@ -7026,29 +7136,86 @@
         return task.schedule_type || 'One-time';
       }
 
+      function taskStatusKey(task) {
+        return String(task?.status || task?.execution_status || 'scheduled').toLowerCase();
+      }
+
+      function taskStatusPresentation(task) {
+        const status = taskStatusKey(task);
+        switch (status) {
+          case 'running':
+            return {
+              key: 'running',
+              className: 'running',
+              label: task?.is_running_long ? 'Running >1h' : 'Running'
+            };
+          case 'retry_scheduled':
+            return { key: status, className: status, label: 'Retry Scheduled' };
+          case 'queued':
+            return { key: status, className: status, label: 'Queued' };
+          case 'scheduled':
+            return { key: status, className: status, label: 'Scheduled' };
+          case 'success':
+            return { key: status, className: 'success', label: 'Completed' };
+          case 'failed':
+            return { key: status, className: 'failed', label: 'Failed' };
+          case 'cancelled':
+            return { key: status, className: status, label: 'Cancelled' };
+          case 'cancellation_requested':
+            return { key: status, className: status, label: 'Stopping' };
+          case 'expired':
+            return { key: status, className: status, label: 'Expired' };
+          case 'superseded':
+            return { key: status, className: status, label: 'Superseded' };
+          case 'paused':
+            return { key: status, className: status, label: 'Paused' };
+          default:
+            return {
+              key: status || 'scheduled',
+              className: status || 'scheduled',
+              label: humanizeTaskToken(status) || 'Scheduled'
+            };
+        }
+      }
+
+      function taskUpdatedAt(task) {
+        return task.status_changed_at || task.last_run || task.execution_started_at || task.created_at;
+      }
+
       function buildTaskModalRows(task) {
+        const status = taskStatusPresentation(task);
         return [
           { label: 'Task ID', value: task.id || 'N/A' },
+          { label: 'Title', value: formatTaskTitle(task) },
           { label: 'Channel', value: formatWorkChannelLabel(task.channel || task.source) },
-          { label: 'Status', value: task.execution_status || 'running' },
+          { label: 'Status', value: status.label },
           { label: 'Enabled', value: task.enabled ? 'Yes' : 'No' },
           { label: 'Schedule Type', value: task.schedule_type || 'N/A' },
+          { label: 'Retry Count', value: Number(task.retry_count || 0) },
           { label: 'Created At', value: formatLocalDateTime(task.created_at, null) },
           { label: 'Next Run', value: formatLocalDateTime(task.next_run, null) },
           { label: 'Last Run', value: formatLocalDateTime(task.last_run, null) },
+          { label: 'Last Status Change', value: formatLocalDateTime(task.status_changed_at, null) },
         ];
       }
 
       function mapTaskToWorkItem(task) {
-        const status = String(task.execution_status || 'running').toLowerCase();
-        const statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
-        const updatedAt = task.last_run || task.execution_started_at || task.created_at;
-        const taskData = encodeURIComponent(JSON.stringify(task));
+        const status = taskStatusPresentation(task);
+        const updatedAt = taskUpdatedAt(task);
+        const isBusy = taskActionBusyIds.has(task.id);
+        const actionError = taskActionErrors[task.id];
         const metaItems = [
           { label: 'Channel', value: formatWorkChannelLabel(task.channel || task.source) },
           { label: 'Schedule', value: buildTaskScheduleDisplay(task) },
           { label: 'Updated', value: formatLocalDateTime(updatedAt) }
         ];
+
+        if (task.status_reason) {
+          metaItems.push({
+            label: 'Note',
+            value: task.status_reason
+          });
+        }
 
         if (task.error_message) {
           metaItems.push({
@@ -7058,15 +7225,39 @@
           });
         }
 
+        const busyLabel = isBusy ? 'Working...' : '';
+        const actions = [];
+        if (task.can_cancel) {
+          actions.push({
+            label: busyLabel || 'Cancel',
+            onClick: `handleTaskAction('${task.id}', 'cancel')`,
+            disabled: isBusy,
+            tone: 'danger'
+          });
+        }
+        if (task.can_resubmit) {
+          actions.push({
+            label: busyLabel || 'Resubmit',
+            onClick: `handleTaskAction('${task.id}', 'resubmit')`,
+            disabled: isBusy
+          });
+        }
+        actions.push({
+          label: 'View details',
+          onClick: `showTaskModal('${task.id}')`,
+          disabled: false
+        });
+
         return {
           tagName: 'li',
           className: 'task-item work-item',
           title: formatTaskTitle(task),
-          badgeLabel: statusLabel,
-          badgeClassName: `task-badge work-item-badge ${status}`,
+          badgeLabel: status.label,
+          badgeClassName: `task-badge work-item-badge ${status.className}`,
           metaLayout: 'flow',
           metaItems,
-          metaSuffixHtml: `<button class="task-info-btn" onclick="showTaskModal('${taskData}')" title="View details" style="margin-left: auto;">i</button>`
+          actions,
+          inlineError: actionError || ''
         };
       }
 
@@ -7106,6 +7297,117 @@
         // Fallback: extract first meaningful line
         const firstLine = errorMessage.split('\n')[0];
         return firstLine.length > 150 ? firstLine.substring(0, 150) + '...' : firstLine;
+      }
+
+      function formatDurationSeconds(seconds) {
+        if (seconds == null || Number.isNaN(Number(seconds))) return 'N/A';
+        const total = Math.max(0, Number(seconds));
+        if (total < 60) return `${total}s`;
+        const minutes = Math.floor(total / 60);
+        const remainingSeconds = total % 60;
+        if (minutes < 60) return remainingSeconds ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+        const hours = Math.floor(minutes / 60);
+        const remainingMinutes = minutes % 60;
+        return remainingMinutes ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+      }
+
+      function renderTaskModalLoading(task) {
+        const title = task ? escapeHtml(formatTaskTitle(task)) : 'Loading task details...';
+        return `
+          <div class="task-modal-section">
+            <div class="task-modal-empty">${title}</div>
+          </div>
+        `;
+      }
+
+      function renderTaskTimeline(executions = []) {
+        if (!Array.isArray(executions) || executions.length === 0) {
+          return '<div class="task-modal-empty">No execution history yet.</div>';
+        }
+
+        return `
+          <div class="task-timeline">
+            ${executions.map((execution) => {
+              const status = taskStatusPresentation({ status: execution.status });
+              const errorHtml = execution.error_message
+                ? `<div class="task-timeline-error">${escapeHtml(parseErrorMessage(execution.error_message))}</div>`
+                : '';
+              return `
+                <div class="task-timeline-item">
+                  <div class="task-timeline-header">
+                    <span class="task-badge ${status.className}">${escapeHtml(status.label)}</span>
+                    <span class="task-timeline-meta-value">Execution #${escapeHtml(String(execution.execution_id || 'N/A'))}</span>
+                  </div>
+                  <div class="task-timeline-meta">
+                    <div class="task-timeline-meta-item">
+                      <span class="task-timeline-meta-label">Started</span>
+                      <span class="task-timeline-meta-value">${escapeHtml(formatLocalDateTime(execution.started_at, null))}</span>
+                    </div>
+                    <div class="task-timeline-meta-item">
+                      <span class="task-timeline-meta-label">Finished</span>
+                      <span class="task-timeline-meta-value">${escapeHtml(formatLocalDateTime(execution.finished_at, null))}</span>
+                    </div>
+                    <div class="task-timeline-meta-item">
+                      <span class="task-timeline-meta-label">Duration</span>
+                      <span class="task-timeline-meta-value">${escapeHtml(formatDurationSeconds(execution.duration_seconds))}</span>
+                    </div>
+                  </div>
+                  ${errorHtml}
+                </div>
+              `;
+            }).join('')}
+          </div>
+        `;
+      }
+
+      function renderTaskModalContent(task, executions = []) {
+        const noteHtml = task.status_reason
+          ? `<div class="task-modal-note">${escapeHtml(task.status_reason)}</div>`
+          : '';
+        return `
+          <div class="task-modal-section">
+            ${noteHtml}
+            ${renderWorkItemModalRows(buildTaskModalRows(task))}
+          </div>
+          <div class="task-modal-section">
+            <h4 class="task-modal-section-title">Execution Timeline</h4>
+            ${renderTaskTimeline(executions)}
+          </div>
+        `;
+      }
+
+      function notifyTaskStatusChanges(previousTasks, nextTasks) {
+        if (!Array.isArray(previousTasks) || previousTasks.length === 0 || !Array.isArray(nextTasks)) {
+          return;
+        }
+
+        const previousById = new Map(previousTasks.map((task) => [task.id, task]));
+        const changes = [];
+        nextTasks.forEach((task) => {
+          const previous = previousById.get(task.id);
+          if (!previous) return;
+
+          const previousStatus = taskStatusKey(previous);
+          const nextStatus = taskStatusKey(task);
+          if (!nextStatus || previousStatus === nextStatus) return;
+          if (!['success', 'failed', 'retry_scheduled', 'cancelled', 'cancellation_requested', 'expired'].includes(nextStatus)) {
+            return;
+          }
+
+          const nextLabel = taskStatusPresentation(task).label;
+          changes.push(`${formatTaskTitle(task)} -> ${nextLabel}`);
+        });
+
+        if (changes.length === 0) return;
+
+        const hasFailure = nextTasks.some((task) => {
+          const previous = previousById.get(task.id);
+          return previous && taskStatusKey(previous) !== taskStatusKey(task) && ['failed', 'expired'].includes(taskStatusKey(task));
+        });
+        const message = changes.length === 1
+          ? `Task update: ${changes[0]}`
+          : `Task updates: ${changes.slice(0, 2).join(' | ')}${changes.length > 2 ? ` (+${changes.length - 2} more)` : ''}`;
+        showMessage(message, hasFailure ? 'error' : 'success');
       }
 
       function setRoutineTabState() {
@@ -7394,6 +7696,71 @@
         }
       }
 
+      async function handleTaskAction(taskId, action) {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session) {
+          showMessage('Please sign in first.');
+          return;
+        }
+
+        const task = cachedTasks.find((item) => item.id === taskId);
+        if (action === 'cancel') {
+          const isRunning = taskStatusKey(task) === 'running';
+          const confirmed = window.confirm(
+            isRunning
+              ? 'Cancel this running task? The worker will stop as soon as it sees the cancellation signal.'
+              : 'Cancel this task before it runs?'
+          );
+          if (!confirmed) {
+            return;
+          }
+        }
+
+        const tasksStatus = document.getElementById('tasks-status');
+        taskActionBusyIds.add(taskId);
+        delete taskActionErrors[taskId];
+        if (Array.isArray(cachedTasks) && cachedTasks.length > 0) {
+          document.getElementById('task-list').innerHTML = cachedTasks.map((item) => renderTask(item)).join('');
+        }
+        tasksStatus.textContent = `${humanizeTaskToken(action)} in progress...`;
+
+        try {
+          const endpoint = `${DOWHIZ_API_URL}/api/account/tasks/${encodeURIComponent(taskId)}/${action}`;
+          const res = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${session.access_token}` }
+          });
+
+          if (!res.ok) {
+            throw new Error(await readApiErrorMessage(res, `Failed to ${action} task.`));
+          }
+
+          const result = await res.json().catch(() => null);
+          await loadTasks(session.access_token);
+          if (action === 'cancel') {
+            showMessage('Task cancellation requested.', 'success');
+          } else if (result?.resubmitted_task_id) {
+            showMessage('Task resubmitted successfully.', 'success');
+          }
+
+          if (openTaskModalTaskId) {
+            const modalTaskId = action === 'resubmit' && result?.resubmitted_task_id
+              ? result.resubmitted_task_id
+              : openTaskModalTaskId;
+            await showTaskModal(modalTaskId, { silent: true });
+          }
+        } catch (err) {
+          console.error(`Failed to ${action} task:`, err);
+          taskActionErrors[taskId] = normalizeApiFetchError(err);
+          tasksStatus.textContent = '';
+        } finally {
+          taskActionBusyIds.delete(taskId);
+          if (Array.isArray(cachedTasks) && cachedTasks.length > 0) {
+            document.getElementById('task-list').innerHTML = cachedTasks.map((item) => renderTask(item)).join('');
+          }
+        }
+      }
+
       function renderWorkItemModalRows(rows) {
         return rows.map((row) => `
           <div class="task-modal-row">
@@ -7404,6 +7771,10 @@
       }
 
       function showWorkItemModal(title, rows) {
+        showWorkItemModalHtml(title, renderWorkItemModalRows(rows));
+      }
+
+      function showWorkItemModalHtml(title, html) {
         const modalTitle = document.getElementById('task-modal-title');
         const modalContent = document.getElementById('task-modal-content');
 
@@ -7411,7 +7782,7 @@
           modalTitle.textContent = title;
         }
 
-        modalContent.innerHTML = renderWorkItemModalRows(rows);
+        modalContent.innerHTML = html;
         document.getElementById('task-modal-overlay').classList.add('active');
       }
 
@@ -7421,14 +7792,64 @@
       }
 
       // Show task details modal
-      function showTaskModal(encodedTask) {
-        const task = JSON.parse(decodeURIComponent(encodedTask));
-        showWorkItemModal('Task Details', buildTaskModalRows(task));
+      async function showTaskModal(taskId, options = {}) {
+        const { silent = false } = options;
+        openTaskModalTaskId = taskId;
+        const fallbackTask = cachedTasks.find((task) => task.id === taskId);
+        showWorkItemModalHtml(
+          fallbackTask ? formatTaskTitle(fallbackTask) : 'Task Details',
+          renderTaskModalLoading(fallbackTask)
+        );
+
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session) {
+          if (!silent) {
+            showMessage('Please sign in first.');
+          }
+          return;
+        }
+
+        try {
+          const res = await fetch(`${DOWHIZ_API_URL}/api/account/tasks/${encodeURIComponent(taskId)}`, {
+            headers: { 'Authorization': `Bearer ${session.access_token}` }
+          });
+
+          if (!res.ok) {
+            throw new Error(await readApiErrorMessage(res, `Failed to load task details (HTTP ${res.status}).`));
+          }
+
+          const detail = await res.json();
+          if (!detail?.task) {
+            throw new Error('Task detail response was empty.');
+          }
+
+          showWorkItemModalHtml(
+            formatTaskTitle(detail.task),
+            renderTaskModalContent(detail.task, Array.isArray(detail.executions) ? detail.executions : [])
+          );
+        } catch (err) {
+          console.error('Failed to load task detail:', err);
+          if (fallbackTask) {
+            showWorkItemModalHtml(
+              formatTaskTitle(fallbackTask),
+              renderTaskModalContent(fallbackTask, [])
+            );
+          } else {
+            showWorkItemModalHtml(
+              'Task Details',
+              `<div class="task-modal-section"><div class="task-modal-empty">${escapeHtml(normalizeApiFetchError(err))}</div></div>`
+            );
+          }
+          if (!silent) {
+            showMessage(normalizeApiFetchError(err));
+          }
+        }
       }
 
       // Close task details modal
       function closeTaskModal(event) {
         if (!event || event.target.id === 'task-modal-overlay') {
+          openTaskModalTaskId = null;
           document.getElementById('task-modal-overlay').classList.remove('active');
         }
       }
@@ -7436,6 +7857,7 @@
       // Expose modal functions globally for onclick handlers
       window.showTaskModal = showTaskModal;
       window.showRoutineModal = showRoutineModal;
+      window.handleTaskAction = handleTaskAction;
       window.handleRoutineAction = handleRoutineAction;
       window.closeTaskModal = closeTaskModal;
 


### PR DESCRIPTION
## Summary
- promote the latest `dev` to `main` for production release
- this release brings in the task dashboard status, task controls, execution timeline, and task state update work from #1412
- local preflight merge of `origin/dev` into `origin/main` completed cleanly with no conflicts

## Validation
- `cd website && npm run lint`
- `cd DoWhiz_service && cargo test -p scheduler_module task_resubmit_ -- --nocapture`
- `cd DoWhiz_service && cargo test -p scheduler_module task_status_summary_marks_ -- --nocapture`
- `cd DoWhiz_service && cargo test -p scheduler_module routine_mutation_actions_disable_and_resume_safely -- --nocapture`

## Notes
- broader `cargo test -p scheduler_module task_ -- --nocapture` still includes unrelated pre-existing / env-sensitive failures (missing `MONGODB_URI`, one scheduler date expectation) and was not used as the release gate for this change
- production deployment is expected to trigger from merging this PR into `main` via `CICD_production`