### PR TITLE
Semaphore limit of 5 concurrent azcopy calls

### DIFF
--- a/DoWhiz_service/Cargo.lock
+++ b/DoWhiz_service/Cargo.lock
@@ -3722,6 +3722,7 @@ dependencies = [
  "send_emails_module",
  "serde",
  "serde_json",
+ "std-semaphore",
  "tempfile",
  "tokio",
  "toml",
@@ -4579,6 +4580,12 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "std-semaphore"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
 
 [[package]]
 name = "string_cache"

--- a/DoWhiz_service/run_task_module/Cargo.toml
+++ b/DoWhiz_service/run_task_module/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4", features = ["serde"] }
 mongodb = { version = "2.8", default-features = false, features = ["sync", "bson-chrono-0_4"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+std-semaphore = "0.1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 toml = "0.8"

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -9,6 +9,8 @@ use std::sync::{LazyLock, Mutex};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use std_semaphore::Semaphore;
+
 use chrono::{Duration as ChronoDuration, Utc};
 use serde::Deserialize;
 
@@ -42,6 +44,11 @@ use super::utils::{
     ThreadSupersedeMonitor,
 };
 use super::workspace::{canonicalize_dir, workspace_path_in_container};
+
+/// Global semaphore to limit concurrent azcopy transfers.
+/// Prevents overloading the system when many tasks run in parallel.
+const AZCOPY_MAX_CONCURRENT: isize = 5;
+static AZCOPY_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(AZCOPY_MAX_CONCURRENT));
 
 const PAYMENT_ENV_KEYS: &[&str] = &[
     "GOATX402_API_URL",
@@ -2068,6 +2075,7 @@ fn upload_workspace_to_share(
     share_name: &str,
     workspace_dir: &Path,
 ) -> Result<(), RunTaskError> {
+    let _permit = AZCOPY_SEMAPHORE.acquire();
     let secrets = [config.storage_key.as_str()];
     let source = format!("{}/*", workspace_dir.display());
     let mut last_error = None;
@@ -2137,6 +2145,7 @@ fn download_workspace_from_share(
     share_name: &str,
     workspace_dir: &Path,
 ) -> Result<(), RunTaskError> {
+    let _permit = AZCOPY_SEMAPHORE.acquire();
     let secrets = [config.storage_key.as_str()];
     let temp_parent = workspace_dir.parent().unwrap_or(workspace_dir);
     let mut last_error = None;


### PR DESCRIPTION
## Summary

- What changed?
Semaphore limit of 5 concurrent azcopy calls- 
- Why is it needed?
On prod,  too many concurrent `azcopy`calls to merge ephemeral fileshare -> global fileshare causes CPU to max out