### PR TITLE
feat: add TPM-focused /oliver hook landing page

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -78,6 +78,7 @@ If you are using a dedicated API subdomain (example: `api.dowhiz.com`) for the R
 
 ## Core route map
 - `/`: Oliver-first landing page with a clear onboarding path.
+- `/oliver`: TPM-focused hook landing page that keeps the current DoWhiz auth/dashboard handoff.
 - `/start`: Legacy startup intake route retained for backward compatibility.
 - `/workspace`: Legacy workspace route that is no longer part of the primary product journey.
 - `/dashboard`: Internal analytics dashboard (supporting page, not the primary product home).
@@ -86,7 +87,7 @@ If you are using a dedicated API subdomain (example: `api.dowhiz.com`) for the R
 
 ## Routing and hosting notes
 - SPA routing uses `BrowserRouter`, so direct deep links require host rewrites to `/index.html`.
-- On Vercel, rewrite coverage is defined in `website/vercel.json`, including `/start`, `/workspace`, and `/dashboard`.
+- On Vercel, rewrite coverage is defined in `website/vercel.json`, including `/start`, `/oliver`, `/workspace`, and `/dashboard`.
 - On VM/Nginx hosting, `try_files $uri /index.html;` is required for SPA routes.
 
 ## Environment variables

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -2691,7 +2691,25 @@
       const ANALYTICS_ANON_KEY = 'dowhiz_analytics_anonymous_id';
       const ANALYTICS_SESSION_KEY = 'dowhiz_analytics_session_id';
       const ANALYTICS_ATTRIBUTION_KEY = 'dowhiz_analytics_attribution';
+      const AUTH_ENTRY_SURFACE_KEY = 'dowhiz_auth_entry_surface';
       const STARTUP_BLUEPRINT_STORAGE_KEY = 'dowhiz_startup_workspace_blueprint_v1';
+      const OLIVER_TPM_ENTRY_SURFACE = 'oliver_tpm';
+      const AUTH_ENTRY_COPY = {
+        [OLIVER_TPM_ENTRY_SURFACE]: {
+          authTitle: 'Run your work with Oliver',
+          authSubtitle:
+            'Sign in to review follow-through, connect the tools Oliver watches, and keep cross-functional context up to date.',
+          dashboardTitle: 'Your Oliver TPM workspace',
+          dashboardSubtitle:
+            'Review signals, follow-through, and the current setup Oliver uses to keep work moving.',
+          sidebarEyebrow: 'Oliver for TPMs',
+          sidebarTitle: 'TPM workspace',
+          sidebarDescription:
+            'Keep the next move, live signals, and the follow-through Oliver is coordinating in one place.',
+          overviewCopy: 'One clear next move, your live execution signals, and the follow-through that needs review.'
+        }
+      };
+      let activeEntrySurface = null;
 
       function analyticsGenerateId(prefix) {
         if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -2724,6 +2742,41 @@
         if (value === undefined || value === null) return null;
         const trimmed = String(value).trim();
         return trimmed.length ? trimmed : null;
+      }
+
+      function normalizeEntrySurface(value) {
+        const normalized = normalizeOptional(value);
+        return normalized === OLIVER_TPM_ENTRY_SURFACE ? normalized : null;
+      }
+
+      function readAuthEntrySurfaceFromSession() {
+        try {
+          return normalizeEntrySurface(window.sessionStorage.getItem(AUTH_ENTRY_SURFACE_KEY));
+        } catch {
+          return null;
+        }
+      }
+
+      function writeAuthEntrySurfaceToSession(value) {
+        try {
+          const normalized = normalizeEntrySurface(value);
+          if (!normalized) {
+            window.sessionStorage.removeItem(AUTH_ENTRY_SURFACE_KEY);
+            return;
+          }
+          window.sessionStorage.setItem(AUTH_ENTRY_SURFACE_KEY, normalized);
+        } catch {
+          // Ignore storage failures so auth never depends on storage.
+        }
+      }
+
+      function resolveAuthEntrySurface(params, expectingDashboard) {
+        const requested = normalizeEntrySurface(params.get('entry'));
+        if (requested) {
+          writeAuthEntrySurfaceToSession(requested);
+          return requested;
+        }
+        return expectingDashboard ? readAuthEntrySurfaceFromSession() : null;
       }
 
       function inferDeviceType(userAgent) {
@@ -2808,6 +2861,7 @@
           utm_campaign: attribution.utm_campaign || null,
           utm_term: attribution.utm_term || null,
           utm_content: attribution.utm_content || null,
+          entry_surface: activeEntrySurface || null,
           device_type: inferDeviceType(ua),
           browser: inferBrowser(ua),
           os: inferOs(ua),
@@ -2857,6 +2911,10 @@
       const authMessage = document.getElementById('auth-message');
       const pageTitle = document.getElementById('page-title');
       const pageSubtitle = document.getElementById('page-subtitle');
+      const dashboardSidebarEyebrow = document.querySelector('.sidebar-eyebrow');
+      const dashboardSidebarTitle = document.querySelector('.sidebar-title');
+      const dashboardSidebarDescription = document.querySelector('.sidebar-description');
+      const dashboardOverviewCopy = document.querySelector('#section-overview .dashboard-overview-copy');
       const existingAccountContainer = document.getElementById('existing-account-container');
       const existingAccountEmail = document.getElementById('existing-account-email');
       const sendResetEmailBtn = document.getElementById('send-reset-email');
@@ -2937,10 +2995,39 @@
       let cachedBalance = null;
       let pendingConnectionOnboarding = loadPendingConnectionOnboardingFromStorage();
 
+      function applyEntryAwareCopy(options = {}) {
+        const copy = AUTH_ENTRY_COPY[activeEntrySurface];
+        if (!copy) {
+          return;
+        }
+
+        const dashboardMode = options.dashboardMode === true;
+
+        if (pageTitle) {
+          pageTitle.textContent = dashboardMode ? copy.dashboardTitle : copy.authTitle;
+        }
+        if (pageSubtitle) {
+          pageSubtitle.textContent = dashboardMode ? copy.dashboardSubtitle : copy.authSubtitle;
+        }
+        if (dashboardSidebarEyebrow) {
+          dashboardSidebarEyebrow.textContent = copy.sidebarEyebrow;
+        }
+        if (dashboardSidebarTitle) {
+          dashboardSidebarTitle.textContent = copy.sidebarTitle;
+        }
+        if (dashboardSidebarDescription) {
+          dashboardSidebarDescription.textContent = copy.sidebarDescription;
+        }
+        if (dashboardOverviewCopy) {
+          dashboardOverviewCopy.textContent = copy.overviewCopy;
+        }
+      }
+
       // Check if user came from logged-in state (expecting dashboard)
       const authQueryParams = new URLSearchParams(window.location.search);
       const expectingDashboard = authQueryParams.get('loggedIn') === 'true';
       const popupAuthFlow = authQueryParams.get('popupAuth') === '1';
+      activeEntrySurface = resolveAuthEntrySurface(authQueryParams, expectingDashboard);
       const authIntentParams = new URLSearchParams();
       if (expectingDashboard) {
         authIntentParams.set('loggedIn', 'true');
@@ -2957,12 +3044,14 @@
         setDashboardMode(false);
         signinFormContainer.classList.remove('hidden');
       }
+      applyEntryAwareCopy({ dashboardMode: false });
 
       persistAttributionFromLocation();
       trackAnalyticsEvent(
         'signup_page_view',
         {
-          entry_mode: expectingDashboard ? 'logged_in_redirect' : 'direct'
+          entry_mode: expectingDashboard ? 'logged_in_redirect' : 'direct',
+          entry_surface: activeEntrySurface
         },
         {
           eventKey: `signup_page_view:${getOrCreateSessionId()}:${window.location.pathname}`
@@ -5693,6 +5782,7 @@
         dashboardContainer.classList.remove('hidden');
         pageTitle.textContent = 'Your Oliver setup';
         pageSubtitle.textContent = 'Connect apps, review tasks, save memory, and decide how Oliver should work for you.';
+        applyEntryAwareCopy({ dashboardMode: true });
 
         document.getElementById('account-id').textContent = accountData.account_id;
         document.getElementById('user-email').textContent = session.user.email;

--- a/website/public/theme.js
+++ b/website/public/theme.js
@@ -188,7 +188,7 @@
 
   function shouldMountSharedNav() {
     const pathname = getContentPathname(window.location.pathname);
-    return pathname !== '/' && pathname !== '/index.html';
+    return pathname !== '/' && pathname !== '/index.html' && pathname !== '/oliver' && pathname !== '/oliver/';
   }
 
   function getActiveNavHref(pathname) {

--- a/website/src/app/AppRouter.jsx
+++ b/website/src/app/AppRouter.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import LandingPage from '../pages/LandingPage';
+import OliverLandingPage from '../pages/OliverLandingPage';
 import StartupIntakePage from '../pages/StartupIntakePage';
 import WorkspaceDemoPage from '../pages/WorkspaceDemoPage';
 import WorkspaceHomePage from '../pages/WorkspaceHomePage';
@@ -11,6 +12,7 @@ function AppRouter() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<LandingPage locale="en-US" />} />
+        <Route path="/oliver" element={<OliverLandingPage />} />
         <Route path="/cn" element={<LandingPage locale="zh-CN" />} />
         <Route path="/cn/*" element={<LandingPage locale="zh-CN" />} />
         <Route path="/start" element={<StartupIntakePage />} />

--- a/website/src/pages/OliverLandingPage.jsx
+++ b/website/src/pages/OliverLandingPage.jsx
@@ -1,0 +1,494 @@
+import { useEffect, useState } from 'react';
+import {
+  getOrCreateSessionId,
+  persistAttributionFromLocation,
+  trackAnalyticsEvent
+} from '../analytics';
+import { getThemeForLocalTime, LOCAL_THEME_CHANGE_EVENT, THEME_META_COLORS } from '../theme/localTheme';
+import {
+  OLIVER_AUTH_OVERVIEW_HREF,
+  OLIVER_AUTH_WORK_HREF,
+  OLIVER_ENTRY_SURFACE,
+  OLIVER_LANDING_VARIANT,
+  oliverLandingContent
+} from './oliverLandingContent';
+
+const updateMetaContent = (selector, content) => {
+  if (typeof document === 'undefined' || !content) {
+    return;
+  }
+
+  const node = document.querySelector(selector);
+  if (node) {
+    node.setAttribute('content', content);
+  }
+};
+
+const updateLinkHref = (selector, href) => {
+  if (typeof document === 'undefined' || !href) {
+    return;
+  }
+
+  const node = document.querySelector(selector);
+  if (node) {
+    node.setAttribute('href', href);
+  }
+};
+
+function ArrowUpRightIcon() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path
+        d="M6 14L14 6M8 6h6v6"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CheckLineIcon() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path
+        d="M4.5 10.5l3.3 3.3L15.5 6"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function OliverLandingPage() {
+  const [theme, setTheme] = useState(() => getThemeForLocalTime());
+  const content = oliverLandingContent;
+
+  useEffect(() => {
+    persistAttributionFromLocation();
+    const sessionId = getOrCreateSessionId();
+
+    trackAnalyticsEvent(
+      'landing_page_view',
+      {
+        landing_page_variant: OLIVER_LANDING_VARIANT,
+        landing_story: 'tpm_hook',
+        entry_surface: OLIVER_ENTRY_SURFACE,
+        role_focus: 'tpm'
+      },
+      {
+        eventKey: `landing_page_view:${sessionId}:/oliver`,
+        routePath: '/oliver',
+        pagePath:
+          typeof window !== 'undefined'
+            ? `${window.location.pathname}${window.location.search}`
+            : '/oliver'
+      }
+    );
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    document.documentElement.lang = content.metadata.htmlLang;
+    document.title = content.metadata.title;
+
+    updateMetaContent('meta[name="description"]', content.metadata.description);
+    updateMetaContent('meta[name="robots"]', content.metadata.robots);
+    updateMetaContent('meta[property="og:title"]', content.metadata.title);
+    updateMetaContent('meta[property="og:description"]', content.metadata.description);
+    updateMetaContent('meta[property="og:url"]', content.metadata.canonicalUrl);
+    updateMetaContent('meta[property="og:locale"]', content.metadata.ogLocale);
+    updateMetaContent('meta[property="og:image"]', content.metadata.ogImage);
+    updateMetaContent('meta[property="og:image:alt"]', content.metadata.ogImageAlt);
+    updateMetaContent('meta[name="twitter:title"]', content.metadata.title);
+    updateMetaContent('meta[name="twitter:description"]', content.metadata.description);
+    updateMetaContent('meta[name="twitter:image"]', content.metadata.ogImage);
+    updateLinkHref('link[rel="canonical"]', content.metadata.canonicalUrl);
+  }, [content.metadata]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const syncTheme = (event) => {
+      setTheme(event?.detail?.theme || getThemeForLocalTime());
+    };
+
+    syncTheme();
+    window.addEventListener(LOCAL_THEME_CHANGE_EVENT, syncTheme);
+
+    return () => {
+      window.removeEventListener(LOCAL_THEME_CHANGE_EVENT, syncTheme);
+    };
+  }, []);
+
+  useEffect(() => {
+    updateMetaContent('meta[name="theme-color"]', THEME_META_COLORS[theme] || content.metadata.themeColor);
+  }, [content.metadata.themeColor, theme]);
+
+  const trackLandingInteraction = (eventName, properties = {}) => {
+    trackAnalyticsEvent(eventName, {
+      landing_page_variant: OLIVER_LANDING_VARIANT,
+      landing_story: 'tpm_hook',
+      entry_surface: OLIVER_ENTRY_SURFACE,
+      ...properties
+    });
+  };
+
+  return (
+    <div className="app-container oliver-hook-page">
+      <div className="oliver-hook-noise" aria-hidden="true" />
+      <div className="content-layer">
+        <header className="oliver-hook-nav">
+          <div className="oliver-hook-nav-inner">
+            <a href="/" className="oliver-hook-brand" aria-label="Back to the DoWhiz homepage">
+              <img src="/assets/DoWhiz.svg" alt="" className="oliver-hook-brand-mark" aria-hidden="true" />
+              <span className="oliver-hook-brand-copy">
+                Do<span className="text-gradient">Whiz</span>
+              </span>
+            </a>
+
+            <nav className="oliver-hook-links" aria-label="Oliver page sections">
+              {content.nav.links.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className="oliver-hook-link"
+                  onClick={() =>
+                    trackLandingInteraction('secondary_cta_click', {
+                      cta_location: 'oliver_nav',
+                      cta_text: link.label
+                    })
+                  }
+                >
+                  {link.label}
+                </a>
+              ))}
+            </nav>
+
+            <div className="oliver-hook-nav-actions">
+              <a
+                className="btn btn-secondary oliver-hook-nav-secondary"
+                href={OLIVER_AUTH_WORK_HREF}
+                onClick={() =>
+                  trackLandingInteraction('secondary_cta_click', {
+                    cta_location: 'oliver_nav_work',
+                    cta_text: content.nav.secondaryCta
+                  })
+                }
+              >
+                {content.nav.secondaryCta}
+              </a>
+              <a
+                className="btn btn-primary oliver-hook-nav-primary"
+                href={OLIVER_AUTH_OVERVIEW_HREF}
+                onClick={() =>
+                  trackLandingInteraction('primary_cta_click', {
+                    cta_location: 'oliver_nav_open',
+                    cta_text: content.nav.primaryCta
+                  })
+                }
+              >
+                {content.nav.primaryCta}
+              </a>
+            </div>
+          </div>
+        </header>
+
+        <main className="oliver-hook-main">
+          <section className="oliver-hook-hero" id="top">
+            <div className="container oliver-hook-hero-grid">
+              <div className="oliver-hook-copy">
+                <p className="oliver-hook-eyebrow">{content.hero.eyebrow}</p>
+                <h1 className="oliver-hook-title">{content.hero.title}</h1>
+                <p className="oliver-hook-subtitle">{content.hero.subtitle}</p>
+
+                <div className="oliver-hook-pill-row" aria-label="Key TPM outputs">
+                  {content.hero.proofPills.map((item) => (
+                    <span key={item} className="oliver-hook-pill">
+                      {item}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="oliver-hook-cta-row">
+                  <a
+                    className="btn btn-primary oliver-hook-primary-button"
+                    href={OLIVER_AUTH_OVERVIEW_HREF}
+                    onClick={() =>
+                      trackLandingInteraction('primary_cta_click', {
+                        cta_location: 'hero_primary_open_oliver',
+                        cta_text: content.hero.primaryCta
+                      })
+                    }
+                  >
+                    {content.hero.primaryCta}
+                  </a>
+                  <a
+                    className="btn btn-secondary oliver-hook-secondary-button"
+                    href="#proof"
+                    onClick={() =>
+                      trackLandingInteraction('secondary_cta_click', {
+                        cta_location: 'hero_secondary_outputs',
+                        cta_text: content.hero.secondaryCta
+                      })
+                    }
+                  >
+                    {content.hero.secondaryCta}
+                  </a>
+                </div>
+
+                <p className="oliver-hook-note">{content.hero.note}</p>
+              </div>
+
+              <aside className="oliver-hook-hero-panel" aria-label="Oliver launch review preview">
+                <div className="oliver-hook-hero-panel-head">
+                  <div>
+                    <p className="oliver-hook-panel-label">{content.hero.artifact.label}</p>
+                    <h2>{content.hero.artifact.title}</h2>
+                  </div>
+                  <div className="oliver-hook-health">
+                    <span className="oliver-hook-health-badge">{content.hero.artifact.healthLabel}</span>
+                    <span className="oliver-hook-health-detail">{content.hero.artifact.healthDetail}</span>
+                  </div>
+                </div>
+
+                <div className="oliver-hook-signal-band" aria-label="Signal sources">
+                  {content.hero.artifact.signalSources.map((item) => (
+                    <span key={item} className="oliver-hook-signal-chip">
+                      {item}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="oliver-hook-hero-panel-grid">
+                  <section className="oliver-hook-artifact-card oliver-hook-artifact-card-update">
+                    <p className="oliver-hook-card-kicker">{content.hero.artifact.summary.label}</p>
+                    <p className="oliver-hook-card-copy">{content.hero.artifact.summary.text}</p>
+                  </section>
+
+                  <section className="oliver-hook-artifact-card oliver-hook-artifact-card-actions">
+                    <p className="oliver-hook-card-kicker">Actions ready</p>
+                    <ul className="oliver-hook-checklist">
+                      {content.hero.artifact.actions.map((item) => (
+                        <li key={`${item.owner}-${item.task}`}>
+                          <span className="oliver-hook-check-icon">
+                            <CheckLineIcon />
+                          </span>
+                          <div>
+                            <strong>{item.owner}</strong>
+                            <span>{item.task}</span>
+                          </div>
+                          <small>{item.due}</small>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                </div>
+
+                <section className="oliver-hook-artifact-card oliver-hook-artifact-card-risks">
+                  <div className="oliver-hook-card-row">
+                    <p className="oliver-hook-card-kicker">Current risks</p>
+                    <a
+                      href={OLIVER_AUTH_WORK_HREF}
+                      className="oliver-hook-inline-link"
+                      onClick={() =>
+                        trackLandingInteraction('secondary_cta_click', {
+                          cta_location: 'hero_risk_register',
+                          cta_text: 'Open current work view'
+                        })
+                      }
+                    >
+                      Open current work view
+                      <ArrowUpRightIcon />
+                    </a>
+                  </div>
+                  <ul className="oliver-hook-risk-list">
+                    {content.hero.artifact.risks.map((item) => (
+                      <li key={item.label}>
+                        <span className={`oliver-hook-risk-level oliver-hook-risk-level-${item.level.toLowerCase()}`}>
+                          {item.level}
+                        </span>
+                        <span>{item.label}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              </aside>
+            </div>
+          </section>
+
+          <section className="oliver-hook-section" id="proof">
+            <div className="container">
+              <div className="oliver-hook-section-head">
+                <p className="oliver-hook-section-eyebrow">{content.proof.eyebrow}</p>
+                <h2 className="oliver-hook-section-title">{content.proof.title}</h2>
+                <p className="oliver-hook-section-intro">{content.proof.intro}</p>
+              </div>
+
+              <div className="oliver-hook-proof-grid">
+                {content.proof.cards.map((card) => (
+                  <article key={card.title} className="oliver-hook-proof-card">
+                    <p className="oliver-hook-card-kicker">{card.eyebrow}</p>
+                    <h3>{card.title}</h3>
+                    <p>{card.summary}</p>
+                    <ul>
+                      {card.bullets.map((bullet) => (
+                        <li key={bullet}>{bullet}</li>
+                      ))}
+                    </ul>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-hook-section" id="ownership">
+            <div className="container">
+              <div className="oliver-hook-section-head">
+                <p className="oliver-hook-section-eyebrow">{content.ownership.eyebrow}</p>
+                <h2 className="oliver-hook-section-title">{content.ownership.title}</h2>
+                <p className="oliver-hook-section-intro">{content.ownership.intro}</p>
+              </div>
+
+              <div className="oliver-hook-outcome-grid">
+                {content.ownership.cards.map((card) => (
+                  <article key={card.title} className="oliver-hook-outcome-card">
+                    <h3>{card.title}</h3>
+                    <p>{card.description}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-hook-section oliver-hook-workflow-section" id="workflow">
+            <div className="container oliver-hook-workflow-layout">
+              <div className="oliver-hook-section-head oliver-hook-section-head-left">
+                <p className="oliver-hook-section-eyebrow">{content.workflow.eyebrow}</p>
+                <h2 className="oliver-hook-section-title">{content.workflow.title}</h2>
+              </div>
+
+              <div className="oliver-hook-workflow-list">
+                {content.workflow.steps.map((step) => (
+                  <article key={step.label} className="oliver-hook-step-card">
+                    <div className="oliver-hook-step-label">{step.label}</div>
+                    <div className="oliver-hook-step-copy">
+                      <h3>{step.title}</h3>
+                      <p>{step.description}</p>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-hook-section oliver-hook-tools-section" id="tools">
+            <div className="container oliver-hook-surface-card">
+              <div className="oliver-hook-surface-copy">
+                <p className="oliver-hook-section-eyebrow">{content.tools.eyebrow}</p>
+                <h2 className="oliver-hook-section-title">{content.tools.title}</h2>
+                <p className="oliver-hook-section-intro oliver-hook-section-intro-left">{content.tools.intro}</p>
+              </div>
+
+              <div className="oliver-hook-tool-chip-grid" aria-label="Signal sources Oliver can work across">
+                {content.tools.items.map((item) => (
+                  <span key={item} className="oliver-hook-tool-chip">
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-hook-section" id="controls">
+            <div className="container">
+              <div className="oliver-hook-section-head">
+                <p className="oliver-hook-section-eyebrow">{content.controls.eyebrow}</p>
+                <h2 className="oliver-hook-section-title">{content.controls.title}</h2>
+                <p className="oliver-hook-section-intro">{content.controls.intro}</p>
+              </div>
+
+              <div className="oliver-hook-control-grid">
+                {content.controls.cards.map((card) => (
+                  <article key={card.title} className="oliver-hook-control-card">
+                    <h3>{card.title}</h3>
+                    <p>{card.description}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-hook-section" id="faq">
+            <div className="container">
+              <div className="oliver-hook-section-head">
+                <p className="oliver-hook-section-eyebrow">{content.faq.eyebrow}</p>
+                <h2 className="oliver-hook-section-title">{content.faq.title}</h2>
+              </div>
+
+              <div className="oliver-hook-faq-grid">
+                {content.faq.items.map((item) => (
+                  <article key={item.question} className="oliver-hook-faq-card">
+                    <h3>{item.question}</h3>
+                    <p>{item.answer}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-hook-section oliver-hook-final-section">
+            <div className="container">
+              <div className="oliver-hook-final-card">
+                <p className="oliver-hook-section-eyebrow">{content.finalCta.eyebrow}</p>
+                <h2 className="oliver-hook-section-title">{content.finalCta.title}</h2>
+                <p className="oliver-hook-section-intro">{content.finalCta.description}</p>
+
+                <div className="oliver-hook-cta-row oliver-hook-final-actions">
+                  <a
+                    className="btn btn-primary oliver-hook-primary-button"
+                    href={OLIVER_AUTH_OVERVIEW_HREF}
+                    onClick={() =>
+                      trackLandingInteraction('primary_cta_click', {
+                        cta_location: 'final_primary_open_oliver',
+                        cta_text: content.finalCta.primaryCta
+                      })
+                    }
+                  >
+                    {content.finalCta.primaryCta}
+                  </a>
+                  <a
+                    className="btn btn-secondary oliver-hook-secondary-button"
+                    href={OLIVER_AUTH_WORK_HREF}
+                    onClick={() =>
+                      trackLandingInteraction('secondary_cta_click', {
+                        cta_location: 'final_secondary_work_view',
+                        cta_text: content.finalCta.secondaryCta
+                      })
+                    }
+                  >
+                    {content.finalCta.secondaryCta}
+                  </a>
+                </div>
+
+                <p className="oliver-hook-disclaimer">{content.finalCta.disclaimer}</p>
+              </div>
+            </div>
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default OliverLandingPage;

--- a/website/src/pages/oliverLandingContent.js
+++ b/website/src/pages/oliverLandingContent.js
@@ -1,0 +1,221 @@
+export const OLIVER_ENTRY_SURFACE = 'oliver_tpm';
+export const OLIVER_LANDING_VARIANT = 'oliver_tpm_hook_v1';
+export const OLIVER_AUTH_OVERVIEW_HREF = '/auth/index.html?loggedIn=true&entry=oliver_tpm#section-overview';
+export const OLIVER_AUTH_WORK_HREF = '/auth/index.html?loggedIn=true&entry=oliver_tpm#section-work';
+
+export const oliverLandingContent = {
+  metadata: {
+    title: 'Oliver by DoWhiz | AI TPM for product and engineering teams',
+    description:
+      'Oliver is the AI TPM for product and engineering teams. Turn scattered execution signals into status updates, risk flags, decision follow-through, and clear next moves.',
+    canonicalUrl: 'https://dowhiz.com/oliver',
+    robots: 'noindex, nofollow',
+    htmlLang: 'en',
+    ogLocale: 'en_US',
+    themeColor: '#eef1f5',
+    ogImage: 'https://dowhiz.com/assets/DoWhiz.svg',
+    ogImageAlt: 'Oliver TPM hook landing page preview'
+  },
+  nav: {
+    links: [
+      { href: '#proof', label: 'Outputs' },
+      { href: '#ownership', label: 'What Oliver Owns' },
+      { href: '#workflow', label: 'How It Works' },
+      { href: '#controls', label: 'Controls' }
+    ],
+    primaryCta: 'Open Oliver',
+    secondaryCta: 'See the work view'
+  },
+  hero: {
+    eyebrow: 'AI TPM for product and engineering teams',
+    title: 'Keep launches, updates, and follow-through moving.',
+    subtitle:
+      'Oliver turns scattered Slack threads, GitHub issues, meeting notes, and docs into owner-based next steps, status drafts, risk flags, and decision follow-through.',
+    note:
+      'This is a TPM-shaped entrypoint on top of the current DoWhiz auth and dashboard flow. The story is narrower now, not the underlying system.',
+    proofPills: [
+      'Weekly status drafts',
+      'Risk register',
+      'Decision follow-through',
+      'Owner nudges across tools'
+    ],
+    primaryCta: 'Open Oliver',
+    secondaryCta: 'See the outputs',
+    artifact: {
+      label: 'Cross-functional launch review',
+      title: 'Mobile release',
+      healthLabel: 'At risk',
+      healthDetail: '2 blockers, 1 pending decision',
+      signalSources: ['Slack blocker thread', 'GitHub regression', 'Meeting recap', 'Release notes draft'],
+      summary: {
+        label: 'Draft update',
+        text:
+          'Checkout is feature-complete, but QA sign-off is blocked by the payment callback regression. Android fallback is defined; iOS fallback still needs approval.'
+      },
+      actions: [
+        { owner: 'Engineering', task: 'Confirm callback fix ETA', due: 'Today, 3:00 PM' },
+        { owner: 'Product', task: 'Approve iOS fallback copy', due: 'Today, 4:30 PM' },
+        { owner: 'Ops', task: 'Update launch note once decision lands', due: 'Before send' }
+      ],
+      risks: [
+        { level: 'High', label: 'QA sign-off depends on one unresolved callback bug' },
+        { level: 'Medium', label: 'Fallback plan is partially drafted but not approved' }
+      ]
+    }
+  },
+  proof: {
+    eyebrow: 'Outputs',
+    title: 'Oliver proves the role through TPM artifacts, not chat.',
+    intro:
+      'The point is not another assistant panel. The point is producing the exact artifacts a TPM has to keep current and reviewable.',
+    cards: [
+      {
+        eyebrow: 'Weekly status update',
+        title: 'A draft you can send, not a transcript you still need to interpret',
+        summary:
+          'Oliver groups signal into what moved, what is blocked, and what needs leadership attention next.',
+        bullets: [
+          'Launch health, milestone movement, and current owner status',
+          'A short escalation block for risks that need help',
+          'A next-48-hours section that turns noise into concrete follow-through'
+        ]
+      },
+      {
+        eyebrow: 'Risk register',
+        title: 'A living view of blockers before they become surprises',
+        summary:
+          'Each risk tracks severity, owner, mitigation, and the next review point instead of vanishing inside threads.',
+        bullets: [
+          'Severity and impact stay explicit',
+          'Mitigation notes stay attached to the source signal',
+          'Owners and review dates stay visible until resolved'
+        ]
+      },
+      {
+        eyebrow: 'Decision log',
+        title: 'Decisions stay linked to owners, rationale, and the next move',
+        summary:
+          'Oliver flags unresolved calls, keeps the latest direction attached to the program, and tracks what each decision changed.',
+        bullets: [
+          'What was decided and why it matters',
+          'Who still needs to act on the decision',
+          'What Oliver should draft or follow up next'
+        ]
+      }
+    ]
+  },
+  ownership: {
+    eyebrow: 'What Oliver Owns',
+    title: 'The story only works if the work objects are clear.',
+    intro:
+      'Oliver should feel like an AI TPM, not a shape-shifting helper. These are the four outcomes this hook is optimizing for.',
+    cards: [
+      {
+        title: 'Turns messy threads into owner-based action plans',
+        description:
+          'He pulls the next move out of meetings, chat, issues, and scattered follow-up without asking you to rewrite everything yourself.'
+      },
+      {
+        title: 'Drafts stakeholder-ready status updates',
+        description:
+          'He turns execution signal into concise, reviewable updates instead of leaving you to translate raw progress on Friday afternoon.'
+      },
+      {
+        title: 'Surfaces risks before they become blockers',
+        description:
+          'He makes dependencies, slippage, and missing approvals visible early enough for you to intervene.'
+      },
+      {
+        title: 'Keeps decisions and follow-through from getting lost',
+        description:
+          'He remembers what changed, who owns the next step, and what still has to be chased down.'
+      }
+    ]
+  },
+  workflow: {
+    eyebrow: 'How Oliver Works',
+    title: 'A TPM loop, not a generic prompt box.',
+    steps: [
+      {
+        label: '01',
+        title: 'Collect signals',
+        description:
+          'Slack messages, GitHub issues, meeting notes, docs, and email become source material instead of isolated fragments.'
+      },
+      {
+        label: '02',
+        title: 'Build the operating picture',
+        description:
+          'Oliver groups what changed, what is blocked, who owns the next move, and which decisions are still open.'
+      },
+      {
+        label: '03',
+        title: 'Drive the next move',
+        description:
+          'He drafts updates, prepares follow-ups, and keeps the coordination loop alive until you review or send.'
+      }
+    ]
+  },
+  tools: {
+    eyebrow: 'Works Across Your Tools',
+    title: 'The tools are signal sources. They are not the product story.',
+    intro:
+      'Slack, GitHub, email, docs, and meetings matter because they hold execution signal. Oliver is the TPM layer that turns that signal into forward motion.',
+    items: ['Slack', 'GitHub', 'Email', 'Docs', 'Meeting notes', 'Shared trackers']
+  },
+  controls: {
+    eyebrow: 'Controls and Review',
+    title: 'You stay in control of the moves that matter.',
+    intro:
+      'This hook should not imply blind automation. The point is tighter follow-through with clear boundaries.',
+    cards: [
+      {
+        title: 'Review before send',
+        description: 'Draft updates and follow-ups can wait for your approval when the stakes are high.'
+      },
+      {
+        title: 'Bounded permissions',
+        description: 'Oliver should act inside the tools and scopes you explicitly connect, not through vague blanket access.'
+      },
+      {
+        title: 'Saved context',
+        description: 'Team norms, recurring deliverables, and known stakeholders should compound instead of being re-explained every time.'
+      },
+      {
+        title: 'Configurable follow-up rules',
+        description: 'You decide what deserves a nudge, what waits, and what should always stay human-reviewed.'
+      }
+    ]
+  },
+  faq: {
+    eyebrow: 'FAQ',
+    title: 'Narrow answers for a narrow story.',
+    items: [
+      {
+        question: 'Is Oliver replacing a TPM?',
+        answer:
+          'No. This hook is for teams that want tighter execution follow-through. You still review the output, decide what matters, and own the actual calls.'
+      },
+      {
+        question: 'Do I need to move my team into a new tool?',
+        answer:
+          'No. `/oliver` is just a TPM-shaped entrypoint. Sign-in and setup still hand off to the current DoWhiz auth and dashboard surface.'
+      },
+      {
+        question: 'Which teams is this for right now?',
+        answer:
+          'Product and engineering teams running launches, releases, migrations, or cross-functional work where follow-through and status clarity matter more than feature planning.'
+      }
+    ]
+  },
+  finalCta: {
+    eyebrow: 'Start Small',
+    title: 'Start with the launch or program that already feels too noisy.',
+    description:
+      'Bring one weekly review, one release train, or one cross-functional stream. If the story is right, the rest of the product can catch up behind it.',
+    primaryCta: 'Open Oliver',
+    secondaryCta: 'See the work view',
+    disclaimer:
+      'This is still the current DoWhiz account flow underneath. The experiment here is the TPM story, not a separate product backend.'
+  }
+};

--- a/website/src/styles/index.css
+++ b/website/src/styles/index.css
@@ -1,5 +1,6 @@
 @import './tokens.css';
 @import './base.css';
 @import './landing.css';
+@import './oliver-landing.css';
 @import './layout.css';
 @import './responsive.css';

--- a/website/src/styles/oliver-landing.css
+++ b/website/src/styles/oliver-landing.css
@@ -1,0 +1,823 @@
+.oliver-hook-page {
+  --oliver-accent: #c4652d;
+  --oliver-accent-soft: rgba(196, 101, 45, 0.12);
+  --oliver-ink-soft: rgba(16, 18, 22, 0.72);
+  --oliver-risk-high: #b9382e;
+  --oliver-risk-medium: #8e6200;
+  --oliver-grid-line: color-mix(in srgb, var(--border-subtle) 92%, transparent);
+  position: relative;
+  background:
+    radial-gradient(circle at 15% 10%, rgba(196, 101, 45, 0.16), transparent 34%),
+    radial-gradient(circle at 82% 18%, rgba(16, 18, 22, 0.08), transparent 30%),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--surface-primary) 96%, #fff4ea 4%) 0%,
+      color-mix(in srgb, var(--surface-primary) 92%, var(--surface-secondary)) 48%,
+      color-mix(in srgb, var(--surface-secondary) 84%, var(--surface-primary)) 100%
+    );
+}
+
+[data-theme='dark'] .oliver-hook-page {
+  --oliver-accent: #f0a36e;
+  --oliver-accent-soft: rgba(240, 163, 110, 0.12);
+  --oliver-ink-soft: rgba(243, 245, 247, 0.74);
+  --oliver-grid-line: rgba(243, 245, 247, 0.08);
+  --oliver-risk-high: #f38b84;
+  --oliver-risk-medium: #d8b050;
+  background:
+    radial-gradient(circle at 12% 14%, rgba(240, 163, 110, 0.12), transparent 34%),
+    radial-gradient(circle at 82% 14%, rgba(255, 255, 255, 0.06), transparent 26%),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--surface-secondary) 44%, var(--surface-primary)) 0%,
+      var(--surface-primary) 58%,
+      color-mix(in srgb, var(--surface-secondary) 74%, var(--surface-primary)) 100%
+    );
+}
+
+.oliver-hook-page::before,
+.oliver-hook-page::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.oliver-hook-page::before {
+  background:
+    linear-gradient(90deg, transparent 0, transparent calc(100% - 1px), var(--oliver-grid-line) 100%),
+    linear-gradient(180deg, transparent 0, transparent calc(100% - 1px), var(--oliver-grid-line) 100%);
+  background-size: 92px 92px;
+  opacity: 0.26;
+}
+
+.oliver-hook-page::after {
+  background: linear-gradient(180deg, transparent 0%, rgba(255, 255, 255, 0) 62%, rgba(255, 255, 255, 0.28) 100%);
+  mix-blend-mode: screen;
+  opacity: 0.25;
+}
+
+[data-theme='dark'] .oliver-hook-page::after {
+  background: linear-gradient(180deg, transparent 0%, rgba(255, 255, 255, 0) 62%, rgba(255, 255, 255, 0.08) 100%);
+  mix-blend-mode: normal;
+}
+
+.oliver-hook-noise {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    radial-gradient(circle at 20% 25%, rgba(255, 255, 255, 0.28) 0 1px, transparent 1px),
+    radial-gradient(circle at 80% 70%, rgba(16, 18, 22, 0.06) 0 1px, transparent 1px);
+  background-size: 24px 24px, 28px 28px;
+  opacity: 0.18;
+}
+
+[data-theme='dark'] .oliver-hook-noise {
+  opacity: 0.12;
+}
+
+.oliver-hook-nav {
+  position: sticky;
+  top: 1rem;
+  z-index: 120;
+  padding: 1rem 1rem 0;
+}
+
+.oliver-hook-nav-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-overlay) 90%, transparent);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: 0 18px 40px -34px var(--shadow-strong);
+  padding: 0.8rem 0.95rem 0.8rem 1.1rem;
+}
+
+.oliver-hook-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  min-width: max-content;
+}
+
+.oliver-hook-brand-mark {
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 0.5rem;
+  flex: 0 0 auto;
+}
+
+.oliver-hook-brand-copy {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: var(--tracking-tight);
+}
+
+.oliver-hook-links {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.oliver-hook-link {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.48rem 0.88rem;
+}
+
+.oliver-hook-link:hover {
+  color: var(--text-primary);
+  background: var(--color-muted);
+}
+
+.oliver-hook-nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-width: max-content;
+}
+
+.oliver-hook-nav-primary,
+.oliver-hook-nav-secondary {
+  min-width: max-content;
+}
+
+.oliver-hook-main {
+  position: relative;
+  z-index: 1;
+  padding-bottom: 5rem;
+}
+
+.oliver-hook-section,
+.oliver-hook-hero {
+  scroll-margin-top: 6.5rem;
+}
+
+.oliver-hook-hero {
+  padding: 6.8rem 0 2.2rem;
+}
+
+.oliver-hook-hero-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1.02fr) minmax(0, 0.98fr);
+  align-items: start;
+}
+
+.oliver-hook-copy {
+  display: grid;
+  gap: 1rem;
+  max-width: 620px;
+  padding-top: 1.6rem;
+}
+
+.oliver-hook-eyebrow,
+.oliver-hook-section-eyebrow,
+.oliver-hook-panel-label,
+.oliver-hook-card-kicker {
+  margin: 0;
+  color: var(--oliver-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.oliver-hook-title,
+.oliver-hook-section-title,
+.oliver-hook-hero-panel h2 {
+  font-family: 'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif;
+  letter-spacing: -0.045em;
+}
+
+.oliver-hook-title {
+  margin: 0;
+  font-size: clamp(3.25rem, 6.4vw, 5.3rem);
+  line-height: 0.94;
+  max-width: 11ch;
+  text-wrap: balance;
+}
+
+.oliver-hook-subtitle {
+  margin: 0;
+  max-width: 39ch;
+  color: var(--oliver-ink-soft);
+  font-size: 1.13rem;
+  line-height: 1.68;
+}
+
+.oliver-hook-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 0.35rem;
+}
+
+.oliver-hook-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--glass-bg) 88%, var(--surface-primary));
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.52rem 0.85rem;
+  box-shadow: 0 10px 22px -24px var(--shadow-strong);
+}
+
+.oliver-hook-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  margin-top: 0.4rem;
+}
+
+.oliver-hook-note,
+.oliver-hook-disclaimer {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.62;
+}
+
+.oliver-hook-hero-panel,
+.oliver-hook-proof-card,
+.oliver-hook-outcome-card,
+.oliver-hook-step-card,
+.oliver-hook-surface-card,
+.oliver-hook-control-card,
+.oliver-hook-faq-card,
+.oliver-hook-final-card,
+.oliver-hook-artifact-card {
+  border: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--glass-bg) 94%, var(--surface-primary));
+  box-shadow: 0 22px 48px -40px var(--shadow-strong);
+}
+
+.oliver-hook-hero-panel {
+  display: grid;
+  gap: 1rem;
+  border-radius: 1.9rem;
+  padding: 1.35rem;
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--surface-primary) 92%, rgba(255, 255, 255, 0.35)) 0%,
+      color-mix(in srgb, var(--surface-primary) 86%, var(--surface-secondary)) 100%
+    );
+}
+
+[data-theme='dark'] .oliver-hook-hero-panel {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--surface-secondary) 94%, rgba(255, 255, 255, 0.02)) 0%,
+      color-mix(in srgb, var(--surface-primary) 96%, var(--surface-secondary)) 100%
+    );
+}
+
+.oliver-hook-hero-panel-head,
+.oliver-hook-card-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.oliver-hook-hero-panel-head h2 {
+  margin: 0.2rem 0 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 0.96;
+}
+
+.oliver-hook-health {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: end;
+  text-align: right;
+}
+
+.oliver-hook-health-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  background: rgba(185, 56, 46, 0.12);
+  color: var(--oliver-risk-high);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.oliver-hook-health-detail {
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  max-width: 20ch;
+}
+
+.oliver-hook-signal-band {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.oliver-hook-signal-chip,
+.oliver-hook-tool-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.46rem 0.78rem;
+  border: 1px solid var(--glass-border);
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--surface-primary) 84%, var(--surface-secondary));
+  font-size: 0.86rem;
+  font-weight: 500;
+}
+
+.oliver-hook-hero-panel-grid {
+  display: grid;
+  grid-template-columns: 1.12fr 0.88fr;
+  gap: 0.9rem;
+}
+
+.oliver-hook-artifact-card {
+  border-radius: 1.35rem;
+  padding: 1rem 1rem 1.05rem;
+}
+
+.oliver-hook-card-copy {
+  margin: 0.45rem 0 0;
+  color: var(--text-primary);
+  line-height: 1.65;
+}
+
+.oliver-hook-checklist,
+.oliver-hook-risk-list,
+.oliver-hook-proof-card ul {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.oliver-hook-checklist li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.7rem;
+  align-items: start;
+}
+
+.oliver-hook-check-icon {
+  width: 1.65rem;
+  height: 1.65rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--oliver-accent-soft);
+  color: var(--oliver-accent);
+  flex: 0 0 auto;
+}
+
+.oliver-hook-check-icon svg,
+.oliver-hook-inline-link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.oliver-hook-checklist li div {
+  display: grid;
+  gap: 0.16rem;
+}
+
+.oliver-hook-checklist li strong,
+.oliver-hook-proof-card h3,
+.oliver-hook-outcome-card h3,
+.oliver-hook-step-card h3,
+.oliver-hook-control-card h3,
+.oliver-hook-faq-card h3 {
+  font-size: 1.02rem;
+  line-height: 1.25;
+}
+
+.oliver-hook-checklist li span,
+.oliver-hook-checklist li small,
+.oliver-hook-proof-card p,
+.oliver-hook-proof-card li,
+.oliver-hook-outcome-card p,
+.oliver-hook-step-card p,
+.oliver-hook-control-card p,
+.oliver-hook-faq-card p,
+.oliver-hook-surface-copy p {
+  color: var(--text-secondary);
+  line-height: 1.62;
+}
+
+.oliver-hook-checklist li small {
+  white-space: nowrap;
+  font-size: 0.77rem;
+}
+
+.oliver-hook-inline-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--text-primary);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.oliver-hook-inline-link:hover {
+  color: var(--oliver-accent);
+}
+
+.oliver-hook-risk-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.7rem;
+  align-items: start;
+}
+
+.oliver-hook-risk-level {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.5rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.oliver-hook-risk-level-high {
+  background: rgba(185, 56, 46, 0.12);
+  color: var(--oliver-risk-high);
+}
+
+.oliver-hook-risk-level-medium {
+  background: rgba(142, 98, 0, 0.12);
+  color: var(--oliver-risk-medium);
+}
+
+.oliver-hook-section {
+  padding: 1.8rem 0 0;
+}
+
+.oliver-hook-section-head {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 760px;
+  margin-bottom: 1.5rem;
+}
+
+.oliver-hook-section-head-left {
+  margin-bottom: 0;
+}
+
+.oliver-hook-section-title {
+  margin: 0;
+  font-size: clamp(2.15rem, 4.4vw, 3.3rem);
+  line-height: 0.97;
+  max-width: 14ch;
+}
+
+.oliver-hook-section-intro {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1.04rem;
+  line-height: 1.68;
+  max-width: 52ch;
+}
+
+.oliver-hook-section-intro-left {
+  max-width: 44ch;
+}
+
+.oliver-hook-proof-grid,
+.oliver-hook-outcome-grid,
+.oliver-hook-control-grid,
+.oliver-hook-faq-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.oliver-hook-proof-grid,
+.oliver-hook-control-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.oliver-hook-outcome-grid,
+.oliver-hook-faq-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.oliver-hook-proof-card,
+.oliver-hook-outcome-card,
+.oliver-hook-control-card,
+.oliver-hook-faq-card {
+  border-radius: 1.5rem;
+  padding: 1.15rem 1.15rem 1.2rem;
+}
+
+.oliver-hook-proof-card h3,
+.oliver-hook-outcome-card h3,
+.oliver-hook-control-card h3,
+.oliver-hook-faq-card h3 {
+  margin: 0.4rem 0 0.55rem;
+}
+
+.oliver-hook-proof-card ul {
+  margin-top: 0.95rem;
+}
+
+.oliver-hook-proof-card li {
+  position: relative;
+  padding-left: 1rem;
+}
+
+.oliver-hook-proof-card li::before {
+  content: '';
+  position: absolute;
+  top: 0.65rem;
+  left: 0;
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 999px;
+  background: var(--oliver-accent);
+}
+
+.oliver-hook-workflow-section {
+  padding-top: 2rem;
+}
+
+.oliver-hook-workflow-layout {
+  display: grid;
+  gap: 1.35rem;
+  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
+  align-items: start;
+}
+
+.oliver-hook-workflow-list {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.oliver-hook-step-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  border-radius: 1.5rem;
+  padding: 1.15rem 1.2rem;
+}
+
+.oliver-hook-step-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  background: var(--oliver-accent-soft);
+  color: var(--oliver-accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.oliver-hook-step-copy {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.oliver-hook-step-copy h3 {
+  margin: 0;
+}
+
+.oliver-hook-surface-card {
+  display: grid;
+  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
+  gap: 1.4rem;
+  align-items: center;
+  border-radius: 1.6rem;
+  padding: 1.25rem;
+}
+
+.oliver-hook-surface-copy .oliver-hook-section-title {
+  max-width: 16ch;
+}
+
+.oliver-hook-tool-chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  justify-content: flex-end;
+}
+
+.oliver-hook-control-card {
+  min-height: 100%;
+}
+
+.oliver-hook-final-section {
+  padding-top: 2.15rem;
+}
+
+.oliver-hook-final-card {
+  border-radius: 1.8rem;
+  padding: 1.45rem;
+  display: grid;
+  gap: 0.8rem;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--surface-primary) 90%, rgba(255, 255, 255, 0.38)) 0%,
+      color-mix(in srgb, var(--surface-secondary) 92%, rgba(196, 101, 45, 0.06)) 100%
+    );
+}
+
+[data-theme='dark'] .oliver-hook-final-card {
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--surface-secondary) 92%, rgba(255, 255, 255, 0.02)) 0%,
+      color-mix(in srgb, var(--surface-primary) 96%, rgba(240, 163, 110, 0.08)) 100%
+    );
+}
+
+.oliver-hook-final-card .oliver-hook-section-title,
+.oliver-hook-final-card .oliver-hook-section-intro {
+  max-width: 17ch;
+}
+
+.oliver-hook-final-actions {
+  margin-top: 0.15rem;
+}
+
+@media (max-width: 1120px) {
+  .oliver-hook-hero-grid,
+  .oliver-hook-workflow-layout,
+  .oliver-hook-surface-card {
+    grid-template-columns: 1fr;
+  }
+
+  .oliver-hook-copy {
+    max-width: none;
+    padding-top: 0;
+  }
+
+  .oliver-hook-proof-grid,
+  .oliver-hook-control-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .oliver-hook-nav {
+    padding: 0.85rem 0.85rem 0;
+  }
+
+  .oliver-hook-nav-inner {
+    border-radius: 1.4rem;
+    padding: 0.9rem;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.8rem;
+  }
+
+  .oliver-hook-links {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+    overflow-x: auto;
+    scrollbar-width: none;
+    padding-bottom: 0.1rem;
+  }
+
+  .oliver-hook-links::-webkit-scrollbar {
+    display: none;
+  }
+
+  .oliver-hook-proof-grid,
+  .oliver-hook-outcome-grid,
+  .oliver-hook-control-grid,
+  .oliver-hook-faq-grid,
+  .oliver-hook-hero-panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .oliver-hook-tool-chip-grid {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 680px) {
+  .oliver-hook-title {
+    font-size: clamp(2.45rem, 12vw, 3.55rem);
+    max-width: 10ch;
+  }
+
+  .oliver-hook-subtitle,
+  .oliver-hook-section-intro {
+    font-size: 0.98rem;
+  }
+
+  .oliver-hook-nav-actions,
+  .oliver-hook-cta-row,
+  .oliver-hook-final-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .oliver-hook-nav-primary,
+  .oliver-hook-nav-secondary,
+  .oliver-hook-primary-button,
+  .oliver-hook-secondary-button {
+    width: 100%;
+  }
+
+  .oliver-hook-nav-inner {
+    grid-template-columns: 1fr;
+  }
+
+  .oliver-hook-brand {
+    justify-content: space-between;
+  }
+
+  .oliver-hook-hero {
+    padding-top: 5.5rem;
+  }
+
+  .oliver-hook-hero-panel,
+  .oliver-hook-proof-card,
+  .oliver-hook-outcome-card,
+  .oliver-hook-step-card,
+  .oliver-hook-surface-card,
+  .oliver-hook-control-card,
+  .oliver-hook-faq-card,
+  .oliver-hook-final-card,
+  .oliver-hook-artifact-card {
+    border-radius: 1.2rem;
+    padding: 1rem;
+  }
+
+  .oliver-hook-hero-panel-head,
+  .oliver-hook-card-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .oliver-hook-health {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .oliver-hook-checklist li {
+    grid-template-columns: auto 1fr;
+  }
+
+  .oliver-hook-checklist li small {
+    grid-column: 2 / -1;
+    padding-left: 0;
+  }
+
+  .oliver-hook-step-card {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .oliver-hook-nav {
+    top: 0.65rem;
+    padding-inline: 0.65rem;
+  }
+
+  .oliver-hook-link {
+    font-size: 0.84rem;
+    padding-inline: 0.72rem;
+  }
+
+  .oliver-hook-pill,
+  .oliver-hook-signal-chip,
+  .oliver-hook-tool-chip {
+    font-size: 0.82rem;
+  }
+}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,4 +1,24 @@
 {
+  "headers": [
+    {
+      "source": "/oliver",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/oliver/",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/start",
@@ -10,6 +30,14 @@
     },
     {
       "source": "/workspace",
+      "destination": "/"
+    },
+    {
+      "source": "/oliver",
+      "destination": "/"
+    },
+    {
+      "source": "/oliver/",
       "destination": "/"
     },
     {


### PR DESCRIPTION
## Summary
- add a new `/oliver` landing-only hook that positions Oliver as an AI TPM for product and engineering teams
- add TPM-shaped proof, workflow, controls, and CTA handoff content without changing the main `/` homepage
- add minimal `entry=oliver_tpm` auth copy polish and analytics tagging on the shared `/auth/index.html` surface
- add `/oliver` rewrites and `noindex, nofollow` headers, and prevent the legacy shared nav from mounting on `/oliver`

## Validation
- `cd website && npm run lint`
- `cd website && npm run build`
- `cd website && npm run test:responsive`
- browser verification on `vite preview` for:
  - `/oliver`
  - `/oliver/`
  - shared-auth handoff via `/auth/index.html?loggedIn=true&entry=oliver_tpm#section-overview`
  - root homepage non-regression at `/`

## Notes / Risks
- `/oliver` route metadata is still client-mutated SPA metadata. The `X-Robots-Tag` header makes `noindex` reliable, but non-JS social scrapers may still see root-level OG/Twitter tags.
- Auth verification was done against `vite preview`, not `npm run dev`, because the dev server currently serves `/auth/connect-onboarding.js` with an HTML MIME type under SPA fallback.
- The existing bundle-size warning in `vite build` remains unchanged.
- Local validation screenshots were captured in `website/output/screenshots/` and intentionally not committed to avoid repo noise.
