### PR TITLE
refactor: make Oliver landing scan-first

### DIFF
--- a/website/src/pages/OliverLandingPage.jsx
+++ b/website/src/pages/OliverLandingPage.jsx
@@ -34,14 +34,47 @@ const updateLinkHref = (selector, href) => {
   }
 };
 
-function CheckLineIcon() {
+function DocumentIcon() {
   return (
     <svg viewBox="0 0 20 20" aria-hidden="true">
       <path
-        d="M4.5 10.5l3.3 3.3L15.5 6"
+        d="M6 3.5h5.8L15 6.7V16a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4.5a1 1 0 0 1 1-1Z"
         fill="none"
         stroke="currentColor"
-        strokeWidth="1.8"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M11.5 3.5V7H15" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M7.5 10H12.5M7.5 13H12.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function AlertIcon() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path
+        d="M10 3.2 16.1 15a1 1 0 0 1-.9 1.5H4.8A1 1 0 0 1 3.9 15L10 3.2Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <path d="M10 7.3v4.1M10 14.2h.01" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function CheckCircleIcon() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <circle cx="10" cy="10" r="6.5" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="m7.2 10.2 1.8 1.9 3.8-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -61,6 +94,113 @@ function ArrowUpRightIcon() {
         strokeLinejoin="round"
       />
     </svg>
+  );
+}
+
+function ProofCardIcon({ type }) {
+  if (type === 'update') {
+    return <DocumentIcon />;
+  }
+  if (type === 'risks') {
+    return <AlertIcon />;
+  }
+  return <CheckCircleIcon />;
+}
+
+function ProofVisual({ visual }) {
+  if (visual.type === 'update') {
+    return (
+      <div className="oliver-proof-visual oliver-proof-visual-update">
+        <div className="oliver-proof-window-bar" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+        <div className="oliver-proof-update-head">
+          <div>
+            <p className="oliver-proof-window-kicker">Weekly update</p>
+            <h4>{visual.windowTitle}</h4>
+          </div>
+          <span className="oliver-proof-status-pill is-risk">{visual.status}</span>
+        </div>
+        <div className="oliver-proof-metric-row">
+          {visual.metrics.map((metric) => (
+            <span key={metric} className="oliver-proof-metric-pill">
+              {metric}
+            </span>
+          ))}
+        </div>
+        <div className="oliver-proof-bars" aria-hidden="true">
+          {visual.lines.map((line) => (
+            <div key={line.label} className="oliver-proof-bar-row">
+              <span>{line.label}</span>
+              <div className="oliver-proof-bar-track">
+                <div className="oliver-proof-bar-fill" style={{ width: `${line.value}%` }}></div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <ul className="oliver-proof-note-list">
+          {visual.bullets.map((bullet) => (
+            <li key={bullet}>{bullet}</li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  if (visual.type === 'risks') {
+    return (
+      <div className="oliver-proof-visual oliver-proof-visual-risks">
+        <div className="oliver-proof-window-bar" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+        <div className="oliver-proof-table-head">
+          <span>Risk</span>
+          <span>Owner</span>
+          <span>Review</span>
+        </div>
+        <div className="oliver-proof-risk-rows">
+          {visual.rows.map((row) => (
+            <div key={row.label} className="oliver-proof-risk-row">
+              <div className="oliver-proof-risk-main">
+                <span className={`oliver-proof-status-pill is-${row.tone}`}>{row.tone}</span>
+                <strong>{row.label}</strong>
+              </div>
+              <span>{row.owner}</span>
+              <span>{row.review}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="oliver-proof-visual oliver-proof-visual-follow-up">
+      <div className="oliver-proof-window-bar" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
+      <div className="oliver-proof-follow-up-list">
+        {visual.rows.map((row) => (
+          <div key={`${row.tool}-${row.owner}-${row.action}`} className="oliver-proof-follow-up-row">
+            <span className="oliver-proof-tool-chip">{row.tool}</span>
+            <div className="oliver-proof-follow-up-copy">
+              <strong>{row.owner}</strong>
+              <span>{row.action}</span>
+            </div>
+            <span className="oliver-proof-follow-up-state">{row.state}</span>
+          </div>
+        ))}
+      </div>
+      <div className="oliver-proof-follow-up-footer">
+        <span>All follow-ups stay attached to the same program.</span>
+      </div>
+    </div>
   );
 }
 
@@ -154,55 +294,38 @@ function OliverLandingPage() {
                 Do<span className="text-gradient">Whiz</span>
               </span>
             </a>
-
-            <div className="oliver-clarity-topbar-actions">
-              <a
-                href="#sample-update"
-                className="oliver-clarity-proof-link"
-                onClick={() =>
-                  trackLandingInteraction('secondary_cta_click', {
-                    cta_location: 'topbar_proof',
-                    cta_text: content.nav.proofLink
-                  })
-                }
-              >
-                {content.nav.proofLink}
-              </a>
-              <a
-                className="btn btn-primary oliver-clarity-nav-cta"
-                href={OLIVER_AUTH_OVERVIEW_HREF}
-                onClick={() =>
-                  trackLandingInteraction('primary_cta_click', {
-                    cta_location: 'topbar_primary',
-                    cta_text: content.nav.primaryCta
-                  })
-                }
-              >
-                {content.nav.primaryCta}
-              </a>
-            </div>
           </div>
         </header>
 
         <main className="oliver-clarity-main">
           <section className="oliver-clarity-hero">
-            <div className="container oliver-clarity-hero-grid">
-              <div className="oliver-clarity-copy">
+            <div className="container oliver-clarity-hero-shell">
+              <div className="oliver-clarity-badge">{content.hero.badge}</div>
+
+              <div className="oliver-clarity-portrait-stage" aria-hidden="true">
+                {content.hero.orbitSignals.map((signal, index) => (
+                  <span
+                    key={signal}
+                    className={`oliver-clarity-orbit-chip is-${index + 1}`}
+                  >
+                    {signal}
+                  </span>
+                ))}
+                <div className="oliver-clarity-portrait-ring">
+                  <div className="oliver-clarity-portrait-ring-outer"></div>
+                  <div className="oliver-clarity-portrait-ring-inner">
+                    <img src="/assets/DoWhiz.svg" alt="" aria-hidden="true" className="oliver-clarity-portrait" />
+                  </div>
+                  <span className="oliver-clarity-portrait-status"></span>
+                </div>
+              </div>
+
+              <div className="oliver-clarity-hero-copy">
                 <p className="oliver-clarity-eyebrow">{content.hero.eyebrow}</p>
                 <h1 className="oliver-clarity-title">{content.hero.title}</h1>
+                <p className="oliver-clarity-accent">{content.hero.accent}</p>
                 <p className="oliver-clarity-subtitle">{content.hero.subtitle}</p>
-
-                <ul className="oliver-clarity-highlight-list" aria-label="Key outputs">
-                  {content.hero.highlights.map((item) => (
-                    <li key={item} className="oliver-clarity-highlight-item">
-                      <span className="oliver-clarity-highlight-icon">
-                        <CheckLineIcon />
-                      </span>
-                      <span>{item}</span>
-                    </li>
-                  ))}
-                </ul>
-
+                <div className="oliver-clarity-activity-pill">{content.hero.activity}</div>
                 <div className="oliver-clarity-cta-row">
                   <a
                     className="btn btn-primary oliver-clarity-primary-button"
@@ -217,8 +340,8 @@ function OliverLandingPage() {
                     {content.hero.primaryCta}
                   </a>
                   <a
-                    className="btn btn-secondary oliver-clarity-secondary-button"
-                    href="#sample-update"
+                    className="oliver-clarity-inline-link"
+                    href="#output-samples"
                     onClick={() =>
                       trackLandingInteraction('secondary_cta_click', {
                         cta_location: 'hero_secondary',
@@ -227,151 +350,118 @@ function OliverLandingPage() {
                     }
                   >
                     {content.hero.secondaryCta}
-                  </a>
-                </div>
-              </div>
-
-              <aside
-                className="oliver-clarity-update-card"
-                id="sample-update"
-                aria-label="Sample weekly update"
-              >
-                <div className="oliver-clarity-update-head">
-                  <div>
-                    <p className="oliver-clarity-card-kicker">{content.hero.artifact.label}</p>
-                    <h2 className="oliver-clarity-card-title">{content.hero.artifact.program}</h2>
-                  </div>
-                  <div className="oliver-clarity-health-group">
-                    <span className="oliver-clarity-health-badge">{content.hero.artifact.healthLabel}</span>
-                    <span className="oliver-clarity-health-detail">{content.hero.artifact.healthDetail}</span>
-                  </div>
-                </div>
-
-                <section className="oliver-clarity-card-section">
-                  <p className="oliver-clarity-card-label">{content.hero.artifact.summaryLabel}</p>
-                  <p className="oliver-clarity-card-summary">{content.hero.artifact.summary}</p>
-                </section>
-
-                <div className="oliver-clarity-update-grid">
-                  <section className="oliver-clarity-card-section">
-                    <p className="oliver-clarity-card-label">{content.hero.artifact.risksLabel}</p>
-                    <ul className="oliver-clarity-issue-list">
-                      {content.hero.artifact.risks.map((risk) => (
-                        <li key={risk}>{risk}</li>
-                      ))}
-                    </ul>
-                  </section>
-
-                  <section className="oliver-clarity-card-section">
-                    <p className="oliver-clarity-card-label">{content.hero.artifact.ownersLabel}</p>
-                    <ul className="oliver-clarity-owner-list">
-                      {content.hero.artifact.owners.map((item) => (
-                        <li key={`${item.owner}-${item.action}`}>
-                          <strong>{item.owner}</strong>
-                          <span>{item.action}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </section>
-                </div>
-
-                <p className="oliver-clarity-source-note">
-                  <span>{content.hero.artifact.sourceLabel}</span>
-                  {content.hero.artifact.sources}
-                </p>
-              </aside>
-            </div>
-          </section>
-
-          <section className="oliver-clarity-section oliver-clarity-section-outputs">
-            <div className="container">
-              <div className="oliver-clarity-section-head">
-                <p className="oliver-clarity-section-eyebrow">{content.outputs.eyebrow}</p>
-                <h2 className="oliver-clarity-section-title">{content.outputs.title}</h2>
-              </div>
-
-              <div className="oliver-clarity-output-grid">
-                {content.outputs.cards.map((card) => (
-                  <article key={card.title} className="oliver-clarity-surface-card">
-                    <h3>{card.title}</h3>
-                    <p>{card.description}</p>
-                    <ul>
-                      {card.bullets.map((bullet) => (
-                        <li key={bullet}>{bullet}</li>
-                      ))}
-                    </ul>
-                  </article>
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="oliver-clarity-section oliver-clarity-section-setup">
-            <div className="container">
-              <div className="oliver-clarity-section-head">
-                <p className="oliver-clarity-section-eyebrow">{content.setup.eyebrow}</p>
-                <h2 className="oliver-clarity-section-title">{content.setup.title}</h2>
-              </div>
-
-              <div className="oliver-clarity-step-grid">
-                {content.setup.steps.map((step) => (
-                  <article key={step.label} className="oliver-clarity-step-card">
-                    <div className="oliver-clarity-step-label">{step.label}</div>
-                    <div className="oliver-clarity-step-copy">
-                      <h3>{step.title}</h3>
-                      <p>{step.description}</p>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="oliver-clarity-section oliver-clarity-section-trust">
-            <div className="container">
-              <div className="oliver-clarity-trust-panel">
-                <div className="oliver-clarity-section-head oliver-clarity-section-head-compact">
-                  <p className="oliver-clarity-section-eyebrow">{content.trust.eyebrow}</p>
-                  <h2 className="oliver-clarity-section-title">{content.trust.title}</h2>
-                  <p className="oliver-clarity-section-intro">{content.trust.intro}</p>
-                </div>
-
-                <div className="oliver-clarity-trust-grid">
-                  {content.trust.items.map((item) => (
-                    <article key={item.title} className="oliver-clarity-trust-card">
-                      <h3>{item.title}</h3>
-                      <p>{item.description}</p>
-                    </article>
-                  ))}
-                </div>
-
-                <div className="oliver-clarity-trust-actions">
-                  <a
-                    className="btn btn-primary oliver-clarity-primary-button"
-                    href={OLIVER_AUTH_OVERVIEW_HREF}
-                    onClick={() =>
-                      trackLandingInteraction('primary_cta_click', {
-                        cta_location: 'trust_primary',
-                        cta_text: content.trust.primaryCta
-                      })
-                    }
-                  >
-                    {content.trust.primaryCta}
-                  </a>
-                  <a
-                    href="#sample-update"
-                    className="oliver-clarity-inline-link"
-                    onClick={() =>
-                      trackLandingInteraction('secondary_cta_click', {
-                        cta_location: 'trust_secondary',
-                        cta_text: 'See sample update'
-                      })
-                    }
-                  >
-                    See sample update
                     <ArrowUpRightIcon />
                   </a>
                 </div>
+                <div className="oliver-clarity-proof-strip" aria-label="Primary outputs">
+                  {content.hero.proofPills.map((item) => (
+                    <span key={item} className="oliver-clarity-proof-pill">
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-clarity-section oliver-clarity-workflow-section">
+            <div className="container">
+              <div className="oliver-clarity-section-head oliver-clarity-section-head-centered">
+                <p className="oliver-clarity-section-eyebrow">{content.workflow.eyebrow}</p>
+                <h2 className="oliver-clarity-section-title">{content.workflow.title}</h2>
+                <p className="oliver-clarity-section-intro">{content.workflow.subtitle}</p>
+              </div>
+
+              <div className="oliver-clarity-orchestration-card">
+                <div className="oliver-clarity-orchestration-column">
+                  <p className="oliver-clarity-column-label">{content.workflow.signalsLabel}</p>
+                  <div className="oliver-clarity-signal-stack">
+                    {content.workflow.signals.map((signal) => (
+                      <article key={signal.title} className={`oliver-clarity-signal-card is-${signal.tone}`}>
+                        <strong>{signal.title}</strong>
+                        <span>{signal.meta}</span>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="oliver-clarity-orchestration-core">
+                  <div className="oliver-clarity-core-avatar">
+                    <img src="/assets/DoWhiz.svg" alt="" aria-hidden="true" className="oliver-clarity-core-portrait" />
+                  </div>
+                  <p className="oliver-clarity-column-label">{content.workflow.coreLabel}</p>
+                  <h3>{content.workflow.coreTitle}</h3>
+                  <p>{content.workflow.coreSubtitle}</p>
+                </div>
+
+                <div className="oliver-clarity-orchestration-column">
+                  <p className="oliver-clarity-column-label">{content.workflow.outputsLabel}</p>
+                  <div className="oliver-clarity-output-stack">
+                    {content.workflow.outputs.map((output) => (
+                      <article key={output.title} className={`oliver-clarity-output-stack-card is-${output.tone}`}>
+                        <strong>{output.title}</strong>
+                        <span>{output.meta}</span>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-clarity-section oliver-clarity-proof-section" id="output-samples">
+            <div className="container">
+              <div className="oliver-clarity-section-head">
+                <p className="oliver-clarity-section-eyebrow">{content.proof.eyebrow}</p>
+                <h2 className="oliver-clarity-section-title">{content.proof.title}</h2>
+              </div>
+
+              <div className="oliver-clarity-proof-grid">
+                {content.proof.cards.map((card) => (
+                  <article key={card.key} className="oliver-clarity-proof-card">
+                    <div className="oliver-clarity-proof-copy">
+                      <span className="oliver-clarity-proof-icon">
+                        <ProofCardIcon type={card.visual.type} />
+                      </span>
+                      <p className="oliver-clarity-section-eyebrow">{card.eyebrow}</p>
+                      <h3>{card.title}</h3>
+                      <p>{card.description}</p>
+                    </div>
+                    <ProofVisual visual={card.visual} />
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="oliver-clarity-section oliver-clarity-trust-section">
+            <div className="container">
+              <div className="oliver-clarity-trust-band">
+                <div className="oliver-clarity-section-head oliver-clarity-section-head-compact">
+                  <p className="oliver-clarity-section-eyebrow">{content.trust.eyebrow}</p>
+                  <h2 className="oliver-clarity-section-title">{content.trust.title}</h2>
+                </div>
+
+                <div className="oliver-clarity-trust-row">
+                  {content.trust.items.map((item) => (
+                    <span key={item} className="oliver-clarity-trust-pill">
+                      {item}
+                    </span>
+                  ))}
+                </div>
+
+                <a
+                  className="btn btn-primary oliver-clarity-primary-button"
+                  href={OLIVER_AUTH_OVERVIEW_HREF}
+                  onClick={() =>
+                    trackLandingInteraction('primary_cta_click', {
+                      cta_location: 'trust_primary',
+                      cta_text: content.trust.primaryCta
+                    })
+                  }
+                >
+                  {content.trust.primaryCta}
+                </a>
               </div>
             </div>
           </section>

--- a/website/src/pages/oliverLandingContent.js
+++ b/website/src/pages/oliverLandingContent.js
@@ -1,129 +1,113 @@
 export const OLIVER_ENTRY_SURFACE = 'oliver_tpm';
-export const OLIVER_LANDING_VARIANT = 'oliver_tpm_hook_v2_clarity';
+export const OLIVER_LANDING_VARIANT = 'oliver_tpm_hook_v4_visual_scan';
 export const OLIVER_AUTH_OVERVIEW_HREF = '/auth/index.html?loggedIn=true&entry=oliver_tpm#section-overview';
 
 export const oliverLandingContent = {
   metadata: {
     title: 'Oliver by DoWhiz | AI TPM for product and engineering teams',
     description:
-      'Oliver is the AI TPM for product and engineering teams. He turns scattered execution signals into a weekly update draft, current risks, and clear next owners.',
+      'Oliver is the AI TPM for product and engineering teams. He watches one program, drafts the weekly update, tracks current risks, and keeps the next owners moving.',
     canonicalUrl: 'https://dowhiz.com/oliver',
     robots: 'noindex, nofollow',
     htmlLang: 'en',
     ogLocale: 'en_US',
-    themeColor: '#f5f7fb',
+    themeColor: '#050816',
     ogImage: 'https://dowhiz.com/assets/DoWhiz.svg',
     ogImageAlt: 'Oliver landing page for product and engineering teams'
   },
-  nav: {
-    proofLink: 'See sample update',
-    primaryCta: 'Try Oliver on one program'
-  },
   hero: {
+    badge: 'TPM loop',
     eyebrow: 'AI TPM for product and engineering teams',
-    title: 'Oliver turns execution noise into updates, risks, and next owners.',
+    title: 'Meet Oliver, your AI TPM.',
+    accent: 'He turns one messy week into a clear next move.',
     subtitle:
-      'Point him at one launch, release, or cross-functional stream. He watches the Slack threads, GitHub issues, meeting notes, and docs around it, then drafts the weekly update and tells you what needs attention next.',
+      'Point him at one launch, release, or cross-functional stream. He watches the Slack threads, GitHub issues, docs, and meeting notes around it, then gives you the update, the risks, and the next owners.',
+    activity: 'Weekly launch review drafted in 8 min. Ready for review.',
     primaryCta: 'Try Oliver on one program',
-    secondaryCta: 'See a sample weekly update',
-    highlights: ['Weekly update draft', 'Current risks', 'Next owners'],
-    artifact: {
-      label: 'Sample weekly update',
-      program: 'Mobile release',
-      healthLabel: 'At risk',
-      healthDetail: '1 blocker needs resolution before QA sign-off',
-      summaryLabel: 'This week',
-      summary:
-        'Checkout is code-complete, but QA is blocked by the payment callback regression. The fallback copy is drafted and still needs one product approval.',
-      risksLabel: 'Current risks',
-      risks: [
-        'Payment callback bug is still blocking QA sign-off.',
-        'Fallback copy is drafted but not approved yet.',
-        'Release note timing depends on the final QA decision.'
-      ],
-      ownersLabel: 'Next owners',
-      owners: [
-        { owner: 'Engineering', action: 'Confirm callback fix ETA by 3 PM' },
-        { owner: 'Product', action: 'Approve fallback copy before today ends' },
-        { owner: 'Ops', action: 'Send the release note once QA goes green' }
-      ],
-      sourceLabel: 'Signals watched',
-      sources: 'Slack, GitHub, meeting notes, and release docs'
-    }
+    secondaryCta: 'See output samples',
+    proofPills: ['Weekly update draft', 'Current risks', 'Owner follow-through'],
+    orbitSignals: ['Slack', 'GitHub', 'Docs', 'Notes']
   },
-  outputs: {
-    eyebrow: 'What You Get This Week',
-    title: 'Three outputs a TPM actually needs.',
-    cards: [
-      {
-        title: 'Weekly update draft',
-        description: 'A concise update you can review and send, not a transcript you still have to interpret.',
-        bullets: [
-          'What moved this week',
-          'What is blocked right now',
-          'What leadership or partners need to know next'
-        ]
-      },
-      {
-        title: 'Current risks',
-        description: 'A short list of blockers with clear severity, owners, and the next review point.',
-        bullets: [
-          'Risks stay visible until they move',
-          'Mitigations stay attached to the issue',
-          'Escalations stay obvious instead of hiding in threads'
-        ]
-      },
-      {
-        title: 'Next owners',
-        description: 'A follow-through list that makes the next move explicit instead of leaving it inside chat.',
-        bullets: [
-          'Who owns the next action',
-          'What they need to do',
-          'What Oliver should draft or chase down next'
-        ]
-      }
+  workflow: {
+    eyebrow: 'How Oliver Works',
+    title: 'Show him one program.',
+    subtitle: 'You connect the signals. Oliver returns the TPM artifacts.',
+    signalsLabel: 'Signals watched',
+    signals: [
+      { title: 'Slack blocker thread', meta: '#launch-ops', tone: 'teal' },
+      { title: 'GitHub regression', meta: 'payments/callback', tone: 'violet' },
+      { title: 'Launch notes', meta: 'decision recap', tone: 'gold' }
+    ],
+    coreLabel: 'Oliver',
+    coreTitle: 'Reviews the week',
+    coreSubtitle: 'Builds the TPM view before it gets lost in threads.',
+    outputsLabel: 'What comes back',
+    outputs: [
+      { title: 'Weekly update', meta: 'Ready to review', tone: 'emerald' },
+      { title: 'Current risks', meta: '2 need decisions', tone: 'amber' },
+      { title: 'Next owners', meta: '3 follow-ups ready', tone: 'sky' }
     ]
   },
-  setup: {
-    eyebrow: 'How To Start',
-    title: 'One short loop from signal to follow-through.',
-    steps: [
+  proof: {
+    eyebrow: 'What You Can Scan',
+    title: 'Three screens explain the product faster than paragraphs.',
+    cards: [
       {
-        label: '01',
-        title: 'Connect one program',
-        description: 'Start with the Slack threads, GitHub issues, docs, and notes around one launch or release.'
+        key: 'update',
+        eyebrow: 'Weekly update',
+        title: 'A status note you can actually send.',
+        description: 'Health, movement, blockers, and next asks in one reviewable draft.',
+        visual: {
+          type: 'update',
+          windowTitle: 'Mobile release weekly update',
+          status: 'At risk',
+          metrics: ['2 blockers', '3 owners', 'Fri review'],
+          lines: [
+            { label: 'Build', value: 86 },
+            { label: 'QA', value: 52 },
+            { label: 'Comms', value: 74 }
+          ],
+          bullets: ['Checkout is code-complete', 'QA waits on callback fix', 'Fallback copy needs approval']
+        }
       },
       {
-        label: '02',
-        title: 'Review the draft',
-        description: 'Oliver pulls the signal into a weekly update, current risks, and clear next owners.'
+        key: 'risks',
+        eyebrow: 'Risk register',
+        title: 'A live blocker list, not a dead recap.',
+        description: 'Severity, owner, and next review stay attached to the problem.',
+        visual: {
+          type: 'risks',
+          rows: [
+            { tone: 'high', label: 'Callback regression', owner: 'Eng', review: 'Today' },
+            { tone: 'medium', label: 'Fallback copy approval', owner: 'Product', review: 'Today' },
+            { tone: 'low', label: 'Release note timing', owner: 'Ops', review: 'Fri' }
+          ]
+        }
       },
       {
-        label: '03',
-        title: 'Send or follow up',
-        description: 'Approve the update, send it, or let Oliver follow up on the moves that need to happen next.'
+        key: 'follow-up',
+        eyebrow: 'Owner follow-through',
+        title: 'One view of what should move next.',
+        description: 'Oliver keeps the next owners, tools, and statuses in the same loop.',
+        visual: {
+          type: 'follow-up',
+          rows: [
+            { tool: 'Slack', owner: 'Engineering', action: 'Confirm ETA', state: 'Queued' },
+            { tool: 'GitHub', owner: 'Product', action: 'Approve fallback copy', state: 'Waiting' },
+            { tool: 'Docs', owner: 'Ops', action: 'Send release note', state: 'Ready' }
+          ]
+        }
       }
     ]
   },
   trust: {
-    eyebrow: 'Trust And Control',
-    title: 'You review the moves that matter.',
-    intro:
-      'Oliver should tighten follow-through, not create mystery automation. The operating rule is simple: clear boundaries, reviewable output, and one shared DoWhiz account flow underneath.',
+    eyebrow: 'Stay In Control',
+    title: 'Review before send. Keep scope tight. Start on the existing DoWhiz account flow.',
     items: [
-      {
-        title: 'Review before send',
-        description: 'Status updates and follow-ups can wait for your approval when the stakes are high.'
-      },
-      {
-        title: 'Bounded permissions',
-        description: 'Oliver only works inside the tools and scopes you explicitly connect.'
-      },
-      {
-        title: 'Current account flow',
-        description: 'This page hands off to the existing DoWhiz auth and dashboard experience for now.'
-      }
+      'Review before send',
+      'Only connected scopes',
+      'Shared DoWhiz auth and dashboard'
     ],
-    primaryCta: 'Start with one weekly review'
+    primaryCta: 'Try Oliver on one program'
   }
 };

--- a/website/src/styles/oliver-landing.css
+++ b/website/src/styles/oliver-landing.css
@@ -1,104 +1,79 @@
 .oliver-clarity-page {
-  --oliver-accent: color-mix(in srgb, var(--brand-primary) 88%, #7c4f2b 12%);
-  --oliver-warm-border: color-mix(in srgb, var(--glass-border) 86%, rgba(124, 79, 43, 0.12));
-  --oliver-risk-bg: color-mix(in srgb, #c04b3f 12%, var(--surface-primary));
-  --oliver-risk-text: #b43f34;
+  --oliver-accent: #4d8dff;
+  --oliver-accent-soft: rgba(77, 141, 255, 0.16);
+  --oliver-surface: rgba(8, 14, 28, 0.88);
+  --oliver-surface-strong: rgba(6, 10, 20, 0.94);
+  --oliver-border: rgba(147, 177, 255, 0.14);
+  --oliver-glow: rgba(77, 141, 255, 0.2);
+  --oliver-text-soft: rgba(228, 234, 247, 0.72);
+  --oliver-risk: #ff9b7a;
+  --oliver-emerald: #16d8a2;
+  --oliver-gold: #f7c86a;
+  --oliver-violet: #9a7cff;
+  --oliver-sky: #79bfff;
   position: relative;
   background:
-    radial-gradient(circle at top center, color-mix(in srgb, var(--brand-primary) 7%, transparent), transparent 34%),
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-primary) 98%, #ffffff 2%) 0%,
-      color-mix(in srgb, var(--surface-primary) 92%, var(--surface-secondary)) 56%,
-      color-mix(in srgb, var(--surface-secondary) 84%, var(--surface-primary)) 100%
-    );
+    radial-gradient(circle at top center, rgba(56, 103, 255, 0.2), transparent 22rem),
+    radial-gradient(circle at 50% 0%, rgba(0, 188, 212, 0.07), transparent 32rem),
+    linear-gradient(180deg, #04070f 0%, #050816 45%, #09101d 100%);
+  color: #f4f7fd;
 }
 
-[data-theme='dark'] .oliver-clarity-page {
-  --oliver-accent: color-mix(in srgb, var(--brand-primary) 80%, #f2a46a 20%);
-  --oliver-risk-bg: color-mix(in srgb, #ff786a 18%, var(--surface-secondary));
-  --oliver-risk-text: #ffb8af;
+.oliver-clarity-page .content-layer {
+  position: relative;
+}
+
+.oliver-clarity-page .content-layer::before {
+  content: '';
+  position: absolute;
+  inset: 0;
   background:
-    radial-gradient(circle at top center, rgba(255, 255, 255, 0.06), transparent 30%),
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-secondary) 48%, var(--surface-primary)) 0%,
-      var(--surface-primary) 55%,
-      color-mix(in srgb, var(--surface-secondary) 72%, var(--surface-primary)) 100%
-    );
+    linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.75), transparent 86%);
+  pointer-events: none;
+  opacity: 0.28;
 }
 
 .oliver-clarity-header {
+  position: relative;
+  z-index: 1;
   padding: 1rem 0 0;
 }
 
 .oliver-clarity-topbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  min-height: 4rem;
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-full);
-  background: var(--navbar-bg);
-  backdrop-filter: var(--glass-blur);
-  -webkit-backdrop-filter: var(--glass-blur);
-  box-shadow: 0 18px 40px -34px var(--shadow-strong);
+  justify-content: flex-start;
+  min-height: 3rem;
 }
 
 .oliver-clarity-brand {
   display: inline-flex;
   align-items: center;
   gap: 0.625rem;
+  color: #f4f7fd;
   text-decoration: none;
-  color: var(--text-primary);
-  min-width: max-content;
 }
 
 .oliver-clarity-brand-mark {
-  width: 1.85rem;
-  height: 1.85rem;
+  width: 1.8rem;
+  height: 1.8rem;
   border-radius: 0.45rem;
   flex: 0 0 auto;
 }
 
 .oliver-clarity-brand-copy {
-  font-size: 1.35rem;
+  font-size: 1.28rem;
   font-weight: 700;
   letter-spacing: var(--tracking-tight);
 }
 
-.oliver-clarity-topbar-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  flex: 0 0 auto;
-}
-
-.oliver-clarity-proof-link,
-.oliver-clarity-inline-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  color: var(--text-secondary);
-  font-size: 0.94rem;
-  font-weight: 500;
-  text-decoration: none;
-}
-
-.oliver-clarity-proof-link:hover,
-.oliver-clarity-inline-link:hover {
-  color: var(--text-primary);
-}
-
-.oliver-clarity-inline-link svg {
-  width: 1rem;
-  height: 1rem;
-}
-
 .oliver-clarity-main {
-  padding-bottom: 5rem;
+  position: relative;
+  z-index: 1;
+  padding-bottom: 5.5rem;
 }
 
 .oliver-clarity-hero,
@@ -107,453 +82,778 @@
 }
 
 .oliver-clarity-hero {
-  padding: 5.5rem 0 2.5rem;
+  padding: 4rem 0 2.25rem;
 }
 
-.oliver-clarity-hero-grid {
+.oliver-clarity-hero-shell {
   display: grid;
-  grid-template-columns: minmax(0, 1.04fr) minmax(0, 0.96fr);
-  gap: 2rem;
-  align-items: center;
+  justify-items: center;
+  gap: 1.35rem;
+  text-align: center;
 }
 
-.oliver-clarity-copy {
-  display: grid;
-  gap: 1rem;
-  max-width: 38rem;
-}
-
-.oliver-clarity-eyebrow,
+.oliver-clarity-badge,
 .oliver-clarity-section-eyebrow,
-.oliver-clarity-card-kicker,
-.oliver-clarity-card-label {
+.oliver-clarity-column-label,
+.oliver-proof-window-kicker {
   margin: 0;
+  width: fit-content;
+  padding: 0.42rem 0.9rem;
+  border: 1px solid rgba(77, 141, 255, 0.2);
+  border-radius: 999px;
+  background: rgba(7, 19, 43, 0.78);
   color: var(--oliver-accent);
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   font-weight: 700;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.oliver-clarity-portrait-stage {
+  position: relative;
+  width: min(22rem, 84vw);
+  height: min(14rem, 52vw);
+}
+
+.oliver-clarity-portrait-ring {
+  position: absolute;
+  left: 50%;
+  top: 56%;
+  width: min(11rem, 34vw);
+  height: min(11rem, 34vw);
+  transform: translate(-50%, -50%);
+}
+
+.oliver-clarity-portrait-ring-outer,
+.oliver-clarity-portrait-ring-inner {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+}
+
+.oliver-clarity-portrait-ring-outer {
+  background:
+    radial-gradient(circle at center, rgba(78, 156, 255, 0.18), rgba(78, 156, 255, 0) 62%),
+    linear-gradient(135deg, rgba(77, 141, 255, 0.95), rgba(12, 222, 177, 0.58));
+  padding: 2px;
+  box-shadow: 0 0 0 10px rgba(77, 141, 255, 0.06), 0 0 80px rgba(77, 141, 255, 0.28);
+}
+
+.oliver-clarity-portrait-ring-inner {
+  inset: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 22%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 40%),
+    linear-gradient(180deg, #16233d 0%, #0b1326 100%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.oliver-clarity-portrait {
+  width: 62%;
+  height: 62%;
+  object-fit: contain;
+  filter: drop-shadow(0 14px 24px rgba(2, 8, 20, 0.44));
+}
+
+.oliver-clarity-portrait-status {
+  position: absolute;
+  right: 0.35rem;
+  bottom: 0.65rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #1fe0aa, #0bbd85);
+  box-shadow: 0 0 0 4px rgba(5, 10, 19, 0.95);
+}
+
+.oliver-clarity-orbit-chip {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.4rem;
+  min-height: 2rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(10, 16, 30, 0.88);
+  color: rgba(240, 244, 255, 0.88);
+  font-size: 0.84rem;
+  font-weight: 600;
+  box-shadow: 0 14px 30px -20px rgba(0, 0, 0, 0.7);
+}
+
+.oliver-clarity-orbit-chip.is-1 {
+  left: 0;
+  top: 1.1rem;
+}
+
+.oliver-clarity-orbit-chip.is-2 {
+  right: 0.35rem;
+  top: 1rem;
+}
+
+.oliver-clarity-orbit-chip.is-3 {
+  left: 1rem;
+  bottom: 0.65rem;
+}
+
+.oliver-clarity-orbit-chip.is-4 {
+  right: 1rem;
+  bottom: 0.45rem;
+}
+
+.oliver-clarity-hero-copy {
+  display: grid;
+  justify-items: center;
+  gap: 0.9rem;
+  max-width: 46rem;
+}
+
+.oliver-clarity-eyebrow {
+  margin: 0;
+  color: rgba(226, 233, 248, 0.92);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
 .oliver-clarity-title {
   margin: 0;
-  font-size: clamp(2.8rem, 5.8vw, 4.5rem);
-  line-height: 1;
-  letter-spacing: -0.05em;
+  max-width: 12ch;
+  font-size: clamp(3.2rem, 7vw, 5.6rem);
+  line-height: 0.92;
+  letter-spacing: -0.06em;
   font-weight: 700;
   text-wrap: balance;
-  max-width: 11.5ch;
+}
+
+.oliver-clarity-accent {
+  margin: 0;
+  color: rgba(239, 243, 255, 0.92);
+  font-size: clamp(1.28rem, 2.8vw, 1.65rem);
+  line-height: 1.2;
+  font-weight: 500;
+  max-width: 25ch;
+  text-wrap: balance;
+}
+
+.oliver-clarity-subtitle,
+.oliver-clarity-section-intro,
+.oliver-clarity-orchestration-core p,
+.oliver-clarity-proof-copy p,
+.oliver-proof-note-list li,
+.oliver-proof-follow-up-copy span,
+.oliver-proof-follow-up-footer,
+.oliver-clarity-output-stack-card span,
+.oliver-clarity-signal-card span {
+  margin: 0;
+  color: var(--oliver-text-soft);
+  line-height: 1.62;
 }
 
 .oliver-clarity-subtitle {
-  margin: 0;
-  max-width: 38ch;
-  color: var(--text-secondary);
-  font-size: clamp(1.03rem, 2vw, 1.15rem);
-  line-height: 1.6;
+  max-width: 54ch;
+  font-size: 1.04rem;
 }
 
-.oliver-clarity-highlight-list,
-.oliver-clarity-issue-list,
-.oliver-clarity-owner-list,
-.oliver-clarity-surface-card ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.oliver-clarity-highlight-list {
-  display: grid;
-  gap: 0.65rem;
-  max-width: 22rem;
-}
-
-.oliver-clarity-highlight-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  color: var(--text-primary);
-  font-size: 0.98rem;
-  font-weight: 500;
-}
-
-.oliver-clarity-highlight-icon {
-  width: 1.6rem;
-  height: 1.6rem;
+.oliver-clarity-activity-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  max-width: min(32rem, 90vw);
+  min-height: 2.2rem;
+  padding: 0.5rem 1rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--brand-primary) 10%, var(--surface-primary));
-  color: var(--brand-primary);
-  flex: 0 0 auto;
+  background: linear-gradient(90deg, rgba(3, 92, 66, 0.86), rgba(9, 69, 102, 0.9));
+  color: #d8fff2;
+  font-size: 0.93rem;
+  font-weight: 600;
+  box-shadow: 0 0 0 1px rgba(44, 197, 144, 0.12) inset, 0 16px 34px -28px rgba(13, 176, 138, 0.9);
 }
 
-.oliver-clarity-highlight-icon svg {
-  width: 0.95rem;
-  height: 0.95rem;
-}
-
-.oliver-clarity-cta-row,
-.oliver-clarity-trust-actions {
+.oliver-clarity-cta-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
+  gap: 0.9rem;
+  padding-top: 0.1rem;
+}
+
+.oliver-clarity-primary-button {
+  min-width: max-content;
+}
+
+.oliver-clarity-inline-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: rgba(241, 245, 255, 0.72);
+  font-size: 0.96rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.oliver-clarity-inline-link:hover {
+  color: #ffffff;
+}
+
+.oliver-clarity-inline-link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.oliver-clarity-proof-strip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.6rem;
+}
+
+.oliver-clarity-proof-pill,
+.oliver-clarity-trust-pill,
+.oliver-proof-metric-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.78rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(10, 16, 30, 0.78);
+  color: rgba(242, 246, 255, 0.88);
+  font-size: 0.84rem;
+  font-weight: 500;
+}
+
+.oliver-clarity-section {
+  padding-top: 1.6rem;
+}
+
+.oliver-clarity-section-head {
+  display: grid;
+  gap: 0.65rem;
+  max-width: 34rem;
+}
+
+.oliver-clarity-section-head-centered {
+  justify-items: center;
+  margin-inline: auto;
+  text-align: center;
+}
+
+.oliver-clarity-section-head-compact {
+  max-width: 40rem;
+}
+
+.oliver-clarity-section-title {
+  margin: 0;
+  max-width: 14ch;
+  font-size: clamp(2rem, 4vw, 3.05rem);
+  line-height: 1.02;
+  letter-spacing: -0.05em;
+  font-weight: 700;
+  text-wrap: balance;
+}
+
+.oliver-clarity-section-intro {
+  max-width: 42ch;
+}
+
+.oliver-clarity-orchestration-card,
+.oliver-clarity-proof-card,
+.oliver-clarity-trust-band,
+.oliver-proof-visual {
+  border: 1px solid var(--oliver-border);
+  background: linear-gradient(180deg, rgba(9, 14, 27, 0.94), rgba(6, 10, 21, 0.94));
+  box-shadow: 0 26px 60px -42px rgba(0, 0, 0, 0.9), 0 0 0 1px rgba(77, 141, 255, 0.04) inset;
+}
+
+.oliver-clarity-workflow-section .oliver-clarity-section-head {
+  margin-bottom: 1.25rem;
+}
+
+.oliver-clarity-orchestration-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 1rem;
+  align-items: center;
+  padding: 1.35rem;
+  border-radius: 1.8rem;
+}
+
+.oliver-clarity-orchestration-column {
+  display: grid;
   gap: 0.85rem;
 }
 
-.oliver-clarity-update-card,
-.oliver-clarity-surface-card,
-.oliver-clarity-step-card,
-.oliver-clarity-trust-card,
-.oliver-clarity-trust-panel {
-  border: 1px solid var(--oliver-warm-border);
-  background: color-mix(in srgb, var(--surface-elevated) 92%, rgba(255, 255, 255, 0.58));
-  box-shadow: 0 22px 48px -40px var(--shadow-strong);
-}
-
-[data-theme='dark'] .oliver-clarity-update-card,
-[data-theme='dark'] .oliver-clarity-surface-card,
-[data-theme='dark'] .oliver-clarity-step-card,
-[data-theme='dark'] .oliver-clarity-trust-card,
-[data-theme='dark'] .oliver-clarity-trust-panel {
-  background: color-mix(in srgb, var(--surface-elevated) 88%, rgba(255, 255, 255, 0.04));
-}
-
-.oliver-clarity-update-card {
+.oliver-clarity-signal-stack,
+.oliver-clarity-output-stack {
   display: grid;
-  gap: 1.1rem;
-  padding: 1.35rem;
-  border-radius: 1.6rem;
+  gap: 0.8rem;
 }
 
-.oliver-clarity-update-head {
+.oliver-clarity-signal-card,
+.oliver-clarity-output-stack-card {
+  display: grid;
+  gap: 0.28rem;
+  padding: 0.95rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(10, 16, 30, 0.88);
+}
+
+.oliver-clarity-signal-card strong,
+.oliver-clarity-output-stack-card strong,
+.oliver-clarity-orchestration-core h3,
+.oliver-clarity-proof-copy h3,
+.oliver-proof-update-head h4,
+.oliver-proof-follow-up-copy strong,
+.oliver-proof-risk-main strong {
+  margin: 0;
+  color: #f4f7fd;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.oliver-clarity-signal-card.is-teal {
+  box-shadow: inset 0 0 0 1px rgba(20, 216, 163, 0.08);
+}
+
+.oliver-clarity-signal-card.is-violet {
+  box-shadow: inset 0 0 0 1px rgba(154, 124, 255, 0.08);
+}
+
+.oliver-clarity-signal-card.is-gold {
+  box-shadow: inset 0 0 0 1px rgba(247, 200, 106, 0.08);
+}
+
+.oliver-clarity-output-stack-card.is-emerald {
+  box-shadow: inset 0 0 0 1px rgba(22, 216, 162, 0.08);
+}
+
+.oliver-clarity-output-stack-card.is-amber {
+  box-shadow: inset 0 0 0 1px rgba(255, 155, 122, 0.08);
+}
+
+.oliver-clarity-output-stack-card.is-sky {
+  box-shadow: inset 0 0 0 1px rgba(121, 191, 255, 0.08);
+}
+
+.oliver-clarity-orchestration-core {
+  display: grid;
+  justify-items: center;
+  gap: 0.7rem;
+  width: min(14rem, 28vw);
+  padding-inline: 0.5rem;
+  text-align: center;
+}
+
+.oliver-clarity-core-avatar {
+  width: 6.8rem;
+  height: 6.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(77, 141, 255, 0.95), rgba(12, 222, 177, 0.62));
+  box-shadow: 0 0 40px rgba(77, 141, 255, 0.22);
+}
+
+.oliver-clarity-core-portrait {
+  width: calc(100% - 4px);
+  height: calc(100% - 4px);
+  padding: 1.25rem;
+  border-radius: 999px;
+  object-fit: contain;
+  background:
+    radial-gradient(circle at 50% 22%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 42%),
+    linear-gradient(180deg, #16233d 0%, #0b1326 100%);
+}
+
+.oliver-clarity-proof-section .oliver-clarity-section-head {
+  margin-bottom: 1.2rem;
+}
+
+.oliver-clarity-proof-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.oliver-clarity-proof-card {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+  gap: 1rem;
+  align-items: stretch;
+  padding: 1.15rem;
+  border-radius: 1.65rem;
+}
+
+.oliver-clarity-proof-copy {
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+  padding: 0.2rem;
+}
+
+.oliver-clarity-proof-icon {
+  width: 2.9rem;
+  height: 2.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 238, 202, 0.94);
+}
+
+.oliver-clarity-proof-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.oliver-proof-visual {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 1.3rem;
+  min-height: 16rem;
+}
+
+.oliver-proof-window-bar {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.oliver-proof-window-bar span {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.oliver-proof-window-kicker {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: 0.7rem;
+}
+
+.oliver-proof-update-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
 }
 
-.oliver-clarity-card-title {
-  margin: 0.2rem 0 0;
-  font-size: clamp(1.45rem, 3vw, 2rem);
-  line-height: 1.05;
-  letter-spacing: -0.04em;
-}
-
-.oliver-clarity-health-group {
-  display: grid;
-  gap: 0.35rem;
-  justify-items: end;
-  text-align: right;
-}
-
-.oliver-clarity-health-badge {
+.oliver-proof-status-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 5.75rem;
-  min-height: 2rem;
-  padding: 0.35rem 0.75rem;
+  width: fit-content;
+  min-height: 1.7rem;
+  padding: 0.25rem 0.72rem;
   border-radius: 999px;
-  background: var(--oliver-risk-bg);
-  color: var(--oliver-risk-text);
-  font-size: 0.8rem;
+  font-size: 0.76rem;
   font-weight: 700;
+  text-transform: capitalize;
 }
 
-.oliver-clarity-health-detail {
-  max-width: 19ch;
-  color: var(--text-secondary);
-  font-size: 0.84rem;
-  line-height: 1.5;
+.oliver-proof-status-pill.is-risk,
+.oliver-proof-status-pill.is-high {
+  background: rgba(255, 123, 90, 0.14);
+  color: #ffaf92;
 }
 
-.oliver-clarity-card-section {
+.oliver-proof-status-pill.is-medium {
+  background: rgba(255, 210, 120, 0.14);
+  color: #ffd78f;
+}
+
+.oliver-proof-status-pill.is-low {
+  background: rgba(124, 196, 255, 0.14);
+  color: #a6d6ff;
+}
+
+.oliver-proof-metric-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.oliver-proof-bars {
   display: grid;
+  gap: 0.68rem;
+}
+
+.oliver-proof-bar-row {
+  display: grid;
+  grid-template-columns: 3rem 1fr;
+  gap: 0.8rem;
+  align-items: center;
+  color: rgba(241, 245, 255, 0.68);
+  font-size: 0.84rem;
+}
+
+.oliver-proof-bar-track {
+  height: 0.55rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.oliver-proof-bar-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(77, 141, 255, 0.8), rgba(22, 216, 162, 0.92));
+}
+
+.oliver-proof-note-list {
+  display: grid;
+  gap: 0.6rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.oliver-proof-note-list li {
+  position: relative;
+  padding-left: 1rem;
+}
+
+.oliver-proof-note-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.58rem;
+  width: 0.36rem;
+  height: 0.36rem;
+  border-radius: 999px;
+  background: rgba(22, 216, 162, 0.9);
+}
+
+.oliver-proof-table-head,
+.oliver-proof-risk-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) 4.5rem 3.5rem;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.oliver-proof-table-head {
+  color: rgba(241, 245, 255, 0.56);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.oliver-proof-risk-rows {
+  display: grid;
+  gap: 0.72rem;
+}
+
+.oliver-proof-risk-row {
+  padding: 0.78rem 0.82rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  color: rgba(241, 245, 255, 0.75);
+  font-size: 0.84rem;
+}
+
+.oliver-proof-risk-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 0.55rem;
 }
 
-.oliver-clarity-card-summary {
-  margin: 0;
-  color: var(--text-primary);
-  line-height: 1.65;
-}
-
-.oliver-clarity-update-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.oliver-clarity-issue-list,
-.oliver-clarity-owner-list {
+.oliver-proof-follow-up-list {
   display: grid;
   gap: 0.7rem;
 }
 
-.oliver-clarity-issue-list li,
-.oliver-clarity-surface-card li {
-  position: relative;
-  padding-left: 1rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-.oliver-clarity-issue-list li::before,
-.oliver-clarity-surface-card li::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0.62rem;
-  width: 0.38rem;
-  height: 0.38rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--brand-primary) 58%, transparent);
-}
-
-.oliver-clarity-owner-list li {
+.oliver-proof-follow-up-row {
   display: grid;
-  gap: 0.18rem;
+  grid-template-columns: 4rem minmax(0, 1fr) auto;
+  gap: 0.8rem;
+  align-items: center;
+  padding: 0.82rem 0.88rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
 }
 
-.oliver-clarity-owner-list strong {
-  font-size: 0.94rem;
-  line-height: 1.3;
-}
-
-.oliver-clarity-owner-list span {
-  color: var(--text-secondary);
-  line-height: 1.55;
-}
-
-.oliver-clarity-source-note {
-  margin: 0;
-  padding-top: 0.95rem;
-  border-top: 1px solid color-mix(in srgb, var(--oliver-warm-border) 88%, transparent);
-  color: var(--text-secondary);
-  font-size: 0.88rem;
-  line-height: 1.55;
-}
-
-.oliver-clarity-source-note span {
-  display: block;
-  margin-bottom: 0.25rem;
-  color: var(--text-primary);
+.oliver-proof-tool-chip,
+.oliver-proof-follow-up-state {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.85rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(242, 246, 255, 0.88);
   font-size: 0.78rem;
   font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
 }
 
-.oliver-clarity-section {
-  padding: 1.5rem 0 0;
-}
-
-.oliver-clarity-section-head {
+.oliver-proof-follow-up-copy {
   display: grid;
-  gap: 0.6rem;
-  max-width: 38rem;
-  margin-bottom: 1.35rem;
+  gap: 0.12rem;
 }
 
-.oliver-clarity-section-head-compact {
-  margin-bottom: 0;
+.oliver-proof-follow-up-footer {
+  padding-top: 0.2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.84rem;
 }
 
-.oliver-clarity-section-title {
-  margin: 0;
-  font-size: clamp(2rem, 4vw, 2.85rem);
-  line-height: 1.02;
-  letter-spacing: -0.045em;
-  max-width: 14ch;
-}
-
-.oliver-clarity-section-intro {
-  margin: 0;
-  color: var(--text-secondary);
-  line-height: 1.6;
-  max-width: 55ch;
-}
-
-.oliver-clarity-output-grid,
-.oliver-clarity-step-grid,
-.oliver-clarity-trust-grid {
+.oliver-clarity-trust-band {
   display: grid;
+  justify-items: center;
   gap: 1rem;
+  padding: 1.35rem 1.45rem;
+  border-radius: 1.65rem;
+  text-align: center;
 }
 
-.oliver-clarity-output-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.oliver-clarity-surface-card,
-.oliver-clarity-step-card,
-.oliver-clarity-trust-card {
-  border-radius: 1.35rem;
-  padding: 1.2rem;
-}
-
-.oliver-clarity-surface-card h3,
-.oliver-clarity-step-copy h3,
-.oliver-clarity-trust-card h3 {
-  margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.3;
-}
-
-.oliver-clarity-surface-card p,
-.oliver-clarity-step-copy p,
-.oliver-clarity-trust-card p {
-  margin: 0.55rem 0 0;
-  color: var(--text-secondary);
-  line-height: 1.62;
-}
-
-.oliver-clarity-surface-card ul {
-  display: grid;
+.oliver-clarity-trust-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 0.65rem;
-  margin-top: 0.85rem;
 }
 
-.oliver-clarity-step-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.oliver-clarity-step-card {
-  display: grid;
-  gap: 1rem;
-}
-
-.oliver-clarity-step-label {
-  width: fit-content;
-  min-width: 2.8rem;
-  padding: 0.4rem 0.7rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--brand-primary) 10%, var(--surface-primary));
-  color: var(--brand-primary);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-}
-
-.oliver-clarity-trust-panel {
-  display: grid;
-  gap: 1.4rem;
-  padding: 1.45rem;
-  border-radius: 1.55rem;
-}
-
-.oliver-clarity-trust-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.oliver-clarity-nav-cta,
-.oliver-clarity-primary-button {
-  min-width: max-content;
-}
-
-@media (max-width: 1024px) {
-  .oliver-clarity-hero {
-    padding-top: 4.75rem;
-  }
-
-  .oliver-clarity-hero-grid,
-  .oliver-clarity-output-grid,
-  .oliver-clarity-step-grid,
-  .oliver-clarity-trust-grid {
+@media (max-width: 1080px) {
+  .oliver-clarity-orchestration-card,
+  .oliver-clarity-proof-card {
     grid-template-columns: 1fr;
   }
 
-  .oliver-clarity-update-grid {
-    grid-template-columns: 1fr;
+  .oliver-clarity-orchestration-card {
+    justify-items: stretch;
+  }
+
+  .oliver-clarity-orchestration-core {
+    width: 100%;
+    order: -1;
   }
 }
 
 @media (max-width: 720px) {
-  .oliver-clarity-header {
-    padding-top: 0.75rem;
-  }
-
-  .oliver-clarity-topbar {
-    padding: 0.75rem 0.9rem;
-  }
-
-  .oliver-clarity-proof-link {
-    display: none;
-  }
-
-  .oliver-clarity-brand-copy {
-    font-size: 1.2rem;
-  }
-
-  .oliver-clarity-nav-cta {
-    padding-inline: 1rem;
+  .oliver-clarity-main {
+    padding-bottom: 4.5rem;
   }
 
   .oliver-clarity-hero {
-    padding-top: 3.5rem;
+    padding-top: 3.25rem;
+  }
+
+  .oliver-clarity-portrait-stage {
+    width: min(19rem, 92vw);
+    height: 12.4rem;
   }
 
   .oliver-clarity-title {
+    font-size: clamp(2.7rem, 13vw, 4.15rem);
     max-width: 10ch;
   }
 
-  .oliver-clarity-cta-row,
-  .oliver-clarity-trust-actions {
+  .oliver-clarity-accent {
+    font-size: 1.14rem;
+  }
+
+  .oliver-clarity-subtitle {
+    font-size: 0.98rem;
+  }
+
+  .oliver-clarity-proof-strip,
+  .oliver-clarity-trust-row,
+  .oliver-clarity-cta-row {
     align-items: stretch;
   }
 
   .oliver-clarity-primary-button,
-  .oliver-clarity-secondary-button,
-  .oliver-clarity-nav-cta {
+  .oliver-clarity-inline-link {
     width: 100%;
     justify-content: center;
   }
 
-  .oliver-clarity-update-card,
-  .oliver-clarity-surface-card,
-  .oliver-clarity-step-card,
-  .oliver-clarity-trust-card,
-  .oliver-clarity-trust-panel {
-    border-radius: 1.25rem;
+  .oliver-clarity-orbit-chip {
+    min-width: 3.9rem;
+    font-size: 0.76rem;
+  }
+
+  .oliver-clarity-orbit-chip.is-1 {
+    left: 0.1rem;
+  }
+
+  .oliver-clarity-orbit-chip.is-2 {
+    right: 0.1rem;
   }
 }
 
 @media (max-width: 560px) {
-  .oliver-clarity-topbar {
-    gap: 0.75rem;
+  .oliver-clarity-page .content-layer::before {
+    background-size: 56px 56px;
   }
 
-  .oliver-clarity-brand-copy {
-    font-size: 1.08rem;
+  .oliver-clarity-badge,
+  .oliver-clarity-section-eyebrow,
+  .oliver-clarity-column-label,
+  .oliver-proof-window-kicker {
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
   }
 
   .oliver-clarity-title {
-    font-size: clamp(2.6rem, 14vw, 4rem);
+    font-size: clamp(2.35rem, 11.8vw, 3.55rem);
   }
 
-  .oliver-clarity-subtitle,
-  .oliver-clarity-section-intro,
-  .oliver-clarity-card-summary {
-    font-size: 1rem;
+  .oliver-clarity-portrait-stage {
+    height: 11.2rem;
   }
 
-  .oliver-clarity-health-group {
+  .oliver-clarity-portrait-ring {
+    width: min(9.25rem, 36vw);
+    height: min(9.25rem, 36vw);
+  }
+
+  .oliver-clarity-orbit-chip.is-3,
+  .oliver-clarity-orbit-chip.is-4 {
+    bottom: 0;
+  }
+
+  .oliver-clarity-section-title {
+    font-size: clamp(1.75rem, 9vw, 2.5rem);
+  }
+
+  .oliver-clarity-orchestration-card,
+  .oliver-clarity-proof-card,
+  .oliver-proof-visual,
+  .oliver-clarity-trust-band {
+    padding: 1rem;
+    border-radius: 1.3rem;
+  }
+
+  .oliver-proof-update-head,
+  .oliver-proof-follow-up-row {
+    grid-template-columns: 1fr;
+  }
+
+  .oliver-proof-table-head,
+  .oliver-proof-risk-row {
+    grid-template-columns: 1fr;
+  }
+
+  .oliver-proof-follow-up-row {
     justify-items: start;
-    text-align: left;
-  }
-
-  .oliver-clarity-update-head {
-    flex-direction: column;
-  }
-
-  .oliver-clarity-source-note {
-    padding-top: 0.8rem;
-  }
-
-  .oliver-clarity-inline-link {
-    width: 100%;
-    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- refactor `/oliver` from a text-heavy TPM explainer into a more scan-first visual landing page
- replace the old text-led flow with a persona-led hero, a visual signal-to-output workflow board, and three large artifact proof cards
- keep the existing shared auth handoff unchanged and leave the root landing at `/` untouched
- replace the misleading teddy-bear Oliver image usage on `/oliver` with a more neutral product emblem treatment

## Why
The previous `/oliver` page still required too much reading to understand what Oliver does. The goal of this pass was to make the product legible through visual objects first:
- who Oliver is
- what signal sources he watches
- what outputs come back
- what to click next

## Test Evidence
- `cd website && npm run lint`
- `cd website && npm run build`
- `cd website && npm run test:responsive`
- browser validation on local preview:
  - `/oliver`
  - `/oliver/`
  - `/`
  - primary CTA still points to `/auth/index.html?loggedIn=true&entry=oliver_tpm#section-overview`

## Screenshots
Captured locally, not committed:
- `website/output/screenshots/oliver-visual-desktop.png`
- `website/output/screenshots/oliver-visual-mobile.png`
- `website/output/screenshots/root-home-visual-check.png`

## Remaining Risks
- this is more scanable than before, but the proof cards still have some explanatory copy that could be reduced further
- the hero now uses a DoWhiz emblem instead of a real Oliver portrait because the existing `Oliver.jpg` asset is not credible for a TPM persona
- bundle size warning remains pre-existing and unchanged
