### PR TITLE
fix(ci): narrow public PR workflow

### DIFF
--- a/.github/workflows/public-pr.yml
+++ b/.github/workflows/public-pr.yml
@@ -2,13 +2,27 @@ name: Public PR
 
 on:
   pull_request:
+    branches:
+      - dev
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   workflow_dispatch:
+
+concurrency:
+  group: public-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   website:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -37,6 +51,9 @@ jobs:
         run: npm run test:auth-onboarding
 
   rust:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/public-pr.yml
+++ b/.github/workflows/public-pr.yml
@@ -20,9 +20,6 @@ permissions:
 
 jobs:
   website:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -51,9 +48,6 @@ jobs:
         run: npm run test:auth-onboarding
 
   rust:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- restrict the `Public PR` workflow to pull requests targeting `dev`, which matches the documented public contributor path
- prevent unnecessary reruns on the same PR by canceling older in-progress `Public PR` runs

## Why
The open-source `Public PR` workflow was running on maintainer promotion PRs like `dev -> main`, which created duplicate Actions entries alongside `CICD_production` in the screenshots you shared.

## Validation
- parsed `.github/workflows/public-pr.yml` successfully with Ruby YAML
- confirmed repo rulesets do not require `Public PR` as a mandatory status check on `dev` or `main`
- `actionlint` is not installed in this shell environment