### PR TITLE
refactor: simplify the Oliver TPM landing page

### DIFF
--- a/website/src/pages/OliverLandingPage.jsx
+++ b/website/src/pages/OliverLandingPage.jsx
@@ -7,7 +7,6 @@ import {
 import { getThemeForLocalTime, LOCAL_THEME_CHANGE_EVENT, THEME_META_COLORS } from '../theme/localTheme';
 import {
   OLIVER_AUTH_OVERVIEW_HREF,
-  OLIVER_AUTH_WORK_HREF,
   OLIVER_ENTRY_SURFACE,
   OLIVER_LANDING_VARIANT,
   oliverLandingContent
@@ -35,14 +34,14 @@ const updateLinkHref = (selector, href) => {
   }
 };
 
-function ArrowUpRightIcon() {
+function CheckLineIcon() {
   return (
     <svg viewBox="0 0 20 20" aria-hidden="true">
       <path
-        d="M6 14L14 6M8 6h6v6"
+        d="M4.5 10.5l3.3 3.3L15.5 6"
         fill="none"
         stroke="currentColor"
-        strokeWidth="1.7"
+        strokeWidth="1.8"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -50,11 +49,11 @@ function ArrowUpRightIcon() {
   );
 }
 
-function CheckLineIcon() {
+function ArrowUpRightIcon() {
   return (
     <svg viewBox="0 0 20 20" aria-hidden="true">
       <path
-        d="M4.5 10.5l3.3 3.3L15.5 6"
+        d="M6 14L14 6M8 6h6v6"
         fill="none"
         stroke="currentColor"
         strokeWidth="1.7"
@@ -145,55 +144,36 @@ function OliverLandingPage() {
   };
 
   return (
-    <div className="app-container oliver-hook-page">
-      <div className="oliver-hook-noise" aria-hidden="true" />
+    <div className="app-container oliver-clarity-page">
       <div className="content-layer">
-        <header className="oliver-hook-nav">
-          <div className="oliver-hook-nav-inner">
-            <a href="/" className="oliver-hook-brand" aria-label="Back to the DoWhiz homepage">
-              <img src="/assets/DoWhiz.svg" alt="" className="oliver-hook-brand-mark" aria-hidden="true" />
-              <span className="oliver-hook-brand-copy">
+        <header className="oliver-clarity-header">
+          <div className="container oliver-clarity-topbar">
+            <a href="/" className="oliver-clarity-brand" aria-label="Back to the DoWhiz homepage">
+              <img src="/assets/DoWhiz.svg" alt="" className="oliver-clarity-brand-mark" aria-hidden="true" />
+              <span className="oliver-clarity-brand-copy">
                 Do<span className="text-gradient">Whiz</span>
               </span>
             </a>
 
-            <nav className="oliver-hook-links" aria-label="Oliver page sections">
-              {content.nav.links.map((link) => (
-                <a
-                  key={link.href}
-                  href={link.href}
-                  className="oliver-hook-link"
-                  onClick={() =>
-                    trackLandingInteraction('secondary_cta_click', {
-                      cta_location: 'oliver_nav',
-                      cta_text: link.label
-                    })
-                  }
-                >
-                  {link.label}
-                </a>
-              ))}
-            </nav>
-
-            <div className="oliver-hook-nav-actions">
+            <div className="oliver-clarity-topbar-actions">
               <a
-                className="btn btn-secondary oliver-hook-nav-secondary"
-                href={OLIVER_AUTH_WORK_HREF}
+                href="#sample-update"
+                className="oliver-clarity-proof-link"
                 onClick={() =>
                   trackLandingInteraction('secondary_cta_click', {
-                    cta_location: 'oliver_nav_work',
-                    cta_text: content.nav.secondaryCta
+                    cta_location: 'topbar_proof',
+                    cta_text: content.nav.proofLink
                   })
                 }
               >
-                {content.nav.secondaryCta}
+                {content.nav.proofLink}
               </a>
               <a
-                className="btn btn-primary oliver-hook-nav-primary"
+                className="btn btn-primary oliver-clarity-nav-cta"
                 href={OLIVER_AUTH_OVERVIEW_HREF}
                 onClick={() =>
                   trackLandingInteraction('primary_cta_click', {
-                    cta_location: 'oliver_nav_open',
+                    cta_location: 'topbar_primary',
                     cta_text: content.nav.primaryCta
                   })
                 }
@@ -204,29 +184,32 @@ function OliverLandingPage() {
           </div>
         </header>
 
-        <main className="oliver-hook-main">
-          <section className="oliver-hook-hero" id="top">
-            <div className="container oliver-hook-hero-grid">
-              <div className="oliver-hook-copy">
-                <p className="oliver-hook-eyebrow">{content.hero.eyebrow}</p>
-                <h1 className="oliver-hook-title">{content.hero.title}</h1>
-                <p className="oliver-hook-subtitle">{content.hero.subtitle}</p>
+        <main className="oliver-clarity-main">
+          <section className="oliver-clarity-hero">
+            <div className="container oliver-clarity-hero-grid">
+              <div className="oliver-clarity-copy">
+                <p className="oliver-clarity-eyebrow">{content.hero.eyebrow}</p>
+                <h1 className="oliver-clarity-title">{content.hero.title}</h1>
+                <p className="oliver-clarity-subtitle">{content.hero.subtitle}</p>
 
-                <div className="oliver-hook-pill-row" aria-label="Key TPM outputs">
-                  {content.hero.proofPills.map((item) => (
-                    <span key={item} className="oliver-hook-pill">
-                      {item}
-                    </span>
+                <ul className="oliver-clarity-highlight-list" aria-label="Key outputs">
+                  {content.hero.highlights.map((item) => (
+                    <li key={item} className="oliver-clarity-highlight-item">
+                      <span className="oliver-clarity-highlight-icon">
+                        <CheckLineIcon />
+                      </span>
+                      <span>{item}</span>
+                    </li>
                   ))}
-                </div>
+                </ul>
 
-                <div className="oliver-hook-cta-row">
+                <div className="oliver-clarity-cta-row">
                   <a
-                    className="btn btn-primary oliver-hook-primary-button"
+                    className="btn btn-primary oliver-clarity-primary-button"
                     href={OLIVER_AUTH_OVERVIEW_HREF}
                     onClick={() =>
                       trackLandingInteraction('primary_cta_click', {
-                        cta_location: 'hero_primary_open_oliver',
+                        cta_location: 'hero_primary',
                         cta_text: content.hero.primaryCta
                       })
                     }
@@ -234,11 +217,11 @@ function OliverLandingPage() {
                     {content.hero.primaryCta}
                   </a>
                   <a
-                    className="btn btn-secondary oliver-hook-secondary-button"
-                    href="#proof"
+                    className="btn btn-secondary oliver-clarity-secondary-button"
+                    href="#sample-update"
                     onClick={() =>
                       trackLandingInteraction('secondary_cta_click', {
-                        cta_location: 'hero_secondary_outputs',
+                        cta_location: 'hero_secondary',
                         cta_text: content.hero.secondaryCta
                       })
                     }
@@ -246,101 +229,72 @@ function OliverLandingPage() {
                     {content.hero.secondaryCta}
                   </a>
                 </div>
-
-                <p className="oliver-hook-note">{content.hero.note}</p>
               </div>
 
-              <aside className="oliver-hook-hero-panel" aria-label="Oliver launch review preview">
-                <div className="oliver-hook-hero-panel-head">
+              <aside
+                className="oliver-clarity-update-card"
+                id="sample-update"
+                aria-label="Sample weekly update"
+              >
+                <div className="oliver-clarity-update-head">
                   <div>
-                    <p className="oliver-hook-panel-label">{content.hero.artifact.label}</p>
-                    <h2>{content.hero.artifact.title}</h2>
+                    <p className="oliver-clarity-card-kicker">{content.hero.artifact.label}</p>
+                    <h2 className="oliver-clarity-card-title">{content.hero.artifact.program}</h2>
                   </div>
-                  <div className="oliver-hook-health">
-                    <span className="oliver-hook-health-badge">{content.hero.artifact.healthLabel}</span>
-                    <span className="oliver-hook-health-detail">{content.hero.artifact.healthDetail}</span>
+                  <div className="oliver-clarity-health-group">
+                    <span className="oliver-clarity-health-badge">{content.hero.artifact.healthLabel}</span>
+                    <span className="oliver-clarity-health-detail">{content.hero.artifact.healthDetail}</span>
                   </div>
                 </div>
 
-                <div className="oliver-hook-signal-band" aria-label="Signal sources">
-                  {content.hero.artifact.signalSources.map((item) => (
-                    <span key={item} className="oliver-hook-signal-chip">
-                      {item}
-                    </span>
-                  ))}
-                </div>
+                <section className="oliver-clarity-card-section">
+                  <p className="oliver-clarity-card-label">{content.hero.artifact.summaryLabel}</p>
+                  <p className="oliver-clarity-card-summary">{content.hero.artifact.summary}</p>
+                </section>
 
-                <div className="oliver-hook-hero-panel-grid">
-                  <section className="oliver-hook-artifact-card oliver-hook-artifact-card-update">
-                    <p className="oliver-hook-card-kicker">{content.hero.artifact.summary.label}</p>
-                    <p className="oliver-hook-card-copy">{content.hero.artifact.summary.text}</p>
+                <div className="oliver-clarity-update-grid">
+                  <section className="oliver-clarity-card-section">
+                    <p className="oliver-clarity-card-label">{content.hero.artifact.risksLabel}</p>
+                    <ul className="oliver-clarity-issue-list">
+                      {content.hero.artifact.risks.map((risk) => (
+                        <li key={risk}>{risk}</li>
+                      ))}
+                    </ul>
                   </section>
 
-                  <section className="oliver-hook-artifact-card oliver-hook-artifact-card-actions">
-                    <p className="oliver-hook-card-kicker">Actions ready</p>
-                    <ul className="oliver-hook-checklist">
-                      {content.hero.artifact.actions.map((item) => (
-                        <li key={`${item.owner}-${item.task}`}>
-                          <span className="oliver-hook-check-icon">
-                            <CheckLineIcon />
-                          </span>
-                          <div>
-                            <strong>{item.owner}</strong>
-                            <span>{item.task}</span>
-                          </div>
-                          <small>{item.due}</small>
+                  <section className="oliver-clarity-card-section">
+                    <p className="oliver-clarity-card-label">{content.hero.artifact.ownersLabel}</p>
+                    <ul className="oliver-clarity-owner-list">
+                      {content.hero.artifact.owners.map((item) => (
+                        <li key={`${item.owner}-${item.action}`}>
+                          <strong>{item.owner}</strong>
+                          <span>{item.action}</span>
                         </li>
                       ))}
                     </ul>
                   </section>
                 </div>
 
-                <section className="oliver-hook-artifact-card oliver-hook-artifact-card-risks">
-                  <div className="oliver-hook-card-row">
-                    <p className="oliver-hook-card-kicker">Current risks</p>
-                    <a
-                      href={OLIVER_AUTH_WORK_HREF}
-                      className="oliver-hook-inline-link"
-                      onClick={() =>
-                        trackLandingInteraction('secondary_cta_click', {
-                          cta_location: 'hero_risk_register',
-                          cta_text: 'Open current work view'
-                        })
-                      }
-                    >
-                      Open current work view
-                      <ArrowUpRightIcon />
-                    </a>
-                  </div>
-                  <ul className="oliver-hook-risk-list">
-                    {content.hero.artifact.risks.map((item) => (
-                      <li key={item.label}>
-                        <span className={`oliver-hook-risk-level oliver-hook-risk-level-${item.level.toLowerCase()}`}>
-                          {item.level}
-                        </span>
-                        <span>{item.label}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </section>
+                <p className="oliver-clarity-source-note">
+                  <span>{content.hero.artifact.sourceLabel}</span>
+                  {content.hero.artifact.sources}
+                </p>
               </aside>
             </div>
           </section>
 
-          <section className="oliver-hook-section" id="proof">
+          <section className="oliver-clarity-section oliver-clarity-section-outputs">
             <div className="container">
-              <div className="oliver-hook-section-head">
-                <p className="oliver-hook-section-eyebrow">{content.proof.eyebrow}</p>
-                <h2 className="oliver-hook-section-title">{content.proof.title}</h2>
-                <p className="oliver-hook-section-intro">{content.proof.intro}</p>
+              <div className="oliver-clarity-section-head">
+                <p className="oliver-clarity-section-eyebrow">{content.outputs.eyebrow}</p>
+                <h2 className="oliver-clarity-section-title">{content.outputs.title}</h2>
               </div>
 
-              <div className="oliver-hook-proof-grid">
-                {content.proof.cards.map((card) => (
-                  <article key={card.title} className="oliver-hook-proof-card">
-                    <p className="oliver-hook-card-kicker">{card.eyebrow}</p>
+              <div className="oliver-clarity-output-grid">
+                {content.outputs.cards.map((card) => (
+                  <article key={card.title} className="oliver-clarity-surface-card">
                     <h3>{card.title}</h3>
-                    <p>{card.summary}</p>
+                    <p>{card.description}</p>
                     <ul>
                       {card.bullets.map((bullet) => (
                         <li key={bullet}>{bullet}</li>
@@ -352,37 +306,18 @@ function OliverLandingPage() {
             </div>
           </section>
 
-          <section className="oliver-hook-section" id="ownership">
+          <section className="oliver-clarity-section oliver-clarity-section-setup">
             <div className="container">
-              <div className="oliver-hook-section-head">
-                <p className="oliver-hook-section-eyebrow">{content.ownership.eyebrow}</p>
-                <h2 className="oliver-hook-section-title">{content.ownership.title}</h2>
-                <p className="oliver-hook-section-intro">{content.ownership.intro}</p>
+              <div className="oliver-clarity-section-head">
+                <p className="oliver-clarity-section-eyebrow">{content.setup.eyebrow}</p>
+                <h2 className="oliver-clarity-section-title">{content.setup.title}</h2>
               </div>
 
-              <div className="oliver-hook-outcome-grid">
-                {content.ownership.cards.map((card) => (
-                  <article key={card.title} className="oliver-hook-outcome-card">
-                    <h3>{card.title}</h3>
-                    <p>{card.description}</p>
-                  </article>
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="oliver-hook-section oliver-hook-workflow-section" id="workflow">
-            <div className="container oliver-hook-workflow-layout">
-              <div className="oliver-hook-section-head oliver-hook-section-head-left">
-                <p className="oliver-hook-section-eyebrow">{content.workflow.eyebrow}</p>
-                <h2 className="oliver-hook-section-title">{content.workflow.title}</h2>
-              </div>
-
-              <div className="oliver-hook-workflow-list">
-                {content.workflow.steps.map((step) => (
-                  <article key={step.label} className="oliver-hook-step-card">
-                    <div className="oliver-hook-step-label">{step.label}</div>
-                    <div className="oliver-hook-step-copy">
+              <div className="oliver-clarity-step-grid">
+                {content.setup.steps.map((step) => (
+                  <article key={step.label} className="oliver-clarity-step-card">
+                    <div className="oliver-clarity-step-label">{step.label}</div>
+                    <div className="oliver-clarity-step-copy">
                       <h3>{step.title}</h3>
                       <p>{step.description}</p>
                     </div>
@@ -392,96 +327,51 @@ function OliverLandingPage() {
             </div>
           </section>
 
-          <section className="oliver-hook-section oliver-hook-tools-section" id="tools">
-            <div className="container oliver-hook-surface-card">
-              <div className="oliver-hook-surface-copy">
-                <p className="oliver-hook-section-eyebrow">{content.tools.eyebrow}</p>
-                <h2 className="oliver-hook-section-title">{content.tools.title}</h2>
-                <p className="oliver-hook-section-intro oliver-hook-section-intro-left">{content.tools.intro}</p>
-              </div>
-
-              <div className="oliver-hook-tool-chip-grid" aria-label="Signal sources Oliver can work across">
-                {content.tools.items.map((item) => (
-                  <span key={item} className="oliver-hook-tool-chip">
-                    {item}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="oliver-hook-section" id="controls">
+          <section className="oliver-clarity-section oliver-clarity-section-trust">
             <div className="container">
-              <div className="oliver-hook-section-head">
-                <p className="oliver-hook-section-eyebrow">{content.controls.eyebrow}</p>
-                <h2 className="oliver-hook-section-title">{content.controls.title}</h2>
-                <p className="oliver-hook-section-intro">{content.controls.intro}</p>
-              </div>
+              <div className="oliver-clarity-trust-panel">
+                <div className="oliver-clarity-section-head oliver-clarity-section-head-compact">
+                  <p className="oliver-clarity-section-eyebrow">{content.trust.eyebrow}</p>
+                  <h2 className="oliver-clarity-section-title">{content.trust.title}</h2>
+                  <p className="oliver-clarity-section-intro">{content.trust.intro}</p>
+                </div>
 
-              <div className="oliver-hook-control-grid">
-                {content.controls.cards.map((card) => (
-                  <article key={card.title} className="oliver-hook-control-card">
-                    <h3>{card.title}</h3>
-                    <p>{card.description}</p>
-                  </article>
-                ))}
-              </div>
-            </div>
-          </section>
+                <div className="oliver-clarity-trust-grid">
+                  {content.trust.items.map((item) => (
+                    <article key={item.title} className="oliver-clarity-trust-card">
+                      <h3>{item.title}</h3>
+                      <p>{item.description}</p>
+                    </article>
+                  ))}
+                </div>
 
-          <section className="oliver-hook-section" id="faq">
-            <div className="container">
-              <div className="oliver-hook-section-head">
-                <p className="oliver-hook-section-eyebrow">{content.faq.eyebrow}</p>
-                <h2 className="oliver-hook-section-title">{content.faq.title}</h2>
-              </div>
-
-              <div className="oliver-hook-faq-grid">
-                {content.faq.items.map((item) => (
-                  <article key={item.question} className="oliver-hook-faq-card">
-                    <h3>{item.question}</h3>
-                    <p>{item.answer}</p>
-                  </article>
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="oliver-hook-section oliver-hook-final-section">
-            <div className="container">
-              <div className="oliver-hook-final-card">
-                <p className="oliver-hook-section-eyebrow">{content.finalCta.eyebrow}</p>
-                <h2 className="oliver-hook-section-title">{content.finalCta.title}</h2>
-                <p className="oliver-hook-section-intro">{content.finalCta.description}</p>
-
-                <div className="oliver-hook-cta-row oliver-hook-final-actions">
+                <div className="oliver-clarity-trust-actions">
                   <a
-                    className="btn btn-primary oliver-hook-primary-button"
+                    className="btn btn-primary oliver-clarity-primary-button"
                     href={OLIVER_AUTH_OVERVIEW_HREF}
                     onClick={() =>
                       trackLandingInteraction('primary_cta_click', {
-                        cta_location: 'final_primary_open_oliver',
-                        cta_text: content.finalCta.primaryCta
+                        cta_location: 'trust_primary',
+                        cta_text: content.trust.primaryCta
                       })
                     }
                   >
-                    {content.finalCta.primaryCta}
+                    {content.trust.primaryCta}
                   </a>
                   <a
-                    className="btn btn-secondary oliver-hook-secondary-button"
-                    href={OLIVER_AUTH_WORK_HREF}
+                    href="#sample-update"
+                    className="oliver-clarity-inline-link"
                     onClick={() =>
                       trackLandingInteraction('secondary_cta_click', {
-                        cta_location: 'final_secondary_work_view',
-                        cta_text: content.finalCta.secondaryCta
+                        cta_location: 'trust_secondary',
+                        cta_text: 'See sample update'
                       })
                     }
                   >
-                    {content.finalCta.secondaryCta}
+                    See sample update
+                    <ArrowUpRightIcon />
                   </a>
                 </div>
-
-                <p className="oliver-hook-disclaimer">{content.finalCta.disclaimer}</p>
               </div>
             </div>
           </section>

--- a/website/src/pages/oliverLandingContent.js
+++ b/website/src/pages/oliverLandingContent.js
@@ -1,221 +1,129 @@
 export const OLIVER_ENTRY_SURFACE = 'oliver_tpm';
-export const OLIVER_LANDING_VARIANT = 'oliver_tpm_hook_v1';
+export const OLIVER_LANDING_VARIANT = 'oliver_tpm_hook_v2_clarity';
 export const OLIVER_AUTH_OVERVIEW_HREF = '/auth/index.html?loggedIn=true&entry=oliver_tpm#section-overview';
-export const OLIVER_AUTH_WORK_HREF = '/auth/index.html?loggedIn=true&entry=oliver_tpm#section-work';
 
 export const oliverLandingContent = {
   metadata: {
     title: 'Oliver by DoWhiz | AI TPM for product and engineering teams',
     description:
-      'Oliver is the AI TPM for product and engineering teams. Turn scattered execution signals into status updates, risk flags, decision follow-through, and clear next moves.',
+      'Oliver is the AI TPM for product and engineering teams. He turns scattered execution signals into a weekly update draft, current risks, and clear next owners.',
     canonicalUrl: 'https://dowhiz.com/oliver',
     robots: 'noindex, nofollow',
     htmlLang: 'en',
     ogLocale: 'en_US',
-    themeColor: '#eef1f5',
+    themeColor: '#f5f7fb',
     ogImage: 'https://dowhiz.com/assets/DoWhiz.svg',
-    ogImageAlt: 'Oliver TPM hook landing page preview'
+    ogImageAlt: 'Oliver landing page for product and engineering teams'
   },
   nav: {
-    links: [
-      { href: '#proof', label: 'Outputs' },
-      { href: '#ownership', label: 'What Oliver Owns' },
-      { href: '#workflow', label: 'How It Works' },
-      { href: '#controls', label: 'Controls' }
-    ],
-    primaryCta: 'Open Oliver',
-    secondaryCta: 'See the work view'
+    proofLink: 'See sample update',
+    primaryCta: 'Try Oliver on one program'
   },
   hero: {
     eyebrow: 'AI TPM for product and engineering teams',
-    title: 'Keep launches, updates, and follow-through moving.',
+    title: 'Oliver turns execution noise into updates, risks, and next owners.',
     subtitle:
-      'Oliver turns scattered Slack threads, GitHub issues, meeting notes, and docs into owner-based next steps, status drafts, risk flags, and decision follow-through.',
-    note:
-      'This is a TPM-shaped entrypoint on top of the current DoWhiz auth and dashboard flow. The story is narrower now, not the underlying system.',
-    proofPills: [
-      'Weekly status drafts',
-      'Risk register',
-      'Decision follow-through',
-      'Owner nudges across tools'
-    ],
-    primaryCta: 'Open Oliver',
-    secondaryCta: 'See the outputs',
+      'Point him at one launch, release, or cross-functional stream. He watches the Slack threads, GitHub issues, meeting notes, and docs around it, then drafts the weekly update and tells you what needs attention next.',
+    primaryCta: 'Try Oliver on one program',
+    secondaryCta: 'See a sample weekly update',
+    highlights: ['Weekly update draft', 'Current risks', 'Next owners'],
     artifact: {
-      label: 'Cross-functional launch review',
-      title: 'Mobile release',
+      label: 'Sample weekly update',
+      program: 'Mobile release',
       healthLabel: 'At risk',
-      healthDetail: '2 blockers, 1 pending decision',
-      signalSources: ['Slack blocker thread', 'GitHub regression', 'Meeting recap', 'Release notes draft'],
-      summary: {
-        label: 'Draft update',
-        text:
-          'Checkout is feature-complete, but QA sign-off is blocked by the payment callback regression. Android fallback is defined; iOS fallback still needs approval.'
-      },
-      actions: [
-        { owner: 'Engineering', task: 'Confirm callback fix ETA', due: 'Today, 3:00 PM' },
-        { owner: 'Product', task: 'Approve iOS fallback copy', due: 'Today, 4:30 PM' },
-        { owner: 'Ops', task: 'Update launch note once decision lands', due: 'Before send' }
-      ],
+      healthDetail: '1 blocker needs resolution before QA sign-off',
+      summaryLabel: 'This week',
+      summary:
+        'Checkout is code-complete, but QA is blocked by the payment callback regression. The fallback copy is drafted and still needs one product approval.',
+      risksLabel: 'Current risks',
       risks: [
-        { level: 'High', label: 'QA sign-off depends on one unresolved callback bug' },
-        { level: 'Medium', label: 'Fallback plan is partially drafted but not approved' }
-      ]
+        'Payment callback bug is still blocking QA sign-off.',
+        'Fallback copy is drafted but not approved yet.',
+        'Release note timing depends on the final QA decision.'
+      ],
+      ownersLabel: 'Next owners',
+      owners: [
+        { owner: 'Engineering', action: 'Confirm callback fix ETA by 3 PM' },
+        { owner: 'Product', action: 'Approve fallback copy before today ends' },
+        { owner: 'Ops', action: 'Send the release note once QA goes green' }
+      ],
+      sourceLabel: 'Signals watched',
+      sources: 'Slack, GitHub, meeting notes, and release docs'
     }
   },
-  proof: {
-    eyebrow: 'Outputs',
-    title: 'Oliver proves the role through TPM artifacts, not chat.',
-    intro:
-      'The point is not another assistant panel. The point is producing the exact artifacts a TPM has to keep current and reviewable.',
+  outputs: {
+    eyebrow: 'What You Get This Week',
+    title: 'Three outputs a TPM actually needs.',
     cards: [
       {
-        eyebrow: 'Weekly status update',
-        title: 'A draft you can send, not a transcript you still need to interpret',
-        summary:
-          'Oliver groups signal into what moved, what is blocked, and what needs leadership attention next.',
+        title: 'Weekly update draft',
+        description: 'A concise update you can review and send, not a transcript you still have to interpret.',
         bullets: [
-          'Launch health, milestone movement, and current owner status',
-          'A short escalation block for risks that need help',
-          'A next-48-hours section that turns noise into concrete follow-through'
+          'What moved this week',
+          'What is blocked right now',
+          'What leadership or partners need to know next'
         ]
       },
       {
-        eyebrow: 'Risk register',
-        title: 'A living view of blockers before they become surprises',
-        summary:
-          'Each risk tracks severity, owner, mitigation, and the next review point instead of vanishing inside threads.',
+        title: 'Current risks',
+        description: 'A short list of blockers with clear severity, owners, and the next review point.',
         bullets: [
-          'Severity and impact stay explicit',
-          'Mitigation notes stay attached to the source signal',
-          'Owners and review dates stay visible until resolved'
+          'Risks stay visible until they move',
+          'Mitigations stay attached to the issue',
+          'Escalations stay obvious instead of hiding in threads'
         ]
       },
       {
-        eyebrow: 'Decision log',
-        title: 'Decisions stay linked to owners, rationale, and the next move',
-        summary:
-          'Oliver flags unresolved calls, keeps the latest direction attached to the program, and tracks what each decision changed.',
+        title: 'Next owners',
+        description: 'A follow-through list that makes the next move explicit instead of leaving it inside chat.',
         bullets: [
-          'What was decided and why it matters',
-          'Who still needs to act on the decision',
-          'What Oliver should draft or follow up next'
+          'Who owns the next action',
+          'What they need to do',
+          'What Oliver should draft or chase down next'
         ]
       }
     ]
   },
-  ownership: {
-    eyebrow: 'What Oliver Owns',
-    title: 'The story only works if the work objects are clear.',
-    intro:
-      'Oliver should feel like an AI TPM, not a shape-shifting helper. These are the four outcomes this hook is optimizing for.',
-    cards: [
-      {
-        title: 'Turns messy threads into owner-based action plans',
-        description:
-          'He pulls the next move out of meetings, chat, issues, and scattered follow-up without asking you to rewrite everything yourself.'
-      },
-      {
-        title: 'Drafts stakeholder-ready status updates',
-        description:
-          'He turns execution signal into concise, reviewable updates instead of leaving you to translate raw progress on Friday afternoon.'
-      },
-      {
-        title: 'Surfaces risks before they become blockers',
-        description:
-          'He makes dependencies, slippage, and missing approvals visible early enough for you to intervene.'
-      },
-      {
-        title: 'Keeps decisions and follow-through from getting lost',
-        description:
-          'He remembers what changed, who owns the next step, and what still has to be chased down.'
-      }
-    ]
-  },
-  workflow: {
-    eyebrow: 'How Oliver Works',
-    title: 'A TPM loop, not a generic prompt box.',
+  setup: {
+    eyebrow: 'How To Start',
+    title: 'One short loop from signal to follow-through.',
     steps: [
       {
         label: '01',
-        title: 'Collect signals',
-        description:
-          'Slack messages, GitHub issues, meeting notes, docs, and email become source material instead of isolated fragments.'
+        title: 'Connect one program',
+        description: 'Start with the Slack threads, GitHub issues, docs, and notes around one launch or release.'
       },
       {
         label: '02',
-        title: 'Build the operating picture',
-        description:
-          'Oliver groups what changed, what is blocked, who owns the next move, and which decisions are still open.'
+        title: 'Review the draft',
+        description: 'Oliver pulls the signal into a weekly update, current risks, and clear next owners.'
       },
       {
         label: '03',
-        title: 'Drive the next move',
-        description:
-          'He drafts updates, prepares follow-ups, and keeps the coordination loop alive until you review or send.'
+        title: 'Send or follow up',
+        description: 'Approve the update, send it, or let Oliver follow up on the moves that need to happen next.'
       }
     ]
   },
-  tools: {
-    eyebrow: 'Works Across Your Tools',
-    title: 'The tools are signal sources. They are not the product story.',
+  trust: {
+    eyebrow: 'Trust And Control',
+    title: 'You review the moves that matter.',
     intro:
-      'Slack, GitHub, email, docs, and meetings matter because they hold execution signal. Oliver is the TPM layer that turns that signal into forward motion.',
-    items: ['Slack', 'GitHub', 'Email', 'Docs', 'Meeting notes', 'Shared trackers']
-  },
-  controls: {
-    eyebrow: 'Controls and Review',
-    title: 'You stay in control of the moves that matter.',
-    intro:
-      'This hook should not imply blind automation. The point is tighter follow-through with clear boundaries.',
-    cards: [
+      'Oliver should tighten follow-through, not create mystery automation. The operating rule is simple: clear boundaries, reviewable output, and one shared DoWhiz account flow underneath.',
+    items: [
       {
         title: 'Review before send',
-        description: 'Draft updates and follow-ups can wait for your approval when the stakes are high.'
+        description: 'Status updates and follow-ups can wait for your approval when the stakes are high.'
       },
       {
         title: 'Bounded permissions',
-        description: 'Oliver should act inside the tools and scopes you explicitly connect, not through vague blanket access.'
+        description: 'Oliver only works inside the tools and scopes you explicitly connect.'
       },
       {
-        title: 'Saved context',
-        description: 'Team norms, recurring deliverables, and known stakeholders should compound instead of being re-explained every time.'
-      },
-      {
-        title: 'Configurable follow-up rules',
-        description: 'You decide what deserves a nudge, what waits, and what should always stay human-reviewed.'
+        title: 'Current account flow',
+        description: 'This page hands off to the existing DoWhiz auth and dashboard experience for now.'
       }
-    ]
-  },
-  faq: {
-    eyebrow: 'FAQ',
-    title: 'Narrow answers for a narrow story.',
-    items: [
-      {
-        question: 'Is Oliver replacing a TPM?',
-        answer:
-          'No. This hook is for teams that want tighter execution follow-through. You still review the output, decide what matters, and own the actual calls.'
-      },
-      {
-        question: 'Do I need to move my team into a new tool?',
-        answer:
-          'No. `/oliver` is just a TPM-shaped entrypoint. Sign-in and setup still hand off to the current DoWhiz auth and dashboard surface.'
-      },
-      {
-        question: 'Which teams is this for right now?',
-        answer:
-          'Product and engineering teams running launches, releases, migrations, or cross-functional work where follow-through and status clarity matter more than feature planning.'
-      }
-    ]
-  },
-  finalCta: {
-    eyebrow: 'Start Small',
-    title: 'Start with the launch or program that already feels too noisy.',
-    description:
-      'Bring one weekly review, one release train, or one cross-functional stream. If the story is right, the rest of the product can catch up behind it.',
-    primaryCta: 'Open Oliver',
-    secondaryCta: 'See the work view',
-    disclaimer:
-      'This is still the current DoWhiz account flow underneath. The experiment here is the TPM story, not a separate product backend.'
+    ],
+    primaryCta: 'Start with one weekly review'
   }
 };

--- a/website/src/styles/oliver-landing.css
+++ b/website/src/styles/oliver-landing.css
@@ -1,196 +1,132 @@
-.oliver-hook-page {
-  --oliver-accent: #c4652d;
-  --oliver-accent-soft: rgba(196, 101, 45, 0.12);
-  --oliver-ink-soft: rgba(16, 18, 22, 0.72);
-  --oliver-risk-high: #b9382e;
-  --oliver-risk-medium: #8e6200;
-  --oliver-grid-line: color-mix(in srgb, var(--border-subtle) 92%, transparent);
+.oliver-clarity-page {
+  --oliver-accent: color-mix(in srgb, var(--brand-primary) 88%, #7c4f2b 12%);
+  --oliver-warm-border: color-mix(in srgb, var(--glass-border) 86%, rgba(124, 79, 43, 0.12));
+  --oliver-risk-bg: color-mix(in srgb, #c04b3f 12%, var(--surface-primary));
+  --oliver-risk-text: #b43f34;
   position: relative;
   background:
-    radial-gradient(circle at 15% 10%, rgba(196, 101, 45, 0.16), transparent 34%),
-    radial-gradient(circle at 82% 18%, rgba(16, 18, 22, 0.08), transparent 30%),
+    radial-gradient(circle at top center, color-mix(in srgb, var(--brand-primary) 7%, transparent), transparent 34%),
     linear-gradient(
       180deg,
-      color-mix(in srgb, var(--surface-primary) 96%, #fff4ea 4%) 0%,
-      color-mix(in srgb, var(--surface-primary) 92%, var(--surface-secondary)) 48%,
+      color-mix(in srgb, var(--surface-primary) 98%, #ffffff 2%) 0%,
+      color-mix(in srgb, var(--surface-primary) 92%, var(--surface-secondary)) 56%,
       color-mix(in srgb, var(--surface-secondary) 84%, var(--surface-primary)) 100%
     );
 }
 
-[data-theme='dark'] .oliver-hook-page {
-  --oliver-accent: #f0a36e;
-  --oliver-accent-soft: rgba(240, 163, 110, 0.12);
-  --oliver-ink-soft: rgba(243, 245, 247, 0.74);
-  --oliver-grid-line: rgba(243, 245, 247, 0.08);
-  --oliver-risk-high: #f38b84;
-  --oliver-risk-medium: #d8b050;
+[data-theme='dark'] .oliver-clarity-page {
+  --oliver-accent: color-mix(in srgb, var(--brand-primary) 80%, #f2a46a 20%);
+  --oliver-risk-bg: color-mix(in srgb, #ff786a 18%, var(--surface-secondary));
+  --oliver-risk-text: #ffb8af;
   background:
-    radial-gradient(circle at 12% 14%, rgba(240, 163, 110, 0.12), transparent 34%),
-    radial-gradient(circle at 82% 14%, rgba(255, 255, 255, 0.06), transparent 26%),
+    radial-gradient(circle at top center, rgba(255, 255, 255, 0.06), transparent 30%),
     linear-gradient(
       180deg,
-      color-mix(in srgb, var(--surface-secondary) 44%, var(--surface-primary)) 0%,
-      var(--surface-primary) 58%,
-      color-mix(in srgb, var(--surface-secondary) 74%, var(--surface-primary)) 100%
+      color-mix(in srgb, var(--surface-secondary) 48%, var(--surface-primary)) 0%,
+      var(--surface-primary) 55%,
+      color-mix(in srgb, var(--surface-secondary) 72%, var(--surface-primary)) 100%
     );
 }
 
-.oliver-hook-page::before,
-.oliver-hook-page::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
+.oliver-clarity-header {
+  padding: 1rem 0 0;
 }
 
-.oliver-hook-page::before {
-  background:
-    linear-gradient(90deg, transparent 0, transparent calc(100% - 1px), var(--oliver-grid-line) 100%),
-    linear-gradient(180deg, transparent 0, transparent calc(100% - 1px), var(--oliver-grid-line) 100%);
-  background-size: 92px 92px;
-  opacity: 0.26;
-}
-
-.oliver-hook-page::after {
-  background: linear-gradient(180deg, transparent 0%, rgba(255, 255, 255, 0) 62%, rgba(255, 255, 255, 0.28) 100%);
-  mix-blend-mode: screen;
-  opacity: 0.25;
-}
-
-[data-theme='dark'] .oliver-hook-page::after {
-  background: linear-gradient(180deg, transparent 0%, rgba(255, 255, 255, 0) 62%, rgba(255, 255, 255, 0.08) 100%);
-  mix-blend-mode: normal;
-}
-
-.oliver-hook-noise {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image:
-    radial-gradient(circle at 20% 25%, rgba(255, 255, 255, 0.28) 0 1px, transparent 1px),
-    radial-gradient(circle at 80% 70%, rgba(16, 18, 22, 0.06) 0 1px, transparent 1px);
-  background-size: 24px 24px, 28px 28px;
-  opacity: 0.18;
-}
-
-[data-theme='dark'] .oliver-hook-noise {
-  opacity: 0.12;
-}
-
-.oliver-hook-nav {
-  position: sticky;
-  top: 1rem;
-  z-index: 120;
-  padding: 1rem 1rem 0;
-}
-
-.oliver-hook-nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
+.oliver-clarity-topbar {
   display: flex;
   align-items: center;
-  gap: 1rem;
   justify-content: space-between;
+  gap: 1rem;
+  min-height: 4rem;
+  padding: 0.75rem 1rem;
   border: 1px solid var(--glass-border);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--surface-overlay) 90%, transparent);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  border-radius: var(--radius-full);
+  background: var(--navbar-bg);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
   box-shadow: 0 18px 40px -34px var(--shadow-strong);
-  padding: 0.8rem 0.95rem 0.8rem 1.1rem;
 }
 
-.oliver-hook-brand {
+.oliver-clarity-brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  color: var(--text-primary);
+  gap: 0.625rem;
   text-decoration: none;
+  color: var(--text-primary);
   min-width: max-content;
 }
 
-.oliver-hook-brand-mark {
+.oliver-clarity-brand-mark {
   width: 1.85rem;
   height: 1.85rem;
-  border-radius: 0.5rem;
+  border-radius: 0.45rem;
   flex: 0 0 auto;
 }
 
-.oliver-hook-brand-copy {
-  font-size: 1.1rem;
+.oliver-clarity-brand-copy {
+  font-size: 1.35rem;
   font-weight: 700;
   letter-spacing: var(--tracking-tight);
 }
 
-.oliver-hook-links {
+.oliver-clarity-topbar-actions {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.3rem;
-  flex: 1 1 auto;
-  min-width: 0;
+  gap: 0.9rem;
+  flex: 0 0 auto;
 }
 
-.oliver-hook-link {
+.oliver-clarity-proof-link,
+.oliver-clarity-inline-link {
   display: inline-flex;
   align-items: center;
-  border-radius: 999px;
+  gap: 0.35rem;
   color: var(--text-secondary);
-  font-size: 0.9rem;
+  font-size: 0.94rem;
   font-weight: 500;
-  padding: 0.48rem 0.88rem;
+  text-decoration: none;
 }
 
-.oliver-hook-link:hover {
+.oliver-clarity-proof-link:hover,
+.oliver-clarity-inline-link:hover {
   color: var(--text-primary);
-  background: var(--color-muted);
 }
 
-.oliver-hook-nav-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-  min-width: max-content;
+.oliver-clarity-inline-link svg {
+  width: 1rem;
+  height: 1rem;
 }
 
-.oliver-hook-nav-primary,
-.oliver-hook-nav-secondary {
-  min-width: max-content;
-}
-
-.oliver-hook-main {
-  position: relative;
-  z-index: 1;
+.oliver-clarity-main {
   padding-bottom: 5rem;
 }
 
-.oliver-hook-section,
-.oliver-hook-hero {
-  scroll-margin-top: 6.5rem;
+.oliver-clarity-hero,
+.oliver-clarity-section {
+  scroll-margin-top: 5rem;
 }
 
-.oliver-hook-hero {
-  padding: 6.8rem 0 2.2rem;
+.oliver-clarity-hero {
+  padding: 5.5rem 0 2.5rem;
 }
 
-.oliver-hook-hero-grid {
+.oliver-clarity-hero-grid {
   display: grid;
+  grid-template-columns: minmax(0, 1.04fr) minmax(0, 0.96fr);
   gap: 2rem;
-  grid-template-columns: minmax(0, 1.02fr) minmax(0, 0.98fr);
-  align-items: start;
+  align-items: center;
 }
 
-.oliver-hook-copy {
+.oliver-clarity-copy {
   display: grid;
   gap: 1rem;
-  max-width: 620px;
-  padding-top: 1.6rem;
+  max-width: 38rem;
 }
 
-.oliver-hook-eyebrow,
-.oliver-hook-section-eyebrow,
-.oliver-hook-panel-label,
-.oliver-hook-card-kicker {
+.oliver-clarity-eyebrow,
+.oliver-clarity-section-eyebrow,
+.oliver-clarity-card-kicker,
+.oliver-clarity-card-label {
   margin: 0;
   color: var(--oliver-accent);
   font-size: 0.78rem;
@@ -199,625 +135,425 @@
   text-transform: uppercase;
 }
 
-.oliver-hook-title,
-.oliver-hook-section-title,
-.oliver-hook-hero-panel h2 {
-  font-family: 'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif;
-  letter-spacing: -0.045em;
-}
-
-.oliver-hook-title {
+.oliver-clarity-title {
   margin: 0;
-  font-size: clamp(3.25rem, 6.4vw, 5.3rem);
-  line-height: 0.94;
-  max-width: 11ch;
+  font-size: clamp(2.8rem, 5.8vw, 4.5rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+  font-weight: 700;
   text-wrap: balance;
+  max-width: 11.5ch;
 }
 
-.oliver-hook-subtitle {
+.oliver-clarity-subtitle {
   margin: 0;
-  max-width: 39ch;
-  color: var(--oliver-ink-soft);
-  font-size: 1.13rem;
-  line-height: 1.68;
+  max-width: 38ch;
+  color: var(--text-secondary);
+  font-size: clamp(1.03rem, 2vw, 1.15rem);
+  line-height: 1.6;
 }
 
-.oliver-hook-pill-row {
+.oliver-clarity-highlight-list,
+.oliver-clarity-issue-list,
+.oliver-clarity-owner-list,
+.oliver-clarity-surface-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.oliver-clarity-highlight-list {
+  display: grid;
+  gap: 0.65rem;
+  max-width: 22rem;
+}
+
+.oliver-clarity-highlight-item {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.7rem;
-  margin-top: 0.35rem;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text-primary);
+  font-size: 0.98rem;
+  font-weight: 500;
 }
 
-.oliver-hook-pill {
+.oliver-clarity-highlight-icon {
+  width: 1.6rem;
+  height: 1.6rem;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   border-radius: 999px;
-  border: 1px solid var(--glass-border);
-  background: color-mix(in srgb, var(--glass-bg) 88%, var(--surface-primary));
-  color: var(--text-primary);
-  font-size: 0.9rem;
-  font-weight: 500;
-  padding: 0.52rem 0.85rem;
-  box-shadow: 0 10px 22px -24px var(--shadow-strong);
+  background: color-mix(in srgb, var(--brand-primary) 10%, var(--surface-primary));
+  color: var(--brand-primary);
+  flex: 0 0 auto;
 }
 
-.oliver-hook-cta-row {
+.oliver-clarity-highlight-icon svg {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+.oliver-clarity-cta-row,
+.oliver-clarity-trust-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.9rem;
-  margin-top: 0.4rem;
+  align-items: center;
+  gap: 0.85rem;
 }
 
-.oliver-hook-note,
-.oliver-hook-disclaimer {
-  margin: 0;
-  max-width: 64ch;
-  color: var(--text-secondary);
-  font-size: 0.95rem;
-  line-height: 1.62;
-}
-
-.oliver-hook-hero-panel,
-.oliver-hook-proof-card,
-.oliver-hook-outcome-card,
-.oliver-hook-step-card,
-.oliver-hook-surface-card,
-.oliver-hook-control-card,
-.oliver-hook-faq-card,
-.oliver-hook-final-card,
-.oliver-hook-artifact-card {
-  border: 1px solid var(--glass-border);
-  background: color-mix(in srgb, var(--glass-bg) 94%, var(--surface-primary));
+.oliver-clarity-update-card,
+.oliver-clarity-surface-card,
+.oliver-clarity-step-card,
+.oliver-clarity-trust-card,
+.oliver-clarity-trust-panel {
+  border: 1px solid var(--oliver-warm-border);
+  background: color-mix(in srgb, var(--surface-elevated) 92%, rgba(255, 255, 255, 0.58));
   box-shadow: 0 22px 48px -40px var(--shadow-strong);
 }
 
-.oliver-hook-hero-panel {
+[data-theme='dark'] .oliver-clarity-update-card,
+[data-theme='dark'] .oliver-clarity-surface-card,
+[data-theme='dark'] .oliver-clarity-step-card,
+[data-theme='dark'] .oliver-clarity-trust-card,
+[data-theme='dark'] .oliver-clarity-trust-panel {
+  background: color-mix(in srgb, var(--surface-elevated) 88%, rgba(255, 255, 255, 0.04));
+}
+
+.oliver-clarity-update-card {
   display: grid;
-  gap: 1rem;
-  border-radius: 1.9rem;
+  gap: 1.1rem;
   padding: 1.35rem;
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-primary) 92%, rgba(255, 255, 255, 0.35)) 0%,
-      color-mix(in srgb, var(--surface-primary) 86%, var(--surface-secondary)) 100%
-    );
+  border-radius: 1.6rem;
 }
 
-[data-theme='dark'] .oliver-hook-hero-panel {
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-secondary) 94%, rgba(255, 255, 255, 0.02)) 0%,
-      color-mix(in srgb, var(--surface-primary) 96%, var(--surface-secondary)) 100%
-    );
-}
-
-.oliver-hook-hero-panel-head,
-.oliver-hook-card-row {
+.oliver-clarity-update-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
 }
 
-.oliver-hook-hero-panel-head h2 {
+.oliver-clarity-card-title {
   margin: 0.2rem 0 0;
-  font-size: clamp(1.6rem, 3vw, 2.2rem);
-  line-height: 0.96;
+  font-size: clamp(1.45rem, 3vw, 2rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
 }
 
-.oliver-hook-health {
+.oliver-clarity-health-group {
   display: grid;
   gap: 0.35rem;
   justify-items: end;
   text-align: right;
 }
 
-.oliver-hook-health-badge {
+.oliver-clarity-health-badge {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  min-width: 5.75rem;
+  min-height: 2rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  padding: 0.35rem 0.7rem;
-  background: rgba(185, 56, 46, 0.12);
-  color: var(--oliver-risk-high);
-  font-size: 0.84rem;
+  background: var(--oliver-risk-bg);
+  color: var(--oliver-risk-text);
+  font-size: 0.8rem;
   font-weight: 700;
 }
 
-.oliver-hook-health-detail {
+.oliver-clarity-health-detail {
+  max-width: 19ch;
   color: var(--text-secondary);
-  font-size: 0.82rem;
-  max-width: 20ch;
+  font-size: 0.84rem;
+  line-height: 1.5;
 }
 
-.oliver-hook-signal-band {
-  display: flex;
-  flex-wrap: wrap;
+.oliver-clarity-card-section {
+  display: grid;
   gap: 0.55rem;
 }
 
-.oliver-hook-signal-chip,
-.oliver-hook-tool-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  border-radius: 999px;
-  padding: 0.46rem 0.78rem;
-  border: 1px solid var(--glass-border);
-  color: var(--text-primary);
-  background: color-mix(in srgb, var(--surface-primary) 84%, var(--surface-secondary));
-  font-size: 0.86rem;
-  font-weight: 500;
-}
-
-.oliver-hook-hero-panel-grid {
-  display: grid;
-  grid-template-columns: 1.12fr 0.88fr;
-  gap: 0.9rem;
-}
-
-.oliver-hook-artifact-card {
-  border-radius: 1.35rem;
-  padding: 1rem 1rem 1.05rem;
-}
-
-.oliver-hook-card-copy {
-  margin: 0.45rem 0 0;
+.oliver-clarity-card-summary {
+  margin: 0;
   color: var(--text-primary);
   line-height: 1.65;
 }
 
-.oliver-hook-checklist,
-.oliver-hook-risk-list,
-.oliver-hook-proof-card ul {
-  margin: 0;
-  padding: 0;
+.oliver-clarity-update-grid {
   display: grid;
-  gap: 0.8rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
 }
 
-.oliver-hook-checklist li {
+.oliver-clarity-issue-list,
+.oliver-clarity-owner-list {
   display: grid;
-  grid-template-columns: auto 1fr auto;
   gap: 0.7rem;
-  align-items: start;
 }
 
-.oliver-hook-check-icon {
-  width: 1.65rem;
-  height: 1.65rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+.oliver-clarity-issue-list li,
+.oliver-clarity-surface-card li {
+  position: relative;
+  padding-left: 1rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.oliver-clarity-issue-list li::before,
+.oliver-clarity-surface-card li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.62rem;
+  width: 0.38rem;
+  height: 0.38rem;
   border-radius: 999px;
-  background: var(--oliver-accent-soft);
-  color: var(--oliver-accent);
-  flex: 0 0 auto;
+  background: color-mix(in srgb, var(--brand-primary) 58%, transparent);
 }
 
-.oliver-hook-check-icon svg,
-.oliver-hook-inline-link svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.oliver-hook-checklist li div {
+.oliver-clarity-owner-list li {
   display: grid;
-  gap: 0.16rem;
+  gap: 0.18rem;
 }
 
-.oliver-hook-checklist li strong,
-.oliver-hook-proof-card h3,
-.oliver-hook-outcome-card h3,
-.oliver-hook-step-card h3,
-.oliver-hook-control-card h3,
-.oliver-hook-faq-card h3 {
-  font-size: 1.02rem;
-  line-height: 1.25;
+.oliver-clarity-owner-list strong {
+  font-size: 0.94rem;
+  line-height: 1.3;
 }
 
-.oliver-hook-checklist li span,
-.oliver-hook-checklist li small,
-.oliver-hook-proof-card p,
-.oliver-hook-proof-card li,
-.oliver-hook-outcome-card p,
-.oliver-hook-step-card p,
-.oliver-hook-control-card p,
-.oliver-hook-faq-card p,
-.oliver-hook-surface-copy p {
+.oliver-clarity-owner-list span {
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.oliver-clarity-source-note {
+  margin: 0;
+  padding-top: 0.95rem;
+  border-top: 1px solid color-mix(in srgb, var(--oliver-warm-border) 88%, transparent);
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.oliver-clarity-source-note span {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--text-primary);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.oliver-clarity-section {
+  padding: 1.5rem 0 0;
+}
+
+.oliver-clarity-section-head {
+  display: grid;
+  gap: 0.6rem;
+  max-width: 38rem;
+  margin-bottom: 1.35rem;
+}
+
+.oliver-clarity-section-head-compact {
+  margin-bottom: 0;
+}
+
+.oliver-clarity-section-title {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.85rem);
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+  max-width: 14ch;
+}
+
+.oliver-clarity-section-intro {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  max-width: 55ch;
+}
+
+.oliver-clarity-output-grid,
+.oliver-clarity-step-grid,
+.oliver-clarity-trust-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.oliver-clarity-output-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.oliver-clarity-surface-card,
+.oliver-clarity-step-card,
+.oliver-clarity-trust-card {
+  border-radius: 1.35rem;
+  padding: 1.2rem;
+}
+
+.oliver-clarity-surface-card h3,
+.oliver-clarity-step-copy h3,
+.oliver-clarity-trust-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.3;
+}
+
+.oliver-clarity-surface-card p,
+.oliver-clarity-step-copy p,
+.oliver-clarity-trust-card p {
+  margin: 0.55rem 0 0;
   color: var(--text-secondary);
   line-height: 1.62;
 }
 
-.oliver-hook-checklist li small {
-  white-space: nowrap;
-  font-size: 0.77rem;
-}
-
-.oliver-hook-inline-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  color: var(--text-primary);
-  font-size: 0.88rem;
-  font-weight: 600;
-}
-
-.oliver-hook-inline-link:hover {
-  color: var(--oliver-accent);
-}
-
-.oliver-hook-risk-list li {
+.oliver-clarity-surface-card ul {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.7rem;
-  align-items: start;
+  gap: 0.65rem;
+  margin-top: 0.85rem;
 }
 
-.oliver-hook-risk-level {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 4.5rem;
-  border-radius: 999px;
-  padding: 0.3rem 0.6rem;
-  font-size: 0.76rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.oliver-hook-risk-level-high {
-  background: rgba(185, 56, 46, 0.12);
-  color: var(--oliver-risk-high);
-}
-
-.oliver-hook-risk-level-medium {
-  background: rgba(142, 98, 0, 0.12);
-  color: var(--oliver-risk-medium);
-}
-
-.oliver-hook-section {
-  padding: 1.8rem 0 0;
-}
-
-.oliver-hook-section-head {
-  display: grid;
-  gap: 0.75rem;
-  max-width: 760px;
-  margin-bottom: 1.5rem;
-}
-
-.oliver-hook-section-head-left {
-  margin-bottom: 0;
-}
-
-.oliver-hook-section-title {
-  margin: 0;
-  font-size: clamp(2.15rem, 4.4vw, 3.3rem);
-  line-height: 0.97;
-  max-width: 14ch;
-}
-
-.oliver-hook-section-intro {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 1.04rem;
-  line-height: 1.68;
-  max-width: 52ch;
-}
-
-.oliver-hook-section-intro-left {
-  max-width: 44ch;
-}
-
-.oliver-hook-proof-grid,
-.oliver-hook-outcome-grid,
-.oliver-hook-control-grid,
-.oliver-hook-faq-grid {
-  display: grid;
-  gap: 1rem;
-}
-
-.oliver-hook-proof-grid,
-.oliver-hook-control-grid {
+.oliver-clarity-step-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.oliver-hook-outcome-grid,
-.oliver-hook-faq-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.oliver-hook-proof-card,
-.oliver-hook-outcome-card,
-.oliver-hook-control-card,
-.oliver-hook-faq-card {
-  border-radius: 1.5rem;
-  padding: 1.15rem 1.15rem 1.2rem;
-}
-
-.oliver-hook-proof-card h3,
-.oliver-hook-outcome-card h3,
-.oliver-hook-control-card h3,
-.oliver-hook-faq-card h3 {
-  margin: 0.4rem 0 0.55rem;
-}
-
-.oliver-hook-proof-card ul {
-  margin-top: 0.95rem;
-}
-
-.oliver-hook-proof-card li {
-  position: relative;
-  padding-left: 1rem;
-}
-
-.oliver-hook-proof-card li::before {
-  content: '';
-  position: absolute;
-  top: 0.65rem;
-  left: 0;
-  width: 0.38rem;
-  height: 0.38rem;
-  border-radius: 999px;
-  background: var(--oliver-accent);
-}
-
-.oliver-hook-workflow-section {
-  padding-top: 2rem;
-}
-
-.oliver-hook-workflow-layout {
+.oliver-clarity-step-card {
   display: grid;
-  gap: 1.35rem;
-  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
-  align-items: start;
-}
-
-.oliver-hook-workflow-list {
-  display: grid;
-  gap: 0.9rem;
-}
-
-.oliver-hook-step-card {
-  display: grid;
-  grid-template-columns: auto 1fr;
   gap: 1rem;
-  border-radius: 1.5rem;
-  padding: 1.15rem 1.2rem;
 }
 
-.oliver-hook-step-label {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 1rem;
-  background: var(--oliver-accent-soft);
-  color: var(--oliver-accent);
+.oliver-clarity-step-label {
+  width: fit-content;
+  min-width: 2.8rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--brand-primary) 10%, var(--surface-primary));
+  color: var(--brand-primary);
   font-size: 0.82rem;
   font-weight: 700;
   letter-spacing: 0.08em;
 }
 
-.oliver-hook-step-copy {
+.oliver-clarity-trust-panel {
   display: grid;
-  gap: 0.35rem;
-}
-
-.oliver-hook-step-copy h3 {
-  margin: 0;
-}
-
-.oliver-hook-surface-card {
-  display: grid;
-  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
   gap: 1.4rem;
-  align-items: center;
-  border-radius: 1.6rem;
-  padding: 1.25rem;
-}
-
-.oliver-hook-surface-copy .oliver-hook-section-title {
-  max-width: 16ch;
-}
-
-.oliver-hook-tool-chip-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.7rem;
-  justify-content: flex-end;
-}
-
-.oliver-hook-control-card {
-  min-height: 100%;
-}
-
-.oliver-hook-final-section {
-  padding-top: 2.15rem;
-}
-
-.oliver-hook-final-card {
-  border-radius: 1.8rem;
   padding: 1.45rem;
-  display: grid;
-  gap: 0.8rem;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--surface-primary) 90%, rgba(255, 255, 255, 0.38)) 0%,
-      color-mix(in srgb, var(--surface-secondary) 92%, rgba(196, 101, 45, 0.06)) 100%
-    );
+  border-radius: 1.55rem;
 }
 
-[data-theme='dark'] .oliver-hook-final-card {
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--surface-secondary) 92%, rgba(255, 255, 255, 0.02)) 0%,
-      color-mix(in srgb, var(--surface-primary) 96%, rgba(240, 163, 110, 0.08)) 100%
-    );
+.oliver-clarity-trust-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.oliver-hook-final-card .oliver-hook-section-title,
-.oliver-hook-final-card .oliver-hook-section-intro {
-  max-width: 17ch;
+.oliver-clarity-nav-cta,
+.oliver-clarity-primary-button {
+  min-width: max-content;
 }
 
-.oliver-hook-final-actions {
-  margin-top: 0.15rem;
-}
+@media (max-width: 1024px) {
+  .oliver-clarity-hero {
+    padding-top: 4.75rem;
+  }
 
-@media (max-width: 1120px) {
-  .oliver-hook-hero-grid,
-  .oliver-hook-workflow-layout,
-  .oliver-hook-surface-card {
+  .oliver-clarity-hero-grid,
+  .oliver-clarity-output-grid,
+  .oliver-clarity-step-grid,
+  .oliver-clarity-trust-grid {
     grid-template-columns: 1fr;
   }
 
-  .oliver-hook-copy {
-    max-width: none;
-    padding-top: 0;
-  }
-
-  .oliver-hook-proof-grid,
-  .oliver-hook-control-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .oliver-clarity-update-grid {
+    grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 900px) {
-  .oliver-hook-nav {
-    padding: 0.85rem 0.85rem 0;
+@media (max-width: 720px) {
+  .oliver-clarity-header {
+    padding-top: 0.75rem;
   }
 
-  .oliver-hook-nav-inner {
-    border-radius: 1.4rem;
-    padding: 0.9rem;
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.8rem;
+  .oliver-clarity-topbar {
+    padding: 0.75rem 0.9rem;
   }
 
-  .oliver-hook-links {
-    grid-column: 1 / -1;
-    justify-content: flex-start;
-    overflow-x: auto;
-    scrollbar-width: none;
-    padding-bottom: 0.1rem;
-  }
-
-  .oliver-hook-links::-webkit-scrollbar {
+  .oliver-clarity-proof-link {
     display: none;
   }
 
-  .oliver-hook-proof-grid,
-  .oliver-hook-outcome-grid,
-  .oliver-hook-control-grid,
-  .oliver-hook-faq-grid,
-  .oliver-hook-hero-panel-grid {
-    grid-template-columns: 1fr;
+  .oliver-clarity-brand-copy {
+    font-size: 1.2rem;
   }
 
-  .oliver-hook-tool-chip-grid {
-    justify-content: flex-start;
+  .oliver-clarity-nav-cta {
+    padding-inline: 1rem;
   }
-}
 
-@media (max-width: 680px) {
-  .oliver-hook-title {
-    font-size: clamp(2.45rem, 12vw, 3.55rem);
+  .oliver-clarity-hero {
+    padding-top: 3.5rem;
+  }
+
+  .oliver-clarity-title {
     max-width: 10ch;
   }
 
-  .oliver-hook-subtitle,
-  .oliver-hook-section-intro {
-    font-size: 0.98rem;
-  }
-
-  .oliver-hook-nav-actions,
-  .oliver-hook-cta-row,
-  .oliver-hook-final-actions {
-    width: 100%;
-    flex-direction: column;
+  .oliver-clarity-cta-row,
+  .oliver-clarity-trust-actions {
     align-items: stretch;
   }
 
-  .oliver-hook-nav-primary,
-  .oliver-hook-nav-secondary,
-  .oliver-hook-primary-button,
-  .oliver-hook-secondary-button {
+  .oliver-clarity-primary-button,
+  .oliver-clarity-secondary-button,
+  .oliver-clarity-nav-cta {
     width: 100%;
+    justify-content: center;
   }
 
-  .oliver-hook-nav-inner {
-    grid-template-columns: 1fr;
-  }
-
-  .oliver-hook-brand {
-    justify-content: space-between;
-  }
-
-  .oliver-hook-hero {
-    padding-top: 5.5rem;
-  }
-
-  .oliver-hook-hero-panel,
-  .oliver-hook-proof-card,
-  .oliver-hook-outcome-card,
-  .oliver-hook-step-card,
-  .oliver-hook-surface-card,
-  .oliver-hook-control-card,
-  .oliver-hook-faq-card,
-  .oliver-hook-final-card,
-  .oliver-hook-artifact-card {
-    border-radius: 1.2rem;
-    padding: 1rem;
-  }
-
-  .oliver-hook-hero-panel-head,
-  .oliver-hook-card-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .oliver-hook-health {
-    justify-items: start;
-    text-align: left;
-  }
-
-  .oliver-hook-checklist li {
-    grid-template-columns: auto 1fr;
-  }
-
-  .oliver-hook-checklist li small {
-    grid-column: 2 / -1;
-    padding-left: 0;
-  }
-
-  .oliver-hook-step-card {
-    grid-template-columns: 1fr;
+  .oliver-clarity-update-card,
+  .oliver-clarity-surface-card,
+  .oliver-clarity-step-card,
+  .oliver-clarity-trust-card,
+  .oliver-clarity-trust-panel {
+    border-radius: 1.25rem;
   }
 }
 
 @media (max-width: 560px) {
-  .oliver-hook-nav {
-    top: 0.65rem;
-    padding-inline: 0.65rem;
+  .oliver-clarity-topbar {
+    gap: 0.75rem;
   }
 
-  .oliver-hook-link {
-    font-size: 0.84rem;
-    padding-inline: 0.72rem;
+  .oliver-clarity-brand-copy {
+    font-size: 1.08rem;
   }
 
-  .oliver-hook-pill,
-  .oliver-hook-signal-chip,
-  .oliver-hook-tool-chip {
-    font-size: 0.82rem;
+  .oliver-clarity-title {
+    font-size: clamp(2.6rem, 14vw, 4rem);
+  }
+
+  .oliver-clarity-subtitle,
+  .oliver-clarity-section-intro,
+  .oliver-clarity-card-summary {
+    font-size: 1rem;
+  }
+
+  .oliver-clarity-health-group {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .oliver-clarity-update-head {
+    flex-direction: column;
+  }
+
+  .oliver-clarity-source-note {
+    padding-top: 0.8rem;
+  }
+
+  .oliver-clarity-inline-link {
+    width: 100%;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- refactor `/oliver` around scan-first TPM positioning instead of a long, section-heavy explainer
- replace ambiguous/internal CTA language with outcome-based actions
- reduce hero density to one main action and one simplified weekly-update proof artifact
- remove the sticky in-page section navigation and collapse the page into four simpler sections
- bring the visual language closer to the root landing family instead of presenting `/oliver` like a separate product

## What was removed
- sticky in-page section nav as the primary pattern
- the hero caveat / experiment explainer paragraph
- the dense multi-card hero proof cluster
- the inline `Open current work view` CTA inside the hero proof
- the old repeated section taxonomy:
  - `What Oliver Owns`
  - `How It Works` as a conceptual explainer block
  - `Works Across Your Tools`
  - `Controls and Review` as a large feature grid
  - `FAQ`
  - `Start Small`
- internal / ambiguous CTA copy like `Open Oliver` and `See the work view`
- decorative visual noise that made `/oliver` feel like a separate brand surface

## What was simplified
- the page is now organized into four sections:
  - hero
  - what you get this week
  - how to start
  - trust and control
- the primary CTA is now `Try Oliver on one program`
- the secondary CTA stays on-page as `See a sample weekly update`
- the hero proof is now one scan-friendly weekly update card with:
  - health
  - current risks
  - next owners
- mobile no longer opens with wrapped nav clutter dominating the first viewport

## Validation
- `cd website && npm run lint`
- `cd website && npm run build`
- `cd website && npm run test:responsive`
- browser verification on `vite preview` for:
  - `/oliver/`
  - mobile `/oliver/`
  - shared-auth handoff via `/auth/index.html?loggedIn=true&entry=oliver_tpm#section-overview`
  - root homepage non-regression at `/`

## Notes / Risks
- the auth handoff remains shared and still stores `entry=oliver_tpm`; this PR does not redesign the authenticated dashboard flow
- `/oliver` metadata is still client-mutated SPA metadata; this PR does not change that behavior
- the existing Vite bundle-size warning remains
- local before/after screenshots were captured in `website/output/screenshots/` and intentionally not committed to avoid repo noise
