### PR TITLE
dev -> main: rustfmt fix for email offload tests

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/email_attachments.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/email_attachments.rs
@@ -502,7 +502,9 @@ mod tests {
             )
         );
         // Links must end up inside the shell, not after </html>.
-        assert!(content.contains("<p>Attachments</p></body>")
-            || content.contains("<p>Attachments</p><!--"));
+        assert!(
+            content.contains("<p>Attachments</p></body>")
+                || content.contains("<p>Attachments</p><!--")
+        );
     }
 }


### PR DESCRIPTION
Promotes the rustfmt fix from #1424 so main stays green on `cargo fmt --check`.