### PR TITLE
Refactor auth dashboard home into an action-first flow

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/claude.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/claude.rs
@@ -359,7 +359,7 @@ fn ensure_claude_settings(
         "model": model_name,
     });
     let rendered = serde_json::to_string_pretty(&payload)
-        .map_err(|err| RunTaskError::Io(io::Error::new(io::ErrorKind::Other, err.to_string())))?;
+        .map_err(|err| RunTaskError::Io(io::Error::other(err)))?;
     fs::write(settings_path, format!("{}\n", rendered))?;
     Ok(())
 }
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn claude_fallback_timeout_defaults_to_run_task_timeout() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "1200"),
             EnvVarGuard::unset("RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS"),
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
@@ -639,7 +639,7 @@ mod tests {
     #[test]
     fn claude_fallback_timeout_respects_explicit_cap() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "1200"),
             EnvVarGuard::set("RUN_TASK_CODEX_FALLBACK_TIMEOUT_SECS", "300"),
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -48,7 +48,8 @@ use super::workspace::{canonicalize_dir, workspace_path_in_container};
 /// Global semaphore to limit concurrent azcopy transfers.
 /// Prevents overloading the system when many tasks run in parallel.
 const AZCOPY_MAX_CONCURRENT: isize = 5;
-static AZCOPY_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(AZCOPY_MAX_CONCURRENT));
+static AZCOPY_SEMAPHORE: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(AZCOPY_MAX_CONCURRENT));
 
 const PAYMENT_ENV_KEYS: &[&str] = &[
     "GOATX402_API_URL",

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -2103,7 +2103,7 @@ fn upload_workspace_to_share(
     share_name: &str,
     workspace_dir: &Path,
 ) -> Result<(), RunTaskError> {
-    let _permit = AZCOPY_SEMAPHORE.acquire();
+    let _permit = AZCOPY_SEMAPHORE.access();
     let secrets = [config.storage_key.as_str()];
     let source = format!("{}/*", workspace_dir.display());
     let mut last_error = None;
@@ -2173,7 +2173,7 @@ fn download_workspace_from_share(
     share_name: &str,
     workspace_dir: &Path,
 ) -> Result<(), RunTaskError> {
-    let _permit = AZCOPY_SEMAPHORE.acquire();
+    let _permit = AZCOPY_SEMAPHORE.access();
     let secrets = [config.storage_key.as_str()];
     let temp_parent = workspace_dir.parent().unwrap_or(workspace_dir);
     let mut last_error = None;
@@ -2312,6 +2312,7 @@ fn build_aci_container_name() -> String {
     format!("dwz-codex-{}-{}-{}", millis, std::process::id(), seq)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_azure_aci_execution(
     config: &AzureAciConfig,
     container_name: &str,
@@ -4659,7 +4660,7 @@ mod tests {
     #[test]
     fn test_collect_payment_env_overrides_uses_employee_prefix_fallback() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset("GOATX402_API_URL"),
             EnvVarGuard::unset("GOATX402_API_KEY"),
             EnvVarGuard::unset("EMPLOYEE_PAYMENT_ENV_PREFIX"),
@@ -4683,7 +4684,7 @@ mod tests {
     #[test]
     fn test_collect_payment_env_overrides_prefers_unprefixed_values() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("EMPLOYEE_PAYMENT_ENV_PREFIX", "OLIVER"),
             EnvVarGuard::set("GOATX402_API_KEY", "api-key-global"),
             EnvVarGuard::set("OLIVER_GOATX402_API_KEY", "api-key-prefixed"),
@@ -4698,7 +4699,7 @@ mod tests {
     #[test]
     fn test_collect_bright_data_env_overrides_sets_canonical_and_alias_keys() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set(BRIGHT_DATA_API_KEY_ENV_KEY, "bright-key"),
             EnvVarGuard::unset(BRIGHTDATA_API_KEY_ENV_KEY),
             EnvVarGuard::set("BRIGHT_DATA_XIAOHONGSHU_COLLECTOR", "collector-123"),
@@ -4723,7 +4724,7 @@ mod tests {
     #[test]
     fn test_collect_bright_data_env_overrides_falls_back_to_cli_alias() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset(BRIGHT_DATA_API_KEY_ENV_KEY),
             EnvVarGuard::set(BRIGHTDATA_API_KEY_ENV_KEY, "alias-only-key"),
             EnvVarGuard::unset("BRIGHT_DATA_XIAOHONGSHU_COLLECTOR"),
@@ -4748,7 +4749,7 @@ mod tests {
     #[test]
     fn test_collect_human_approval_gate_env_overrides_collects_expected_keys() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("POSTMARK_SERVER_TOKEN", "pm-token"),
             EnvVarGuard::set("HUMAN_APPROVAL_REPLY_TO", "inbox@example.com"),
             EnvVarGuard::set("GOOGLE_PASSWORD", "google-password"),
@@ -4771,7 +4772,7 @@ mod tests {
     #[test]
     fn test_collect_human_approval_gate_env_overrides_skips_unset_or_blank_values() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset("POSTMARK_SERVER_TOKEN"),
             EnvVarGuard::set("HUMAN_APPROVAL_FROM", "   "),
             EnvVarGuard::unset("HUMAN_APPROVAL_REPLY_TO"),
@@ -4802,7 +4803,7 @@ addresses = ["dowhiz@deep-tutor.com"]
         )
         .expect("write employee config");
 
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set(
                 "EMPLOYEE_CONFIG_PATH",
                 config_path.to_string_lossy().as_ref(),
@@ -4843,7 +4844,7 @@ addresses = ["dowhiz@deep-tutor.com"]
         .expect("write employee config");
 
         let _cwd_guard = CurrentDirGuard::set(temp.path());
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("EMPLOYEE_CONFIG_PATH", "employee.staging.toml"),
             EnvVarGuard::set("EMPLOYEE_ID", "boiled_egg"),
             EnvVarGuard::unset("HUMAN_APPROVAL_FROM"),
@@ -4875,7 +4876,7 @@ addresses = ["dowhiz@deep-tutor.com"]
         )
         .expect("write employee config");
 
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set(
                 "EMPLOYEE_CONFIG_PATH",
                 config_path.to_string_lossy().as_ref(),
@@ -4902,7 +4903,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_collect_google_workspace_cli_env_overrides_builds_credentials_file() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset(GOOGLE_WORKSPACE_CLI_CREDENTIAL_FILE_ENV),
             EnvVarGuard::set(
                 "GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE_CLIENT_ID",
@@ -4960,7 +4961,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_collect_google_workspace_cli_env_overrides_uses_existing_file_env() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set(
                 GOOGLE_WORKSPACE_CLI_CREDENTIAL_FILE_ENV,
                 ".auth/google_workspace_cli_credentials.json",
@@ -4999,7 +5000,7 @@ addresses = ["dowhiz@deep-tutor.com"]
         )
         .expect("write external credentials");
 
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set(GOOGLE_WORKSPACE_CLI_CREDENTIAL_FILE_ENV, &external_file_str),
             EnvVarGuard::unset("GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE_CLIENT_ID"),
             EnvVarGuard::unset("GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE_CLIENT_SECRET"),
@@ -5030,7 +5031,7 @@ addresses = ["dowhiz@deep-tutor.com"]
         let workspace = tempfile::tempdir().expect("workspace tempdir");
         let missing_external = workspace.path().join("..").join("missing-credentials.json");
         let missing_external_str = missing_external.to_string_lossy().to_string();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set(
                 GOOGLE_WORKSPACE_CLI_CREDENTIAL_FILE_ENV,
                 &missing_external_str,
@@ -5075,7 +5076,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_collect_google_workspace_cli_env_overrides_skips_when_components_incomplete() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset(GOOGLE_WORKSPACE_CLI_CREDENTIAL_FILE_ENV),
             EnvVarGuard::set(
                 "GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE_CLIENT_ID",
@@ -5099,7 +5100,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_codex_sandbox_mode_prefers_codex_sandbox_mode() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("CODEX_SANDBOX_MODE", "danger-full-access"),
             EnvVarGuard::set("RUN_TASK_CODEX_SANDBOX_MODE", "workspace-write"),
         ];
@@ -5110,7 +5111,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_codex_bypass_sandbox_respects_unprefixed_key() {
         let _lock = env_lock();
-        let _guards = vec![EnvVarGuard::set("CODEX_BYPASS_SANDBOX", "1")];
+        let _guards = [EnvVarGuard::set("CODEX_BYPASS_SANDBOX", "1")];
 
         assert!(codex_bypass_sandbox());
     }
@@ -5118,7 +5119,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_resolve_execution_backend_defaults_to_local() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset("RUN_TASK_EXECUTION_BACKEND"),
             EnvVarGuard::unset("DEPLOY_TARGET"),
         ];
@@ -5128,7 +5129,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_resolve_execution_backend_auto_staging_uses_azure_aci() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset("RUN_TASK_EXECUTION_BACKEND"),
             EnvVarGuard::set("DEPLOY_TARGET", "staging"),
         ];
@@ -5138,7 +5139,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_resolve_execution_backend_auto_production_uses_azure_aci() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset("RUN_TASK_EXECUTION_BACKEND"),
             EnvVarGuard::set("DEPLOY_TARGET", "production"),
         ];
@@ -5148,7 +5149,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_resolve_execution_backend_uses_run_task_execution_backend_when_set() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("DEPLOY_TARGET", "staging"),
             EnvVarGuard::set("RUN_TASK_EXECUTION_BACKEND", "azure_aci"),
         ];
@@ -5158,7 +5159,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_codex_command_timeout_defaults_to_overall_budget_when_unset() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "1200"),
             EnvVarGuard::unset("RUN_TASK_CODEX_TIMEOUT_SECS"),
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
@@ -5170,7 +5171,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_codex_command_timeout_respects_explicit_override_and_budget() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "300"),
             EnvVarGuard::set("RUN_TASK_CODEX_TIMEOUT_SECS", "900"),
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
@@ -5200,7 +5201,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_load_azure_aci_config_uses_unprefixed_keys() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_AZURE_ACI_RESOURCE_GROUP", "stg-rg"),
             EnvVarGuard::set(
                 "RUN_TASK_AZURE_ACI_IMAGE",
@@ -5224,7 +5225,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_load_azure_aci_config_requires_unprefixed_resource_group() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset("RUN_TASK_AZURE_ACI_RESOURCE_GROUP"),
             EnvVarGuard::set(
                 "RUN_TASK_AZURE_ACI_IMAGE",
@@ -5247,7 +5248,7 @@ addresses = ["dowhiz@deep-tutor.com"]
     #[test]
     fn test_ensure_local_execution_allowed_rejects_staging_without_override() {
         let _lock = env_lock();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("DEPLOY_TARGET", "staging"),
             EnvVarGuard::unset("RUN_TASK_ALLOW_LOCAL_EXECUTION"),
         ];
@@ -5295,7 +5296,7 @@ printf '%s\n' "$@" > "$capture_file"
         let original_path = env::var("PATH").unwrap_or_default();
         let path_value = format!("{}:{}", bin_dir.display(), original_path);
         let capture_value = capture_path.to_string_lossy().to_string();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("PATH", &path_value),
             EnvVarGuard::set("TEST_AZ_CAPTURE_FILE", &capture_value),
         ];
@@ -5373,7 +5374,7 @@ printf '%s\n' "$@" > "$capture_file"
         let original_path = env::var("PATH").unwrap_or_default();
         let path_value = format!("{}:{}", bin_dir.display(), original_path);
         let capture_value = capture_path.to_string_lossy().to_string();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("PATH", &path_value),
             EnvVarGuard::set("TEST_AZ_CAPTURE_FILE", &capture_value),
         ];
@@ -5701,7 +5702,7 @@ printf '%s\n' "$@" > "$capture_file"
 
         let original_path = env::var("PATH").unwrap_or_default();
         let path_value = format!("{}:{}", bin_dir.display(), original_path);
-        let _guards = vec![EnvVarGuard::set("PATH", &path_value)];
+        let _guards = [EnvVarGuard::set("PATH", &path_value)];
 
         let config = AzureAciConfig {
             resource_group: "stg-rg".to_string(),
@@ -5937,7 +5938,7 @@ printf '%s\n' "$@" > "$capture_file"
         let original_path = env::var("PATH").unwrap_or_default();
         let path_value = format!("{}:{}", bin_dir.display(), original_path);
         let capture_value = capture_path.to_string_lossy().to_string();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("PATH", &path_value),
             EnvVarGuard::set("TEST_AZ_CAPTURE_FILE", &capture_value),
         ];
@@ -6022,7 +6023,7 @@ printf '%s\n' "$@" > "$capture_file"
         let original_path = env::var("PATH").unwrap_or_default();
         let path_value = format!("{}:{}", bin_dir.display(), original_path);
         let capture_value = capture_path.to_string_lossy().to_string();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("PATH", &path_value),
             EnvVarGuard::set("TEST_AZCOPY_CAPTURE_FILE", &capture_value),
         ];
@@ -6105,7 +6106,7 @@ printf 'downloaded result' > "$3/result.txt"
         let original_path = env::var("PATH").unwrap_or_default();
         let path_value = format!("{}:{}", bin_dir.display(), original_path);
         let capture_value = capture_path.to_string_lossy().to_string();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("PATH", &path_value),
             EnvVarGuard::set("TEST_AZCOPY_CAPTURE_FILE", &capture_value),
         ];
@@ -6167,7 +6168,7 @@ printf '%s\n' "$@" > "$capture_file"
         let original_path = env::var("PATH").unwrap_or_default();
         let path_value = format!("{}:{}", bin_dir.display(), original_path);
         let capture_value = capture_path.to_string_lossy().to_string();
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("PATH", &path_value),
             EnvVarGuard::set("TEST_AZ_CAPTURE_FILE", &capture_value),
         ];

--- a/DoWhiz_service/run_task_module/src/run_task/github_auth.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/github_auth.rs
@@ -223,7 +223,7 @@ pub(super) fn ensure_github_cli_auth(github_auth: &GitHubAuthConfig) -> Result<(
 
 fn apply_env_overrides(cmd: &mut Command, overrides: &[(String, String)], skip: &[&str]) {
     for (key, value) in overrides {
-        if skip.iter().any(|blocked| *blocked == key.as_str()) {
+        if skip.contains(&key.as_str()) {
             continue;
         }
         cmd.env(key, value);

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -20,6 +20,7 @@ fn mark_registration_prompted(workspace_dir: &Path) {
     let _ = fs::write(workspace_dir.join(".registration_prompted"), "1");
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_prompt(
     input_email_dir: &Path,
     input_attachments_dir: &Path,
@@ -49,6 +50,7 @@ pub(super) fn build_prompt(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_prompt_with_fast_completion(
     input_email_dir: &Path,
     input_attachments_dir: &Path,
@@ -79,6 +81,7 @@ pub(super) fn build_prompt_with_fast_completion(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_prompt_internal(
     input_email_dir: &Path,
     input_attachments_dir: &Path,

--- a/DoWhiz_service/run_task_module/src/run_task/trace.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/trace.rs
@@ -55,6 +55,7 @@ pub(super) fn trace_dir(workspace_dir: &Path) -> PathBuf {
 }
 
 impl RunTaskTraceRecorder {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         workspace_dir: &Path,
         runner: &str,

--- a/DoWhiz_service/run_task_module/src/run_task/utils.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/utils.rs
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn run_task_timeout_defaults_to_watchdog_budget_minus_headroom() {
         let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset("RUN_TASK_TIMEOUT_SECS"),
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
         ];
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn run_task_timeout_respects_shorter_explicit_override() {
         let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "120"),
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
         ];
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn run_task_timeout_caps_explicit_value_to_watchdog_budget() {
         let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "36000"),
             EnvVarGuard::unset("TASK_TIMEOUT_SECS"),
         ];
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn run_task_timeout_uses_custom_task_timeout_budget() {
         let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::unset("RUN_TASK_TIMEOUT_SECS"),
             EnvVarGuard::set("TASK_TIMEOUT_SECS", "900"),
         ];
@@ -300,7 +300,7 @@ mod tests {
     #[test]
     fn run_task_timeout_caps_to_custom_task_timeout_budget() {
         let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "880"),
             EnvVarGuard::set("TASK_TIMEOUT_SECS", "900"),
         ];
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     fn run_task_timeout_ignores_invalid_values() {
         let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guards = vec![
+        let _guards = [
             EnvVarGuard::set("RUN_TASK_TIMEOUT_SECS", "abc"),
             EnvVarGuard::set("TASK_TIMEOUT_SECS", "0"),
         ];

--- a/DoWhiz_service/run_task_module/tests/drift_audit.rs
+++ b/DoWhiz_service/run_task_module/tests/drift_audit.rs
@@ -245,7 +245,7 @@ fn manual_drift_audit_reports_contract_drift() {
     audit_legacy_cli_references(&root, &mut findings);
     audit_google_docs_usage_dispatch(&root, &mut findings);
 
-    findings.sort_by(|a, b| a.render().cmp(&b.render()));
+    findings.sort_by_key(|finding| finding.render());
 
     if findings.is_empty() {
         eprintln!("No drift findings detected.");

--- a/website/public/auth/connect-onboarding.js
+++ b/website/public/auth/connect-onboarding.js
@@ -197,10 +197,10 @@ function genericConnectModel(provider) {
     description: `${label} is linked to your account. Keep the first ask small and concrete so you can review the result quickly.`,
     examples: providerExamples[provider] || [
       `Start with one small request in ${lowerLabel}.`,
-      'Review the result in Tasks before you expand the workflow.',
+      'Review the result in Work before you expand the workflow.',
       'Save any tone or approval rules in Memory once the first task lands.'
     ],
-    cta: anchorCta('Open Tasks', '#section-tasks'),
+    cta: anchorCta('Open Work', '#section-work'),
     footnote: 'Aim for a first win that takes less than five minutes to review.'
   };
 }
@@ -229,7 +229,7 @@ export function buildConnectOnboardingModel({
           '@Oliver draft a crisp reply I can send from here.',
           '@Oliver turn this request into a task I can review in DoWhiz.'
         ],
-        cta: anchorCta('Open Tasks', '#section-tasks'),
+        cta: anchorCta('Open Work', '#section-work'),
         footnote: 'If you want a tighter tone or approval rules, save them in Memory before the next request.'
       };
     }
@@ -261,7 +261,7 @@ export function buildConnectOnboardingModel({
           '@Oliver draft a reply I can post back in this channel.',
           '@Oliver turn this request into a task I can review in DoWhiz.'
         ],
-        cta: anchorCta('Open Tasks', '#section-tasks'),
+        cta: anchorCta('Open Work', '#section-work'),
         footnote: 'If you want Oliver to follow team tone or approval rules, save them in Memory now.'
       };
     }

--- a/website/public/auth/homepage-state.js
+++ b/website/public/auth/homepage-state.js
@@ -1,0 +1,287 @@
+const DEFAULT_PROVIDER_ORDER = ['notion', 'slack', 'github', 'discord', 'lark', 'wechat'];
+
+const PROVIDER_LABELS = {
+  discord: 'Discord',
+  github: 'GitHub',
+  lark: 'Lark',
+  notion: 'Notion',
+  slack: 'Slack',
+  wechat: 'WeCom'
+};
+
+function normalizeString(value) {
+  return String(value || '').trim();
+}
+
+function normalizeProvider(provider) {
+  return normalizeString(provider).toLowerCase();
+}
+
+function uniqueProviders(providers = []) {
+  return Array.from(
+    new Set(
+      (Array.isArray(providers) ? providers : [])
+        .map((provider) => normalizeProvider(provider))
+        .filter(Boolean)
+    )
+  );
+}
+
+export function providerLabel(provider) {
+  const normalized = normalizeProvider(provider);
+  if (!normalized) {
+    return 'Connected app';
+  }
+  return PROVIDER_LABELS[normalized]
+    || normalized
+      .split(/[_\-\s]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
+}
+
+export function summarizeProviders(providers = []) {
+  const labels = uniqueProviders(providers).map((provider) => providerLabel(provider));
+  if (labels.length === 0) {
+    return 'no connected apps yet';
+  }
+  if (labels.length === 1) {
+    return labels[0];
+  }
+  if (labels.length === 2) {
+    return `${labels[0]} and ${labels[1]}`;
+  }
+  return `${labels.slice(0, -1).join(', ')}, and ${labels[labels.length - 1]}`;
+}
+
+export function buildPreferredHomepageProviderOrder(preferredChannels = [], baseOrder = DEFAULT_PROVIDER_ORDER) {
+  const normalizedBaseOrder = uniqueProviders(baseOrder);
+  const preferredOrder = [];
+
+  (Array.isArray(preferredChannels) ? preferredChannels : []).forEach((channel) => {
+    const normalizedChannel = normalizeProvider(channel);
+    const matchedProvider = normalizedBaseOrder.find((provider) => normalizedChannel.includes(provider));
+    if (matchedProvider && !preferredOrder.includes(matchedProvider)) {
+      preferredOrder.push(matchedProvider);
+    }
+  });
+
+  return preferredOrder.concat(
+    normalizedBaseOrder.filter((provider) => !preferredOrder.includes(provider))
+  );
+}
+
+function countInProgressTasks(taskCount, reviewableTaskCount) {
+  return Math.max(Number(taskCount || 0) - Number(reviewableTaskCount || 0), 0);
+}
+
+function buildPrimaryAction(section, label) {
+  return {
+    kind: 'open_dashboard_section',
+    section,
+    label
+  };
+}
+
+function stateLabel(stateKey) {
+  switch (stateKey) {
+    case 'no_connected_app':
+      return 'Needs connection';
+    case 'connected_no_tasks':
+      return 'Needs first request';
+    case 'tasks_in_progress':
+      return 'Work in progress';
+    case 'review_ready':
+      return 'Review ready';
+    case 'ongoing_usage':
+      return 'Ongoing usage';
+    default:
+      return 'In progress';
+  }
+}
+
+export function buildDashboardHomepageModel({
+  connectedTypes = [],
+  taskCount = 0,
+  successfulTaskCount = 0,
+  reviewableTaskCount = 0,
+  hasSavedMemory = false,
+  preferredChannels = []
+} = {}) {
+  const normalizedConnectedTypes = uniqueProviders(connectedTypes);
+  const nextSuggestedProvider = buildPreferredHomepageProviderOrder(preferredChannels)
+    .find((provider) => !normalizedConnectedTypes.includes(provider)) || null;
+  const normalizedTaskCount = Number(taskCount || 0);
+  const normalizedSuccessfulTaskCount = Number(successfulTaskCount || 0);
+  const normalizedReviewableTaskCount = Number(reviewableTaskCount || 0);
+  const normalizedHasSavedMemory = hasSavedMemory === true;
+  const inProgressCount = countInProgressTasks(normalizedTaskCount, normalizedReviewableTaskCount);
+  const connectedSummary = summarizeProviders(normalizedConnectedTypes);
+
+  let stateKey = 'no_connected_app';
+  let title = 'Connect the first place Oliver should work';
+  let summary = 'Until one app is connected, Oliver has nowhere to receive requests. Start with the surface where work already lands.';
+  let helper = 'Results will appear in Work after a request comes in from a connected app.';
+  let primaryAction = buildPrimaryAction('section-channels', 'Open Connections');
+
+  if (normalizedConnectedTypes.length === 0) {
+    stateKey = 'no_connected_app';
+  } else if (normalizedTaskCount === 0) {
+    stateKey = 'connected_no_tasks';
+    title = 'Send one small request from a connected app';
+    summary = `You already connected ${connectedSummary}. The first request still has to start in that app. Work stays empty until that request is sent.`;
+    helper = 'Use Connections to confirm the best place to start, then send one small request there and review the result in Work.';
+    primaryAction = buildPrimaryAction('section-channels', 'See Where to Start');
+  } else if (normalizedReviewableTaskCount === 0) {
+    stateKey = 'tasks_in_progress';
+    title = normalizedTaskCount === 1 ? 'Your first request is in motion' : `${normalizedTaskCount} requests are in motion`;
+    summary = inProgressCount <= 1
+      ? 'Work already has activity, but nothing is reviewable yet. The next step is to watch Work until the first result lands.'
+      : `${inProgressCount} requests are still in progress. Review should happen in Work once the first result lands.`;
+    helper = normalizedHasSavedMemory
+      ? 'If the next result needs a tighter tone or approval rule, adjust Memory before the second request.'
+      : 'Once the first result lands, review it in Work before you connect more surfaces or expand the setup.';
+    primaryAction = buildPrimaryAction('section-work', 'Open Work');
+  } else if (
+    normalizedHasSavedMemory &&
+    normalizedSuccessfulTaskCount > 0 &&
+    normalizedReviewableTaskCount > 0 &&
+    normalizedTaskCount >= 3
+  ) {
+    stateKey = 'ongoing_usage';
+    title = 'Oliver is already active in your workflow';
+    summary = `${normalizedReviewableTaskCount} result${normalizedReviewableTaskCount === 1 ? '' : 's'} are ready in Work, ${normalizedSuccessfulTaskCount} completed successfully, and Memory is already saved. The next gain is in reviewing fresh work, not adding more setup.`;
+    helper = nextSuggestedProvider
+      ? `Only connect ${providerLabel(nextSuggestedProvider)} next if it supports work you already trust Oliver to handle.`
+      : 'Use Memory or Settings only when you need a sharper boundary, not as the default next step.';
+    primaryAction = buildPrimaryAction('section-work', 'Open Work');
+  } else {
+    stateKey = 'review_ready';
+    title = normalizedReviewableTaskCount === 1
+      ? 'Review the latest result in Work'
+      : `Review ${normalizedReviewableTaskCount} results in Work`;
+    summary = normalizedReviewableTaskCount === 1
+      ? 'A result is ready. Review it before you connect more surfaces or add more workflow complexity.'
+      : `${normalizedReviewableTaskCount} results are ready. Review them in Work before you expand the setup.`;
+    helper = normalizedHasSavedMemory
+      ? 'Once the review loop feels right, keep the workflow tight instead of adding more setup.'
+      : 'After the first review, save tone or approval rules in Memory so the next result needs less cleanup.';
+    primaryAction = buildPrimaryAction('section-work', 'Open Work');
+  }
+
+  return {
+    stateKey,
+    title,
+    summary,
+    helper,
+    primaryAction,
+    connectedSummary,
+    nextSuggestedProvider,
+    chips: [
+      {
+        label: 'State',
+        value: stateLabel(stateKey)
+      },
+      {
+        label: 'Connections',
+        value: normalizedConnectedTypes.length > 0
+          ? `${normalizedConnectedTypes.length} connected`
+          : 'None connected'
+      },
+      {
+        label: 'Work',
+        value: normalizedReviewableTaskCount > 0
+          ? `${normalizedReviewableTaskCount} ready to review`
+          : normalizedTaskCount > 0
+            ? `${Math.max(inProgressCount, 1)} in progress`
+            : 'No work yet'
+      },
+      {
+        label: 'Memory',
+        value: normalizedHasSavedMemory ? 'Saved' : 'Needs setup'
+      }
+    ]
+  };
+}
+
+function buildSetupStep({ key, title, description, status, action }) {
+  return {
+    key,
+    title,
+    description,
+    status,
+    action
+  };
+}
+
+export function buildDashboardSetupModel({
+  connectedTypes = [],
+  taskCount = 0,
+  reviewableTaskCount = 0,
+  hasSavedMemory = false
+} = {}) {
+  const normalizedConnectedTypes = uniqueProviders(connectedTypes);
+  const normalizedTaskCount = Number(taskCount || 0);
+  const normalizedReviewableTaskCount = Number(reviewableTaskCount || 0);
+  const normalizedHasSavedMemory = hasSavedMemory === true;
+  const hasConnectedApp = normalizedConnectedTypes.length > 0;
+  const hasStartedWork = normalizedTaskCount > 0;
+  const hasReviewReadyWork = normalizedReviewableTaskCount > 0;
+  const coreStepsComplete = [hasConnectedApp, hasStartedWork, hasReviewReadyWork].filter(Boolean).length;
+
+  const steps = [
+    buildSetupStep({
+      key: 'connect',
+      title: 'Connect one app',
+      description: 'Start with the first place where requests already land.',
+      status: hasConnectedApp ? 'complete' : 'current',
+      action: buildPrimaryAction('section-channels', 'Open Connections')
+    }),
+    buildSetupStep({
+      key: 'send',
+      title: 'Send one small request',
+      description: hasConnectedApp
+        ? `Send it in ${summarizeProviders(normalizedConnectedTypes)}. It cannot start from inside Work.`
+        : 'Connect an app first, then send one small request there.',
+      status: hasStartedWork ? 'complete' : hasConnectedApp ? 'current' : 'pending',
+      action: buildPrimaryAction('section-channels', hasConnectedApp ? 'See Connected Apps' : 'Open Connections')
+    }),
+    buildSetupStep({
+      key: 'review',
+      title: 'Review the result in Work',
+      description: hasStartedWork
+        ? 'Once the result lands, review it in Work before you expand anything else.'
+        : 'Work becomes useful after the first request lands.',
+      status: hasReviewReadyWork ? 'complete' : hasStartedWork ? 'current' : 'pending',
+      action: buildPrimaryAction('section-work', 'Open Work')
+    })
+  ];
+
+  let note = null;
+  if (!normalizedHasSavedMemory) {
+    note = {
+      title: 'Memory is still optional, but it should come after the first review loop.',
+      description: 'Save tone, recurring context, or approval rules only after the first result tells you what is actually missing.',
+      action: buildPrimaryAction('section-memo', 'Open Memory')
+    };
+  } else if (coreStepsComplete === 3) {
+    note = {
+      title: 'Setup is no longer the bottleneck.',
+      description: 'Only come back here when you add another app or need to re-check the first-loop basics.',
+      action: buildPrimaryAction('section-work', 'Open Work')
+    };
+  }
+
+  return {
+    title: coreStepsComplete === 3 && normalizedHasSavedMemory
+      ? 'Setup is no longer the main job'
+      : 'Keep setup lean',
+    intro: coreStepsComplete === 3 && normalizedHasSavedMemory
+      ? 'The basics are in place. Review Work first, then expand only when the current loop already feels solid.'
+      : 'Connect one app, send one request from that app, then review the result in Work.',
+    progressLabel: `${coreStepsComplete} of 3 core steps done`,
+    steps,
+    note,
+    isComplete: coreStepsComplete === 3 && normalizedHasSavedMemory
+  };
+}

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -1356,19 +1356,19 @@
 
       .dashboard-home-shell {
         display: grid;
-        grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.8fr);
-        gap: 1.1rem;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 1rem;
         align-items: start;
       }
 
       .dashboard-home-main,
       .dashboard-home-aside {
         display: grid;
-        gap: 1rem;
+        gap: 0.9rem;
       }
 
       .dashboard-home-header {
-        gap: 1rem;
+        gap: 0.6rem;
       }
 
       .dashboard-inline-action {
@@ -1389,8 +1389,8 @@
 
       .workspace-recommendation-card {
         display: grid;
-        gap: 0.9rem;
-        padding: 1.05rem;
+        gap: 1rem;
+        padding: 1.2rem;
         border-radius: 1.1rem;
         border: 1px solid color-mix(in srgb, var(--text, #fff) 12%, var(--border, #333));
         background:
@@ -1590,8 +1590,8 @@
       }
 
       .workspace-summary-grid {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        display: flex;
+        flex-wrap: wrap;
         gap: 0.75rem;
       }
 
@@ -1818,10 +1818,199 @@
       }
 
       .workspace-summary-empty {
-        grid-column: 1 / -1;
+        width: 100%;
         padding: 0.8rem;
         border-radius: 0.7rem;
         border: 1px dashed var(--border, #333);
+        color: var(--text-muted, #888);
+      }
+
+      .dashboard-home-primary {
+        display: grid;
+        gap: 0.95rem;
+      }
+
+      .dashboard-home-state-line {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        flex-wrap: wrap;
+        font-size: 0.78rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--text-muted, #888);
+      }
+
+      .dashboard-home-kicker {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.28rem 0.58rem;
+        border-radius: 999px;
+        border: 1px solid color-mix(in srgb, var(--text, #fff) 10%, var(--border, #333));
+        background: color-mix(in srgb, var(--surface-secondary, #17191d) 84%, transparent);
+        color: var(--text, #fff);
+        font-weight: 600;
+      }
+
+      .dashboard-home-primary-title {
+        margin: 0;
+        font-size: 1.45rem;
+        line-height: 1.2;
+        letter-spacing: -0.02em;
+      }
+
+      .dashboard-home-primary-summary {
+        margin: 0;
+        max-width: 52rem;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: var(--text, #fff);
+      }
+
+      .dashboard-home-primary-helper {
+        margin: 0;
+        max-width: 48rem;
+        font-size: 0.92rem;
+        line-height: 1.55;
+        color: var(--text-muted, #888);
+      }
+
+      .dashboard-home-primary-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .dashboard-home-guide {
+        margin: 0;
+        padding: 0.9rem 1rem;
+        border-radius: 0.9rem;
+        border: 1px solid var(--border, #333);
+        background: color-mix(in srgb, var(--surface-secondary, #17191d) 78%, transparent);
+        font-size: 0.9rem;
+        line-height: 1.55;
+        color: var(--text-muted, #888);
+      }
+
+      .dashboard-home-guide strong {
+        color: var(--text, #fff);
+      }
+
+      .dashboard-home-chip {
+        min-width: 0;
+        flex: 1 1 170px;
+        padding: 0.8rem 0.9rem;
+        border-radius: 0.9rem;
+        border: 1px solid color-mix(in srgb, var(--text, #fff) 8%, var(--border, #333));
+        background:
+          linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--surface-secondary, #17191d) 74%, transparent) 0%,
+            color-mix(in srgb, var(--surface, #1a1a1a) 92%, transparent) 100%
+          );
+      }
+
+      .dashboard-home-chip-label {
+        margin: 0 0 0.3rem;
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--text-muted, #888);
+      }
+
+      .dashboard-home-chip-value {
+        margin: 0;
+        font-size: 0.96rem;
+        line-height: 1.4;
+        color: var(--text, #fff);
+      }
+
+      .dashboard-home-loading {
+        padding: 1rem;
+        border-radius: 0.85rem;
+        border: 1px dashed var(--border, #333);
+        color: var(--text-muted, #888);
+        line-height: 1.5;
+      }
+
+      .next-step-compact-list {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .next-step-compact-item {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 0.85rem;
+        align-items: start;
+        padding: 0.95rem 1rem;
+        border-radius: 0.9rem;
+        border: 1px solid var(--border, #333);
+        background: color-mix(in srgb, var(--surface, #1a1a1a) 82%, transparent);
+      }
+
+      .next-step-status-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 2rem;
+        padding: 0.34rem 0.58rem;
+        border-radius: 999px;
+        border: 1px solid var(--border, #333);
+        background: color-mix(in srgb, var(--surface-secondary, #17191d) 80%, transparent);
+        color: var(--text-muted, #888);
+        font-size: 0.78rem;
+        font-weight: 700;
+      }
+
+      .next-step-status-pill.is-complete {
+        border-color: rgba(34, 197, 94, 0.35);
+        background: rgba(34, 197, 94, 0.12);
+        color: #22c55e;
+      }
+
+      .next-step-status-pill.is-current {
+        border-color: rgba(245, 158, 11, 0.35);
+        background: rgba(245, 158, 11, 0.12);
+        color: #f59e0b;
+      }
+
+      .next-step-compact-copy {
+        min-width: 0;
+      }
+
+      .next-step-compact-title {
+        margin: 0 0 0.25rem;
+        font-size: 0.96rem;
+      }
+
+      .next-step-compact-description {
+        margin: 0;
+        font-size: 0.88rem;
+        line-height: 1.5;
+        color: var(--text-muted, #888);
+      }
+
+      .next-step-note-card {
+        display: grid;
+        gap: 0.5rem;
+        padding: 0.95rem 1rem;
+        border-radius: 0.9rem;
+        border: 1px solid color-mix(in srgb, var(--text, #fff) 8%, var(--border, #333));
+        background: color-mix(in srgb, var(--surface-secondary, #17191d) 78%, transparent);
+      }
+
+      .next-step-note-title {
+        margin: 0;
+        font-size: 0.92rem;
+      }
+
+      .next-step-note-copy {
+        margin: 0;
+        font-size: 0.88rem;
+        line-height: 1.55;
         color: var(--text-muted, #888);
       }
 
@@ -1990,9 +2179,14 @@
       @media (max-width: 780px) {
         .dashboard-home-header,
         .workspace-recommendation-actions,
-        .next-step-item {
+        .next-step-item,
+        .dashboard-home-primary-actions {
           flex-direction: column;
           align-items: stretch;
+        }
+
+        .next-step-compact-item {
+          grid-template-columns: 1fr;
         }
 
         .next-step-action {
@@ -2005,7 +2199,6 @@
 
         .account-grid,
         .workspace-recommendation-grid,
-        .workspace-summary-grid,
         .settings-grid {
           grid-template-columns: 1fr;
         }
@@ -2250,10 +2443,10 @@
                 <nav class="sidebar-nav" aria-label="Dashboard Sections">
                   <a class="sidebar-link is-active" href="#section-overview">Home</a>
                   <a class="sidebar-link" href="#section-channels">Connections</a>
-                  <a class="sidebar-link" href="#section-workspace">Checklist</a>
+                  <a class="sidebar-link" href="#section-workspace">Setup</a>
                   <a class="sidebar-link" href="#section-work">Work</a>
-                  <a class="sidebar-link" href="#section-organization">Organization</a>
-                  <a class="sidebar-link" href="#section-settings">Preferences</a>
+                  <a class="sidebar-link" href="#section-memo">Memory</a>
+                  <a class="sidebar-link" href="#section-settings">Settings</a>
                 </nav>
                 <div class="sidebar-note">
                   <div class="sidebar-note-title">Support</div>
@@ -2272,11 +2465,8 @@
                         <div>
                           <p class="dashboard-section-eyebrow">Home</p>
                           <h2>Today with Oliver</h2>
-                          <p class="dashboard-overview-copy">One clear next move, your current setup, and the latest work signal.</p>
+                          <p class="dashboard-overview-copy">Current state, one honest next move, and where work will show up.</p>
                         </div>
-                        <button id="info-btn" class="auth-btn auth-btn-oauth dashboard-inline-action">
-                          Account and billing
-                        </button>
                       </div>
                       <div id="workspace-recommendation-card" class="workspace-recommendation-card">
                         <div class="workspace-recommendation-empty">Looking at your setup for the clearest next step...</div>
@@ -2285,27 +2475,12 @@
                         <div class="workspace-summary-empty">Loading your setup snapshot...</div>
                       </div>
                     </div>
-                    <aside class="dashboard-home-aside">
-                      <div class="dashboard-account-panel">
-                        <p class="dashboard-section-eyebrow">Account</p>
-                        <div class="account-grid dashboard-account-grid">
-                          <div class="account-meta-item">
-                            <p class="account-meta-label">Account</p>
-                            <span id="account-id">Loading...</span>
-                          </div>
-                          <div class="account-meta-item">
-                            <p class="account-meta-label">Sign-in email</p>
-                            <span id="user-email">Loading...</span>
-                          </div>
-                        </div>
-                      </div>
-                    </aside>
                   </div>
                 </section>
 
                 <section id="section-channels" class="legal-card dashboard-section">
                   <p class="dashboard-section-eyebrow">Connections</p>
-                  <h2>Connected Apps</h2>
+                  <h2>Connections</h2>
                   <p>Connect and manage the apps Oliver can use for your account.</p>
                   <div class="settings-panel">
                     <h3>Add a connection</h3>
@@ -2362,31 +2537,31 @@
                 <section id="section-workspace" class="legal-card dashboard-section">
                   <div class="dashboard-header">
                     <div>
-                      <p class="dashboard-section-eyebrow">Setup plan</p>
-                      <h2>Checklist and next steps</h2>
+                      <p class="dashboard-section-eyebrow">Setup</p>
+                      <h2>Setup</h2>
                     </div>
-                    <a id="update-team-brief-btn" class="auth-btn auth-btn-oauth" href="#section-channels">Open Connected Apps</a>
+                    <a id="update-team-brief-btn" class="auth-btn auth-btn-oauth" href="#section-channels">Open Connections</a>
                   </div>
                   <p class="dashboard-overview-copy">
-                    Keep the next win small, personal, and easy to review.
+                    Keep setup lean: connect one app, send one request there, then review it in Work.
                   </p>
                   <div id="workspace-next-steps" class="workspace-next-steps" style="margin-top: 2rem;">
                     <div class="dashboard-header">
                       <div>
-                        <h3 style="margin-bottom: 0.35rem;">Setup checklist</h3>
-                        <p class="next-step-section-intro">Keep the next win small, personal, and easy to review.</p>
+                        <h3 style="margin-bottom: 0.35rem;">Core setup loop</h3>
+                        <p class="next-step-section-intro">This should stay small. More setup only helps after the first review loop works.</p>
                       </div>
-                      <span id="next-steps-progress" class="next-step-progress">0 of 4 done</span>
+                      <span id="next-steps-progress" class="next-step-progress">0 of 3 core steps done</span>
                     </div>
                     <div id="next-steps-list" class="next-steps-list">
-                      <p style="color: var(--text-muted, #888);">Loading your checklist...</p>
+                      <p style="color: var(--text-muted, #888);">Loading your setup loop...</p>
                     </div>
                   </div>
                 </section>
 
                 <section id="section-work" class="legal-card dashboard-section">
                   <p class="dashboard-section-eyebrow">Work</p>
-                  <h2>Recent work</h2>
+                  <h2>Work</h2>
                   <p>Review incoming tasks and manage recurring Oliver work across your connected apps.</p>
                   <div class="work-view-tabs" role="tablist" aria-label="Work views">
                     <button
@@ -2477,7 +2652,7 @@
 
                 <section id="section-memo" class="legal-card dashboard-section">
                   <p class="dashboard-section-eyebrow">Memory</p>
-                  <h2>Saved memory</h2>
+                  <h2>Memory</h2>
                   <p>Save the tone, context, and rules Oliver should remember across tasks.</p>
                   <div id="memo-container" style="margin-top: 1rem;">
                     <textarea id="memo-content" style="
@@ -2550,10 +2725,28 @@
                 </section>
 
                 <section id="section-settings" class="legal-card dashboard-section">
-                  <p class="dashboard-section-eyebrow">Preferences</p>
-                  <h2>Preferences and controls</h2>
-                  <p>Manage entry points and choose how proactive Oliver should be.</p>
+                  <p class="dashboard-section-eyebrow">Settings</p>
+                  <h2>Settings</h2>
+                  <p>Manage account details, entry points, and how proactive Oliver should be.</p>
                   <div class="settings-grid">
+                    <div class="settings-panel">
+                      <h3>Account and billing</h3>
+                      <p>Keep billing and account details out of the homepage and here with the rest of your settings.</p>
+                      <div class="account-grid">
+                        <div class="account-meta-item">
+                          <p class="account-meta-label">Account</p>
+                          <span id="account-id">Loading...</span>
+                        </div>
+                        <div class="account-meta-item">
+                          <p class="account-meta-label">Sign-in email</p>
+                          <span id="user-email">Loading...</span>
+                        </div>
+                      </div>
+                      <button id="info-btn" class="auth-btn auth-btn-oauth" style="margin-top: 0.85rem;">
+                        View billing
+                      </button>
+                    </div>
+
                     <div class="settings-panel">
                       <h3>Manual linking</h3>
                       <p>Add an email, phone number, or chat identifier Oliver should recognize for your account.</p>
@@ -2656,6 +2849,10 @@
         filterOptionalExtensionsForNextSteps,
         parseStoredConnectOnboarding
       } from './connect-onboarding.js';
+      import {
+        buildDashboardHomepageModel,
+        buildDashboardSetupModel
+      } from './homepage-state.js';
 
       // Configuration
       // TODO: Update Supabase credentials for staging if using a separate Supabase project
@@ -2705,8 +2902,8 @@
           sidebarEyebrow: 'Oliver for TPMs',
           sidebarTitle: 'TPM workspace',
           sidebarDescription:
-            'Keep the next move, live signals, and the follow-through Oliver is coordinating in one place.',
-          overviewCopy: 'One clear next move, your live execution signals, and the follow-through that needs review.'
+            'See the current state, the next move, and the follow-through Oliver is coordinating in one place.',
+          overviewCopy: 'Current state, one honest next move, and the follow-through that needs review.'
         }
       };
       let activeEntrySurface = null;
@@ -2931,6 +3128,7 @@
         .map((link) => document.querySelector(link.getAttribute('href')))
         .filter(Boolean);
       const workspaceRecommendationCard = document.getElementById('workspace-recommendation-card');
+      const workspaceSummaryContent = document.getElementById('workspace-summary-content');
       const proactivityLevelSelect = document.getElementById('proactivity-level-select');
       const proactivityLevelStatus = document.getElementById('proactivity-level-status');
 
@@ -2956,12 +3154,12 @@
       };
       const RECOMMENDATION_SECTION_LABELS = {
         'section-work': 'Open Work',
-        'section-channels': 'Open Connected Apps',
+        'section-channels': 'Open Connections',
         'section-memo': 'Open Memory',
         'section-routines': 'Open Routines',
         'section-settings': 'Open Settings',
-        'section-tasks': 'Open Tasks',
-        'section-workspace': 'Open Checklist',
+        'section-tasks': 'Open Work',
+        'section-workspace': 'Open Setup',
         'section-organization': 'Open Organization'
       };
       const WORKSPACE_RECOMMENDATION_CACHE_KEY = 'dowhiz_workspace_recommendation_cache_v2';
@@ -2993,6 +3191,7 @@
       let routineActionErrors = {};
       let cachedMemoContent = '';
       let cachedBalance = null;
+      let dashboardHomeLoading = false;
       let pendingConnectionOnboarding = loadPendingConnectionOnboardingFromStorage();
 
       function applyEntryAwareCopy(options = {}) {
@@ -3433,7 +3632,7 @@
             <a
               class="auth-btn auth-btn-primary"
               data-connect-onboarding-action="anchor"
-              href="${escapeHtml(cta.href || '#section-tasks')}"
+              href="${escapeHtml(cta.href || '#section-work')}"
             >
               ${escapeHtml(cta.label || 'Open')}
             </a>
@@ -3544,6 +3743,27 @@
         return Boolean(founderName) && Boolean(thesis) && goals.length > 0;
       }
 
+      function buildDashboardHomeContext() {
+        const workspaceBlueprint = loadWorkspaceBlueprintFromStorage();
+        const connectedTypes = connectedProviderTypes(cachedIdentifiers);
+        const successfulTaskCount = countSuccessfulTasks(cachedTasks);
+        const taskCount = Array.isArray(cachedTasks) ? cachedTasks.length : 0;
+        const reviewableTaskCount = countReviewableTasks(cachedTasks);
+        const hasSavedMemory = hasSavedMemoryNote();
+        const preferredChannels = normalizeWorkspaceList(workspaceBlueprint?.preferred_channels)
+          .map((item) => String(item || '').toLowerCase());
+
+        return {
+          workspaceBlueprint,
+          connectedTypes,
+          successfulTaskCount,
+          taskCount,
+          reviewableTaskCount,
+          hasSavedMemory,
+          preferredChannels
+        };
+      }
+
       function updateTeamBriefLinkFromStorage() {
         if (!updateTeamBriefBtn) {
           return;
@@ -3552,69 +3772,28 @@
       }
 
       function loadWorkspaceSummaryFromStorage() {
-        const container = document.getElementById('workspace-summary-content');
-        if (!container) {
+        if (!workspaceSummaryContent) {
           return;
         }
-        const workspaceBlueprint = loadWorkspaceBlueprintFromStorage();
         updateTeamBriefLinkFromStorage();
 
-        const connectedTypes = connectedProviderTypes(cachedIdentifiers);
-        const successfulTaskCount = countSuccessfulTasks(cachedTasks);
-        const taskCount = Array.isArray(cachedTasks) ? cachedTasks.length : 0;
-        const hasMemory = hasSavedMemoryNote();
-        const memoLines = getMemoValue()
-          .split(/\n+/)
-          .map((line) => line.trim())
-          .filter(Boolean)
-          .slice(0, 3);
-        const savedFocus = normalizeWorkspaceList(workspaceBlueprint?.goals_30_90_days).slice(0, 3);
+        if (dashboardHomeLoading) {
+          workspaceSummaryContent.innerHTML = `
+            <div class="workspace-summary-empty">Loading your current state...</div>
+          `;
+          renderNextSteps(cachedIdentifiers || []);
+          renderConnectionOnboardingCard();
+          return;
+        }
 
-        const setupSummary = connectedTypes.length
-          ? `${connectedTypes.length} app${connectedTypes.length === 1 ? '' : 's'} connected`
-          : 'Start with one connected app';
-        const connectedItems = connectedTypes.length
-          ? connectedTypes.map((provider) => `<li>${escapeHtml(providerDisplayName(provider))}</li>`).join('')
-          : '<li>Connect the first app where Oliver should receive work.</li>';
-        const memoryItems = hasMemory
-          ? memoLines.map((line) => `<li>${escapeHtml(line)}</li>`).join('')
-          : (savedFocus.length
-            ? savedFocus.map((goal) => `<li>${escapeHtml(goal)}</li>`).join('')
-            : [
-                'Your preferred tone or writing style',
-                'Sensitive actions that should wait for approval',
-                'Recurring context Oliver should remember'
-              ].map((item) => `<li>${escapeHtml(item)}</li>`).join(''));
-        const memoryTitle = hasMemory ? 'Memory preview' : (savedFocus.length ? 'Saved focus' : 'What to save next');
-        const memorySummary = hasMemory ? 'Ready to reuse' : 'Add first note';
-        const reviewableTaskCount = countReviewableTasks(cachedTasks);
-        const workSummary = taskCount === 0
-          ? 'No task history yet'
-          : `${successfulTaskCount} completed, ${reviewableTaskCount} reviewable`;
-
-        container.innerHTML = `
-          <article class="workspace-summary-card workspace-summary-card-stat">
-            <p class="workspace-summary-kicker">Connected surfaces</p>
-            <p class="workspace-summary-stat">${connectedTypes.length}</p>
-            <p class="workspace-summary-meta"><strong>${escapeHtml(setupSummary)}</strong></p>
-            <ul class="workspace-summary-list">${connectedItems}</ul>
-          </article>
-          <article class="workspace-summary-card workspace-summary-card-stat">
-            <p class="workspace-summary-kicker">Recent work</p>
-            <p class="workspace-summary-stat">${taskCount}</p>
-            <p class="workspace-summary-meta"><strong>${taskCount === 1 ? '1 task seen' : `${taskCount} tasks seen`}</strong></p>
-            <p class="workspace-summary-meta">${escapeHtml(workSummary)}</p>
-          </article>
-          <article class="workspace-summary-card">
-            <div class="workspace-summary-card-head">
-              <div>
-                <p class="workspace-summary-kicker">Memory</p>
-                <h3>${memoryTitle}</h3>
-              </div>
-              <span class="workspace-summary-badge">${escapeHtml(memorySummary)}</span>
-            </div>
-            <ul class="workspace-summary-list">${memoryItems}</ul>
-          </article>
+        const homeModel = buildDashboardHomepageModel(buildDashboardHomeContext());
+        workspaceSummaryContent.innerHTML = `
+          ${homeModel.chips.map((chip) => `
+            <article class="dashboard-home-chip">
+              <p class="dashboard-home-chip-label">${escapeHtml(chip.label)}</p>
+              <p class="dashboard-home-chip-value">${escapeHtml(chip.value)}</p>
+            </article>
+          `).join('')}
         `;
 
         // Render next steps with current cached identifiers
@@ -3790,7 +3969,7 @@
           pushRecommendation({
             key: 'open_connected_apps',
             triggerType: 'setup_blocker',
-            title: 'Open Connected Apps and choose your first connection',
+            title: 'Open Connections and choose your first connection',
             whyNow: 'The first setup step should stay small and reversible.',
             outcome: 'You can connect one tool without changing the rest of your workflow.',
             action: { kind: 'open_dashboard_section', section: 'section-channels' }
@@ -3811,7 +3990,7 @@
             triggerType: 'first_value_gap',
             title: 'Give Oliver one small task in a connected app',
             whyNow: `You already connected ${summarizeConnectedProviders(connectedTypes)}. The next win is one task you can quickly review.`,
-            outcome: 'Your first task will show up in Tasks so you can see the loop from request to result.',
+            outcome: 'Your first task will show up in Work so you can see the loop from request to result.',
             action: { kind: 'open_dashboard_section', section: 'section-tasks' }
           });
           if (!hasMemory) {
@@ -3846,7 +4025,7 @@
           pushRecommendation({
             key: 'review_tasks',
             triggerType: 'continuation_opportunity',
-            title: 'Review the first task result in Tasks',
+            title: 'Review the first task result in Work',
             whyNow: 'The fastest way to build trust is to inspect one finished loop end to end.',
             outcome: 'You will see what Oliver should keep doing and what should stay behind review.',
             action: { kind: 'open_dashboard_section', section: 'section-tasks' }
@@ -3865,7 +4044,7 @@
           pushRecommendation({
             key: 'review_in_progress',
             triggerType: 'setup_blocker',
-            title: 'Check Tasks and review the first result before repeating it',
+            title: 'Check Work and review the first result before repeating it',
             whyNow: 'You have work in motion; the next step is to see how Oliver handled it.',
             outcome: 'Review gives you a clear sense of what should repeat and what should still need approval.',
             action: { kind: 'open_dashboard_section', section: 'section-tasks' }
@@ -3933,7 +4112,7 @@
           pushRecommendation({
             key: 'check_connected_apps',
             triggerType: 'continuation_opportunity',
-            title: 'Open Connected Apps if you want broader coverage',
+            title: 'Open Connections if you want broader coverage',
             whyNow: 'More connections help only when they support work you already trust Oliver with.',
             outcome: 'Expansion stays deliberate instead of noisy.',
             action: { kind: 'open_dashboard_section', section: 'section-channels' }
@@ -3960,10 +4139,10 @@
           return RECOMMENDATION_SECTION_LABELS[recommendation?.action?.section] || 'Open section';
         }
         if (actionKind === 'trigger_create_brief') {
-          return 'Open Checklist';
+          return 'Open Setup';
         }
         if (actionKind === 'trigger_create_plan') {
-          return 'Open Tasks';
+          return 'Open Work';
         }
         if (actionKind === 'update_team_brief') {
           return 'Open Settings';
@@ -4234,218 +4413,45 @@
           return;
         }
 
-        const current = currentWorkspaceRecommendation();
-        const currentIdentity = recommendationIdentity(current);
-        const currentLevel = proactivityLevelSelect?.value || 'minimal';
-
-        if (workspaceRecommendationStatus === 'loading') {
+        if (dashboardHomeLoading) {
           workspaceRecommendationCard.innerHTML = `
-            <div class="workspace-recommendation-empty">
-              Reviewing your connected apps, memory, and recent tasks for the clearest next move...
+            <div class="dashboard-home-loading">
+              Loading the current state, next move, and where work will show up...
             </div>
           `;
           return;
         }
 
-        if (workspaceRecommendationStatus === 'needs_brief') {
-          workspaceRecommendationCard.innerHTML = `
-            <div class="workspace-recommendation-helper">
-              <p><strong>Start with one connection</strong></p>
-              <p>Once Oliver has one approved app and one small task, this card will start surfacing the clearest next step automatically.</p>
-            </div>
-            <div class="workspace-recommendation-actions">
-              <button id="workspace-recommendation-edit-brief" class="auth-btn auth-btn-primary">Open Connected Apps</button>
-              <span class="workspace-recommendation-status">Recommendations turn on automatically as your setup becomes more complete.</span>
-            </div>
-          `;
-          document.getElementById('workspace-recommendation-edit-brief')?.addEventListener('click', () => {
-            openDashboardSection('section-channels');
-          });
-          return;
-        }
-
-        if (workspaceRecommendationStatus === 'error') {
-          workspaceRecommendationCard.innerHTML = `
-            <div class="workspace-recommendation-helper">
-              <p><strong>We could not load a recommendation right now.</strong></p>
-              <p>${escapeHtml(workspaceRecommendationErrorMessage || 'Please try again in a moment.')}</p>
-            </div>
-            <div class="workspace-recommendation-actions">
-              <button id="workspace-recommendation-retry" class="auth-btn auth-btn-primary">Try again</button>
-            </div>
-          `;
-          document.getElementById('workspace-recommendation-retry')?.addEventListener('click', async () => {
-            const { data: { session } } = await supabase.auth.getSession();
-            if (session) {
-              await loadWorkspaceRecommendation(session.access_token, { force: true });
-            }
-          });
-          return;
-        }
-
-        if (!current) {
-          const freshnessMessage = workspaceRecommendationFreshnessMessage();
-          const canManualRefresh = currentLevel !== 'off';
-          const emptyMessage = workspaceRecommendationDismissedForDay
-            ? 'You dismissed today\'s recommendation. Refresh anytime or check back tomorrow.'
-            : currentLevel === 'off'
-              ? 'Proactive suggestions are off. Turn them back on in Settings whenever you want a clear next-step nudge.'
-              : 'No proactive suggestion right now. As soon as Oliver sees a clear next step, it will show up here.';
-          workspaceRecommendationCard.innerHTML = `
-            <div class="workspace-recommendation-empty">${escapeHtml(emptyMessage)}</div>
-            ${(canManualRefresh || freshnessMessage) ? `
-              <div class="workspace-recommendation-actions">
-                ${canManualRefresh ? '<button id="workspace-recommendation-refresh" class="auth-btn auth-btn-oauth">Refresh</button>' : ''}
-                <span class="workspace-recommendation-status">${escapeHtml(freshnessMessage || '')}</span>
-              </div>
-            ` : ''}
-          `;
-          document.getElementById('workspace-recommendation-refresh')?.addEventListener('click', () => {
-            handleWorkspaceRecommendationManualRefresh();
-          });
-          return;
-        }
-
-        const alternatives = recommendationItems().filter(
-          (item) => recommendationIdentity(item) !== currentIdentity
-        );
-        const busyAttribute = workspaceRecommendationBusy ? ' disabled' : '';
-        const statusClass = workspaceRecommendationErrorMessage ? 'workspace-recommendation-status is-error' : 'workspace-recommendation-status';
-        const freshnessMessage = workspaceRecommendationFreshnessMessage();
-        const statusMessage = workspaceRecommendationBusy
-          ? 'Working on this recommendation...'
-          : workspaceRecommendationErrorMessage || freshnessMessage || '';
-        const triggerLabel = RECOMMENDATION_TRIGGER_LABELS[current.trigger_type] || formatRecommendationToken(current.trigger_type);
-
-        const alternativesHtml = workspaceRecommendationAlternativesVisible && alternatives.length > 0
-          ? `
-            <div class="workspace-recommendation-alternatives">
-              ${alternatives.map((item) => `
-                <article class="workspace-recommendation-alt-item">
-                  <h4>${escapeHtml(item.title)}</h4>
-                  <p class="workspace-recommendation-alt-copy">${escapeHtml(item.why_now)}</p>
-                  <p class="workspace-recommendation-alt-copy">${escapeHtml(item.outcome)}</p>
-                  <div>
-                    <button class="auth-btn auth-btn-oauth" data-recommendation-select="${escapeHtml(recommendationIdentity(item))}"${busyAttribute}>Use this instead</button>
-                  </div>
-                </article>
-              `).join('')}
-            </div>
-          `
-          : '';
-
-        const whyHtml = workspaceRecommendationWhyVisible
-          ? `
-            <div class="workspace-recommendation-why">
-              <p>We only surface one recommendation at a time, using your connected apps, saved memory, and recent task outcomes.</p>
-              <p>This one is showing because it matches the <strong>${escapeHtml(triggerLabel)}</strong> trigger class. Choosing “Not now” hides it for the rest of today unless you manually refresh.</p>
-            </div>
-          `
-          : '';
+        const homeModel = buildDashboardHomepageModel(buildDashboardHomeContext());
+        const stateChip = homeModel.chips[0];
+        const guideCopy = homeModel.stateKey === 'connected_no_tasks'
+          ? 'Requests start in a connected app, not inside Work. Work becomes useful after the first request lands.'
+          : homeModel.stateKey === 'no_connected_app'
+            ? 'Connections decide where requests can start. Work is where the result shows up after that request lands.'
+            : 'Work is the review surface. Memory is where you tighten tone, context, and approval rules after the first loop is clear.';
 
         workspaceRecommendationCard.innerHTML = `
-          <div class="workspace-recommendation-header">
-            <div class="workspace-recommendation-kicker">
-              <span class="workspace-recommendation-badge">Oliver guidance</span>
-              <span class="workspace-recommendation-trigger">${escapeHtml(triggerLabel)}</span>
+          <div class="dashboard-home-primary">
+            <div class="dashboard-home-state-line">
+              <span class="dashboard-home-kicker">Oliver focus</span>
+              <span>${escapeHtml(stateChip?.value || 'In progress')}</span>
             </div>
-          </div>
-          <h3 class="workspace-recommendation-title">${escapeHtml(current.title)}</h3>
-          <div class="workspace-recommendation-grid">
-            <div class="workspace-recommendation-detail">
-              <p class="workspace-recommendation-label">Why now</p>
-              <p class="workspace-recommendation-copy">${escapeHtml(current.why_now)}</p>
-            </div>
-            <div class="workspace-recommendation-detail">
-              <p class="workspace-recommendation-label">What this unlocks</p>
-              <p class="workspace-recommendation-copy">${escapeHtml(current.outcome)}</p>
-            </div>
-          </div>
-          <div class="workspace-recommendation-actions">
-            <button id="workspace-recommendation-primary" class="auth-btn auth-btn-primary"${busyAttribute}>
-              ${escapeHtml(recommendationPrimaryActionLabel(current))}
-            </button>
-            <div class="workspace-recommendation-secondary-actions">
-              ${alternatives.length > 0 ? `
-                <button id="workspace-recommendation-toggle-options" class="workspace-recommendation-text-btn"${busyAttribute}>
-                  ${workspaceRecommendationAlternativesVisible ? 'Hide options' : `Show ${Math.min(alternatives.length, 2)} options`}
-                </button>
-              ` : ''}
-              <button id="workspace-recommendation-refresh" class="workspace-recommendation-text-btn"${busyAttribute}>Refresh</button>
-              <button id="workspace-recommendation-defer" class="workspace-recommendation-text-btn"${busyAttribute}>Not now</button>
-              <button id="workspace-recommendation-why-btn" class="workspace-recommendation-text-btn"${busyAttribute}>
-                ${workspaceRecommendationWhyVisible ? 'Hide details' : 'Why am I seeing this?'}
+            <h3 class="dashboard-home-primary-title">${escapeHtml(homeModel.title)}</h3>
+            <p class="dashboard-home-primary-summary">${escapeHtml(homeModel.summary)}</p>
+            <div class="dashboard-home-primary-actions">
+              <button id="dashboard-home-primary-action" class="auth-btn auth-btn-primary">
+                ${escapeHtml(homeModel.primaryAction.label)}
               </button>
             </div>
+            <p class="dashboard-home-primary-helper">${escapeHtml(homeModel.helper)}</p>
+            <p class="dashboard-home-guide"><strong>Keep the loop honest:</strong> ${escapeHtml(guideCopy)}</p>
           </div>
-          <div class="${statusClass}">${statusMessage ? escapeHtml(statusMessage) : '&nbsp;'}</div>
-          ${whyHtml}
-          ${alternativesHtml}
         `;
 
-        document.getElementById('workspace-recommendation-primary')?.addEventListener('click', () => {
-          handleWorkspaceRecommendationPrimaryAction();
-        });
-
-        document.getElementById('workspace-recommendation-refresh')?.addEventListener('click', () => {
-          handleWorkspaceRecommendationManualRefresh();
-        });
-
-        document.getElementById('workspace-recommendation-defer')?.addEventListener('click', () => {
-          handleWorkspaceRecommendationDefer();
-        });
-
-        document.getElementById('workspace-recommendation-toggle-options')?.addEventListener('click', async () => {
-          workspaceRecommendationAlternativesVisible = !workspaceRecommendationAlternativesVisible;
-          renderWorkspaceRecommendationCard();
-
-          if (workspaceRecommendationAlternativesVisible) {
-            const { data: { session } } = await supabase.auth.getSession();
-            trackAnalyticsEvent(
-              'workspace_recommendation_alternatives_opened',
-              recommendationAnalyticsProperties(current),
-              session ? { accessToken: session.access_token } : {}
-            );
+        document.getElementById('dashboard-home-primary-action')?.addEventListener('click', () => {
+          if (homeModel.primaryAction.kind === 'open_dashboard_section') {
+            openDashboardSection(homeModel.primaryAction.section);
           }
-        });
-
-        document.getElementById('workspace-recommendation-why-btn')?.addEventListener('click', async () => {
-          workspaceRecommendationWhyVisible = !workspaceRecommendationWhyVisible;
-          renderWorkspaceRecommendationCard();
-
-          if (workspaceRecommendationWhyVisible) {
-            const { data: { session } } = await supabase.auth.getSession();
-            trackAnalyticsEvent(
-              'workspace_recommendation_reason_opened',
-              recommendationAnalyticsProperties(current),
-              session ? { accessToken: session.access_token } : {}
-            );
-          }
-        });
-
-        workspaceRecommendationCard.querySelectorAll('[data-recommendation-select]').forEach((button) => {
-          button.addEventListener('click', async (event) => {
-            const nextKey = event.currentTarget?.getAttribute('data-recommendation-select');
-            if (!nextKey || nextKey === workspaceRecommendationSelectedKey) {
-              return;
-            }
-
-            workspaceRecommendationSelectedKey = nextKey;
-            workspaceRecommendationWhyVisible = false;
-            workspaceRecommendationErrorMessage = '';
-            renderWorkspaceRecommendationCard();
-
-            const selected = currentWorkspaceRecommendation();
-            const { data: { session } } = await supabase.auth.getSession();
-            if (session && selected) {
-              await maybeTrackWorkspaceRecommendationShown(session.access_token);
-              trackAnalyticsEvent(
-                'workspace_recommendation_alternative_selected',
-                recommendationAnalyticsProperties(selected),
-                { accessToken: session.access_token }
-              );
-            }
-          });
         });
       }
 
@@ -4757,7 +4763,7 @@
         }
 
         if (actionKind === 'trigger_create_plan') {
-          openDashboardSection('section-tasks');
+          openDashboardSection('section-work');
           return;
         }
 
@@ -5071,178 +5077,69 @@
         if (!container) return;
 
         const progress = document.getElementById('next-steps-progress');
-        const connectedTypes = connectedProviderTypes(identifiers);
-        const hasAnyConnected = connectedTypes.length > 0;
-        const taskCount = Array.isArray(cachedTasks) ? cachedTasks.length : 0;
-        const successfulTaskCount = countSuccessfulTasks(cachedTasks);
-        const reviewableTaskCount = countReviewableTasks(cachedTasks);
-        const hasMemory = hasSavedMemoryNote();
-        const completedChecklistCount = [
-          hasAnyConnected,
-          taskCount > 0,
-          hasMemory,
-          reviewableTaskCount > 0
-        ].filter(Boolean).length;
+        if (dashboardHomeLoading) {
+          if (progress) {
+            progress.textContent = 'Loading...';
+          }
+          container.innerHTML = '<p class="next-step-empty">Loading your setup loop...</p>';
+          return;
+        }
+
+        const setupModel = buildDashboardSetupModel({
+          connectedTypes: connectedProviderTypes(identifiers),
+          taskCount: Array.isArray(cachedTasks) ? cachedTasks.length : 0,
+          reviewableTaskCount: countReviewableTasks(cachedTasks),
+          hasSavedMemory: hasSavedMemoryNote()
+        });
 
         if (progress) {
-          progress.textContent = `${completedChecklistCount} of 4 done`;
+          progress.textContent = setupModel.progressLabel;
         }
 
-        const preferredChannels = normalizeWorkspaceList(loadWorkspaceBlueprintFromStorage()?.preferred_channels).map((item) => item.toLowerCase());
-        const providerOrder = buildPreferredProviderOrder(preferredChannels);
-        const suggestedConnections = providerOrder
-          .filter((provider) => !connectedTypes.includes(provider))
-          .map((provider) => OAUTH_TASKS.find((task) => task.identifierType === provider))
-          .filter(Boolean)
-          .slice(0, 3);
-        const optionalExtensions = filterOptionalExtensionsForNextSteps(
-          ADMIN_TASKS_CONFIG,
-          connectedTypes
-        );
-
-        const checklistTasks = [
-          {
-            id: 'connect-one-app',
-            title: 'Connect one app',
-            description: 'Start with the first app where Oliver should receive or complete work.',
-            status: hasAnyConnected ? 'complete' : 'pending',
-            completeLabel: `${connectedTypes.length} connected`,
-            actionLabel: 'Open Connected Apps',
-            href: '#section-channels'
-          },
-          {
-            id: 'try-first-task',
-            title: 'Try one starter task',
-            description: hasAnyConnected
-              ? 'Send Oliver one small request in a connected app so it appears in Tasks.'
-              : 'Connect an app first, then send Oliver one small request from there.',
-            status: taskCount > 0 ? (reviewableTaskCount > 0 ? 'complete' : 'in_progress') : 'pending',
-            completeLabel: `${taskCount} task${taskCount === 1 ? '' : 's'} started`,
-            pendingLabel: 'Waiting for first result',
-            actionLabel: 'Open Tasks',
-            href: '#section-tasks'
-          },
-          {
-            id: 'save-memory',
-            title: 'Save preferences in Memory',
-            description: 'Add tone, recurring context, or approval rules Oliver should remember.',
-            status: hasMemory ? 'complete' : 'pending',
-            completeLabel: 'Saved',
-            actionLabel: 'Open Memory',
-            href: '#section-memo'
-          },
-          {
-            id: 'review-result',
-            title: 'Review the result',
-            description: taskCount > 0
-              ? 'Use Tasks to review the first result before expanding the workflow.'
-              : 'Once a task runs, review the result here before you repeat it.',
-            status: reviewableTaskCount > 0 ? 'complete' : 'pending',
-            completeLabel: successfulTaskCount > 0
-              ? `${successfulTaskCount} successful`
-              : `${reviewableTaskCount} result${reviewableTaskCount === 1 ? '' : 's'} ready`,
-            actionLabel: 'Open Tasks',
-            href: '#section-tasks'
+        function renderAction(action) {
+          if (!action) {
+            return '';
           }
-        ];
-
-        function renderCompleteBadge(label) {
-          return `<span class="next-step-complete"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg> ${escapeHtml(label)}</span>`;
+          return `<a class="auth-btn auth-btn-oauth" href="#${escapeHtml(action.section || 'section-work')}">${escapeHtml(action.label || 'Open')}</a>`;
         }
 
-        function renderPendingBadge(label) {
-          return `<span class="next-step-pending-text"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 6v6l4 2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg> ${escapeHtml(label)}</span>`;
+        function renderStatus(status) {
+          const label = status === 'complete'
+            ? 'Done'
+            : status === 'current'
+              ? 'Now'
+              : 'Later';
+          const className = status === 'complete'
+            ? 'next-step-status-pill is-complete'
+            : status === 'current'
+              ? 'next-step-status-pill is-current'
+              : 'next-step-status-pill';
+          return `<span class="${className}">${escapeHtml(label)}</span>`;
         }
 
-        function renderTaskAction(task) {
-          if (task.status === 'complete') {
-            return renderCompleteBadge(task.completeLabel || 'Complete');
-          }
-
-          if (task.status === 'in_progress') {
-            return `
-              <div class="next-step-pending">
-                ${renderPendingBadge(task.pendingLabel || 'In progress')}
-                <a class="auth-btn auth-btn-oauth" href="${task.href || '#section-tasks'}">${escapeHtml(task.actionLabel || 'Open')}</a>
+        container.innerHTML = `
+          <div class="next-step-compact-list">
+            ${setupModel.steps.map((step) => `
+              <div class="next-step-compact-item" data-step-key="${escapeHtml(step.key)}">
+                ${renderStatus(step.status)}
+                <div class="next-step-compact-copy">
+                  <p class="next-step-compact-title">${escapeHtml(step.title)}</p>
+                  <p class="next-step-compact-description">${escapeHtml(step.description)}</p>
+                </div>
+                <div class="next-step-action">
+                  ${renderAction(step.action)}
+                </div>
               </div>
-            `;
-          }
-
-          if (task.href) {
-            return `<a class="auth-btn auth-btn-oauth" href="${task.href}">${escapeHtml(task.actionLabel || 'Open')}</a>`;
-          }
-
-          if (task.oauthButtonId) {
-            return `<button class="auth-btn auth-btn-oauth" onclick="document.getElementById('${task.oauthButtonId}').click()">${escapeHtml(task.actionLabel || 'Connect')}</button>`;
-          }
-
-          if (task.externalUrl) {
-            const completedTasks = JSON.parse(localStorage.getItem('dw_completed_admin_tasks') || '[]');
-            if (completedTasks.includes(task.id)) {
-              return renderCompleteBadge('Added');
-            }
-            if (task.id === 'add-oliver-discord') {
-              return `<a href="#" class="auth-btn auth-btn-primary" onclick="openDiscordBotAuth(event)">${escapeHtml(task.actionLabel || 'Add')}</a>`;
-            }
-            if (task.id === 'add-oliver-slack') {
-              return `<a href="#" class="auth-btn auth-btn-primary" onclick="openSlackBotAuth(event)">${escapeHtml(task.actionLabel || 'Add')}</a>`;
-            }
-            return `<a href="${task.externalUrl}" target="_blank" rel="noopener noreferrer" class="auth-btn auth-btn-primary">${escapeHtml(task.actionLabel || 'Open')}</a>`;
-          }
-
-          return `<a class="auth-btn auth-btn-oauth" href="#section-channels">Open Connected Apps</a>`;
-        }
-
-        function renderTaskItem(task) {
-          return `
-            <div class="next-step-item" data-task-id="${task.id}">
-              <div class="next-step-info">
-                <p class="next-step-title">${escapeHtml(task.title)}</p>
-                <p class="next-step-description">${escapeHtml(task.description)}</p>
+            `).join('')}
+            ${setupModel.note ? `
+              <div class="next-step-note-card">
+                <p class="next-step-note-title">${escapeHtml(setupModel.note.title)}</p>
+                <p class="next-step-note-copy">${escapeHtml(setupModel.note.description)}</p>
+                <div>${renderAction(setupModel.note.action)}</div>
               </div>
-              <div class="next-step-action">
-                ${renderTaskAction(task)}
-              </div>
-            </div>
-          `;
-        }
-
-        function renderSection(title, intro, tasks, emptyMessage) {
-          const tasksHtml = tasks.length > 0
-            ? tasks.map(renderTaskItem).join('')
-            : `<p class="next-step-empty">${escapeHtml(emptyMessage)}</p>`;
-          return `
-            <div class="next-step-section">
-              <h4 class="next-step-subheader">${escapeHtml(title)}</h4>
-              <p class="next-step-section-intro">${escapeHtml(intro)}</p>
-              ${tasksHtml}
-            </div>
-          `;
-        }
-
-        let html = '';
-        html += renderSection(
-          'Checklist',
-          'These four steps matter most for a clean first run with Oliver.',
-          checklistTasks,
-          'No checklist items right now.'
-        );
-        html += renderSection(
-          'Suggested connections',
-          'Only add the next app when it supports a real task you already want Oliver to handle.',
-          suggestedConnections,
-          'You already connected the currently supported apps.'
-        );
-        if (optionalExtensions.length > 0) {
-          html += renderSection(
-            'Optional extensions',
-            'Use these only after the matching app connection is already in place.',
-            optionalExtensions,
-            'No optional extensions to show right now.'
-          );
-        }
-
-        container.innerHTML = html;
+            ` : ''}
+          </div>
+        `;
       }
 
       function scrollToDashboardHashTarget() {
@@ -5491,6 +5388,7 @@
         routineActionBusyIds = new Set();
         routineActionErrors = {};
         cachedMemoContent = '';
+        dashboardHomeLoading = false;
         workspaceRecommendationResponse = null;
         workspaceRecommendationStatus = 'idle';
         workspaceRecommendationErrorMessage = '';
@@ -5781,13 +5679,14 @@
         hideExistingAccountOptions();
         dashboardContainer.classList.remove('hidden');
         pageTitle.textContent = 'Your Oliver setup';
-        pageSubtitle.textContent = 'Connect apps, review tasks, save memory, and decide how Oliver should work for you.';
+        pageSubtitle.textContent = 'Connect apps, review work, save memory, and decide how Oliver should work for you.';
         applyEntryAwareCopy({ dashboardMode: true });
 
         document.getElementById('account-id').textContent = accountData.account_id;
         document.getElementById('user-email').textContent = session.user.email;
         initOrganizationUI(accountData);
         setupOrganizationListeners();
+        dashboardHomeLoading = true;
         loadWorkspaceSummaryFromStorage();
         workspaceRecommendationStatus = 'loading';
         workspaceRecommendationErrorMessage = '';
@@ -5803,7 +5702,9 @@
           loadWorkspaceRecommendationPreferences(session.access_token),
           loadBalanceAndBadges(session.access_token)
         ]);
+        dashboardHomeLoading = false;
         loadWorkspaceSummaryFromStorage();
+        renderWorkspaceRecommendationCard();
         await loadWorkspaceRecommendation(session.access_token);
 
         updateSidebarNavigation();
@@ -6947,7 +6848,7 @@
               taskList.innerHTML = renderWorkListState({
                 tagName: 'li',
                 className: 'task-item work-item',
-                message: 'No tasks yet. Send Oliver one request from a connected app and it will show up here.'
+                message: 'No work yet. Send one small request from a connected app and it will show up here for review.'
               });
               tasksStatus.textContent = `Updated ${new Date().toLocaleTimeString()}`;
               loadWorkspaceSummaryFromStorage();
@@ -7006,7 +6907,7 @@
             taskList.innerHTML = renderWorkListState({
               tagName: 'li',
               className: 'task-item work-item',
-              message: 'No tasks yet. Send Oliver one request from a connected app and it will show up here.'
+              message: 'No work yet. Send one small request from a connected app and it will show up here for review.'
             });
           } else {
             taskList.innerHTML = allTasks.map(task => renderTask(task)).join('');

--- a/website/tests/connect-onboarding.test.mjs
+++ b/website/tests/connect-onboarding.test.mjs
@@ -51,7 +51,7 @@ test('Slack install onboarding switches to a calm live-state CTA', () => {
 
   assert.equal(model.title, 'Oliver is now available in Slack');
   assert.equal(model.cta.kind, 'anchor');
-  assert.equal(model.cta.href, '#section-tasks');
+  assert.equal(model.cta.href, '#section-work');
   assert.equal(model.examples.length, 3);
   assertContentGuardrails(model);
 });
@@ -78,7 +78,7 @@ test('Generic connected apps still produce a deterministic onboarding model', ()
 
   assert.equal(model.title, 'GitHub connected');
   assert.equal(model.cta.kind, 'anchor');
-  assert.equal(model.cta.href, '#section-tasks');
+  assert.equal(model.cta.href, '#section-work');
   assert.equal(model.examples.length, 3);
   assertContentGuardrails(model);
 });

--- a/website/tests/homepage-state.test.mjs
+++ b/website/tests/homepage-state.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildDashboardHomepageModel,
+  buildDashboardSetupModel
+} from '../public/auth/homepage-state.js';
+
+test('connected apps without tasks no longer send the user to Work as the next step', () => {
+  const model = buildDashboardHomepageModel({
+    connectedTypes: ['slack', 'github'],
+    taskCount: 0,
+    successfulTaskCount: 0,
+    reviewableTaskCount: 0,
+    hasSavedMemory: false
+  });
+
+  assert.equal(model.stateKey, 'connected_no_tasks');
+  assert.equal(model.primaryAction.section, 'section-channels');
+  assert.equal(model.primaryAction.label, 'See Where to Start');
+  assert.match(model.summary, /work stays empty until that request is sent/i);
+});
+
+test('review-ready work resolves to a truthful open-work next step', () => {
+  const model = buildDashboardHomepageModel({
+    connectedTypes: ['slack'],
+    taskCount: 2,
+    successfulTaskCount: 1,
+    reviewableTaskCount: 1,
+    hasSavedMemory: false
+  });
+
+  assert.equal(model.stateKey, 'review_ready');
+  assert.equal(model.primaryAction.section, 'section-work');
+  assert.equal(model.primaryAction.label, 'Open Work');
+});
+
+test('mature usage keeps setup demoted and marks the core setup loop complete', () => {
+  const homeModel = buildDashboardHomepageModel({
+    connectedTypes: ['slack', 'github'],
+    taskCount: 4,
+    successfulTaskCount: 3,
+    reviewableTaskCount: 2,
+    hasSavedMemory: true
+  });
+  const setupModel = buildDashboardSetupModel({
+    connectedTypes: ['slack', 'github'],
+    taskCount: 4,
+    reviewableTaskCount: 2,
+    hasSavedMemory: true
+  });
+
+  assert.equal(homeModel.stateKey, 'ongoing_usage');
+  assert.equal(setupModel.progressLabel, '3 of 3 core steps done');
+  assert.equal(setupModel.isComplete, true);
+  assert.equal(setupModel.note?.action?.section, 'section-work');
+});

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -33,6 +33,15 @@ function servePublicHtml() {
         const isStaticPath = staticPaths.some(p => url.startsWith(p))
 
         if (isStaticPath) {
+          const hasExplicitExtension = /\.[^/]+$/.test(url)
+          const isHtmlRequest = url.endsWith('.html')
+
+          // Let Vite serve JS, CSS, images, and other public assets normally.
+          if (hasExplicitExtension && !isHtmlRequest) {
+            next()
+            return
+          }
+
           // Try to serve index.html from the public folder
           let filePath = url.endsWith('/') ? url + 'index.html' : url
           if (!filePath.endsWith('.html') && !filePath.includes('.')) {


### PR DESCRIPTION
## Summary
- replace the logged-in auth dashboard homepage with a state-driven, single-primary-action flow instead of the old recommendation + checklist + summary-card stack
- demote redundant setup and admin surfaces, unify the top-level vocabulary around Connections / Setup / Work / Memory / Settings, and add explicit homepage state helpers with regression tests
- fix the misleading no-task CTA loop so connected accounts without work point to Connections instead of pretending Work can start the first request
- fix the local Vite `/auth/` middleware so JS modules under `website/public/auth/` are served as assets instead of HTML, which unblocks localhost auth/dashboard rendering

## Validation
- `npm run lint`
- `npm run test:responsive`
- `npm run test:auth-onboarding`
- `node --test tests/homepage-state.test.mjs`
- browser validation across homepage states: no connected app, connected app with no tasks, tasks in progress, review ready, ongoing usage, plus a narrow/mobile width check
