### PR TITLE
Enforce final artifact contract for Oliver investment replies

### DIFF
--- a/DoWhiz_service/Cargo.lock
+++ b/DoWhiz_service/Cargo.lock
@@ -3718,6 +3718,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "send_emails_module",
  "serde",
  "serde_json",
  "tempfile",

--- a/DoWhiz_service/run_task_module/Cargo.toml
+++ b/DoWhiz_service/run_task_module/Cargo.toml
@@ -17,6 +17,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 toml = "0.8"
 uuid = { version = "1", features = ["v4"] }
 
+[dev-dependencies]
+send_emails_module = { path = "../send_emails_module" }
+
 [[bin]]
 name = "load_test"
 path = "src/bin/load_test.rs"

--- a/DoWhiz_service/run_task_module/README.md
+++ b/DoWhiz_service/run_task_module/README.md
@@ -24,6 +24,11 @@ Output files are channel-aware:
 - email/google workspace channels -> `reply_email_draft.html` + `reply_email_attachments/`
 - chat channels (slack/discord/telegram/sms/whatsapp/bluebubbles) -> `reply_message.txt` + `reply_attachments/`
 
+For email tasks, `reply_email_draft.html` is the pre-send workspace artifact. The final user-visible
+HTML is produced later by `send_emails_module::normalize_email_html(...)`, so tests that care about
+the rendered customer-facing structure should grade the normalized final HTML, not just an internal
+model transcript or the raw shell logs.
+
 Late-finalization recovery:
 - when Codex has already written the expected reply artifact, `run_task` now treats that artifact as
   a recoverable completion signal even if the CLI later disconnects, refuses, or exits non-zero

--- a/DoWhiz_service/run_task_module/src/run_task/claude.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/claude.rs
@@ -50,6 +50,7 @@ use super::env::{load_env_sources, read_env_trimmed, remove_restricted_agent_env
 use super::errors::RunTaskError;
 use super::github_auth::{ensure_github_cli_auth, resolve_github_auth};
 use super::prompt::{build_prompt_with_fast_completion, load_memory_context};
+use super::reply_contract::{ensure_expected_reply_artifact, reply_artifact_ready_for_workspace};
 use super::scheduled::{extract_scheduled_tasks, extract_scheduler_actions};
 use super::trace::RunTaskTraceRecorder;
 use super::types::{RunTaskOutput, RunTaskRequest};
@@ -143,6 +144,7 @@ pub(super) fn run_claude_task(
                 resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
             if let Some(recovery_note) = maybe_recover_from_ready_reply_artifact(
                 !request.reply_to.is_empty(),
+                request.workspace_dir,
                 &expected_reply_path,
                 &err,
             ) {
@@ -200,10 +202,28 @@ pub(super) fn run_claude_task(
     // Use cross-channel routing to determine actual expected path
     let expected_reply_path =
         resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
-    if !request.reply_to.is_empty() && !expected_reply_path.exists() {
-        let err = RunTaskError::OutputMissing {
-            path: expected_reply_path,
-            output: assistant_tail,
+    if !request.reply_to.is_empty() {
+        let err = match ensure_expected_reply_artifact(
+            request.workspace_dir,
+            &expected_reply_path,
+            &assistant_tail,
+        ) {
+            Ok(()) => {
+                let _ = trace.finish(output.status.code(), true, None, None);
+
+                return Ok(RunTaskOutput {
+                    reply_html_path: expected_reply_path,
+                    reply_attachments_dir,
+                    codex_output: assistant_tail,
+                    scheduled_tasks,
+                    scheduled_tasks_error,
+                    scheduler_actions,
+                    scheduler_actions_error,
+                    token_usage: None, // TODO: Extract from Claude API response
+                    recovery_note: None,
+                });
+            }
+            Err(err) => err,
         };
         let _ = trace.finish(output.status.code(), false, Some(&err.to_string()), None);
         return Err(err);
@@ -378,27 +398,13 @@ fn run_claude_command(
     }
 }
 
-fn reply_artifact_ready(path: &Path) -> bool {
-    if !path.is_file() {
-        return false;
-    }
-    if path.file_name().and_then(|value| value.to_str()) == Some(".notion_api_replied") {
-        return true;
-    }
-    match fs::read_to_string(path) {
-        Ok(contents) => !contents.trim().is_empty(),
-        Err(_) => fs::metadata(path)
-            .map(|meta| meta.len() > 0)
-            .unwrap_or(false),
-    }
-}
-
 fn maybe_recover_from_ready_reply_artifact(
     reply_expected: bool,
+    workspace_dir: &Path,
     expected_reply_path: &Path,
     err: &RunTaskError,
 ) -> Option<String> {
-    if !reply_expected || !reply_artifact_ready(expected_reply_path) {
+    if !reply_expected || !reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path) {
         return None;
     }
 

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -28,6 +28,7 @@ use super::env::{
 use super::errors::RunTaskError;
 use super::github_auth::{ensure_github_cli_auth, resolve_github_auth};
 use super::prompt::{build_prompt, load_memory_context};
+use super::reply_contract::{ensure_expected_reply_artifact, reply_artifact_ready_for_workspace};
 use super::scheduled::{extract_scheduled_tasks, extract_scheduler_actions};
 use super::timing::{TaskTimingBuilder, TIMING_COLLECTOR};
 use super::trace::RunTaskTraceRecorder;
@@ -267,28 +268,14 @@ fn resolve_expected_reply_path(workspace_dir: &Path, default_path: PathBuf) -> P
     }
 }
 
-fn reply_artifact_ready(path: &Path) -> bool {
-    if !path.is_file() {
-        return false;
-    }
-    if path.file_name().and_then(|value| value.to_str()) == Some(".notion_api_replied") {
-        return true;
-    }
-    match fs::read_to_string(path) {
-        Ok(contents) => !contents.trim().is_empty(),
-        Err(_) => fs::metadata(path)
-            .map(|meta| meta.len() > 0)
-            .unwrap_or(false),
-    }
-}
-
 fn maybe_recover_from_ready_reply_artifact(
     reply_expected: bool,
+    workspace_dir: &Path,
     expected_reply_path: &Path,
     exit_status: Option<i32>,
     failure_output: &str,
 ) -> Option<String> {
-    if !reply_expected || !reply_artifact_ready(expected_reply_path) {
+    if !reply_expected || !reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path) {
         return None;
     }
 
@@ -328,6 +315,7 @@ fn record_codex_success(
 
 fn validate_warm_pool_codex_result(
     reply_expected: bool,
+    workspace_dir: &Path,
     expected_reply_path: &Path,
     exit_status: i32,
     codex_output: &str,
@@ -340,6 +328,7 @@ fn validate_warm_pool_codex_result(
         };
         if let Some(recovery_note) = maybe_recover_from_ready_reply_artifact(
             reply_expected,
+            workspace_dir,
             expected_reply_path,
             Some(exit_status),
             &err.to_string(),
@@ -364,6 +353,7 @@ fn validate_warm_pool_codex_result(
         };
         if let Some(recovery_note) = maybe_recover_from_ready_reply_artifact(
             reply_expected,
+            workspace_dir,
             expected_reply_path,
             status,
             &err.to_string(),
@@ -373,11 +363,8 @@ fn validate_warm_pool_codex_result(
         return Err(err);
     }
 
-    if reply_expected && !reply_artifact_ready(expected_reply_path) {
-        return Err(RunTaskError::OutputMissing {
-            path: expected_reply_path.to_path_buf(),
-            output: output_tail,
-        });
+    if reply_expected {
+        ensure_expected_reply_artifact(workspace_dir, expected_reply_path, &output_tail)?;
     }
 
     Ok(None)
@@ -906,6 +893,7 @@ pub(super) fn run_codex_task(
         };
         if let Some(recovery_note) = maybe_recover_from_ready_reply_artifact(
             !request.reply_to.is_empty(),
+            request.workspace_dir,
             &expected_reply_path,
             output.status.code(),
             &err.to_string(),
@@ -962,6 +950,7 @@ pub(super) fn run_codex_task(
         };
         if let Some(recovery_note) = maybe_recover_from_ready_reply_artifact(
             !request.reply_to.is_empty(),
+            request.workspace_dir,
             &expected_reply_path,
             status,
             &err.to_string(),
@@ -991,10 +980,34 @@ pub(super) fn run_codex_task(
 
     // Only check for reply file if a reply was expected
     // Use cross-channel routing to determine actual expected path
-    if !request.reply_to.is_empty() && !reply_artifact_ready(&expected_reply_path) {
-        let err = RunTaskError::OutputMissing {
-            path: expected_reply_path,
-            output: output_tail.clone(),
+    if !request.reply_to.is_empty() {
+        let err = match ensure_expected_reply_artifact(
+            request.workspace_dir,
+            &expected_reply_path,
+            &output_tail,
+        ) {
+            Ok(()) => {
+                record_codex_success(
+                    &mut trace,
+                    output.status.code(),
+                    &output_tail,
+                    None,
+                    token_usage.as_ref(),
+                );
+
+                return Ok(RunTaskOutput {
+                    reply_html_path: expected_reply_path,
+                    reply_attachments_dir,
+                    codex_output: output_tail,
+                    scheduled_tasks,
+                    scheduled_tasks_error,
+                    scheduler_actions,
+                    scheduler_actions_error,
+                    token_usage,
+                    recovery_note: None,
+                });
+            }
+            Err(err) => err,
         };
         let _ = trace.finish(
             output.status.code(),
@@ -1463,6 +1476,7 @@ fn run_codex_task_azure_aci(
         };
         if let Some(recovery_note) = maybe_recover_from_ready_reply_artifact(
             !request.reply_to.is_empty(),
+            request.workspace_dir,
             &expected_reply_path,
             exit_status,
             &err.to_string(),
@@ -1497,10 +1511,35 @@ fn run_codex_task_azure_aci(
     }
 
     // Use cross-channel routing to determine actual expected path
-    if !request.reply_to.is_empty() && !reply_artifact_ready(&expected_reply_path) {
-        let err = RunTaskError::OutputMissing {
-            path: expected_reply_path,
-            output: output_tail,
+    if !request.reply_to.is_empty() {
+        let err = match ensure_expected_reply_artifact(
+            request.workspace_dir,
+            &expected_reply_path,
+            &output_tail,
+        ) {
+            Ok(()) => {
+                record_codex_success(
+                    &mut trace,
+                    exit_status,
+                    &output_tail,
+                    None,
+                    token_usage.as_ref(),
+                );
+                TIMING_COLLECTOR.record(timing.finish());
+
+                return Ok(RunTaskOutput {
+                    reply_html_path: expected_reply_path,
+                    reply_attachments_dir,
+                    codex_output: output_tail,
+                    scheduled_tasks,
+                    scheduled_tasks_error,
+                    scheduler_actions,
+                    scheduler_actions_error,
+                    token_usage,
+                    recovery_note: None,
+                });
+            }
+            Err(err) => err,
         };
         let _ = trace.finish(
             exit_status,
@@ -3808,6 +3847,7 @@ pub fn run_codex_warm_pool(
     let token_usage = extract_token_usage(&codex_output);
     let recovery_note = validate_warm_pool_codex_result(
         !request.reply_to.is_empty(),
+        workspace_dir,
         &reply_html_path,
         completion.exit_code,
         &codex_output,
@@ -5190,7 +5230,7 @@ printf '%s\n' "$@" > "$capture_file"
         let reply = temp.path().join("reply_email_draft.html");
         fs::write(&reply, "   \n\t").expect("write reply");
 
-        assert!(!reply_artifact_ready(&reply));
+        assert!(!reply_artifact_ready_for_workspace(temp.path(), &reply));
     }
 
     #[test]
@@ -5254,6 +5294,7 @@ printf '%s\n' "$@" > "$capture_file"
 
         let note = maybe_recover_from_ready_reply_artifact(
             true,
+            temp.path(),
             &reply,
             Some(23),
             "response.failed event received",
@@ -5268,8 +5309,9 @@ printf '%s\n' "$@" > "$capture_file"
         let temp = tempfile::tempdir().expect("tempdir");
         let reply = temp.path().join("reply_email_draft.html");
 
-        let err = validate_warm_pool_codex_result(true, &reply, 1, "stream disconnected")
-            .expect_err("expected CodexFailed");
+        let err =
+            validate_warm_pool_codex_result(true, temp.path(), &reply, 1, "stream disconnected")
+                .expect_err("expected CodexFailed");
 
         match err {
             RunTaskError::CodexFailed { status, output } => {
@@ -5288,6 +5330,7 @@ printf '%s\n' "$@" > "$capture_file"
 
         let err = validate_warm_pool_codex_result(
             true,
+            temp.path(),
             &reply,
             0,
             r#"{"type":"event_msg","payload":{"type":"task_complete","status":"success","exit_code":0}}"#,
@@ -5305,6 +5348,7 @@ printf '%s\n' "$@" > "$capture_file"
 
         let note = validate_warm_pool_codex_result(
             true,
+            temp.path(),
             &reply,
             1,
             "I'm sorry, but I cannot assist with that request.",

--- a/DoWhiz_service/run_task_module/src/run_task/core.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/core.rs
@@ -159,7 +159,8 @@ fn should_fallback_to_claude(primary_runner: &str, err: &RunTaskError) -> bool {
         | RunTaskError::DockerNotFound
         | RunTaskError::DockerFailed { .. }
         | RunTaskError::AzureCliNotFound
-        | RunTaskError::OutputMissing { .. } => true,
+        | RunTaskError::OutputMissing { .. }
+        | RunTaskError::OutputContractViolation { .. } => true,
         RunTaskError::CommandTimeout { command, .. } => {
             is_codex_timeout_eligible_for_fallback(command)
         }
@@ -249,6 +250,9 @@ fn primary_error_summary(err: &RunTaskError) -> &'static str {
         }
         RunTaskError::OutputMissing { .. } => {
             "Codex finished without writing the expected reply artifact"
+        }
+        RunTaskError::OutputContractViolation { .. } => {
+            "Codex wrote a reply artifact that failed the required output contract"
         }
         _ => "Codex execution failed",
     }

--- a/DoWhiz_service/run_task_module/src/run_task/errors.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/errors.rs
@@ -64,6 +64,11 @@ pub enum RunTaskError {
         path: PathBuf,
         output: String,
     },
+    OutputContractViolation {
+        path: PathBuf,
+        reason: String,
+        output: String,
+    },
 }
 
 impl fmt::Display for RunTaskError {
@@ -153,6 +158,17 @@ impl fmt::Display for RunTaskError {
                     output
                 )
             }
+            RunTaskError::OutputContractViolation {
+                path,
+                reason,
+                output,
+            } => write!(
+                f,
+                "Output contract violation at {}: {}\nCodex output tail:\n{}",
+                path.display(),
+                reason,
+                output
+            ),
         }
     }
 }

--- a/DoWhiz_service/run_task_module/src/run_task/mod.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/mod.rs
@@ -9,6 +9,7 @@ mod errors;
 mod github_auth;
 pub mod pool_manager;
 mod prompt;
+mod reply_contract;
 mod scheduled;
 pub mod timing;
 mod trace;

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -235,6 +235,7 @@ Do not pretend the job has been done without actually doing it."#
     let human_approval_gate_section = build_human_approval_gate_section();
     let chat_history_capabilities_section =
         build_chat_history_capabilities_section(workspace_dir, channel);
+    let investment_capabilities_section = build_investment_capabilities_section();
     let fast_completion_section = if prefer_fast_completion {
         r#"Claude fallback execution guidance:
 - This run is a recovery path after the primary runner failed. These recovery instructions take precedence over conflicting planning or artifact-building advice elsewhere in this prompt.
@@ -320,6 +321,7 @@ Scheduling:
 {human_approval_gate_section}
 {user_identities_section}
 {tpm_capabilities_section}
+{investment_capabilities_section}
 {fast_completion_section}
 Rules:
 - Each workspace includes a `.env` file at the workspace root. You may edit it to manage per-user secrets; updates are synced back after the task completes.
@@ -344,6 +346,7 @@ Rules:
         human_approval_gate_section = human_approval_gate_section,
         user_identities_section = user_identities_section,
         tpm_capabilities_section = tpm_capabilities_section,
+        investment_capabilities_section = investment_capabilities_section,
         fast_completion_section = fast_completion_section,
         filesystem_security_section = filesystem_security_section,
         registration_section = registration_section,
@@ -523,6 +526,29 @@ Example workflow for "create a Notion page about X":
 4. If no token: Reply to user asking them to link Notion at dowhiz.com
 
 See `.agents/skills/notion/SKILL.md` for detailed command reference.
+
+"#
+}
+
+fn build_investment_capabilities_section() -> &'static str {
+    r#"Investment research requests:
+- When the user asks about one U.S. stock or one U.S. ETF, asks whether now is a good time to buy, asks about buying before earnings, or wants a Buy / Wait / Sell investment view, read `.agents/skills/us-equity-daily-monitor/SKILL.md` and follow it.
+- Keep the final user-visible reply structured. Do not collapse it into generic commentary.
+- For email replies, preserve these exact visible labels in `reply_email_draft.html`:
+  - `Rating:`
+  - `Horizon:`
+  - `Confidence:`
+  - `Timing Verdict:`
+  - `Verified Facts`
+  - `Derived Metrics`
+  - `Bull Case`
+  - `Base Case`
+  - `Bear Case`
+  - `Add Criteria:`
+  - `Invalidation Criteria:`
+  - `Biggest Near-Term Risk:`
+  - `Biggest Long-Term Strength:`
+- If the user states a conflicting earnings date or similar factual premise, correct it explicitly in the final reply instead of silently accepting it.
 
 "#
 }
@@ -1581,6 +1607,30 @@ mod tests {
         assert!(prompt.contains("Never include raw credentials"));
         assert!(prompt.contains("persistent remote browser context"));
         assert!(prompt.contains("single browser tab"));
+    }
+
+    #[test]
+    fn build_prompt_includes_investment_skill_guidance() {
+        let temp = TempDir::new().expect("tempdir");
+
+        let prompt = build_prompt(
+            Path::new("incoming_email"),
+            Path::new("incoming_attachments"),
+            Path::new("memory"),
+            Path::new("references"),
+            temp.path(),
+            "codex",
+            "",
+            true,
+            "email",
+            true,
+            &UserIdentities::default(),
+        );
+
+        assert!(prompt.contains(".agents/skills/us-equity-daily-monitor/SKILL.md"));
+        assert!(prompt.contains("Timing Verdict"));
+        assert!(prompt.contains("Biggest Near-Term Risk"));
+        assert!(prompt.contains("final user-visible reply structured"));
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
@@ -1,0 +1,327 @@
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::errors::RunTaskError;
+
+const REQUIRED_INVESTMENT_LABELS: &[(&str, bool)] = &[
+    ("Rating", true),
+    ("Horizon", true),
+    ("Confidence", true),
+    ("Timing Verdict", true),
+    ("Verified Facts", false),
+    ("Derived Metrics", false),
+    ("Bull Case", false),
+    ("Base Case", false),
+    ("Bear Case", false),
+    ("Add Criteria", true),
+    ("Invalidation Criteria", true),
+    ("Biggest Near-Term Risk", true),
+    ("Biggest Long-Term Strength", true),
+];
+
+const FINANCE_CONTEXT_KEYWORDS: &[&str] = &[
+    "stock",
+    "etf",
+    "ticker",
+    "earnings",
+    "position",
+    "shares",
+    "valuation",
+    "market cap",
+    "revenue",
+    "eps",
+    "free cash flow",
+    "fcf",
+];
+
+const INVESTMENT_INTENT_KEYWORDS: &[&str] = &[
+    "good time to buy",
+    "should i buy",
+    "should i sell",
+    "worth buying",
+    "buy before",
+    "sell before",
+    "deep research",
+    "analyze",
+    "analysis",
+    "investment",
+    "investing",
+    "starter position",
+    "starter only",
+    "buy now",
+    "wait",
+];
+
+pub(super) fn ensure_expected_reply_artifact(
+    workspace_dir: &Path,
+    reply_path: &Path,
+    output_tail: &str,
+) -> Result<(), RunTaskError> {
+    if !reply_artifact_present(reply_path) {
+        return Err(RunTaskError::OutputMissing {
+            path: reply_path.to_path_buf(),
+            output: output_tail.to_string(),
+        });
+    }
+
+    let Some(missing_labels) = investment_contract_missing_labels(workspace_dir, reply_path)?
+    else {
+        return Ok(());
+    };
+
+    Err(RunTaskError::OutputContractViolation {
+        path: reply_path.to_path_buf(),
+        reason: format!(
+            "investment reply is missing required labels: {}",
+            missing_labels.join(", ")
+        ),
+        output: output_tail.to_string(),
+    })
+}
+
+pub(super) fn reply_artifact_ready_for_workspace(workspace_dir: &Path, reply_path: &Path) -> bool {
+    ensure_expected_reply_artifact(workspace_dir, reply_path, "").is_ok()
+}
+
+fn investment_contract_missing_labels(
+    workspace_dir: &Path,
+    reply_path: &Path,
+) -> Result<Option<Vec<String>>, RunTaskError> {
+    let request_text = load_inbound_request_text(workspace_dir)?;
+    if !is_investment_request(&request_text) {
+        return Ok(None);
+    }
+
+    let reply_body = fs::read_to_string(reply_path)?;
+    let normalized_reply = normalize_search_text(&reply_body);
+    let mut missing = Vec::new();
+
+    for (label, require_colon) in REQUIRED_INVESTMENT_LABELS {
+        let present = if *require_colon {
+            normalized_reply.contains(&format!("{}:", label.to_ascii_lowercase()))
+        } else {
+            normalized_reply.contains(&label.to_ascii_lowercase())
+        };
+        if !present {
+            missing.push((*label).to_string());
+        }
+    }
+
+    if missing.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(missing))
+    }
+}
+
+fn load_inbound_request_text(workspace_dir: &Path) -> Result<String, RunTaskError> {
+    let incoming_dir = workspace_dir.join("incoming_email");
+    let mut parts = Vec::new();
+
+    for name in ["thread_request.md", "email.txt", "email.html"] {
+        let path = incoming_dir.join(name);
+        if !path.exists() {
+            continue;
+        }
+        parts.push(fs::read_to_string(path)?);
+    }
+
+    let payload_path = incoming_dir.join("postmark_payload.json");
+    if payload_path.exists() {
+        let payload = fs::read_to_string(&payload_path)?;
+        parts.push(payload.clone());
+        if let Ok(json) = serde_json::from_str::<Value>(&payload) {
+            for key in ["Subject", "TextBody", "StrippedTextReply", "HtmlBody"] {
+                if let Some(value) = json.get(key).and_then(Value::as_str) {
+                    parts.push(value.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(parts.join("\n"))
+}
+
+fn reply_artifact_present(reply_path: &Path) -> bool {
+    if !reply_path.is_file() {
+        return false;
+    }
+    if reply_path.file_name().and_then(|value| value.to_str()) == Some(".notion_api_replied") {
+        return true;
+    }
+    match fs::read_to_string(reply_path) {
+        Ok(contents) => !contents.trim().is_empty(),
+        Err(_) => fs::metadata(reply_path)
+            .map(|meta| meta.len() > 0)
+            .unwrap_or(false),
+    }
+}
+
+fn is_investment_request(raw: &str) -> bool {
+    let normalized = normalize_search_text(raw);
+    let has_finance_context = FINANCE_CONTEXT_KEYWORDS
+        .iter()
+        .any(|keyword| normalized.contains(keyword));
+    let has_investment_intent = INVESTMENT_INTENT_KEYWORDS
+        .iter()
+        .any(|keyword| normalized.contains(keyword));
+    let has_probable_ticker = contains_probable_ticker(raw);
+
+    (has_finance_context && has_investment_intent)
+        || (has_probable_ticker
+            && (has_investment_intent
+                || normalized.contains("earnings")
+                || normalized.contains("position")
+                || normalized.contains("deep research")))
+}
+
+fn contains_probable_ticker(raw: &str) -> bool {
+    const STOPWORDS: &[&str] = &[
+        "A", "AI", "AM", "AND", "ARE", "BUY", "ETF", "EPS", "HTML", "I", "JSON", "NOW", "THE",
+        "WAIT",
+    ];
+
+    raw.split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '$')
+        .filter(|token| !token.is_empty())
+        .any(|token| {
+            let trimmed = token.trim_start_matches('$');
+            let len = trimmed.len();
+            if !(1..=5).contains(&len) {
+                return false;
+            }
+            if STOPWORDS.iter().any(|stop| stop == &trimmed) {
+                return false;
+            }
+            let has_alpha = trimmed.chars().any(|ch| ch.is_ascii_alphabetic());
+            has_alpha && trimmed.chars().all(|ch| ch.is_ascii_uppercase())
+        })
+}
+
+fn normalize_search_text(raw: &str) -> String {
+    let without_tags = rough_html_to_text(raw);
+    let without_entities = without_tags
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">");
+    without_entities
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+fn rough_html_to_text(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut in_tag = false;
+
+    for ch in raw.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                out.push(' ');
+            }
+            '>' => {
+                in_tag = false;
+                out.push(' ');
+            }
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ensure_expected_reply_artifact, is_investment_request, reply_artifact_ready_for_workspace,
+    };
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_workspace(raw_request: &str, reply_body: &str) -> std::path::PathBuf {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.keep();
+        let incoming_dir = root.join("incoming_email");
+        fs::create_dir_all(&incoming_dir).expect("incoming_email");
+        fs::write(
+            incoming_dir.join("postmark_payload.json"),
+            serde_json::json!({
+                "Subject": "NVIDIA stock",
+                "TextBody": raw_request,
+            })
+            .to_string(),
+        )
+        .expect("payload");
+        fs::write(root.join("reply_email_draft.html"), reply_body).expect("reply");
+        root
+    }
+
+    #[test]
+    fn investment_request_detection_handles_single_ticker_prompts() {
+        assert!(is_investment_request(
+            "Give me deep research on NVDA and tell me whether now is a good time to buy."
+        ));
+        assert!(is_investment_request(
+            "Is NVDA a buy this week for a 3-month position?"
+        ));
+        assert!(!is_investment_request(
+            "Please buy an NVDA GPU and compare keyboard options."
+        ));
+    }
+
+    #[test]
+    fn structured_investment_reply_passes_contract_validation() {
+        let workspace = write_workspace(
+            "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+            r#"
+            <h2>Request Framing</h2>
+            <ul><li><strong>Horizon:</strong> Long-term (inferred)</li></ul>
+            <h2>Final Recommendation</h2>
+            <ul>
+              <li><strong>Rating:</strong> Wait</li>
+              <li><strong>Horizon:</strong> Long-term (inferred)</li>
+              <li><strong>Confidence:</strong> Medium</li>
+              <li><strong>Timing Verdict:</strong> Wait</li>
+              <li><strong>Add Criteria:</strong> Better valuation or cleaner post-earnings setup.</li>
+              <li><strong>Invalidation Criteria:</strong> Demand slowdown or margin compression.</li>
+              <li><strong>Biggest Near-Term Risk:</strong> Event volatility.</li>
+              <li><strong>Biggest Long-Term Strength:</strong> AI platform leadership.</li>
+            </ul>
+            <h2>Verified Facts</h2><ul><li>Fact</li></ul>
+            <h2>Derived Metrics</h2><ul><li>Metric: price / eps = 10x</li></ul>
+            <h2>Inference / Judgment</h2><ul><li>Judgment</li></ul>
+            <h2>Scenario Analysis</h2>
+            <p><strong>Bull Case:</strong> Demand remains strong.</p>
+            <p><strong>Base Case:</strong> Growth normalizes.</p>
+            <p><strong>Bear Case:</strong> Spending slows.</p>
+            "#,
+        );
+        let reply_path = workspace.join("reply_email_draft.html");
+
+        ensure_expected_reply_artifact(&workspace, &reply_path, "").expect("valid contract");
+        assert!(reply_artifact_ready_for_workspace(&workspace, &reply_path));
+    }
+
+    #[test]
+    fn generic_investment_commentary_fails_contract_validation() {
+        let workspace = write_workspace(
+            "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+            "<p>NVIDIA is a good business, but I would wait until after earnings and buy in tranches.</p>",
+        );
+        let reply_path = workspace.join("reply_email_draft.html");
+
+        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "tail")
+            .expect_err("expected contract violation");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("Output contract violation")
+                || rendered.contains("missing required labels")
+        );
+        assert!(!reply_artifact_ready_for_workspace(&workspace, &reply_path));
+    }
+}

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -3,12 +3,14 @@ mod support;
 use run_task_module::{
     run_claude_fallback_after_codex_failure, run_task, RunTaskError, RunTaskParams,
 };
+use send_emails_module::normalize_email_html;
 use std::env;
 use std::fs;
 use std::path::Path;
 use support::{
-    build_params, create_workspace, write_fake_claude, write_fake_codex, write_fake_gh, EnvGuard,
-    EnvUnsetGuard, FakeClaudeMode, FakeCodexMode, TempDir, ENV_MUTEX,
+    build_params, create_workspace, install_runtime_skills_and_employee_guidance,
+    write_fake_claude, write_fake_codex, write_fake_gh, EnvGuard, EnvUnsetGuard, FakeClaudeMode,
+    FakeCodexMode, TempDir, ENV_MUTEX,
 };
 
 fn env_enabled(key: &str) -> bool {
@@ -20,6 +22,48 @@ fn require_env(key: &'static str) {
     if value.trim().is_empty() {
         panic!("{key} must be set to run the real Codex E2E test");
     }
+}
+
+fn assert_investment_contract_labels(text: &str) {
+    for label in [
+        "Rating:",
+        "Horizon:",
+        "Confidence:",
+        "Timing Verdict:",
+        "Verified Facts",
+        "Derived Metrics",
+        "Bull Case",
+        "Base Case",
+        "Bear Case",
+        "Add Criteria:",
+        "Invalidation Criteria:",
+        "Biggest Near-Term Risk:",
+        "Biggest Long-Term Strength:",
+    ] {
+        assert!(text.contains(label), "missing label {label}");
+    }
+}
+
+fn write_investment_request(workspace: &Path, subject: &str, prompt: &str) {
+    let payload = format!(
+        r#"{{
+  "Subject": "{subject}",
+  "TextBody": "{prompt}",
+  "HtmlBody": "<p>{prompt}</p>"
+}}"#
+    );
+    fs::write(
+        workspace
+            .join("incoming_email")
+            .join("postmark_payload.json"),
+        payload,
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("incoming_email").join("email.html"),
+        format!("<p>{prompt}</p>"),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -1070,6 +1114,150 @@ fn run_task_codex_disabled_skips_placeholder_without_reply_to() {
 
 #[test]
 #[cfg(unix)]
+fn run_task_accepts_structured_investment_reply_from_fake_codex() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_investment_structured").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+    write_investment_request(
+        &workspace,
+        "NVDA investment memo",
+        "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+    );
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_codex(&bin_dir, FakeCodexMode::InvestmentStructured).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let result = run_task(&build_params(&workspace)).unwrap();
+    let html = fs::read_to_string(result.reply_html_path).unwrap();
+    assert!(html.contains("Timing Verdict"));
+    assert!(html.contains("Verified Facts"));
+}
+
+#[test]
+#[cfg(unix)]
+fn run_task_final_artifact_preserves_investment_contract_after_email_normalization() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_investment_final_artifact").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+    write_investment_request(
+        &workspace,
+        "NVDA investment memo",
+        "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+    );
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_codex(&bin_dir, FakeCodexMode::InvestmentStructured).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let result = run_task(&build_params(&workspace)).unwrap();
+    assert!(result.reply_html_path.ends_with("reply_email_draft.html"));
+
+    let raw_reply = fs::read_to_string(&result.reply_html_path).unwrap();
+    assert_investment_contract_labels(&raw_reply);
+
+    let final_html = normalize_email_html("NVDA investment memo", &raw_reply);
+    assert_investment_contract_labels(&final_html);
+}
+
+#[test]
+#[cfg(unix)]
+fn run_task_investment_contract_violation_triggers_claude_fallback() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_investment_fallback").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+    write_investment_request(
+        &workspace,
+        "NVDA investment memo",
+        "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+    );
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_codex(&bin_dir, FakeCodexMode::InvestmentGeneric).unwrap();
+    write_fake_claude(&bin_dir, FakeClaudeMode::InvestmentStructured).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let result = run_task(&build_params(&workspace)).unwrap();
+    let html = fs::read_to_string(result.reply_html_path).unwrap();
+    let recovery = result.recovery_note.unwrap_or_default();
+    assert!(recovery.contains("Claude fallback"));
+    assert!(html.contains("Timing Verdict"));
+    assert!(html.contains("Bull Case"));
+}
+
+#[test]
+#[cfg(unix)]
+fn run_task_investment_contract_violation_fails_closed_when_fallback_is_still_generic() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_investment_fail_closed").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+    write_investment_request(
+        &workspace,
+        "NVDA investment memo",
+        "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+    );
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_codex(&bin_dir, FakeCodexMode::InvestmentGeneric).unwrap();
+    write_fake_claude(&bin_dir, FakeClaudeMode::InvestmentGeneric).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let err = run_task(&build_params(&workspace)).expect_err("expected fail-closed contract error");
+    let rendered = err.to_string();
+    assert!(rendered.contains("Output contract violation"));
+    assert!(rendered.contains("missing required labels"));
+}
+
+#[test]
+#[cfg(unix)]
 fn run_task_real_codex_e2e_when_enabled() {
     let _lock = ENV_MUTEX.lock().unwrap();
     if !env_enabled("RUN_CODEX_E2E") {
@@ -1097,4 +1285,36 @@ fn run_task_real_codex_e2e_when_enabled() {
 
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
     assert!(!html.trim().is_empty());
+}
+
+#[test]
+#[cfg(unix)]
+fn run_task_real_codex_investment_contract_e2e_when_enabled() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    if !env_enabled("RUN_CODEX_E2E") {
+        eprintln!("RUN_CODEX_E2E not set; skipping investment Codex E2E test.");
+        return;
+    }
+
+    require_env("AZURE_OPENAI_API_KEY_BACKUP");
+    require_env("AZURE_OPENAI_ENDPOINT_BACKUP");
+
+    let temp = TempDir::new("codex_task_investment_real_e2e").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+    install_runtime_skills_and_employee_guidance(&workspace, "little_bear").unwrap();
+    write_investment_request(
+        &workspace,
+        "NVDA investment memo",
+        "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+    );
+
+    let home_dir = temp.path.join("home");
+    fs::create_dir_all(&home_dir).unwrap();
+    let _env = EnvGuard::set(&[("HOME", home_dir.to_str().unwrap())]);
+
+    let result = run_task(&build_params(&workspace)).unwrap_or_else(|err| {
+        panic!("Real investment Codex E2E test failed: {err}");
+    });
+    let html = fs::read_to_string(&result.reply_html_path).unwrap();
+    assert_investment_contract_labels(&html);
 }

--- a/DoWhiz_service/run_task_module/tests/support/mod.rs
+++ b/DoWhiz_service/run_task_module/tests/support/mod.rs
@@ -121,6 +121,8 @@ impl Drop for EnvUnsetGuard {
 #[derive(Clone, Copy)]
 pub enum FakeCodexMode {
     Success,
+    InvestmentStructured,
+    InvestmentGeneric,
     NoOutput,
     EmptyReply,
     Fail,
@@ -147,6 +149,56 @@ pub fn write_fake_codex(dir: &Path, mode: FakeCodexMode) -> io::Result<PathBuf> 
 set -e
 echo '{"type":"item.delta","item":{"type":"agent_message"},"delta":{"text":"ok"}}'
 echo "<html><body>Test reply</body></html>" > reply_email_draft.html
+mkdir -p reply_email_attachments
+echo "attachment" > reply_email_attachments/attachment.txt
+"#
+        }
+        FakeCodexMode::InvestmentStructured => {
+            r#"#!/bin/sh
+set -e
+cat > reply_email_draft.html <<'HTML'
+<h2>Request Framing</h2>
+<ul>
+  <li><strong>Ticker:</strong> NVDA</li>
+  <li><strong>Name:</strong> NVIDIA</li>
+  <li><strong>Type:</strong> Stock</li>
+  <li><strong>Research Mode:</strong> Deep research</li>
+  <li><strong>User Objective:</strong> Decide whether now is actionable (stated)</li>
+  <li><strong>Horizon:</strong> Long-term (inferred)</li>
+  <li><strong>Question Type:</strong> Long-term accumulation</li>
+</ul>
+<h2>Final Recommendation</h2>
+<ul>
+  <li><strong>Rating:</strong> Wait</li>
+  <li><strong>Horizon:</strong> Long-term (inferred)</li>
+  <li><strong>Confidence:</strong> Medium</li>
+  <li><strong>Timing Verdict:</strong> Wait</li>
+  <li><strong>Add Criteria:</strong> Better entry after earnings or improved valuation support.</li>
+  <li><strong>Invalidation Criteria:</strong> Demand slows or margin guidance weakens.</li>
+  <li><strong>Biggest Near-Term Risk:</strong> Event volatility around earnings.</li>
+  <li><strong>Biggest Long-Term Strength:</strong> AI compute leadership.</li>
+</ul>
+<h2>Verified Facts</h2>
+<ul><li>Fact.</li></ul>
+<h2>Derived Metrics</h2>
+<ul><li>Metric: price / eps = 10x</li></ul>
+<h2>Inference / Judgment</h2>
+<ul><li>Judgment.</li></ul>
+<h2>Scenario Analysis</h2>
+<p><strong>Bull Case:</strong> Demand remains strong.</p>
+<p><strong>Base Case:</strong> Growth normalizes.</p>
+<p><strong>Bear Case:</strong> Spending slows.</p>
+HTML
+mkdir -p reply_email_attachments
+echo "attachment" > reply_email_attachments/attachment.txt
+"#
+        }
+        FakeCodexMode::InvestmentGeneric => {
+            r#"#!/bin/sh
+set -e
+cat > reply_email_draft.html <<'HTML'
+<p>NVIDIA is a good business, but I would wait until after earnings and buy in tranches instead of going all in now.</p>
+HTML
 mkdir -p reply_email_attachments
 echo "attachment" > reply_email_attachments/attachment.txt
 "#
@@ -385,6 +437,8 @@ exit 0
 #[derive(Clone, Copy)]
 pub enum FakeClaudeMode {
     Success,
+    InvestmentStructured,
+    InvestmentGeneric,
     EnsureModel,
     Fail,
     ReplyThenSleep,
@@ -403,6 +457,58 @@ pub fn write_fake_claude(dir: &Path, mode: FakeClaudeMode) -> io::Result<PathBuf
 set -e
 echo '{"type":"message_delta","delta":{"text":"ok"}}'
 echo "<html><body>Test reply</body></html>" > reply_email_draft.html
+mkdir -p reply_email_attachments
+echo "attachment" > reply_email_attachments/attachment.txt
+"#
+        }
+        FakeClaudeMode::InvestmentStructured => {
+            r#"#!/bin/sh
+set -e
+echo '{"type":"message_delta","delta":{"text":"ok"}}'
+cat > reply_email_draft.html <<'HTML'
+<h2>Request Framing</h2>
+<ul>
+  <li><strong>Ticker:</strong> NVDA</li>
+  <li><strong>Name:</strong> NVIDIA</li>
+  <li><strong>Type:</strong> Stock</li>
+  <li><strong>Research Mode:</strong> Deep research</li>
+  <li><strong>User Objective:</strong> Decide whether now is actionable (stated)</li>
+  <li><strong>Horizon:</strong> Long-term (inferred)</li>
+  <li><strong>Question Type:</strong> Long-term accumulation</li>
+</ul>
+<h2>Final Recommendation</h2>
+<ul>
+  <li><strong>Rating:</strong> Wait</li>
+  <li><strong>Horizon:</strong> Long-term (inferred)</li>
+  <li><strong>Confidence:</strong> Medium</li>
+  <li><strong>Timing Verdict:</strong> Wait</li>
+  <li><strong>Add Criteria:</strong> Better entry after earnings or improved valuation support.</li>
+  <li><strong>Invalidation Criteria:</strong> Demand slows or margin guidance weakens.</li>
+  <li><strong>Biggest Near-Term Risk:</strong> Event volatility around earnings.</li>
+  <li><strong>Biggest Long-Term Strength:</strong> AI compute leadership.</li>
+</ul>
+<h2>Verified Facts</h2>
+<ul><li>Fact.</li></ul>
+<h2>Derived Metrics</h2>
+<ul><li>Metric: price / eps = 10x</li></ul>
+<h2>Inference / Judgment</h2>
+<ul><li>Judgment.</li></ul>
+<h2>Scenario Analysis</h2>
+<p><strong>Bull Case:</strong> Demand remains strong.</p>
+<p><strong>Base Case:</strong> Growth normalizes.</p>
+<p><strong>Bear Case:</strong> Spending slows.</p>
+HTML
+mkdir -p reply_email_attachments
+echo "attachment" > reply_email_attachments/attachment.txt
+"#
+        }
+        FakeClaudeMode::InvestmentGeneric => {
+            r#"#!/bin/sh
+set -e
+echo '{"type":"message_delta","delta":{"text":"ok"}}'
+cat > reply_email_draft.html <<'HTML'
+<p>Good business, but not a good all-in buy. Wait until after earnings.</p>
+HTML
 mkdir -p reply_email_attachments
 echo "attachment" > reply_email_attachments/attachment.txt
 "#
@@ -503,4 +609,41 @@ pub fn build_params(workspace: &Path) -> RunTaskParams {
         thread_epoch: None,
         thread_state_path: None,
     }
+}
+
+pub fn install_runtime_skills_and_employee_guidance(
+    workspace: &Path,
+    employee_id: &str,
+) -> io::Result<()> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let service_root = manifest_dir
+        .parent()
+        .expect("run_task_module lives under DoWhiz_service");
+    let skills_root = service_root.join("skills");
+    let employee_root = service_root.join("employees").join(employee_id);
+
+    copy_dir_recursive(&skills_root, &workspace.join(".agents").join("skills"))?;
+    for filename in ["AGENTS.md", "CLAUDE.md", "SOUL.md"] {
+        let src = employee_root.join(filename);
+        if src.exists() {
+            fs::copy(src, workspace.join(filename))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) -> io::Result<()> {
+    fs::create_dir_all(dest)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dest_path)?;
+        } else {
+            fs::copy(&src_path, &dest_path)?;
+        }
+    }
+    Ok(())
 }

--- a/DoWhiz_service/run_task_module/tests/support/mod.rs
+++ b/DoWhiz_service/run_task_module/tests/support/mod.rs
@@ -611,6 +611,8 @@ pub fn build_params(workspace: &Path) -> RunTaskParams {
     }
 }
 
+// This helper is used only by the investment-focused integration test crate.
+#[allow(dead_code)]
 pub fn install_runtime_skills_and_employee_guidance(
     workspace: &Path,
     employee_id: &str,
@@ -633,6 +635,7 @@ pub fn install_runtime_skills_and_employee_guidance(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn copy_dir_recursive(src: &Path, dest: &Path) -> io::Result<()> {
     fs::create_dir_all(dest)?;
     for entry in fs::read_dir(src)? {

--- a/DoWhiz_service/scheduler_module/Cargo.toml
+++ b/DoWhiz_service/scheduler_module/Cargo.toml
@@ -103,6 +103,10 @@ path = "src/bin/grocery_cli.rs"
 name = "task_status_cli"
 path = "src/bin/task_status_cli.rs"
 
+[[bin]]
+name = "investment_eval"
+path = "src/bin/investment_eval.rs"
+
 [dev-dependencies]
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "builder"] }
 mockito = "1"

--- a/DoWhiz_service/scheduler_module/src/bin/investment_eval.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/investment_eval.rs
@@ -1,0 +1,121 @@
+use clap::Parser;
+use run_task_module::{run_task, RunTaskParams, UserIdentities};
+use send_emails_module::normalize_email_html;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Parser, Debug)]
+#[command(name = "investment_eval")]
+struct Args {
+    #[arg(long)]
+    workspace_dir: PathBuf,
+    #[arg(long)]
+    prompt: String,
+    #[arg(long)]
+    subject: String,
+    #[arg(long, default_value = "little_bear")]
+    employee: String,
+    #[arg(long, default_value = "gpt-5.4")]
+    model: String,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    prepare_workspace(&args.workspace_dir)?;
+    write_inbound_email(&args.workspace_dir, &args.subject, &args.prompt)?;
+    install_runtime_skills_and_guidance(&args.workspace_dir, &args.employee)?;
+
+    let output = run_task(&RunTaskParams {
+        workspace_dir: args.workspace_dir.clone(),
+        input_email_dir: PathBuf::from("incoming_email"),
+        input_attachments_dir: PathBuf::from("incoming_attachments"),
+        memory_dir: PathBuf::from("memory"),
+        reference_dir: PathBuf::from("references"),
+        reply_to: vec!["user@example.com".to_string()],
+        model_name: args.model.clone(),
+        runner: "codex".to_string(),
+        codex_disabled: false,
+        channel: "email".to_string(),
+        google_access_token: None,
+        notion_access_token: None,
+        has_unified_account: true,
+        user_identities: UserIdentities::default(),
+        thread_epoch: None,
+        thread_state_path: None,
+    })?;
+
+    let raw_reply = fs::read_to_string(&output.reply_html_path)?;
+    let final_rendered_path = args.workspace_dir.join("final_rendered_email.html");
+    let final_rendered_html = normalize_email_html(&args.subject, &raw_reply);
+    fs::write(&final_rendered_path, &final_rendered_html)?;
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "workspace_dir": args.workspace_dir,
+            "reply_draft_path": output.reply_html_path,
+            "final_rendered_path": final_rendered_path,
+            "reply_attachments_dir": output.reply_attachments_dir,
+            "recovery_note": output.recovery_note,
+        })
+    );
+
+    Ok(())
+}
+
+fn prepare_workspace(workspace_dir: &Path) -> Result<(), std::io::Error> {
+    fs::create_dir_all(workspace_dir.join("incoming_email"))?;
+    fs::create_dir_all(workspace_dir.join("incoming_attachments"))?;
+    fs::create_dir_all(workspace_dir.join("memory"))?;
+    fs::create_dir_all(workspace_dir.join("references"))?;
+    Ok(())
+}
+
+fn write_inbound_email(
+    workspace_dir: &Path,
+    subject: &str,
+    prompt: &str,
+) -> Result<(), std::io::Error> {
+    let payload = serde_json::json!({
+        "Subject": subject,
+        "TextBody": prompt,
+        "HtmlBody": format!("<p>{}</p>", prompt),
+    });
+    fs::write(
+        workspace_dir
+            .join("incoming_email")
+            .join("postmark_payload.json"),
+        serde_json::to_string_pretty(&payload).map_err(std::io::Error::other)?,
+    )?;
+    fs::write(
+        workspace_dir.join("incoming_email").join("email.html"),
+        format!("<p>{}</p>", prompt),
+    )?;
+    Ok(())
+}
+
+fn install_runtime_skills_and_guidance(
+    workspace_dir: &Path,
+    employee_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let service_root = manifest_dir
+        .parent()
+        .expect("scheduler_module lives under DoWhiz_service");
+    let skills_root = service_root.join("skills");
+    let employee_root = service_root.join("employees").join(employee_id);
+
+    scheduler_module::service::copy_dir_recursive(
+        &skills_root,
+        &workspace_dir.join(".agents").join("skills"),
+    )?;
+
+    for filename in ["AGENTS.md", "CLAUDE.md", "SOUL.md"] {
+        let src = employee_root.join(filename);
+        if src.exists() {
+            fs::copy(src, workspace_dir.join(filename))?;
+        }
+    }
+
+    Ok(())
+}

--- a/DoWhiz_service/scheduler_module/src/service/workspace.rs
+++ b/DoWhiz_service/scheduler_module/src/service/workspace.rs
@@ -826,8 +826,12 @@ pub(super) fn create_unique_dir(root: &Path, base: &str) -> Result<PathBuf, std:
 mod tests {
     use super::*;
     use crate::domain::workspace_blueprint::StartupWorkspaceBlueprint;
+    use crate::employee_config::EmployeeProfile;
+    use crate::user_store::UserPaths;
     use serde_json::json;
+    use std::collections::HashSet;
     use std::fs;
+    use std::path::Path;
     use tempfile::tempdir;
 
     #[test]
@@ -936,5 +940,60 @@ mod tests {
         assert!(incoming_attachments.join("brief_v1.txt").exists());
         assert!(incoming_attachments.join("brief_v2.txt").exists());
         assert!(incoming_attachments.join("thread_manifest.json").exists());
+    }
+
+    #[test]
+    fn ensure_thread_workspace_copies_runtime_investment_skill() {
+        let temp = tempdir().expect("tempdir");
+        let user_root = temp.path().join("user");
+        let user_paths = UserPaths {
+            root: user_root.clone(),
+            state_dir: user_root.join("state"),
+            tasks_db_path: user_root.join("state/tasks.db"),
+            memory_dir: user_root.join("memory"),
+            secrets_dir: user_root.join("secrets"),
+            mail_root: user_root.join("mail"),
+            workspaces_root: user_root.join("workspaces"),
+        };
+        fs::create_dir_all(&user_paths.mail_root).expect("mail root");
+        fs::create_dir_all(&user_paths.workspaces_root).expect("workspaces root");
+
+        let employee = EmployeeProfile {
+            id: "little_bear".to_string(),
+            display_name: Some("Oliver".to_string()),
+            runner: "codex".to_string(),
+            model: Some("gpt-5.4".to_string()),
+            addresses: vec!["oliver@dowhiz.com".to_string()],
+            address_set: HashSet::from(["oliver@dowhiz.com".to_string()]),
+            runtime_root: None,
+            agents_path: None,
+            claude_path: None,
+            soul_path: None,
+            skills_dir: None,
+            discord_enabled: false,
+            slack_enabled: false,
+            bluebubbles_enabled: false,
+        };
+
+        let service_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("scheduler_module lives under DoWhiz_service");
+        let skills_root = service_root.join("skills");
+
+        let workspace = ensure_thread_workspace(
+            &user_paths,
+            "user-123",
+            "thread:investment",
+            &employee,
+            Some(&skills_root),
+        )
+        .expect("workspace");
+
+        assert!(
+            workspace
+                .join(".agents/skills/us-equity-daily-monitor/SKILL.md")
+                .exists(),
+            "runtime investment skill should be copied into the live workspace skill path"
+        );
     }
 }

--- a/DoWhiz_service/send_emails_module/src/lib.rs
+++ b/DoWhiz_service/send_emails_module/src/lib.rs
@@ -1379,6 +1379,54 @@ mod tests {
     }
 
     #[test]
+    fn normalize_email_html_preserves_investment_contract_labels() {
+        let normalized = normalize_email_html(
+            "NVDA investment memo",
+            r#"
+            <h2>Final Recommendation</h2>
+            <ul>
+              <li><strong>Rating:</strong> Wait</li>
+              <li><strong>Horizon:</strong> Medium-term (stated)</li>
+              <li><strong>Confidence:</strong> Medium</li>
+              <li><strong>Timing Verdict:</strong> Wait</li>
+              <li><strong>Add Criteria:</strong> Better entry after earnings.</li>
+              <li><strong>Invalidation Criteria:</strong> Margin guide weakens.</li>
+              <li><strong>Biggest Near-Term Risk:</strong> Earnings volatility.</li>
+              <li><strong>Biggest Long-Term Strength:</strong> AI compute leadership.</li>
+            </ul>
+            <h2>Verified Facts</h2><ul><li>Fact one.</li></ul>
+            <h2>Derived Metrics</h2><ul><li>Metric: price / eps = 10x</li></ul>
+            <h2>Scenario Analysis</h2>
+            <p><strong>Bull Case:</strong> Demand stays strong.</p>
+            <p><strong>Base Case:</strong> Growth normalizes.</p>
+            <p><strong>Bear Case:</strong> Spending slows.</p>
+            "#,
+        );
+
+        let text = plain_text_body_from_html(&normalized);
+        for label in [
+            "Rating:",
+            "Horizon:",
+            "Confidence:",
+            "Timing Verdict:",
+            "Verified Facts",
+            "Derived Metrics",
+            "Bull Case:",
+            "Base Case:",
+            "Bear Case:",
+            "Add Criteria:",
+            "Invalidation Criteria:",
+            "Biggest Near-Term Risk:",
+            "Biggest Long-Term Strength:",
+        ] {
+            assert!(
+                normalized.contains(label) || text.contains(label),
+                "expected normalized email content to preserve label {label}"
+            );
+        }
+    }
+
+    #[test]
     fn normalize_email_html_wraps_data_tables_in_scroll_container() {
         let normalized = normalize_email_html(
             "Weekly metrics",

--- a/DoWhiz_service/skills/manifest.toml
+++ b/DoWhiz_service/skills/manifest.toml
@@ -34,6 +34,7 @@ shared_skill_dirs = [
   "spreadsheet",
   "theme-factory",
   "tpm",
+  "us-equity-daily-monitor",
   "us-tax-filing-assistant",
   "vercel-deploy",
   "web-artifacts-builder",

--- a/DoWhiz_service/skills/us-equity-daily-monitor/SKILL.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: us-equity-daily-monitor
+description: One-off investment research for a single U.S. stock or single U.S. ETF. Use this skill whenever the user asks to analyze one ticker, asks whether now is a good time to buy, asks about buying before earnings, requests deep research on one U.S. stock or ETF, or wants a clear Buy / Wait / Sell view. Return a decision-useful memo with exact visible labels for Rating, Horizon, Confidence, Timing Verdict, Verified Facts, Derived Metrics, Bull Case, Base Case, Bear Case, Add Criteria, Invalidation Criteria, Biggest Near-Term Risk, and Biggest Long-Term Strength.
+---
+
+# U.S. Equity Decision Memo
+
+Use this skill for one U.S. public stock or one U.S. ETF.
+
+Do not use it for:
+
+- crypto
+- options
+- portfolio allocation
+- multi-asset screeners
+- automated trading
+- recurring monitoring
+
+## Core job
+
+Return one final user-visible investment memo that helps the user decide what to do now.
+
+This memo must not collapse into generic stock commentary. It must separate:
+
+- verified facts
+- derived metrics
+- inference or judgment
+
+It must also give:
+
+- one final `Buy`, `Wait`, or `Sell` rating
+- one direct timing verdict
+- explicit bull, base, and bear cases
+- explicit add criteria
+- explicit invalidation criteria
+
+## Hard output contract
+
+The final user-visible artifact must contain these exact visible labels.
+
+For email replies, write semantic HTML in `reply_email_draft.html` and keep these labels visible in the HTML body.
+
+For chat replies, keep the same visible labels in markdown or plain text.
+
+Do not rename, collapse, or replace them with softer alternatives.
+
+Required labels:
+
+- `Rating`
+- `Horizon`
+- `Confidence`
+- `Timing Verdict`
+- `Verified Facts`
+- `Derived Metrics`
+- `Bull Case`
+- `Base Case`
+- `Bear Case`
+- `Add Criteria`
+- `Invalidation Criteria`
+- `Biggest Near-Term Risk`
+- `Biggest Long-Term Strength`
+
+## Request framing
+
+Before making claims, identify:
+
+- ticker
+- company or fund name
+- `Stock` or `ETF`
+- research mode: `Quick analysis` or `Deep research`
+- user objective: mark `stated` or `inferred`
+- horizon: `Short-term`, `Medium-term`, or `Long-term`, and mark `stated` or `inferred`
+- question type: `Long-term accumulation`, `Medium-term investment`, `Short-term trade`, or `Event-driven timing`
+
+Inference rules:
+
+- days or weeks usually map to `Short-term`
+- months usually map to `Medium-term`
+- broad "is this worth buying?" questions usually map to `Long-term (inferred)`
+- earnings or catalyst timing questions map to `Event-driven timing`
+
+If the prompt is ambiguous or points to multiple possible tickers, resolve the ambiguity before giving the memo.
+
+## Facts, metrics, and judgment
+
+### Verified Facts
+
+Only sourced facts belong here.
+
+Examples:
+
+- latest reported revenue, EPS, cash, debt, margin, or guidance
+- next earnings date
+- major concentration or regulatory facts
+- recent price or trend context when available from accessible public data
+
+Do not mix opinion into this section.
+
+### Derived Metrics
+
+This section is mandatory even when the conclusion is that a metric is not reliably derivable.
+
+Rules:
+
+- show the metric name
+- show the formula
+- show the inputs used
+- show the result, or say what missing input prevents a reliable result
+
+Examples:
+
+- trailing GAAP P/E = share price / trailing diluted EPS
+- forward P/E = share price / forward EPS consensus
+- net cash or net debt = cash and equivalents - total debt
+- FCF margin = trailing free cash flow / trailing revenue
+
+If the metric is approximate, mark it clearly as approximate.
+
+### Inference / Judgment
+
+Keep judgment separate from fact.
+
+Make it clear when you are interpreting mixed evidence, valuation stretch, event risk, or poor timing.
+
+## Timing and scenarios
+
+### Timing Verdict
+
+Give one direct action from this set:
+
+- `Buy now`
+- `Starter only`
+- `Wait`
+- `Avoid for now`
+
+Do not hide behind vague language such as:
+
+- "good company"
+- "buy in tranches"
+- "wait and see"
+- "not a good all-in buy"
+
+Translate vague language into an explicit `Timing Verdict`, `Add Criteria`, and `Invalidation Criteria`.
+
+### Scenario Analysis
+
+This section is mandatory and must include:
+
+- `Bull Case`
+- `Base Case`
+- `Bear Case`
+
+Do not invent precise price targets unless the supporting math is shown.
+
+## Wrong-premise handling
+
+If the user states a factual premise and trusted public sources conflict with it, correct the premise explicitly in the final memo before proceeding.
+
+Do not silently absorb a wrong earnings date, filing date, or guidance number.
+
+## Confidence
+
+Use only:
+
+- `Low`
+- `Medium`
+- `High`
+
+Lower confidence when data is incomplete, conflicting, stale, messy, or heavily catalyst-dependent.
+
+## Exact final structure
+
+Use this exact visible structure and keep the labels exactly as written.
+
+### Request Framing
+- `Ticker`: ...
+- `Name`: ...
+- `Type`: `Stock` or `ETF`
+- `Research Mode`: `Quick analysis` or `Deep research`
+- `User Objective`: ... `(<stated or inferred>)`
+- `Horizon`: `Short-term`, `Medium-term`, or `Long-term` `(<stated or inferred>)`
+- `Question Type`: `Long-term accumulation`, `Medium-term investment`, `Short-term trade`, or `Event-driven timing`
+
+### Final Recommendation
+- `Rating`: `Buy`, `Wait`, or `Sell`
+- `Horizon`: `Short-term`, `Medium-term`, or `Long-term` `(<stated or inferred>)`
+- `Confidence`: `Low`, `Medium`, or `High`
+- `Timing Verdict`: `Buy now`, `Starter only`, `Wait`, or `Avoid for now`
+- `Add Criteria`: ...
+- `Invalidation Criteria`: ...
+- `Biggest Near-Term Risk`: ...
+- `Biggest Long-Term Strength`: ...
+
+### Verified Facts
+- 4 to 8 concise bullets with sourced facts only
+
+### Derived Metrics
+- 2 to 4 concise bullets in the form `Metric: formula = result`
+- or explicit `Not reliably derivable from accessible public data today: ...`
+
+### Inference / Judgment
+- 2 to 5 concise bullets
+
+### Scenario Analysis
+- `Bull Case`: ...
+- `Base Case`: ...
+- `Bear Case`: ...
+
+### Sources
+- name the primary public sources used
+- list official or primary sources first
+
+### Disclaimer
+`Public-information-based research only, not personalized investment advice or trade execution.`
+
+## Email formatting guidance
+
+For email replies:
+
+- use semantic HTML such as `<h2>`, `<p>`, `<ul>`, `<li>`, and `<strong>`
+- keep the contract labels visible as text inside the HTML body
+- do not hide the labels inside images or attachments
+- do not replace the labeled structure with one prose paragraph
+
+## Failure mode to avoid
+
+This is bad:
+
+`NVIDIA is a great company, but I would wait and buy in tranches after earnings.`
+
+This is acceptable only when translated into the exact labeled memo with a clear `Rating`, `Timing Verdict`, `Add Criteria`, and `Invalidation Criteria`.

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/evals.json
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/evals.json
@@ -1,0 +1,63 @@
+{
+  "skill_name": "us-equity-daily-monitor",
+  "evals": [
+    {
+      "id": 1,
+      "name": "final-artifact-contract-nvda",
+      "kind": "live_run",
+      "subject": "NVDA investment memo",
+      "prompt": "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+      "require_contract": true
+    },
+    {
+      "id": 2,
+      "name": "anti-generic-output-fixture",
+      "kind": "fixture",
+      "artifact_html": "<p>NVIDIA is a good business, but I would wait until after earnings and buy in tranches.</p>",
+      "expected_failure": true
+    },
+    {
+      "id": 3,
+      "name": "horizon-awareness-nvda-3-month",
+      "kind": "live_run",
+      "subject": "NVDA 3-month position",
+      "prompt": "Is NVDA a buy this week for a 3-month position?",
+      "require_contract": true,
+      "expected_horizon_contains": "medium-term",
+      "expected_question_type_contains": "medium-term investment"
+    },
+    {
+      "id": 4,
+      "name": "live-path-alignment-nvda",
+      "kind": "live_run",
+      "subject": "NVDA alignment check",
+      "prompt": "Give me deep research on NVDA and tell me whether now is a good time to buy.",
+      "require_contract": true,
+      "require_live_path_alignment": true
+    },
+    {
+      "id": 5,
+      "name": "wrong-premise-correction-nvda",
+      "kind": "live_run",
+      "subject": "NVDA earnings timing",
+      "prompt": "NVDA earnings are on May 27, 2026, right? Should I buy before them?",
+      "require_contract": true,
+      "must_contain_any": [
+        "May 20, 2026",
+        "May 20 2026"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "weak-case-confidence-plug",
+      "kind": "live_run",
+      "subject": "PLUG investment memo",
+      "prompt": "Give me deep research on PLUG and tell me whether now is a good time to buy.",
+      "require_contract": true,
+      "allowed_confidence": [
+        "low",
+        "medium"
+      ]
+    }
+  ]
+}

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Run final-artifact investment regressions through the real DoWhiz email reply path.
+
+This runner does not grade an intermediate model transcript. It invokes the
+`investment_eval` helper, which:
+1. creates a DoWhiz-style workspace
+2. copies runtime skills from DoWhiz_service/skills
+3. runs `run_task`
+4. writes `reply_email_draft.html`
+5. renders the final user-visible email artifact to `final_rendered_email.html`
+
+The grader then checks the final rendered email artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[3]
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+WORKSPACE_ROOT = SKILL_ROOT.parent.parent / "us-equity-daily-monitor-workspace"
+REQUIRED_LABELS = [
+    "rating:",
+    "horizon:",
+    "confidence:",
+    "timing verdict:",
+    "verified facts",
+    "derived metrics",
+    "bull case",
+    "base case",
+    "bear case",
+    "add criteria:",
+    "invalidation criteria:",
+    "biggest near-term risk:",
+    "biggest long-term strength:",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iteration", default="iteration-final-artifact")
+    parser.add_argument("--eval-ids", nargs="*", type=int)
+    return parser.parse_args()
+
+
+def load_evals() -> list[dict[str, Any]]:
+    payload = json.loads((SKILL_ROOT / "evals" / "evals.json").read_text())
+    return payload["evals"]
+
+
+def normalize_text(raw_html: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", raw_html)
+    text = (
+        text.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+    )
+    return " ".join(text.split()).lower()
+
+
+def extract_field(text: str, label: str) -> str | None:
+    pattern = re.compile(rf"{re.escape(label)}\s*:\s*([^<\n\r]+)", re.IGNORECASE)
+    match = pattern.search(text)
+    if not match:
+        return None
+    return match.group(1).strip().lower()
+
+
+def grade_contract(text: str) -> list[str]:
+    return [label for label in REQUIRED_LABELS if label not in text]
+
+
+def run_live_eval(case: dict[str, Any], eval_dir: Path) -> dict[str, Any]:
+    workspace_dir = eval_dir / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "cargo",
+        "run",
+        "-q",
+        "-p",
+        "scheduler_module",
+        "--bin",
+        "investment_eval",
+        "--",
+        "--workspace-dir",
+        str(workspace_dir),
+        "--subject",
+        case["subject"],
+        "--prompt",
+        case["prompt"],
+        "--employee",
+        "little_bear",
+    ]
+
+    env = os.environ.copy()
+    env.setdefault("CARGO_INCREMENTAL", "0")
+    env.setdefault("CARGO_BUILD_JOBS", "1")
+    env.setdefault("RUSTFLAGS", "-C debuginfo=0")
+
+    completed = subprocess.run(
+        cmd,
+        cwd=SERVICE_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (eval_dir / "stdout.log").write_text(completed.stdout)
+    (eval_dir / "stderr.log").write_text(completed.stderr)
+
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"investment_eval failed for {case['name']} with code {completed.returncode}\n"
+            f"{completed.stderr}"
+        )
+
+    result = json.loads(completed.stdout.strip().splitlines()[-1])
+    final_rendered_path = Path(result["final_rendered_path"])
+    reply_draft_path = Path(result["reply_draft_path"])
+    artifact_html = final_rendered_path.read_text()
+
+    return {
+        "artifact_html": artifact_html,
+        "final_rendered_path": str(final_rendered_path),
+        "reply_draft_path": str(reply_draft_path),
+        "recovery_note": result.get("recovery_note"),
+    }
+
+
+def run_fixture_eval(case: dict[str, Any], eval_dir: Path) -> dict[str, Any]:
+    artifact_html = case["artifact_html"]
+    rendered_path = eval_dir / "final_rendered_email.html"
+    rendered_path.write_text(artifact_html)
+    return {
+        "artifact_html": artifact_html,
+        "final_rendered_path": str(rendered_path),
+        "reply_draft_path": None,
+        "recovery_note": None,
+    }
+
+
+def grade_case(case: dict[str, Any], run_result: dict[str, Any]) -> dict[str, Any]:
+    artifact_html = run_result["artifact_html"]
+    text = normalize_text(artifact_html)
+    checks: list[dict[str, Any]] = []
+
+    missing_contract = grade_contract(text)
+    if case.get("expected_failure"):
+        checks.append(
+            {
+                "name": "generic_commentary_fixture_rejected",
+                "passed": bool(missing_contract),
+                "detail": "grader rejected fixture" if missing_contract else "fixture unexpectedly passed",
+            }
+        )
+    elif case.get("require_contract"):
+        checks.append(
+            {
+                "name": "required_contract_labels_present",
+                "passed": not missing_contract,
+                "detail": "ok"
+                if not missing_contract
+                else f"missing: {', '.join(missing_contract)}",
+            }
+        )
+
+    if case.get("expected_horizon_contains"):
+        horizon = extract_field(text, "horizon") or ""
+        checks.append(
+            {
+                "name": "horizon_awareness",
+                "passed": case["expected_horizon_contains"] in horizon,
+                "detail": f"horizon={horizon or '(missing)'}",
+            }
+        )
+
+    if case.get("expected_question_type_contains"):
+        checks.append(
+            {
+                "name": "question_type_alignment",
+                "passed": case["expected_question_type_contains"] in text,
+                "detail": "ok"
+                if case["expected_question_type_contains"] in text
+                else "question type missing from final artifact",
+            }
+        )
+
+    if case.get("require_live_path_alignment"):
+        checks.append(
+            {
+                "name": "live_path_alignment",
+                "passed": str(run_result["reply_draft_path"]).endswith("reply_email_draft.html")
+                and str(run_result["final_rendered_path"]).endswith("final_rendered_email.html"),
+                "detail": f"reply={run_result['reply_draft_path']} final={run_result['final_rendered_path']}",
+            }
+        )
+
+    if case.get("must_contain_any"):
+        passed = any(s.lower() in artifact_html.lower() for s in case["must_contain_any"])
+        checks.append(
+            {
+                "name": "required_correction_or_phrase_present",
+                "passed": passed,
+                "detail": "ok" if passed else f"missing any of {case['must_contain_any']}",
+            }
+        )
+
+    if case.get("allowed_confidence"):
+        confidence = extract_field(text, "confidence") or ""
+        allowed = [value.lower() for value in case["allowed_confidence"]]
+        checks.append(
+            {
+                "name": "confidence_degrades_for_weaker_case",
+                "passed": any(value in confidence for value in allowed),
+                "detail": f"confidence={confidence or '(missing)'}",
+            }
+        )
+
+    return {
+        "checks": checks,
+        "passed": all(check["passed"] for check in checks),
+        "artifact_path": run_result["final_rendered_path"],
+        "reply_draft_path": run_result["reply_draft_path"],
+        "recovery_note": run_result.get("recovery_note"),
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    evals = load_evals()
+    selected = [case for case in evals if not args.eval_ids or case["id"] in args.eval_ids]
+    iteration_dir = WORKSPACE_ROOT / args.iteration
+    iteration_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = []
+    for case in selected:
+        eval_dir = iteration_dir / f"eval-{case['id']}-{case['name']}"
+        eval_dir.mkdir(parents=True, exist_ok=True)
+        if case["kind"] == "live_run":
+            run_result = run_live_eval(case, eval_dir)
+        else:
+            run_result = run_fixture_eval(case, eval_dir)
+
+        grading = grade_case(case, run_result)
+        (eval_dir / "final_rendered_email.html").write_text(run_result["artifact_html"])
+        (eval_dir / "grading.json").write_text(json.dumps(grading, indent=2))
+        summary.append(
+            {
+                "id": case["id"],
+                "name": case["name"],
+                "passed": grading["passed"],
+                "artifact_path": grading["artifact_path"],
+                "reply_draft_path": grading["reply_draft_path"],
+            }
+        )
+
+    summary_path = iteration_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2))
+    failed = [item for item in summary if not item["passed"]]
+    print(json.dumps({"summary_path": str(summary_path), "failed": failed}, indent=2))
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add the runtime `us-equity-daily-monitor` skill under `DoWhiz_service/skills` and route Oliver investment requests to it in the live `run_task` prompt
- hard-enforce the investment memo contract at the reply artifact boundary so generic stock-commentary emails fail closed instead of counting as success
- add final-artifact-focused coverage for renderer preservation, runtime skill copying, and regression grading of the rendered email artifact

## Validation
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p run_task_module --lib investment -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p run_task_module --test run_task_tests investment -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p scheduler_module --lib ensure_thread_workspace_copies_runtime_investment_skill -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p send_emails_module normalize_email_html_preserves_investment_contract_labels -- --nocapture`
- `python3 DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py --iteration iteration-fixture --eval-ids 2`

## Notes
- the final-artifact eval runner now grades `final_rendered_email.html`, not an intermediate transcript
- a true local live-model run is still blocked by the current local runner environment: `codex exec --add-dir` is not supported by the installed Codex CLI here, and the configured Claude fallback model returns a 404 in this environment
