### PR TITLE
Fix email follow-up canonicalization for stripped replies

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -1726,6 +1726,7 @@ mod tests {
         let task = sample_one_shot_task(started_at - ChronoDuration::minutes(5));
         let execution = ExecutionRow {
             doc_id: Bson::Null,
+            task_id: task.id.to_string(),
             execution_id: 42,
             started_at,
             finished_at: None,
@@ -1762,6 +1763,7 @@ mod tests {
         task.last_run = Some(now - ChronoDuration::minutes(9));
         let execution = ExecutionRow {
             doc_id: Bson::Null,
+            task_id: task.id.to_string(),
             execution_id: 7,
             started_at,
             finished_at: Some(now - ChronoDuration::minutes(9)),

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -1299,6 +1299,52 @@ mod tests {
     }
 
     #[test]
+    fn append_inbound_payload_uses_stripped_reply_for_followup_thread_request() {
+        let temp = TempDir::new().expect("tempdir");
+
+        let original_raw = r#"{
+  "From": "Logan <logan@example.com>",
+  "To": "Oliver <oliver@dowhiz.com>",
+  "Subject": "Nvidia stock",
+  "TextBody": "Give me a deep research about the Nvidia stock, and tell me whether it is a good time to buy",
+  "MessageID": "<msg-1@example.com>"
+}"#;
+        let original_payload: PostmarkInbound =
+            serde_json::from_str(original_raw).expect("original payload");
+        append_inbound_payload(temp.path(), &original_payload, original_raw.as_bytes(), 1)
+            .expect("append original payload");
+
+        let followup_text =
+            "Can you help me do some deep research for the competitors, and the upstream/downstream for Nvidia. Give me suggestion to some of the investment options among those companies";
+        let followup_raw = format!(
+            r#"{{
+  "From": "Logan <logan@example.com>",
+  "To": "Oliver <oliver@dowhiz.com>",
+  "Subject": "Re: Nvidia stock",
+  "TextBody": "{followup_text}\n\nOn Sat, Apr 18, 2026 at 1:14 PM Logan wrote:\n> Give me a deep research about the Nvidia stock, and tell me whether it is a good time to buy",
+  "StrippedTextReply": "{followup_text}",
+  "MessageID": "<msg-2@example.com>"
+}}"#
+        );
+        let followup_payload: PostmarkInbound =
+            serde_json::from_str(&followup_raw).expect("followup payload");
+        append_inbound_payload(temp.path(), &followup_payload, followup_raw.as_bytes(), 2)
+            .expect("append followup payload");
+
+        let thread_request =
+            fs::read_to_string(temp.path().join("incoming_email/thread_request.md"))
+                .expect("thread_request");
+        let latest_section = thread_request
+            .split("## Latest inbound message\n")
+            .nth(1)
+            .and_then(|section| section.split("\n## Thread timeline\n").next())
+            .expect("latest inbound message section");
+
+        assert!(latest_section.contains("competitors"));
+        assert!(!latest_section.contains("Give me a deep research about the Nvidia stock"));
+    }
+
+    #[test]
     fn resolve_attachment_bytes_prefers_base64_content() {
         let attachment = super::super::postmark::PostmarkAttachment {
             name: "report.txt".to_string(),

--- a/DoWhiz_service/scheduler_module/src/service/html.rs
+++ b/DoWhiz_service/scheduler_module/src/service/html.rs
@@ -10,8 +10,8 @@ pub fn derive_inbound_email_text(
     stripped_text_reply: Option<&str>,
     html_body: Option<&str>,
 ) -> Option<String> {
-    if let Some(text) = normalize_plain_text_option(text_body)
-        .or_else(|| normalize_plain_text_option(stripped_text_reply))
+    if let Some(text) = normalize_plain_text_option(stripped_text_reply)
+        .or_else(|| normalize_plain_text_option(text_body))
     {
         return Some(append_missing_html_links(text, html_body));
     }
@@ -742,6 +742,23 @@ mod tests {
 
         assert!(text.starts_with("Reply body"));
         assert!(text.contains("Links:\n- https://example.com/doc"));
+    }
+
+    #[test]
+    fn derive_inbound_email_text_prefers_stripped_reply_over_full_text_body() {
+        let text = derive_inbound_email_text(
+            Some(
+                "Can you help me do some deep research for the competitors, and the upstream/downstream for Nvidia.\n\nOn Sat, Apr 18, 2026 at 1:14 PM Logan wrote:\n> Give me a deep research about the Nvidia stock, and tell me whether it is a good time to buy",
+            ),
+            Some(
+                "Can you help me do some deep research for the competitors, and the upstream/downstream for Nvidia.",
+            ),
+            Some("<p>Can you help me do some deep research for the competitors, and the upstream/downstream for Nvidia.</p>"),
+        )
+        .expect("text");
+
+        assert!(text.contains("competitors"));
+        assert!(!text.contains("Give me a deep research about the Nvidia stock"));
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/service/workspace.rs
+++ b/DoWhiz_service/scheduler_module/src/service/workspace.rs
@@ -753,8 +753,8 @@ fn load_payload_summary(payload_path: &Path) -> Option<PayloadSummary> {
         message_id: json_string(&payload_json, "MessageID")
             .or_else(|| json_string(&payload_json, "MessageId"))
             .unwrap_or_default(),
-        text_body: json_string(&payload_json, "TextBody")
-            .or_else(|| json_string(&payload_json, "StrippedTextReply")),
+        text_body: json_string(&payload_json, "StrippedTextReply")
+            .or_else(|| json_string(&payload_json, "TextBody")),
         html_body: json_string(&payload_json, "HtmlBody"),
     })
 }

--- a/DoWhiz_service/scheduler_module/tests/email_html_e2e_2.rs
+++ b/DoWhiz_service/scheduler_module/tests/email_html_e2e_2.rs
@@ -338,3 +338,102 @@ fn inbound_email_falls_back_to_text_when_html_is_removed(
 
     Ok(())
 }
+
+#[test]
+fn inbound_email_followup_prefers_stripped_reply_in_thread_request(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let Some((_temp, config, user_store, index_store, account_store)) =
+        setup_service_for_test("inbound_email_followup_prefers_stripped_reply_in_thread_request")?
+    else {
+        return Ok(());
+    };
+
+    let original_payload = serde_json::json!({
+        "From": "Logan <logan@example.com>",
+        "To": "Service <service@example.com>",
+        "Subject": "Nvidia stock",
+        "TextBody": "Give me a deep research about the Nvidia stock, and tell me whether it is a good time to buy",
+        "Headers": [{"Name": "Message-ID", "Value": "<msg-1@example.com>"}]
+    });
+    let original_raw = serde_json::to_string(&original_payload)?;
+    let original: PostmarkInbound = serde_json::from_str(&original_raw)?;
+    process_inbound_payload(
+        &config,
+        &user_store,
+        &index_store,
+        &account_store,
+        &original,
+        original_raw.as_bytes(),
+        None,
+    )?;
+
+    let followup_text = "Can you help me do some deep research for the competitors, and the upstream/downstream for Nvidia. Give me suggestion to some of the investment options among those companies";
+    let followup_payload = serde_json::json!({
+        "From": "Logan <logan@example.com>",
+        "To": "Service <service@example.com>",
+        "Subject": "Re: Nvidia stock",
+        "TextBody": format!(
+            "{followup_text}\n\nOn Sat, Apr 18, 2026 at 1:14 PM Logan wrote:\n> Give me a deep research about the Nvidia stock, and tell me whether it is a good time to buy"
+        ),
+        "StrippedTextReply": followup_text,
+        "Headers": [
+            {"Name": "Message-ID", "Value": "<msg-2@example.com>"},
+            {"Name": "In-Reply-To", "Value": "<msg-1@example.com>"}
+        ]
+    });
+    let followup_raw = serde_json::to_string(&followup_payload)?;
+    let followup: PostmarkInbound = serde_json::from_str(&followup_raw)?;
+    process_inbound_payload(
+        &config,
+        &user_store,
+        &index_store,
+        &account_store,
+        &followup,
+        followup_raw.as_bytes(),
+        None,
+    )?;
+
+    let user = user_store.get_or_create_user("email", "logan@example.com")?;
+    let user_paths = user_store.user_paths(&config.users_root, &user.user_id);
+    let workspace = first_dir(&user_paths.workspaces_root);
+
+    let thread_request =
+        fs::read_to_string(workspace.join("incoming_email").join("thread_request.md"))?;
+    let latest_section = thread_request
+        .split("## Latest inbound message\n")
+        .nth(1)
+        .and_then(|section| section.split("\n## Thread timeline\n").next())
+        .expect("latest inbound section");
+    assert!(
+        latest_section.contains("competitors"),
+        "latest section should use follow-up request"
+    );
+    assert!(
+        !latest_section.contains("Give me a deep research about the Nvidia stock"),
+        "latest section should not fall back to quoted original request"
+    );
+
+    let workspace_payload: serde_json::Value = serde_json::from_str(&fs::read_to_string(
+        workspace
+            .join("incoming_email")
+            .join("postmark_payload.json"),
+    )?)?;
+    assert_eq!(workspace_payload["TextBody"].as_str(), Some(followup_text));
+
+    let workspace_html = fs::read_to_string(workspace.join("incoming_email").join("email.html"))?;
+    assert!(
+        workspace_html.contains("competitors"),
+        "workspace html should reflect follow-up request"
+    );
+    assert!(
+        !workspace_html.contains("Give me a deep research about the Nvidia stock"),
+        "workspace html should not contain the quoted original request"
+    );
+
+    let entry_count = fs::read_dir(workspace.join("incoming_email").join("entries"))?
+        .filter_map(Result::ok)
+        .count();
+    assert_eq!(entry_count, 2, "thread should retain both inbound entries");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- prefer `StrippedTextReply` over full-thread `TextBody` when canonicalizing inbound email follow-ups
- keep workspace thread previews aligned with the same priority so `thread_request.md` reflects the newest ask
- add regressions for the Nvidia follow-up case and fix two stale test fixtures that were missing `task_id`

## Testing
- PASS: `cargo check -p scheduler_module --lib`
- PASS: `cargo test -p scheduler_module --lib derive_inbound_email_text_ -- --nocapture`
- PASS: `cargo test -p scheduler_module --lib write_inbound_payload_sanitizes_workspace_email_views -- --nocapture`
- PASS: `cargo test -p scheduler_module --lib load_reply_context_uses_stripped_reply_when_subject_missing -- --nocapture`
- PASS: `cargo test -p scheduler_module --lib refresh_thread_input_snapshot_builds_merged_request_and_attachments -- --nocapture`
- PASS: `cargo test -p scheduler_module --lib stripped_reply -- --nocapture`
- SKIP/BLOCKED: `cargo test -p scheduler_module --test email_html_e2e` not run locally because this environment has no reachable MongoDB for the repo's configured `MONGODB_URI`
- SKIP/BLOCKED: `cargo test -p scheduler_module --test email_html_e2e_2 -- --nocapture` fails locally on MongoDB connectivity because `DoWhiz_service/.env` points `MONGODB_URI` to `127.0.0.1:27017` and no local `mongod` is available
- SKIP/BLOCKED: `cargo test -p scheduler_module --test scheduler_followups -- --nocapture` fails locally because `MONGODB_URI` is required and no local `mongod` is available
- SKIP/BLOCKED: `cargo test -p scheduler_module --test thread_latest_epoch_e2e -- --nocapture` not run locally because it also depends on the same Mongo-backed scheduler environment
