### PR TITLE
Handle Slack file-share inbound requests

### DIFF
--- a/DoWhiz_service/scheduler_module/src/adapters/slack.rs
+++ b/DoWhiz_service/scheduler_module/src/adapters/slack.rs
@@ -47,6 +47,17 @@ impl SlackInboundAdapter {
     }
 }
 
+fn normalized_slack_message_subtype(subtype: Option<&str>) -> Option<&str> {
+    subtype.map(str::trim).filter(|value| !value.is_empty())
+}
+
+pub fn slack_message_subtype_is_supported_for_inbound(subtype: Option<&str>) -> bool {
+    matches!(
+        normalized_slack_message_subtype(subtype),
+        None | Some("file_share")
+    )
+}
+
 impl InboundAdapter for SlackInboundAdapter {
     fn parse(&self, raw_payload: &[u8]) -> Result<InboundMessage, AdapterError> {
         let wrapper: SlackEventWrapper = serde_json::from_slice(raw_payload)
@@ -77,11 +88,15 @@ impl InboundAdapter for SlackInboundAdapter {
             )));
         }
 
-        // Ignore message subtypes (edits, deletes, etc.) - only process new messages
-        if event.subtype.is_some() {
-            return Err(AdapterError::ParseError(
-                "ignoring message with subtype".to_string(),
-            ));
+        // Most message subtypes are edits/deletes/system events and should be ignored.
+        // Keep `file_share`, which is how Slack represents a newly-sent message with files.
+        if !slack_message_subtype_is_supported_for_inbound(event.subtype.as_deref()) {
+            let subtype =
+                normalized_slack_message_subtype(event.subtype.as_deref()).unwrap_or("unknown");
+            return Err(AdapterError::ParseError(format!(
+                "ignoring message with unsupported subtype: {}",
+                subtype
+            )));
         }
 
         let sender = event
@@ -516,6 +531,51 @@ mod tests {
         let adapter = SlackInboundAdapter::default();
         let result = adapter.parse(payload.as_bytes());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_file_share_message_subtype() {
+        let payload = r#"{
+            "type": "event_callback",
+            "team_id": "T123ABC456",
+            "event": {
+                "type": "message",
+                "subtype": "file_share",
+                "channel": "D123ABC456",
+                "channel_type": "im",
+                "user": "U123ABC456",
+                "text": "Attached the project zip",
+                "ts": "1355517536.000003",
+                "files": [
+                    {
+                        "id": "F123ABC456",
+                        "name": "SkyShake.zip",
+                        "mimetype": "application/zip",
+                        "url_private_download": "https://files.example.test/SkyShake.zip"
+                    }
+                ]
+            },
+            "event_id": "Ev123ABC789"
+        }"#;
+
+        let adapter = SlackInboundAdapter::default();
+        let message = adapter
+            .parse(payload.as_bytes())
+            .expect("file_share parses");
+
+        assert_eq!(message.channel, Channel::Slack);
+        assert_eq!(message.sender, "U123ABC456");
+        assert_eq!(
+            message.text_body,
+            Some("Attached the project zip".to_string())
+        );
+        assert_eq!(message.attachments.len(), 1);
+        assert_eq!(message.attachments[0].name, "SkyShake.zip");
+        assert_eq!(message.attachments[0].content_type, "application/zip");
+        assert_eq!(
+            message.metadata.slack_channel_id,
+            Some("D123ABC456".to_string())
+        );
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/handlers.rs
@@ -20,7 +20,8 @@ use scheduler_module::adapters::bluebubbles::BlueBubblesInboundAdapter;
 use scheduler_module::adapters::lark::LarkInboundAdapter;
 use scheduler_module::adapters::postmark::PostmarkInboundPayload;
 use scheduler_module::adapters::slack::{
-    is_url_verification, SlackChallengeResponse, SlackEventWrapper, SlackInboundAdapter,
+    is_url_verification, slack_message_subtype_is_supported_for_inbound, SlackChallengeResponse,
+    SlackEventWrapper, SlackInboundAdapter,
 };
 use scheduler_module::adapters::telegram::TelegramInboundAdapter;
 use scheduler_module::adapters::wechat::WeChatInboundAdapter;
@@ -328,7 +329,7 @@ fn should_enqueue_slack_message(wrapper: &SlackEventWrapper, bot_user_id: Option
     let Some(event) = wrapper.event.as_ref() else {
         return false;
     };
-    if event.subtype.is_some() {
+    if !slack_message_subtype_is_supported_for_inbound(event.subtype.as_deref()) {
         return false;
     }
     // Filter out bot messages to prevent self-loops
@@ -2188,6 +2189,35 @@ mod tests {
                 event_ts: None,
             }),
             event_id: Some("Ev3".to_string()),
+            event_time: None,
+        };
+
+        assert!(should_enqueue_slack_message(&wrapper, None));
+    }
+
+    #[test]
+    fn should_enqueue_slack_message_accepts_file_share_dm_message() {
+        let wrapper = SlackEventWrapper {
+            event_type: "event_callback".to_string(),
+            challenge: None,
+            token: None,
+            team_id: Some("T1".to_string()),
+            api_app_id: Some("A1".to_string()),
+            event: Some(SlackMessageEvent {
+                event_type: "message".to_string(),
+                subtype: Some("file_share".to_string()),
+                channel: Some("D1".to_string()),
+                user: Some("U1".to_string()),
+                text: Some("project zip attached".to_string()),
+                ts: "1.031".to_string(),
+                thread_ts: None,
+                bot_id: None,
+                app_id: None,
+                files: None,
+                channel_type: Some("im".to_string()),
+                event_ts: None,
+            }),
+            event_id: Some("Ev3_file_share".to_string()),
             event_time: None,
         };
 

--- a/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
@@ -9,7 +9,7 @@ use crate::account_store::AccountStore;
 use crate::adapters::slack::SlackEventWrapper;
 use crate::channel::{Channel, InboundAdapter};
 use crate::index_store::IndexStore;
-use crate::slack_store::SlackStore;
+use crate::slack_store::{resolve_slack_bot_token_for_runtime, SlackStore};
 use crate::thread_state::ThreadState;
 use crate::user_store::{UserPaths, UserRecord, UserStore};
 use crate::{ModuleExecutor, RunTaskTask, Scheduler, TaskKind};
@@ -308,6 +308,15 @@ pub(crate) fn persist_slack_ingest_context(
         raw_payload,
         thread_state.last_email_seq,
     )?;
+    if let Err(err) =
+        hydrate_slack_attachments(config, &workspace, raw_payload, thread_state.last_email_seq)
+    {
+        warn!(
+            "failed to hydrate Slack attachments for {}: {}",
+            workspace.display(),
+            err
+        );
+    }
 
     Ok(PersistedSlackContext {
         user,
@@ -505,10 +514,391 @@ fn build_slack_workspace_payload(
     })
 }
 
+fn hydrate_slack_attachments(
+    config: &ServiceConfig,
+    workspace: &Path,
+    raw_payload: &[u8],
+    seq: u64,
+) -> Result<(), BoxError> {
+    let incoming_attachments = workspace.join("incoming_attachments");
+    let entries_dir = incoming_attachments.join("entries");
+    std::fs::create_dir_all(&entries_dir)?;
+    clear_dir_except(&incoming_attachments, &entries_dir)?;
+
+    if raw_payload.is_empty() {
+        return Ok(());
+    }
+
+    let wrapper: SlackEventWrapper = match serde_json::from_slice(raw_payload) {
+        Ok(value) => value,
+        Err(err) => {
+            warn!(
+                "failed to parse slack raw payload for attachment hydration: {}",
+                err
+            );
+            return Ok(());
+        }
+    };
+
+    let team_id = wrapper.team_id.clone();
+    let attachments = wrapper
+        .event
+        .and_then(|event| event.files)
+        .unwrap_or_default();
+    if attachments.is_empty() {
+        return Ok(());
+    }
+
+    let Some(bot_token) =
+        resolve_slack_bot_token_for_runtime(team_id.as_deref(), Some(&config.employee_profile.id))
+    else {
+        warn!(
+            "unable to download Slack attachments for workspace {}: missing runtime bot token (team_id={})",
+            workspace.display(),
+            team_id.as_deref().unwrap_or("")
+        );
+        return Ok(());
+    };
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+    let entry_dir = entries_dir.join(format!("{:05}_slack_attachments", seq));
+    std::fs::create_dir_all(&entry_dir)?;
+
+    let mut saved = 0usize;
+    let mut used_names = HashSet::new();
+    for attachment in attachments {
+        let source_name = attachment
+            .name
+            .as_deref()
+            .or(attachment.title.as_deref())
+            .unwrap_or("attachment");
+        let file_name = ascii_safe_attachment_name(source_name, &mut used_names);
+        match download_slack_attachment(&client, &attachment, &bot_token) {
+            Ok(bytes) => {
+                std::fs::write(incoming_attachments.join(&file_name), &bytes)?;
+                std::fs::write(entry_dir.join(&file_name), &bytes)?;
+                saved += 1;
+            }
+            Err(err) => {
+                warn!(
+                    "failed to download Slack attachment '{}' for workspace {}: {}",
+                    source_name,
+                    workspace.display(),
+                    err
+                );
+            }
+        }
+    }
+
+    if saved > 0 {
+        info!(
+            "saved {} Slack attachment(s) seq={} to {}",
+            saved,
+            seq,
+            incoming_attachments.display()
+        );
+    }
+
+    if let Err(err) =
+        refresh_thread_input_snapshot(&workspace.join("incoming_email"), &incoming_attachments)
+    {
+        warn!(
+            "failed to refresh Slack thread input snapshot after attachment hydration for {}: {}",
+            workspace.display(),
+            err
+        );
+    }
+
+    Ok(())
+}
+
+fn download_slack_attachment(
+    client: &reqwest::blocking::Client,
+    attachment: &crate::adapters::slack::SlackFile,
+    bot_token: &str,
+) -> Result<Vec<u8>, BoxError> {
+    let mut candidate_urls = Vec::new();
+    if let Some(url) = attachment
+        .url_private_download
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        candidate_urls.push(url.to_string());
+    }
+    if let Some(url) = attachment
+        .url_private
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if !candidate_urls.iter().any(|existing| existing == url) {
+            candidate_urls.push(url.to_string());
+        }
+    }
+
+    if candidate_urls.is_empty() {
+        let attachment_name = attachment
+            .name
+            .as_deref()
+            .or(attachment.title.as_deref())
+            .unwrap_or("attachment");
+        return Err(format!(
+            "no downloadable Slack URL found for attachment '{}'",
+            attachment_name
+        )
+        .into());
+    }
+
+    let mut last_error = None;
+    for url in candidate_urls {
+        match download_slack_attachment_from_url(client, &url, bot_token) {
+            Ok(bytes) => return Ok(bytes),
+            Err(err) => {
+                last_error = Some(format!("{url}: {err}"));
+            }
+        }
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| "unknown Slack attachment download error".to_string())
+        .into())
+}
+
+fn download_slack_attachment_from_url(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    bot_token: &str,
+) -> Result<Vec<u8>, BoxError> {
+    let response = client
+        .get(url)
+        .header("Authorization", format!("Bearer {}", bot_token))
+        .send()?;
+    if !response.status().is_success() {
+        return Err(format!("slack attachment download returned {}", response.status()).into());
+    }
+
+    Ok(response.bytes()?.to_vec())
+}
+
+fn clear_dir_except(root: &Path, keep: &Path) -> Result<(), std::io::Error> {
+    if !root.exists() {
+        std::fs::create_dir_all(root)?;
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path == keep {
+            continue;
+        }
+        if path.is_dir() {
+            std::fs::remove_dir_all(path)?;
+        } else {
+            std::fs::remove_file(path)?;
+        }
+    }
+    Ok(())
+}
+
+fn ascii_safe_attachment_name(path: &str, used_names: &mut HashSet<String>) -> String {
+    let trimmed = path.trim();
+    let (stem, extension) = match trimmed.rsplit_once('.') {
+        Some((stem, extension)) if !stem.is_empty() && !extension.is_empty() => {
+            (stem, Some(extension))
+        }
+        _ => (trimmed, None),
+    };
+    let mut base = sanitize_ascii_attachment_stem(stem);
+    if base.is_empty() {
+        base = "attachment".to_string();
+    }
+
+    let extension = extension
+        .map(sanitize_ascii_attachment_extension)
+        .filter(|value| !value.is_empty());
+    uniquify_attachment_name(base, extension.as_deref(), used_names)
+}
+
+fn sanitize_ascii_attachment_stem(value: &str) -> String {
+    let mut output = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            output.push(ch.to_ascii_lowercase());
+        } else if matches!(ch, '.' | '_' | '-') {
+            output.push(ch);
+        } else if !output.ends_with('_') {
+            output.push('_');
+        }
+    }
+    let trimmed = output.trim_matches(['.', '_', '-']);
+    truncate_ascii(trimmed, 80)
+}
+
+fn sanitize_ascii_attachment_extension(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect()
+}
+
+fn uniquify_attachment_name(
+    base: String,
+    extension: Option<&str>,
+    used_names: &mut HashSet<String>,
+) -> String {
+    let build_name = |suffix: Option<usize>| match (extension, suffix) {
+        (Some(ext), Some(idx)) => format!("{base}_{idx}.{ext}"),
+        (Some(ext), None) => format!("{base}.{ext}"),
+        (None, Some(idx)) => format!("{base}_{idx}"),
+        (None, None) => base.clone(),
+    };
+
+    let mut candidate = build_name(None);
+    if used_names.insert(candidate.clone()) {
+        return candidate;
+    }
+
+    for idx in 2..10_000 {
+        candidate = build_name(Some(idx));
+        if used_names.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+
+    build_name(Some(10_000))
+}
+
+fn truncate_ascii(value: &str, max_len: usize) -> String {
+    if value.len() <= max_len {
+        return value.to_string();
+    }
+    let mut out = value[..max_len].to_string();
+    while out.ends_with(['.', '_', '-']) {
+        out.pop();
+    }
+    if out.is_empty() {
+        value.to_string()
+    } else {
+        out
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::channel::{Channel, ChannelMetadata, InboundMessage};
+    use crate::employee_config::{EmployeeDirectory, EmployeeProfile};
+    use mockito::Server;
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::path::Path;
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::TempDir;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    fn build_test_config(root: &Path) -> ServiceConfig {
+        let users_root = root.join("users");
+        let state_root = root.join("state");
+
+        let addresses = vec!["service@example.com".to_string()];
+        let address_set: HashSet<String> = addresses
+            .iter()
+            .map(|value| value.to_ascii_lowercase())
+            .collect();
+        let employee = EmployeeProfile {
+            id: "test-employee".to_string(),
+            display_name: None,
+            runner: "codex".to_string(),
+            model: None,
+            addresses,
+            address_set: address_set.clone(),
+            runtime_root: None,
+            agents_path: None,
+            claude_path: None,
+            soul_path: None,
+            skills_dir: None,
+            discord_enabled: false,
+            slack_enabled: false,
+            bluebubbles_enabled: false,
+        };
+        let mut employee_by_id = HashMap::new();
+        employee_by_id.insert(employee.id.clone(), employee.clone());
+        let employee_directory = EmployeeDirectory {
+            employees: vec![employee.clone()],
+            employee_by_id,
+            default_employee_id: Some(employee.id.clone()),
+            service_addresses: address_set,
+        };
+
+        ServiceConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            employee_id: employee.id.clone(),
+            employee_config_path: root.join("employee.toml"),
+            employee_profile: employee,
+            employee_directory,
+            workspace_root: root.join("workspaces"),
+            scheduler_state_path: state_root.join("tasks.db"),
+            processed_ids_path: state_root.join("processed_ids.txt"),
+            ingestion_db_url: "postgres://localhost/test".to_string(),
+            ingestion_poll_interval: Duration::from_millis(50),
+            users_root,
+            users_db_path: state_root.join("users.db"),
+            task_index_path: state_root.join("task_index.db"),
+            codex_model: "gpt-5.4".to_string(),
+            codex_disabled: true,
+            scheduler_poll_interval: Duration::from_millis(50),
+            scheduler_max_concurrency: 1,
+            scheduler_user_max_concurrency: 1,
+            inbound_body_max_bytes: crate::service::DEFAULT_INBOUND_BODY_MAX_BYTES,
+            skills_source_dir: None,
+            slack_bot_token: None,
+            slack_bot_user_id: None,
+            slack_store_path: state_root.join("slack.db"),
+            slack_client_id: None,
+            slack_client_secret: None,
+            slack_redirect_uri: None,
+            discord_bot_token: None,
+            discord_bot_user_id: None,
+            google_docs_enabled: false,
+            bluebubbles_url: None,
+            bluebubbles_password: None,
+            telegram_bot_token: None,
+            whatsapp_access_token: None,
+            whatsapp_phone_number_id: None,
+            whatsapp_verify_token: None,
+        }
+    }
 
     fn build_message(text: &str, thread_id: &str, message_id: &str) -> InboundMessage {
         InboundMessage {
@@ -619,5 +1009,71 @@ mod tests {
             slack_message_task_id(&first),
             slack_message_task_id(&second)
         );
+    }
+
+    #[test]
+    fn hydrate_slack_attachments_downloads_file_share_attachments() -> Result<(), BoxError> {
+        let _guard = env_lock().lock().expect("env lock");
+        let temp = TempDir::new()?;
+        let root = temp.path();
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace)?;
+
+        let _employee_token =
+            EnvGuard::set("TEST_EMPLOYEE_SLACK_BOT_TOKEN", "xoxb-test-employee-token");
+        let config = build_test_config(root);
+
+        let mut server = Server::new();
+        let attachment_bytes = b"zip-bytes";
+        let attachment_mock = server
+            .mock("GET", "/files/SkyShake.zip")
+            .match_header("authorization", "Bearer xoxb-test-employee-token")
+            .with_status(200)
+            .with_body(attachment_bytes.as_slice())
+            .create();
+
+        let raw_payload = serde_json::to_vec(&serde_json::json!({
+            "type": "event_callback",
+            "team_id": "T123",
+            "event": {
+                "type": "message",
+                "subtype": "file_share",
+                "channel": "D123",
+                "channel_type": "im",
+                "user": "U123",
+                "text": "Attached project zip",
+                "ts": "1700.1",
+                "files": [{
+                    "id": "F123",
+                    "name": "SkyShake.zip",
+                    "title": "SkyShake.zip",
+                    "mimetype": "application/zip",
+                    "url_private_download": format!("{}/files/SkyShake.zip", server.url())
+                }]
+            },
+            "event_id": "Ev123"
+        }))?;
+
+        hydrate_slack_attachments(&config, &workspace, &raw_payload, 7)?;
+
+        attachment_mock.assert();
+
+        let attachment_path = workspace.join("incoming_attachments").join("skyshake.zip");
+        assert_eq!(fs::read(&attachment_path)?, attachment_bytes);
+
+        let archived_attachment = workspace
+            .join("incoming_attachments")
+            .join("entries")
+            .join("00007_slack_attachments")
+            .join("skyshake.zip");
+        assert_eq!(fs::read(archived_attachment)?, attachment_bytes);
+
+        let manifest = fs::read_to_string(
+            workspace
+                .join("incoming_attachments")
+                .join("thread_manifest.json"),
+        )?;
+        assert!(manifest.contains("skyshake.zip"));
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- allow Slack `message` events with subtype `file_share` through the gateway and inbound parser instead of dropping all subtypes
- hydrate Slack file attachments into `incoming_attachments/` so file-share requests actually reach the workspace with their files
- add focused coverage for parser acceptance, gateway acceptance, and attachment hydration

## Testing
- `cargo test -p scheduler_module --lib parse_file_share_message_subtype -- --nocapture`
- `cargo test -p scheduler_module --lib hydrate_slack_attachments_downloads_file_share_attachments -- --nocapture`
- `cargo check -p scheduler_module --bin inbound_gateway`

## Notes
- I intentionally staged only the Slack-related files for this PR; other local workspace changes remain uncommitted.
