### PR TITLE
Merge origin/dev into main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,3 @@
-# Replace these owners if the public maintainer roster changes.
-* @Oliver-DoWhiz @Maggie-DoWhiz
-
-/.github/ @Oliver-DoWhiz @Maggie-DoWhiz
-/README.md @Oliver-DoWhiz @Maggie-DoWhiz
-/OPEN_SOURCE_SCOPE.md @Oliver-DoWhiz @Maggie-DoWhiz
-/docs/ @Oliver-DoWhiz @Maggie-DoWhiz
-/DoWhiz_service/ @Oliver-DoWhiz @Maggie-DoWhiz
-/website/ @Oliver-DoWhiz @Maggie-DoWhiz
+# CODEOWNERS is intentionally disabled for now.
+# Keeping the file makes it easy to restore explicit owners later
+# without recreating the repo-level GitHub configuration entry point.

--- a/cleanup/cleanup_executions_by_account.py
+++ b/cleanup/cleanup_executions_by_account.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import time
+from pymongo import MongoClient
+
+
+def load_env(env_path):
+    conn_str = None
+    db_name = None
+    with open(env_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith("MONGODB_URI="):
+                conn_str = line.split("=", 1)[1].strip().strip("\"").strip("'")
+            elif line.startswith("MONGODB_DATABASE="):
+                db_name = line.split("=", 1)[1].strip().strip("\"").strip("'")
+    return conn_str, db_name
+
+
+def cleanup_executions(account_id, dry_run=True):
+    env_path = os.path.join(os.path.dirname(__file__), "..", ".env")
+    conn_str, db_name = load_env(env_path)
+    print(f"Database: {db_name}")
+    
+    client = MongoClient(conn_str)
+    db = client[db_name]
+    
+    query = {"owner_scope.id": account_id}
+    count = db.task_executions.count_documents(query)
+    print(f"Found {count} executions for {account_id}")
+    
+    if count > 0 and not dry_run:
+        print("Deleting in small batches...")
+        deleted = 0
+        while True:
+            docs = list(db.task_executions.find(query, {"_id": 1}).limit(10))
+            if not docs:
+                break
+            for d in docs:
+                for attempt in range(3):
+                    try:
+                        db.task_executions.delete_one({"_id": d["_id"]})
+                        deleted += 1
+                        break
+                    except Exception as e:
+                        if "16500" in str(e):
+                            time.sleep(1)
+                        else:
+                            raise
+            print(f"  Deleted {deleted}...")
+            time.sleep(0.5)
+        print(f"Total deleted: {deleted}")
+    elif dry_run:
+        print("DRY RUN - use --execute to delete")
+    print("Done!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("account_id")
+    parser.add_argument("--execute", action="store_true")
+    args = parser.parse_args()
+    cleanup_executions(args.account_id, dry_run=not args.execute)


### PR DESCRIPTION
## Summary
- promote the latest `origin/dev` into `main`
- include the CODEOWNERS disablement so Oliver and Maggie are no longer auto-requested on PRs
- include the new `cleanup/cleanup_executions_by_account.py` maintenance script from `dev`

## Validation
- merged `origin/dev` into `origin/main` locally with no conflicts
- `python3 -m py_compile cleanup/cleanup_executions_by_account.py` passed
- `python3 cleanup/cleanup_executions_by_account.py --help` could not run locally because `pymongo` is not installed in this shell environment
- `cargo test --locked -p scheduler_module` is still running as extra, non-required sanity coverage because this promotion does not change `DoWhiz_service` files