### PR TITLE
fix(debug_archive): log underlying error on upload failure

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/debug_archive.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/debug_archive.rs
@@ -779,13 +779,14 @@ fn upload_archive_bundle(
                             local_fallback_path: None,
                         });
                     }
-                    Err(_) => {
+                    Err(err) => {
                         eprintln!(
-                            "[task_debug_archive] upload attempt failed backend={} account={} container={} path={}",
+                            "[task_debug_archive] upload attempt failed backend={} account={} container={} path={} error={}",
                             target.storage_backend,
                             target.storage_account.as_deref().unwrap_or("unknown"),
                             target.container,
-                            blob_path
+                            blob_path,
+                            err
                         );
                     }
                 }

--- a/DoWhiz_service/scheduler_module/src/scheduler/debug_archive.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/debug_archive.rs
@@ -833,7 +833,11 @@ fn upload_archive_bytes(
                 .header("x-ms-blob-type", "BlockBlob")
                 .body(bytes.to_vec())
                 .send()
-                .map_err(|err| SchedulerError::Storage(format!("blob upload failed: {}", err)))?;
+                .map_err(|err| {
+                    // `reqwest::Error` includes the full request URL by default, which would leak
+                    // the container SAS query params into logs.
+                    SchedulerError::Storage(format!("blob upload failed: {}", err.without_url()))
+                })?;
             if !response.status().is_success() {
                 let status = response.status();
                 let body = response.text().unwrap_or_default();
@@ -855,7 +859,11 @@ fn upload_archive_bytes(
                 .header("x-ms-blob-type", "BlockBlob")
                 .body(bytes.to_vec())
                 .send()
-                .map_err(|err| SchedulerError::Storage(format!("blob upload failed: {}", err)))?;
+                .map_err(|err| {
+                    // `reqwest::Error` includes the full request URL by default, which would leak
+                    // the account SAS query params into logs.
+                    SchedulerError::Storage(format!("blob upload failed: {}", err.without_url()))
+                })?;
             if !response.status().is_success() {
                 let status = response.status();
                 let body = response.text().unwrap_or_default();


### PR DESCRIPTION
## Summary
- Include the underlying `SchedulerError` (status code + response body for HTTP errors) in the `[task_debug_archive] upload attempt failed` log line.
- Before: `Err(_)` swallowed the only diagnostic signal we had.
- Diagnostic-only change; no behavior difference.

## Why
Production and staging both log dozens of `upload attempt failed` lines per day, but with the error discarded we can't tell whether the cause is SAS expiry, missing permissions, missing container, or transient network. This blocks triage of #1485.

## Test plan
- [x] `cargo check -p scheduler_module` passes locally.
- [ ] After deploy, verify the next `[task_debug_archive] upload attempt failed` line in pm2 logs includes the `error=...` suffix.

Closes #1485 once the underlying blob-auth issue is identified & fixed.