### PR TITLE
Tighten Oliver investment decision email

### DIFF
--- a/DoWhiz_service/run_task_module/README.md
+++ b/DoWhiz_service/run_task_module/README.md
@@ -28,6 +28,9 @@ For email tasks, `reply_email_draft.html` is the pre-send workspace artifact. Th
 HTML is produced later by `send_emails_module::normalize_email_html(...)`, so tests that care about
 the rendered customer-facing structure should grade the normalized final HTML, not just an internal
 model transcript or the raw shell logs.
+For investment replies, the final artifact contract is intentionally stricter than a generic memo:
+the normalized HTML must preserve the scan-first decision card, dual action tracks, expectations,
+and inline clickable evidence chips with tiered sources.
 
 Late-finalization recovery:
 - when Codex has already written the expected reply artifact, `run_task` now treats that artifact as

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -535,22 +535,47 @@ See `.agents/skills/notion/SKILL.md` for detailed command reference.
 
 fn build_investment_capabilities_section() -> &'static str {
     r#"Investment research requests:
-- When the user asks about one U.S. stock or one U.S. ETF, asks whether now is a good time to buy, asks about buying before earnings, or wants a Buy / Wait / Sell investment view, read `.agents/skills/us-equity-daily-monitor/SKILL.md` and follow it.
-- Keep the final user-visible reply structured. Do not collapse it into generic commentary.
+- When the user asks about one U.S. stock or one U.S. ETF, asks whether now is a good time to buy, asks about buying before earnings, or wants a decision-useful investment view, read `.agents/skills/us-equity-daily-monitor/SKILL.md` and follow it.
+- Keep the final user-visible reply structured and scan-first. Do not collapse it into generic commentary or one long research wall.
 - For email replies, preserve these exact visible labels in `reply_email_draft.html`:
-  - `Rating:`
-  - `Horizon:`
+  - `Request Framing`
+  - `Ticker:`
+  - `Name:`
+  - `Type:`
+  - `Research Mode:`
+  - `User Objective:`
+  - `Horizon Basis:`
+  - `Question Type:`
+  - `Decision Card`
+  - `New Money Action:`
+  - `Existing Holder Action:`
+  - `Near-Term Timing View:`
+  - `Long-Term Ownership View:`
   - `Confidence:`
-  - `Timing Verdict:`
+  - `One-Line Rationale:`
+  - `Why in 3 bullets`
+  - `What Is Priced In:`
+  - `What Keeps This From Being Stronger:`
+  - `What Would Change The View:`
+  - `Trigger Block`
+  - `Upgrade / Add Triggers:`
+  - `Stay Wait Unless:`
+  - `Invalidation Criteria:`
   - `Verified Facts`
   - `Derived Metrics`
-  - `Bull Case`
-  - `Base Case`
-  - `Bear Case`
-  - `Add Criteria:`
-  - `Invalidation Criteria:`
-  - `Biggest Near-Term Risk:`
-  - `Biggest Long-Term Strength:`
+  - `Expectations`
+  - `What the Next Catalyst Must Show:`
+  - `What Could Disappoint Even If Fundamentals Are Fine:`
+  - `Opportunity-Cost / Peer Check`
+  - `Inference / Judgment`
+  - `Scenario Analysis`
+  - `Bull Case:`
+  - `Base Case:`
+  - `Bear Case:`
+  - `Source Notes`
+  - `Disclaimer`
+- Material factual and derived-metric claims must keep clickable source links near the claim, preferably as compact evidence chips such as `<a class="dw-evidence-chip" data-source-tier="primary|independent|reference" href="https://...">...</a>`.
+- Use a mix of source tiers: primary filings/IR, at least one reputable independent external source when relevant, and at least one quote/reference source for market-data cross-checking.
 - If the user states a conflicting earnings date or similar factual premise, correct it explicitly in the final reply instead of silently accepting it.
 
 "#
@@ -1631,8 +1656,10 @@ mod tests {
         );
 
         assert!(prompt.contains(".agents/skills/us-equity-daily-monitor/SKILL.md"));
-        assert!(prompt.contains("Timing Verdict"));
-        assert!(prompt.contains("Biggest Near-Term Risk"));
+        assert!(prompt.contains("New Money Action"));
+        assert!(prompt.contains("Existing Holder Action"));
+        assert!(prompt.contains("What Is Priced In"));
+        assert!(prompt.contains("dw-evidence-chip"));
         assert!(prompt.contains("final user-visible reply structured"));
     }
 

--- a/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
@@ -5,20 +5,72 @@ use serde_json::Value;
 
 use super::errors::RunTaskError;
 
-const REQUIRED_INVESTMENT_LABELS: &[(&str, bool)] = &[
-    ("Rating", true),
-    ("Horizon", true),
+const REQUIRED_INVESTMENT_MARKERS: &[(&str, bool)] = &[
+    ("Request Framing", false),
+    ("Ticker", true),
+    ("Name", true),
+    ("Type", true),
+    ("Research Mode", true),
+    ("User Objective", true),
+    ("Horizon Basis", true),
+    ("Question Type", true),
+    ("Decision Card", false),
+    ("New Money Action", true),
+    ("Existing Holder Action", true),
+    ("Near-Term Timing View", true),
+    ("Long-Term Ownership View", true),
     ("Confidence", true),
-    ("Timing Verdict", true),
+    ("One-Line Rationale", true),
+    ("Why in 3 bullets", false),
+    ("What Is Priced In", true),
+    ("What Keeps This From Being Stronger", true),
+    ("What Would Change The View", true),
+    ("Trigger Block", false),
+    ("Upgrade / Add Triggers", true),
+    ("Stay Wait Unless", true),
+    ("Invalidation Criteria", true),
     ("Verified Facts", false),
     ("Derived Metrics", false),
-    ("Bull Case", false),
-    ("Base Case", false),
-    ("Bear Case", false),
-    ("Add Criteria", true),
-    ("Invalidation Criteria", true),
-    ("Biggest Near-Term Risk", true),
-    ("Biggest Long-Term Strength", true),
+    ("Expectations", false),
+    ("What the Next Catalyst Must Show", true),
+    ("What Could Disappoint Even If Fundamentals Are Fine", true),
+    ("Opportunity-Cost / Peer Check", false),
+    ("Inference / Judgment", false),
+    ("Bull Case", true),
+    ("Base Case", true),
+    ("Bear Case", true),
+    ("Source Notes", false),
+    ("Disclaimer", false),
+];
+
+const SUMMARY_FIRST_HEADINGS: &[&str] = &[
+    "request framing",
+    "decision card",
+    "why in 3 bullets",
+    "trigger block",
+    "verified facts",
+];
+
+const SECTION_HEADINGS: &[&str] = &[
+    "request framing",
+    "decision card",
+    "why in 3 bullets",
+    "trigger block",
+    "verified facts",
+    "derived metrics",
+    "expectations",
+    "opportunity-cost / peer check",
+    "inference / judgment",
+    "scenario analysis",
+    "source notes",
+    "disclaimer",
+];
+
+const LINKED_EVIDENCE_SECTIONS: &[&str] = &[
+    "verified facts",
+    "derived metrics",
+    "expectations",
+    "source notes",
 ];
 
 const FINANCE_CONTEXT_KEYWORDS: &[&str] = &[
@@ -54,6 +106,9 @@ const INVESTMENT_INTENT_KEYWORDS: &[&str] = &[
     "wait",
 ];
 
+const NEW_MONEY_ACTIONS: &[&str] = &["buy", "wait", "starter only", "avoid for now"];
+const EXISTING_HOLDER_ACTIONS: &[&str] = &["hold", "add", "trim", "exit", "hold / do not add"];
+
 pub(super) fn ensure_expected_reply_artifact(
     workspace_dir: &Path,
     reply_path: &Path,
@@ -66,16 +121,15 @@ pub(super) fn ensure_expected_reply_artifact(
         });
     }
 
-    let Some(missing_labels) = investment_contract_missing_labels(workspace_dir, reply_path)?
-    else {
+    let Some(violations) = investment_contract_violations(workspace_dir, reply_path)? else {
         return Ok(());
     };
 
     Err(RunTaskError::OutputContractViolation {
         path: reply_path.to_path_buf(),
         reason: format!(
-            "investment reply is missing required labels: {}",
-            missing_labels.join(", ")
+            "investment reply violates required contract: {}",
+            violations.join("; ")
         ),
         output: output_tail.to_string(),
     })
@@ -85,7 +139,7 @@ pub(super) fn reply_artifact_ready_for_workspace(workspace_dir: &Path, reply_pat
     ensure_expected_reply_artifact(workspace_dir, reply_path, "").is_ok()
 }
 
-fn investment_contract_missing_labels(
+fn investment_contract_violations(
     workspace_dir: &Path,
     reply_path: &Path,
 ) -> Result<Option<Vec<String>>, RunTaskError> {
@@ -96,9 +150,69 @@ fn investment_contract_missing_labels(
 
     let reply_body = fs::read_to_string(reply_path)?;
     let normalized_reply = normalize_search_text(&reply_body);
+    let lowered_reply = reply_body.to_ascii_lowercase();
+    let mut violations = Vec::new();
+
+    let missing_markers = missing_required_markers(&normalized_reply);
+    if !missing_markers.is_empty() {
+        violations.push(format!(
+            "missing required labels: {}",
+            missing_markers.join(", ")
+        ));
+    }
+
+    if !contains_markers_in_order(&normalized_reply, SUMMARY_FIRST_HEADINGS) {
+        violations.push(
+            "summary-first section order must be Request Framing -> Decision Card -> Why in 3 bullets -> Trigger Block -> Verified Facts"
+                .to_string(),
+        );
+    }
+
+    if let Some(issue) = validate_action_field(&reply_body, "New Money Action", NEW_MONEY_ACTIONS) {
+        violations.push(issue);
+    }
+    if let Some(issue) = validate_action_field(
+        &reply_body,
+        "Existing Holder Action",
+        EXISTING_HOLDER_ACTIONS,
+    ) {
+        violations.push(issue);
+    }
+
+    let evidence_chip_count = lowered_reply.matches("dw-evidence-chip").count();
+    if evidence_chip_count < 4 {
+        violations.push(format!(
+            "expected at least 4 evidence chips, found {}",
+            evidence_chip_count
+        ));
+    }
+
+    for tier in ["primary", "independent", "reference"] {
+        if !contains_source_tier(&lowered_reply, tier) {
+            violations.push(format!("missing source tier evidence chip: {}", tier));
+        }
+    }
+
+    for heading in LINKED_EVIDENCE_SECTIONS {
+        if !section_contains_clickable_link(&lowered_reply, heading) {
+            violations.push(format!(
+                "section `{}` must include a clickable source link",
+                heading
+            ));
+        }
+    }
+
+    if violations.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(violations))
+    }
+}
+
+fn missing_required_markers(normalized_reply: &str) -> Vec<String> {
     let mut missing = Vec::new();
 
-    for (label, require_colon) in REQUIRED_INVESTMENT_LABELS {
+    for (label, require_colon) in REQUIRED_INVESTMENT_MARKERS {
         let present = if *require_colon {
             normalized_reply.contains(&format!("{}:", label.to_ascii_lowercase()))
         } else {
@@ -109,11 +223,105 @@ fn investment_contract_missing_labels(
         }
     }
 
-    if missing.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(missing))
+    missing
+}
+
+fn contains_markers_in_order(normalized_reply: &str, markers: &[&str]) -> bool {
+    let mut search_start = 0;
+    for marker in markers {
+        let haystack = &normalized_reply[search_start..];
+        let Some(found) = haystack.find(marker) else {
+            return false;
+        };
+        search_start += found + marker.len();
     }
+    true
+}
+
+fn validate_action_field(raw_html: &str, label: &str, allowed_values: &[&str]) -> Option<String> {
+    let value = extract_labeled_value(raw_html, label)?;
+    let value = normalize_action_value(&value);
+
+    if allowed_values
+        .iter()
+        .any(|candidate| normalize_action_value(candidate) == value)
+    {
+        return None;
+    }
+
+    Some(format!(
+        "`{}` must be one of: {}",
+        label,
+        allowed_values.join(", ")
+    ))
+}
+
+fn extract_labeled_value(raw_html: &str, label: &str) -> Option<String> {
+    let lower = raw_html.to_ascii_lowercase();
+    let marker = format!("{}:", label.to_ascii_lowercase());
+    let start = lower.find(&marker)?;
+    let tail = &raw_html[start..];
+    let lower_tail = &lower[start..];
+    let mut end = tail.len();
+    for boundary in ["</li", "</p", "</div", "<br", "\n"] {
+        if let Some(idx) = lower_tail.find(boundary) {
+            end = end.min(idx);
+        }
+    }
+    let fragment = rough_html_to_text(&tail[..end]);
+    let lowered_fragment = fragment.to_ascii_lowercase();
+    let marker_index = lowered_fragment.find(&marker)?;
+    let value = fragment[marker_index + marker.len()..].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn normalize_action_value(raw: &str) -> String {
+    raw.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+fn contains_source_tier(lowered_reply: &str, tier: &str) -> bool {
+    lowered_reply.contains(&format!("data-source-tier=\"{}\"", tier))
+        || lowered_reply.contains(&format!("data-source-tier='{}'", tier))
+}
+
+fn section_contains_clickable_link(lowered_reply: &str, heading: &str) -> bool {
+    let Some(section) = extract_section(lowered_reply, heading) else {
+        return false;
+    };
+    section.contains("href=\"http") || section.contains("href='http")
+}
+
+fn extract_section<'a>(lowered_reply: &'a str, heading: &str) -> Option<&'a str> {
+    let start = find_heading_position(lowered_reply, heading)?;
+    let section_start = start + 1;
+    let mut end = lowered_reply.len();
+
+    for next_heading in SECTION_HEADINGS {
+        if *next_heading == heading {
+            continue;
+        }
+        if let Some(offset) = find_heading_position(&lowered_reply[section_start..], next_heading) {
+            end = end.min(section_start + offset);
+        }
+    }
+
+    Some(&lowered_reply[start..end])
+}
+
+fn find_heading_position(lowered_reply: &str, heading: &str) -> Option<usize> {
+    for marker in [format!(">{}</", heading), format!(">{}<", heading)] {
+        if let Some(idx) = lowered_reply.find(&marker) {
+            return Some(idx);
+        }
+    }
+    None
 }
 
 fn load_inbound_request_text(workspace_dir: &Path) -> Result<String, RunTaskError> {
@@ -279,26 +487,48 @@ mod tests {
         let workspace = write_workspace(
             "Give me deep research on NVDA and tell me whether now is a good time to buy.",
             r#"
-            <h2>Request Framing</h2>
-            <ul><li><strong>Horizon:</strong> Long-term (inferred)</li></ul>
-            <h2>Final Recommendation</h2>
-            <ul>
-              <li><strong>Rating:</strong> Wait</li>
-              <li><strong>Horizon:</strong> Long-term (inferred)</li>
+            <section><h2>Request Framing</h2><ul>
+              <li><strong>Ticker:</strong> NVDA</li>
+              <li><strong>Name:</strong> NVIDIA</li>
+              <li><strong>Type:</strong> Stock</li>
+              <li><strong>Research Mode:</strong> Deep research</li>
+              <li><strong>User Objective:</strong> Decide whether now is actionable (stated)</li>
+              <li><strong>Horizon Basis:</strong> Dual-horizon default because the user did not specify one (inferred)</li>
+              <li><strong>Question Type:</strong> Long-term accumulation</li>
+            </ul></section>
+            <section class="dw-investment-card"><h2>Decision Card</h2><ul>
+              <li><strong>New Money Action:</strong> Starter Only</li>
+              <li><strong>Existing Holder Action:</strong> Hold / Do not add</li>
+              <li><strong>Near-Term Timing View:</strong> Wait for a cleaner post-earnings setup.</li>
+              <li><strong>Long-Term Ownership View:</strong> Attractive if AI demand durability remains intact.</li>
               <li><strong>Confidence:</strong> Medium</li>
-              <li><strong>Timing Verdict:</strong> Wait</li>
-              <li><strong>Add Criteria:</strong> Better valuation or cleaner post-earnings setup.</li>
-              <li><strong>Invalidation Criteria:</strong> Demand slowdown or margin compression.</li>
-              <li><strong>Biggest Near-Term Risk:</strong> Event volatility.</li>
-              <li><strong>Biggest Long-Term Strength:</strong> AI platform leadership.</li>
-            </ul>
-            <h2>Verified Facts</h2><ul><li>Fact</li></ul>
-            <h2>Derived Metrics</h2><ul><li>Metric: price / eps = 10x</li></ul>
-            <h2>Inference / Judgment</h2><ul><li>Judgment</li></ul>
-            <h2>Scenario Analysis</h2>
-            <p><strong>Bull Case:</strong> Demand remains strong.</p>
-            <p><strong>Base Case:</strong> Growth normalizes.</p>
-            <p><strong>Bear Case:</strong> Spending slows.</p>
+              <li><strong>One-Line Rationale:</strong> Quality is high, but expectations and valuation leave a thin near-term margin for error.</li>
+            </ul></section>
+            <section><h2>Why in 3 bullets</h2><ul>
+              <li><strong>What Is Priced In:</strong> Sustained AI spending and another strong quarter.</li>
+              <li><strong>What Keeps This From Being Stronger:</strong> Valuation already assumes very little execution slippage.</li>
+              <li><strong>What Would Change The View:</strong> Better evidence that demand durability is outrunning already-high expectations.</li>
+            </ul></section>
+            <section><h2>Trigger Block</h2><ul>
+              <li><strong>Upgrade / Add Triggers:</strong> Strong beat plus durable margin guidance.</li>
+              <li><strong>Stay Wait Unless:</strong> Setup de-risks after earnings or valuation resets.</li>
+              <li><strong>Invalidation Criteria:</strong> Demand or gross margin thesis weakens materially.</li>
+            </ul></section>
+            <section><h2>Verified Facts</h2><ul><li>Revenue grew. <div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="primary" href="https://investor.nvidia.com">IR</a><a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a></div></li></ul></section>
+            <section><h2>Derived Metrics</h2><ul><li>Forward P/E: price / forward EPS = 31x. <div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="primary" href="https://www.sec.gov">Filing</a><a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com">Quote</a></div></li></ul></section>
+            <section><h2>Expectations</h2><ul>
+              <li><strong>What the Next Catalyst Must Show:</strong> Sustained data-center demand plus margin resilience. <div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a></div></li>
+              <li><strong>What Could Disappoint Even If Fundamentals Are Fine:</strong> Guidance that is merely good rather than exceptional.</li>
+            </ul></section>
+            <section><h2>Opportunity-Cost / Peer Check</h2><ul><li>NVIDIA still has the strongest AI platform position, but buying the index avoids single-report valuation compression. <div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="reference" href="https://www.nasdaq.com">Quote</a></div></li></ul></section>
+            <section><h2>Inference / Judgment</h2><ul><li>Judgment.</li></ul></section>
+            <section><h2>Scenario Analysis</h2>
+              <p><strong>Bull Case:</strong> Demand remains strong.</p>
+              <p><strong>Base Case:</strong> Growth normalizes.</p>
+              <p><strong>Bear Case:</strong> Spending slows.</p>
+            </section>
+            <section><h2>Source Notes</h2><ul><li>Primary, independent, and reference sources were cross-checked. <div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="primary" href="https://investor.nvidia.com">IR</a><a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a><a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com">Quote</a></div></li></ul></section>
+            <section><h2>Disclaimer</h2><p>Public-information-based research only, not personalized investment advice or trade execution.</p></section>
             "#,
         );
         let reply_path = workspace.join("reply_email_draft.html");
@@ -320,7 +550,7 @@ mod tests {
         let rendered = err.to_string();
         assert!(
             rendered.contains("Output contract violation")
-                || rendered.contains("missing required labels")
+                || rendered.contains("violates required contract")
         );
         assert!(!reply_artifact_ready_for_workspace(&workspace, &reply_path));
     }

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -26,21 +26,76 @@ fn require_env(key: &'static str) {
 
 fn assert_investment_contract_labels(text: &str) {
     for label in [
-        "Rating:",
-        "Horizon:",
+        "Request Framing",
+        "Ticker:",
+        "Name:",
+        "Type:",
+        "Research Mode:",
+        "User Objective:",
+        "Horizon Basis:",
+        "Question Type:",
+        "Decision Card",
+        "New Money Action:",
+        "Existing Holder Action:",
+        "Near-Term Timing View:",
+        "Long-Term Ownership View:",
         "Confidence:",
-        "Timing Verdict:",
+        "One-Line Rationale:",
+        "Why in 3 bullets",
+        "What Is Priced In:",
+        "What Keeps This From Being Stronger:",
+        "What Would Change The View:",
+        "Trigger Block",
+        "Upgrade / Add Triggers:",
+        "Stay Wait Unless:",
+        "Invalidation Criteria:",
         "Verified Facts",
         "Derived Metrics",
+        "Expectations",
+        "What the Next Catalyst Must Show:",
+        "What Could Disappoint Even If Fundamentals Are Fine:",
+        "Opportunity-Cost / Peer Check",
+        "Inference / Judgment",
         "Bull Case",
         "Base Case",
         "Bear Case",
-        "Add Criteria:",
-        "Invalidation Criteria:",
-        "Biggest Near-Term Risk:",
-        "Biggest Long-Term Strength:",
+        "Source Notes",
+        "Disclaimer",
     ] {
         assert!(text.contains(label), "missing label {label}");
+    }
+    assert!(
+        text.contains("dw-evidence-chip") || text.contains("data-source-tier="),
+        "missing evidence chips"
+    );
+    for tier in ["primary", "independent", "reference"] {
+        assert!(
+            text.contains(&format!("data-source-tier=\"{tier}\""))
+                || text.contains(&format!("data-source-tier='{tier}'")),
+            "missing source tier {tier}"
+        );
+    }
+    for marker in [
+        "Request Framing",
+        "Decision Card",
+        "Why in 3 bullets",
+        "Trigger Block",
+        "Verified Facts",
+    ]
+    .windows(2)
+    {
+        let earlier = text
+            .find(marker[0])
+            .unwrap_or_else(|| panic!("missing marker {}", marker[0]));
+        let later = text
+            .find(marker[1])
+            .unwrap_or_else(|| panic!("missing marker {}", marker[1]));
+        assert!(
+            earlier < later,
+            "expected {} to appear before {}",
+            marker[0],
+            marker[1]
+        );
     }
 }
 
@@ -1142,8 +1197,11 @@ fn run_task_accepts_structured_investment_reply_from_fake_codex() {
 
     let result = run_task(&build_params(&workspace)).unwrap();
     let html = fs::read_to_string(result.reply_html_path).unwrap();
-    assert!(html.contains("Timing Verdict"));
+    assert!(html.contains("New Money Action"));
     assert!(html.contains("Verified Facts"));
+    assert!(html.contains("Opportunity-Cost / Peer Check"));
+    assert!(html.contains("New Money Action:</strong> Starter Only"));
+    assert!(html.contains("Existing Holder Action:</strong> Hold / Do not add"));
 }
 
 #[test]
@@ -1217,7 +1275,7 @@ fn run_task_investment_contract_violation_triggers_claude_fallback() {
     let html = fs::read_to_string(result.reply_html_path).unwrap();
     let recovery = result.recovery_note.unwrap_or_default();
     assert!(recovery.contains("Claude fallback"));
-    assert!(html.contains("Timing Verdict"));
+    assert!(html.contains("New Money Action"));
     assert!(html.contains("Bull Case"));
 }
 
@@ -1253,7 +1311,7 @@ fn run_task_investment_contract_violation_fails_closed_when_fallback_is_still_ge
     let err = run_task(&build_params(&workspace)).expect_err("expected fail-closed contract error");
     let rendered = err.to_string();
     assert!(rendered.contains("Output contract violation"));
-    assert!(rendered.contains("missing required labels"));
+    assert!(rendered.contains("violates required contract"));
 }
 
 #[test]

--- a/DoWhiz_service/run_task_module/tests/support/mod.rs
+++ b/DoWhiz_service/run_task_module/tests/support/mod.rs
@@ -138,11 +138,151 @@ pub enum FakeCodexMode {
     Sleep,
 }
 
+const STRUCTURED_INVESTMENT_REPLY_HTML: &str = r#"
+<section>
+  <h2>Request Framing</h2>
+  <ul>
+    <li><strong>Ticker:</strong> NVDA</li>
+    <li><strong>Name:</strong> NVIDIA</li>
+    <li><strong>Type:</strong> Stock</li>
+    <li><strong>Research Mode:</strong> Deep research</li>
+    <li><strong>User Objective:</strong> Decide whether initiating now is attractive (stated)</li>
+    <li><strong>Horizon Basis:</strong> Dual-horizon default because the user did not specify one (inferred)</li>
+    <li><strong>Question Type:</strong> Long-term accumulation</li>
+  </ul>
+</section>
+<section class="dw-investment-card">
+  <div class="dw-investment-kicker">Decision-ready memo</div>
+  <h2>Decision Card</h2>
+  <ul class="dw-investment-list">
+    <li><strong>New Money Action:</strong> Starter Only</li>
+    <li><strong>Existing Holder Action:</strong> Hold / Do not add</li>
+    <li><strong>Near-Term Timing View:</strong> Wait for a cleaner post-earnings setup because expectations are already demanding.</li>
+    <li><strong>Long-Term Ownership View:</strong> Still worth owning if AI compute demand and margin durability remain intact.</li>
+    <li><strong>Confidence:</strong> Medium</li>
+    <li><strong>One-Line Rationale:</strong> The business is elite, but near-term upside needs another strong report to beat what the market already expects.</li>
+  </ul>
+</section>
+<section>
+  <h2>Why in 3 bullets</h2>
+  <ul>
+    <li><strong>What Is Priced In:</strong> Continued data-center strength, durable gross margin, and another clean beat.</li>
+    <li><strong>What Keeps This From Being Stronger:</strong> The setup leaves little room for merely good results.</li>
+    <li><strong>What Would Change The View:</strong> Better evidence that demand durability is widening faster than valuation expectations.</li>
+  </ul>
+</section>
+<section class="dw-trigger-grid">
+  <h2>Trigger Block</h2>
+  <ul class="dw-trigger-list">
+    <li><strong>Upgrade / Add Triggers:</strong> Another beat plus guidance that still shows durable AI spending and margin resilience.</li>
+    <li><strong>Stay Wait Unless:</strong> The next report materially beats what is already priced in or the stock resets without a thesis break.</li>
+    <li><strong>Invalidation Criteria:</strong> Demand slows, customer digestion extends, or gross-margin structure deteriorates.</li>
+  </ul>
+</section>
+<section>
+  <h2>Verified Facts</h2>
+  <ul>
+    <li>
+      NVIDIA's latest filings and prepared remarks showed data-center revenue still dominating the growth story.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="primary" href="https://investor.nvidia.com">IR</a>
+        <a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a>
+      </div>
+    </li>
+    <li>
+      Market-data cross-checks still show the stock trading at a premium versus the broader index.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com">Quote</a>
+      </div>
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Derived Metrics</h2>
+  <ul>
+    <li>
+      Forward P/E: share price / next-twelve-month EPS consensus = roughly 31x, which keeps the burden of proof high.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="primary" href="https://www.sec.gov">Filing</a>
+        <a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com">Quote</a>
+      </div>
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Expectations</h2>
+  <ul>
+    <li>
+      <strong>What the Next Catalyst Must Show:</strong> Revenue and margin strength that remains clearly ahead of the already-bullish setup.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="primary" href="https://investor.nvidia.com">Transcript</a>
+        <a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a>
+      </div>
+    </li>
+    <li>
+      <strong>What Could Disappoint Even If Fundamentals Are Fine:</strong> Guidance that confirms growth but not enough incremental upside to justify the current multiple.
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Opportunity-Cost / Peer Check</h2>
+  <ul>
+    <li>
+      Versus buying the index, NVIDIA still offers better direct AI exposure, but it also carries much more single-report expectation risk.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a>
+        <a class="dw-evidence-chip" data-source-tier="reference" href="https://www.nasdaq.com">Quote</a>
+      </div>
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Inference / Judgment</h2>
+  <ul>
+    <li>Judgment: the company remains best-in-class, but the near-term setup is still more "great business, demanding setup" than clear asymmetric entry.</li>
+  </ul>
+</section>
+<section>
+  <h2>Scenario Analysis</h2>
+  <p><strong>Bull Case:</strong> Demand and margins stay stronger than the market already expects.</p>
+  <p><strong>Base Case:</strong> Fundamentals stay solid, but upside is constrained by how much is already priced in.</p>
+  <p><strong>Bear Case:</strong> Customers digest capacity longer than expected and valuation compresses.</p>
+</section>
+<section class="dw-source-note">
+  <h2>Source Notes</h2>
+  <ul>
+    <li>
+      Primary, independent, and reference sources were cross-checked instead of relying only on company-controlled material.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="primary" href="https://investor.nvidia.com">IR</a>
+        <a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a>
+        <a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com">Quote</a>
+      </div>
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Disclaimer</h2>
+  <p>Public-information-based research only, not personalized investment advice or trade execution.</p>
+</section>
+"#;
+
 #[cfg(unix)]
 pub fn write_fake_codex(dir: &Path, mode: FakeCodexMode) -> io::Result<PathBuf> {
     use std::os::unix::fs::PermissionsExt;
 
     let script_path = dir.join("codex");
+    let investment_structured_script = format!(
+        r#"#!/bin/sh
+set -e
+cat > reply_email_draft.html <<'HTML'
+{structured_reply}
+HTML
+mkdir -p reply_email_attachments
+echo "attachment" > reply_email_attachments/attachment.txt
+"#,
+        structured_reply = STRUCTURED_INVESTMENT_REPLY_HTML
+    );
     let script = match mode {
         FakeCodexMode::Success => {
             r#"#!/bin/sh
@@ -153,46 +293,7 @@ mkdir -p reply_email_attachments
 echo "attachment" > reply_email_attachments/attachment.txt
 "#
         }
-        FakeCodexMode::InvestmentStructured => {
-            r#"#!/bin/sh
-set -e
-cat > reply_email_draft.html <<'HTML'
-<h2>Request Framing</h2>
-<ul>
-  <li><strong>Ticker:</strong> NVDA</li>
-  <li><strong>Name:</strong> NVIDIA</li>
-  <li><strong>Type:</strong> Stock</li>
-  <li><strong>Research Mode:</strong> Deep research</li>
-  <li><strong>User Objective:</strong> Decide whether now is actionable (stated)</li>
-  <li><strong>Horizon:</strong> Long-term (inferred)</li>
-  <li><strong>Question Type:</strong> Long-term accumulation</li>
-</ul>
-<h2>Final Recommendation</h2>
-<ul>
-  <li><strong>Rating:</strong> Wait</li>
-  <li><strong>Horizon:</strong> Long-term (inferred)</li>
-  <li><strong>Confidence:</strong> Medium</li>
-  <li><strong>Timing Verdict:</strong> Wait</li>
-  <li><strong>Add Criteria:</strong> Better entry after earnings or improved valuation support.</li>
-  <li><strong>Invalidation Criteria:</strong> Demand slows or margin guidance weakens.</li>
-  <li><strong>Biggest Near-Term Risk:</strong> Event volatility around earnings.</li>
-  <li><strong>Biggest Long-Term Strength:</strong> AI compute leadership.</li>
-</ul>
-<h2>Verified Facts</h2>
-<ul><li>Fact.</li></ul>
-<h2>Derived Metrics</h2>
-<ul><li>Metric: price / eps = 10x</li></ul>
-<h2>Inference / Judgment</h2>
-<ul><li>Judgment.</li></ul>
-<h2>Scenario Analysis</h2>
-<p><strong>Bull Case:</strong> Demand remains strong.</p>
-<p><strong>Base Case:</strong> Growth normalizes.</p>
-<p><strong>Bear Case:</strong> Spending slows.</p>
-HTML
-mkdir -p reply_email_attachments
-echo "attachment" > reply_email_attachments/attachment.txt
-"#
-        }
+        FakeCodexMode::InvestmentStructured => investment_structured_script.as_str(),
         FakeCodexMode::InvestmentGeneric => {
             r#"#!/bin/sh
 set -e
@@ -451,6 +552,18 @@ pub fn write_fake_claude(dir: &Path, mode: FakeClaudeMode) -> io::Result<PathBuf
     use std::os::unix::fs::PermissionsExt;
 
     let script_path = dir.join("claude");
+    let investment_structured_script = format!(
+        r#"#!/bin/sh
+set -e
+echo '{{"type":"message_delta","delta":{{"text":"ok"}}}}'
+cat > reply_email_draft.html <<'HTML'
+{structured_reply}
+HTML
+mkdir -p reply_email_attachments
+echo "attachment" > reply_email_attachments/attachment.txt
+"#,
+        structured_reply = STRUCTURED_INVESTMENT_REPLY_HTML
+    );
     let script = match mode {
         FakeClaudeMode::Success => {
             r#"#!/bin/sh
@@ -461,47 +574,7 @@ mkdir -p reply_email_attachments
 echo "attachment" > reply_email_attachments/attachment.txt
 "#
         }
-        FakeClaudeMode::InvestmentStructured => {
-            r#"#!/bin/sh
-set -e
-echo '{"type":"message_delta","delta":{"text":"ok"}}'
-cat > reply_email_draft.html <<'HTML'
-<h2>Request Framing</h2>
-<ul>
-  <li><strong>Ticker:</strong> NVDA</li>
-  <li><strong>Name:</strong> NVIDIA</li>
-  <li><strong>Type:</strong> Stock</li>
-  <li><strong>Research Mode:</strong> Deep research</li>
-  <li><strong>User Objective:</strong> Decide whether now is actionable (stated)</li>
-  <li><strong>Horizon:</strong> Long-term (inferred)</li>
-  <li><strong>Question Type:</strong> Long-term accumulation</li>
-</ul>
-<h2>Final Recommendation</h2>
-<ul>
-  <li><strong>Rating:</strong> Wait</li>
-  <li><strong>Horizon:</strong> Long-term (inferred)</li>
-  <li><strong>Confidence:</strong> Medium</li>
-  <li><strong>Timing Verdict:</strong> Wait</li>
-  <li><strong>Add Criteria:</strong> Better entry after earnings or improved valuation support.</li>
-  <li><strong>Invalidation Criteria:</strong> Demand slows or margin guidance weakens.</li>
-  <li><strong>Biggest Near-Term Risk:</strong> Event volatility around earnings.</li>
-  <li><strong>Biggest Long-Term Strength:</strong> AI compute leadership.</li>
-</ul>
-<h2>Verified Facts</h2>
-<ul><li>Fact.</li></ul>
-<h2>Derived Metrics</h2>
-<ul><li>Metric: price / eps = 10x</li></ul>
-<h2>Inference / Judgment</h2>
-<ul><li>Judgment.</li></ul>
-<h2>Scenario Analysis</h2>
-<p><strong>Bull Case:</strong> Demand remains strong.</p>
-<p><strong>Base Case:</strong> Growth normalizes.</p>
-<p><strong>Bear Case:</strong> Spending slows.</p>
-HTML
-mkdir -p reply_email_attachments
-echo "attachment" > reply_email_attachments/attachment.txt
-"#
-        }
+        FakeClaudeMode::InvestmentStructured => investment_structured_script.as_str(),
         FakeClaudeMode::InvestmentGeneric => {
             r#"#!/bin/sh
 set -e

--- a/DoWhiz_service/send_emails_module/src/lib.rs
+++ b/DoWhiz_service/send_emails_module/src/lib.rs
@@ -343,6 +343,98 @@ pub fn normalize_email_html(subject: &str, raw_html: &str) -> String {
         border-top: 1px solid #e4e8ee;
       }}
 
+      .dw-content section {{
+        margin: 0 0 1.4em;
+      }}
+
+      .dw-investment-card,
+      .dw-trigger-grid,
+      .dw-source-note,
+      .dw-chart-card {{
+        margin: 0 0 1.25em;
+        padding: 16px 18px;
+        border: 1px solid #e4e8ee;
+        border-radius: 14px;
+        background-color: #fbfcfe;
+      }}
+
+      .dw-investment-card {{
+        border-color: #d9e3f0;
+        background: linear-gradient(180deg, #f7fbff 0%, #ffffff 100%);
+      }}
+
+      .dw-investment-kicker {{
+        display: inline-block;
+        margin: 0 0 10px;
+        padding: 4px 10px;
+        border-radius: 999px;
+        background-color: #eef4fb;
+        color: #31506f;
+        font-size: 12px;
+        line-height: 1.3;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }}
+
+      .dw-investment-list,
+      .dw-trigger-list {{
+        margin: 0 0 0.2em 1.1em !important;
+      }}
+
+      .dw-investment-list li,
+      .dw-trigger-list li {{
+        margin: 0 0 0.5em;
+      }}
+
+      .dw-evidence-row {{
+        margin: 8px 0 0;
+      }}
+
+      .dw-evidence-chip {{
+        display: inline-block;
+        margin: 0 8px 8px 0;
+        padding: 4px 10px;
+        border-radius: 999px;
+        border: 1px solid #d8dee9;
+        background-color: #ffffff;
+        color: #35506c !important;
+        text-decoration: none;
+        font-size: 12px;
+        line-height: 1.25;
+        font-weight: 700;
+      }}
+
+      .dw-evidence-chip[data-source-tier="primary"] {{
+        border-color: #9fc3ff;
+        background-color: #eef5ff;
+        color: #184a90 !important;
+      }}
+
+      .dw-evidence-chip[data-source-tier="independent"] {{
+        border-color: #b7d9c0;
+        background-color: #eef8f1;
+        color: #1f6a39 !important;
+      }}
+
+      .dw-evidence-chip[data-source-tier="reference"] {{
+        border-color: #dfcfad;
+        background-color: #fcf6e8;
+        color: #8a5a08 !important;
+      }}
+
+      .dw-source-note {{
+        background-color: #fffdf8;
+      }}
+
+      .dw-chart-card figcaption,
+      .dw-chart-caption {{
+        margin-top: 10px;
+        color: #5b616d;
+        font-size: 13px;
+        line-height: 1.5;
+      }}
+
       @media screen and (max-width: 640px) {{
         .dw-shell-pad {{
           padding: 10px !important;
@@ -379,6 +471,19 @@ pub fn normalize_email_html(subject: &str, raw_html: &str) -> String {
           padding: 9px 10px !important;
           font-size: 13px !important;
           line-height: 1.45 !important;
+        }}
+
+        .dw-investment-card,
+        .dw-trigger-grid,
+        .dw-source-note,
+        .dw-chart-card {{
+          padding: 14px !important;
+          border-radius: 12px !important;
+        }}
+
+        .dw-evidence-chip {{
+          margin-right: 6px !important;
+          margin-bottom: 6px !important;
         }}
       }}
     </style>
@@ -1383,47 +1488,100 @@ mod tests {
         let normalized = normalize_email_html(
             "NVDA investment memo",
             r#"
-            <h2>Final Recommendation</h2>
-            <ul>
-              <li><strong>Rating:</strong> Wait</li>
-              <li><strong>Horizon:</strong> Medium-term (stated)</li>
-              <li><strong>Confidence:</strong> Medium</li>
-              <li><strong>Timing Verdict:</strong> Wait</li>
-              <li><strong>Add Criteria:</strong> Better entry after earnings.</li>
+            <section><h2>Request Framing</h2><ul>
+              <li><strong>Ticker:</strong> NVDA</li>
+              <li><strong>Name:</strong> NVIDIA</li>
+              <li><strong>Type:</strong> Stock</li>
+              <li><strong>Research Mode:</strong> Deep research</li>
+              <li><strong>User Objective:</strong> Decide whether now is actionable (stated)</li>
+              <li><strong>Horizon Basis:</strong> Dual-horizon default because the user did not specify one (inferred)</li>
+              <li><strong>Question Type:</strong> Long-term accumulation</li>
+            </ul></section>
+            <section class="dw-investment-card">
+              <h2>Decision Card</h2>
+              <ul class="dw-investment-list">
+                <li><strong>New Money Action:</strong> Wait</li>
+                <li><strong>Existing Holder Action:</strong> Hold / Do not add</li>
+                <li><strong>Near-Term Timing View:</strong> Wait for a cleaner setup.</li>
+                <li><strong>Long-Term Ownership View:</strong> Attractive if execution remains strong.</li>
+                <li><strong>Confidence:</strong> Medium</li>
+                <li><strong>One-Line Rationale:</strong> Great business, expensive setup.</li>
+              </ul>
+            </section>
+            <section><h2>Why in 3 bullets</h2><ul>
+              <li><strong>What Is Priced In:</strong> Another strong quarter.</li>
+              <li><strong>What Keeps This From Being Stronger:</strong> Little room for error.</li>
+              <li><strong>What Would Change The View:</strong> Cleaner valuation or stronger evidence.</li>
+            </ul></section>
+            <section class="dw-trigger-grid"><h2>Trigger Block</h2><ul>
+              <li><strong>Upgrade / Add Triggers:</strong> Durable beat plus guidance.</li>
+              <li><strong>Stay Wait Unless:</strong> Setup de-risks.</li>
               <li><strong>Invalidation Criteria:</strong> Margin guide weakens.</li>
-              <li><strong>Biggest Near-Term Risk:</strong> Earnings volatility.</li>
-              <li><strong>Biggest Long-Term Strength:</strong> AI compute leadership.</li>
-            </ul>
-            <h2>Verified Facts</h2><ul><li>Fact one.</li></ul>
-            <h2>Derived Metrics</h2><ul><li>Metric: price / eps = 10x</li></ul>
-            <h2>Scenario Analysis</h2>
-            <p><strong>Bull Case:</strong> Demand stays strong.</p>
-            <p><strong>Base Case:</strong> Growth normalizes.</p>
-            <p><strong>Bear Case:</strong> Spending slows.</p>
+            </ul></section>
+            <section><h2>Verified Facts</h2><ul><li>Fact one.<div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="primary" href="https://investor.nvidia.com">IR</a><a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a></div></li></ul></section>
+            <section><h2>Derived Metrics</h2><ul><li>Metric: price / eps = 10x<div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com">Quote</a></div></li></ul></section>
+            <section><h2>Expectations</h2><ul>
+              <li><strong>What the Next Catalyst Must Show:</strong> Demand and margin durability.<div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="primary" href="https://www.sec.gov">Filing</a></div></li>
+              <li><strong>What Could Disappoint Even If Fundamentals Are Fine:</strong> Good but not great guidance.</li>
+            </ul></section>
+            <section><h2>Opportunity-Cost / Peer Check</h2><ul><li>Buying the index has lower single-report risk.</li></ul></section>
+            <section><h2>Inference / Judgment</h2><ul><li>Judgment.</li></ul></section>
+            <section><h2>Scenario Analysis</h2>
+              <p><strong>Bull Case:</strong> Demand stays strong.</p>
+              <p><strong>Base Case:</strong> Growth normalizes.</p>
+              <p><strong>Bear Case:</strong> Spending slows.</p>
+            </section>
+            <section class="dw-source-note"><h2>Source Notes</h2><ul><li>Cross-checked primary, independent, and reference sources.<div class="dw-evidence-row"><a class="dw-evidence-chip" data-source-tier="primary" href="https://investor.nvidia.com">IR</a><a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com">Reuters</a><a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com">Quote</a></div></li></ul></section>
+            <section><h2>Disclaimer</h2><p>Public-information-based research only, not personalized investment advice or trade execution.</p></section>
             "#,
         );
 
         let text = plain_text_body_from_html(&normalized);
         for label in [
-            "Rating:",
-            "Horizon:",
+            "Request Framing",
+            "Ticker:",
+            "Name:",
+            "Type:",
+            "Research Mode:",
+            "User Objective:",
+            "Horizon Basis:",
+            "Question Type:",
+            "Decision Card",
+            "New Money Action:",
+            "Existing Holder Action:",
+            "Near-Term Timing View:",
+            "Long-Term Ownership View:",
             "Confidence:",
-            "Timing Verdict:",
+            "One-Line Rationale:",
+            "Why in 3 bullets",
+            "What Is Priced In:",
+            "What Keeps This From Being Stronger:",
+            "What Would Change The View:",
+            "Trigger Block",
+            "Upgrade / Add Triggers:",
+            "Stay Wait Unless:",
+            "Invalidation Criteria:",
             "Verified Facts",
             "Derived Metrics",
+            "Expectations",
+            "What the Next Catalyst Must Show:",
+            "What Could Disappoint Even If Fundamentals Are Fine:",
+            "Opportunity-Cost / Peer Check",
+            "Inference / Judgment",
             "Bull Case:",
             "Base Case:",
             "Bear Case:",
-            "Add Criteria:",
-            "Invalidation Criteria:",
-            "Biggest Near-Term Risk:",
-            "Biggest Long-Term Strength:",
+            "Source Notes",
+            "Disclaimer",
         ] {
             assert!(
                 normalized.contains(label) || text.contains(label),
                 "expected normalized email content to preserve label {label}"
             );
         }
+        assert!(normalized.contains("dw-investment-card"));
+        assert!(normalized.contains("dw-evidence-chip"));
+        assert!(normalized.contains(r#"data-source-tier="primary""#));
     }
 
     #[test]

--- a/DoWhiz_service/skills/us-equity-daily-monitor/SKILL.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: us-equity-daily-monitor
-description: One-off investment research for a single U.S. stock or single U.S. ETF. Use this skill whenever the user asks to analyze one ticker, asks whether now is a good time to buy, asks about buying before earnings, requests deep research on one U.S. stock or ETF, or wants a clear Buy / Wait / Sell view. Return a decision-useful memo with exact visible labels for Rating, Horizon, Confidence, Timing Verdict, Verified Facts, Derived Metrics, Bull Case, Base Case, Bear Case, Add Criteria, Invalidation Criteria, Biggest Near-Term Risk, and Biggest Long-Term Strength.
+description: One-off investment research for a single U.S. stock or single U.S. ETF. Use this skill whenever the user asks to analyze one ticker, asks whether now is a good time to buy, asks about buying before earnings, requests deep research on one U.S. stock or ETF, or wants a decision-useful investment memo. Return a scan-first decision memo with exact visible labels for Decision Card, New Money Action, Existing Holder Action, Near-Term Timing View, Long-Term Ownership View, Confidence, What Is Priced In, Verified Facts, Derived Metrics, Expectations, Bull Case, Base Case, Bear Case, Upgrade / Add Triggers, Invalidation Criteria, Opportunity-Cost / Peer Check, Source Notes, and Disclaimer.
 ---
 
 # U.S. Equity Decision Memo
@@ -18,21 +18,19 @@ Do not use it for:
 
 ## Core job
 
-Return one final user-visible investment memo that helps the user decide what to do now.
+Return one final user-visible investment memo that helps the user decide what to do now with the least possible cognitive load.
 
-This memo must not collapse into generic stock commentary. It must separate:
+The memo must:
 
-- verified facts
-- derived metrics
-- inference or judgment
+- front-load the decision
+- separate `New Money Action` from `Existing Holder Action`
+- separate `Near-Term Timing View` from `Long-Term Ownership View`
+- separate verified fact from derived metric from judgment
+- explain what appears priced in
+- explain what would upgrade the view, keep it in wait mode, or break the thesis
+- make the evidence easy to click without pushing everything into a generic appendix
 
-It must also give:
-
-- one final `Buy`, `Wait`, or `Sell` rating
-- one direct timing verdict
-- explicit bull, base, and bear cases
-- explicit add criteria
-- explicit invalidation criteria
+This skill must not collapse into generic stock commentary or a long reading-heavy research email.
 
 ## Hard output contract
 
@@ -44,21 +42,74 @@ For chat replies, keep the same visible labels in markdown or plain text.
 
 Do not rename, collapse, or replace them with softer alternatives.
 
-Required labels:
+Required headings and labels:
 
-- `Rating`
-- `Horizon`
+- `Request Framing`
+- `Decision Card`
+- `New Money Action`
+- `Existing Holder Action`
+- `Near-Term Timing View`
+- `Long-Term Ownership View`
 - `Confidence`
-- `Timing Verdict`
+- `One-Line Rationale`
+- `Why in 3 bullets`
+- `What Is Priced In`
+- `What Keeps This From Being Stronger`
+- `What Would Change The View`
+- `Trigger Block`
+- `Upgrade / Add Triggers`
+- `Stay Wait Unless`
+- `Invalidation Criteria`
 - `Verified Facts`
 - `Derived Metrics`
+- `Expectations`
+- `What the Next Catalyst Must Show`
+- `What Could Disappoint Even If Fundamentals Are Fine`
+- `Opportunity-Cost / Peer Check`
+- `Inference / Judgment`
 - `Bull Case`
 - `Base Case`
 - `Bear Case`
-- `Add Criteria`
+- `Source Notes`
+- `Disclaimer`
+
+## Recommendation rules
+
+### Two action tracks are mandatory
+
+The memo must answer both:
+
+- `New Money Action`: one of `Buy`, `Wait`, `Starter Only`, or `Avoid for now`
+- `Existing Holder Action`: one of `Hold`, `Add`, `Trim`, `Exit`, or `Hold / Do not add`
+
+Do not answer a new-money question with only `Hold`.
+
+### Dual-horizon framing is the default
+
+If the user does not give a clear horizon, default to both:
+
+- `Near-Term Timing View`
+- `Long-Term Ownership View`
+
+Do not force an arbitrary exact horizon such as "6 months" unless the prompt or evidence clearly supports it.
+
+If the user gives a specific horizon, keep the dual-horizon view anyway when it helps explain why short-term timing and long-term ownership differ.
+
+### Trigger-based verdicts
+
+Every actionable view must include:
+
+- `Upgrade / Add Triggers`
+- `Stay Wait Unless`
 - `Invalidation Criteria`
-- `Biggest Near-Term Risk`
-- `Biggest Long-Term Strength`
+
+Do not use vague wording such as:
+
+- "watch for a pullback"
+- "wait for more clarity"
+- "buy in tranches"
+
+unless it is translated into explicit conditions.
 
 ## Request framing
 
@@ -69,15 +120,17 @@ Before making claims, identify:
 - `Stock` or `ETF`
 - research mode: `Quick analysis` or `Deep research`
 - user objective: mark `stated` or `inferred`
-- horizon: `Short-term`, `Medium-term`, or `Long-term`, and mark `stated` or `inferred`
 - question type: `Long-term accumulation`, `Medium-term investment`, `Short-term trade`, or `Event-driven timing`
+- horizon basis:
+  - use the user-stated horizon when available
+  - otherwise say that the note defaults to dual-horizon framing because the user did not specify one
 
 Inference rules:
 
-- days or weeks usually map to `Short-term`
-- months usually map to `Medium-term`
-- broad "is this worth buying?" questions usually map to `Long-term (inferred)`
-- earnings or catalyst timing questions map to `Event-driven timing`
+- days or weeks usually matter most for `Near-Term Timing View`
+- months usually matter for both `Near-Term Timing View` and `Long-Term Ownership View`
+- broad "is this worth buying?" questions usually need a long-term ownership answer plus a separate near-term timing answer
+- earnings or catalyst questions require an explicit expectations layer
 
 If the prompt is ambiguous or points to multiple possible tickers, resolve the ambiguity before giving the memo.
 
@@ -92,9 +145,13 @@ Examples:
 - latest reported revenue, EPS, cash, debt, margin, or guidance
 - next earnings date
 - major concentration or regulatory facts
-- recent price or trend context when available from accessible public data
+- recent price context from a quote or reference source
 
-Do not mix opinion into this section.
+Rules:
+
+- 3 to 6 concise bullets
+- each material factual bullet must include at least one clickable evidence chip
+- do not mix opinion into this section
 
 ### Derived Metrics
 
@@ -106,6 +163,7 @@ Rules:
 - show the formula
 - show the inputs used
 - show the result, or say what missing input prevents a reliable result
+- each material metric bullet must include at least one clickable evidence chip
 
 Examples:
 
@@ -120,29 +178,33 @@ If the metric is approximate, mark it clearly as approximate.
 
 Keep judgment separate from fact.
 
-Make it clear when you are interpreting mixed evidence, valuation stretch, event risk, or poor timing.
+Use cited evidence to support the reasoning, but do not pretend the judgment itself is a directly sourced fact.
 
-## Timing and scenarios
+## Expectations and opportunity cost
 
-### Timing Verdict
+### Expectations
 
-Give one direct action from this set:
+This section is mandatory for "is now a good time to buy?" or catalyst-timing questions.
 
-- `Buy now`
-- `Starter only`
-- `Wait`
-- `Avoid for now`
+It must answer:
 
-Do not hide behind vague language such as:
+- `What Is Priced In`
+- `What the Next Catalyst Must Show`
+- `What Could Disappoint Even If Fundamentals Are Fine`
 
-- "good company"
-- "buy in tranches"
-- "wait and see"
-- "not a good all-in buy"
+### Opportunity-Cost / Peer Check
 
-Translate vague language into an explicit `Timing Verdict`, `Add Criteria`, and `Invalidation Criteria`.
+This section is mandatory and concise.
 
-### Scenario Analysis
+It must answer one of these clearly:
+
+- why this stock versus a key peer or alternative
+- why this stock versus the index
+- why this stock versus doing nothing / holding cash
+
+Do not omit opportunity cost just because the company is high quality.
+
+## Scenario analysis
 
 This section is mandatory and must include:
 
@@ -151,12 +213,6 @@ This section is mandatory and must include:
 - `Bear Case`
 
 Do not invent precise price targets unless the supporting math is shown.
-
-## Wrong-premise handling
-
-If the user states a factual premise and trusted public sources conflict with it, correct the premise explicitly in the final memo before proceeding.
-
-Do not silently absorb a wrong earnings date, filing date, or guidance number.
 
 ## Confidence
 
@@ -168,6 +224,69 @@ Use only:
 
 Lower confidence when data is incomplete, conflicting, stale, messy, or heavily catalyst-dependent.
 
+## Citation and source policy
+
+### Clickable evidence is mandatory for material factual and derived claims
+
+Do not cite every sentence.
+
+Do cite every material factual claim and every material derived-metric claim with clickable source links at the bullet or paragraph level.
+
+Use compact evidence chips such as:
+
+```html
+<div class="dw-evidence-row">
+  <a class="dw-evidence-chip" data-source-tier="primary" href="https://...">IR</a>
+  <a class="dw-evidence-chip" data-source-tier="independent" href="https://...">Reuters</a>
+  <a class="dw-evidence-chip" data-source-tier="reference" href="https://...">Quote</a>
+</div>
+```
+
+Rules:
+
+- use real clickable links
+- keep chips compact and close to the claim they support
+- use at least one `primary` chip somewhere in the note
+- use at least one `independent` chip somewhere in the note when relevant
+- use at least one `reference` chip for price or quote cross-checking when relevant
+- do not use the appendix as the only place where sources appear
+
+### Tiered source policy
+
+Use a mix of source types.
+
+Tier 1 `primary`:
+
+- company investor relations pages
+- earnings releases
+- SEC filings such as `10-K`, `10-Q`, `8-K`, `20-F`
+- official transcripts or prepared remarks when available
+- official exchange or company filings
+
+Tier 2 `independent`:
+
+- Reuters
+- Bloomberg
+- WSJ
+- FT
+- AP when relevant
+- other reputable independent reporting when justified
+
+Tier 3 `reference`:
+
+- Yahoo Finance
+- Nasdaq
+- MarketWatch
+- Investing.com
+- other quote or reference sources when justified
+
+Source rules:
+
+- do not rely only on company-controlled sources
+- do not let reference sites substitute for primary filings on core fundamentals
+- when an external report is lower-confidence or indirect, say so
+- if a user premise is wrong and a trusted source conflicts with it, correct the premise explicitly
+
 ## Exact final structure
 
 Use this exact visible structure and keep the labels exactly as written.
@@ -178,25 +297,42 @@ Use this exact visible structure and keep the labels exactly as written.
 - `Type`: `Stock` or `ETF`
 - `Research Mode`: `Quick analysis` or `Deep research`
 - `User Objective`: ... `(<stated or inferred>)`
-- `Horizon`: `Short-term`, `Medium-term`, or `Long-term` `(<stated or inferred>)`
+- `Horizon Basis`: ... `(<stated or inferred>)`
 - `Question Type`: `Long-term accumulation`, `Medium-term investment`, `Short-term trade`, or `Event-driven timing`
 
-### Final Recommendation
-- `Rating`: `Buy`, `Wait`, or `Sell`
-- `Horizon`: `Short-term`, `Medium-term`, or `Long-term` `(<stated or inferred>)`
+### Decision Card
+- `New Money Action`: `Buy`, `Wait`, `Starter Only`, or `Avoid for now`
+- `Existing Holder Action`: `Hold`, `Add`, `Trim`, `Exit`, or `Hold / Do not add`
+- `Near-Term Timing View`: ...
+- `Long-Term Ownership View`: ...
 - `Confidence`: `Low`, `Medium`, or `High`
-- `Timing Verdict`: `Buy now`, `Starter only`, `Wait`, or `Avoid for now`
-- `Add Criteria`: ...
+- `One-Line Rationale`: ...
+
+### Why in 3 bullets
+- `What Is Priced In`: ...
+- `What Keeps This From Being Stronger`: ...
+- `What Would Change The View`: ...
+
+### Trigger Block
+- `Upgrade / Add Triggers`: ...
+- `Stay Wait Unless`: ...
 - `Invalidation Criteria`: ...
-- `Biggest Near-Term Risk`: ...
-- `Biggest Long-Term Strength`: ...
 
 ### Verified Facts
-- 4 to 8 concise bullets with sourced facts only
+- 3 to 6 concise bullets with sourced facts only
+- each bullet ends with a compact evidence row or inline evidence chips
 
 ### Derived Metrics
 - 2 to 4 concise bullets in the form `Metric: formula = result`
 - or explicit `Not reliably derivable from accessible public data today: ...`
+- each bullet ends with a compact evidence row or inline evidence chips
+
+### Expectations
+- `What the Next Catalyst Must Show`: ...
+- `What Could Disappoint Even If Fundamentals Are Fine`: ...
+
+### Opportunity-Cost / Peer Check
+- 2 to 4 concise bullets
 
 ### Inference / Judgment
 - 2 to 5 concise bullets
@@ -206,9 +342,9 @@ Use this exact visible structure and keep the labels exactly as written.
 - `Base Case`: ...
 - `Bear Case`: ...
 
-### Sources
-- name the primary public sources used
-- list official or primary sources first
+### Source Notes
+- 3 to 8 concise bullets summarizing what each source contributed
+- call out `primary`, `independent`, and `reference` source types visibly
 
 ### Disclaimer
 `Public-information-based research only, not personalized investment advice or trade execution.`
@@ -217,15 +353,45 @@ Use this exact visible structure and keep the labels exactly as written.
 
 For email replies:
 
-- use semantic HTML such as `<h2>`, `<p>`, `<ul>`, `<li>`, and `<strong>`
-- keep the contract labels visible as text inside the HTML body
+- write semantic HTML and make the note scan-first
+- use sections and cards, not one long prose block
+- keep the answer visible in the first screen or two
+- use compact `<ul>` blocks, short paragraphs, and clear subheads
+- place evidence chips close to the claims they support
+- use CSS classes when helpful:
+  - `dw-investment-card`
+  - `dw-investment-grid`
+  - `dw-investment-list`
+  - `dw-trigger-grid`
+  - `dw-evidence-row`
+  - `dw-evidence-chip`
+  - `dw-source-note`
+  - `dw-chart-card`
 - do not hide the labels inside images or attachments
-- do not replace the labeled structure with one prose paragraph
+- do not rely on JavaScript or fragile interactivity
 
-## Failure mode to avoid
+## Chart policy
 
-This is bad:
+Charts are optional, not mandatory.
 
-`NVIDIA is a great company, but I would wait and buy in tranches after earnings.`
+Only include a chart if it directly supports the verdict and can be rendered safely in the final HTML email.
 
-This is acceptable only when translated into the exact labeled memo with a clear `Rating`, `Timing Verdict`, `Add Criteria`, and `Invalidation Criteria`.
+If included:
+
+- limit to one or two charts
+- prefer a simple static chart or table-style visual
+- include a one-line caption explaining why it matters
+- include a click-through link for fuller detail when helpful
+
+If a clean chart is not available from accessible public data, omit it instead of faking precision.
+
+## Failure modes to avoid
+
+These are bad:
+
+- `Great company, but not a good all-in buy.`
+- `Wait until after earnings and see.`
+- `Buy in tranches.`
+- `Watch for a pullback.`
+
+These are acceptable only when translated into the exact labeled memo with explicit actions, expectations, triggers, and evidence chips.

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/evals.json
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/evals.json
@@ -3,11 +3,17 @@
   "evals": [
     {
       "id": 1,
-      "name": "final-artifact-contract-nvda",
-      "kind": "live_run",
-      "subject": "NVDA investment memo",
-      "prompt": "Give me deep research on NVDA and tell me whether now is a good time to buy.",
-      "require_contract": true
+      "name": "structured-scan-first-fixture",
+      "kind": "fixture",
+      "artifact_file": "fixtures/structured_scan_first_email.html",
+      "require_contract": true,
+      "require_actions": true,
+      "require_dual_horizon": true,
+      "require_expectations": true,
+      "require_evidence_chips": true,
+      "require_source_tiers": true,
+      "require_scan_first": true,
+      "require_opportunity_cost": true
     },
     {
       "id": 2,
@@ -18,42 +24,53 @@
     },
     {
       "id": 3,
-      "name": "horizon-awareness-nvda-3-month",
+      "name": "nokia-live-decision-memo",
       "kind": "live_run",
-      "subject": "NVDA 3-month position",
-      "prompt": "Is NVDA a buy this week for a 3-month position?",
+      "subject": "Nokia investment memo",
+      "prompt": "Give me a deep research about the Nokia stock, and tell me whether it is a good time to buy.",
       "require_contract": true,
-      "expected_horizon_contains": "medium-term",
-      "expected_question_type_contains": "medium-term investment"
-    },
-    {
-      "id": 4,
-      "name": "live-path-alignment-nvda",
-      "kind": "live_run",
-      "subject": "NVDA alignment check",
-      "prompt": "Give me deep research on NVDA and tell me whether now is a good time to buy.",
-      "require_contract": true,
+      "require_actions": true,
+      "require_dual_horizon": true,
+      "require_expectations": true,
+      "require_evidence_chips": true,
+      "require_source_tiers": true,
+      "require_scan_first": true,
+      "require_opportunity_cost": true,
       "require_live_path_alignment": true
     },
     {
-      "id": 5,
+      "id": 4,
       "name": "wrong-premise-correction-nvda",
       "kind": "live_run",
       "subject": "NVDA earnings timing",
       "prompt": "NVDA earnings are on May 27, 2026, right? Should I buy before them?",
       "require_contract": true,
+      "require_actions": true,
+      "require_dual_horizon": true,
+      "require_expectations": true,
+      "require_evidence_chips": true,
+      "require_source_tiers": true,
+      "require_scan_first": true,
+      "require_opportunity_cost": true,
       "must_contain_any": [
         "May 20, 2026",
         "May 20 2026"
       ]
     },
     {
-      "id": 6,
+      "id": 5,
       "name": "weak-case-confidence-plug",
       "kind": "live_run",
       "subject": "PLUG investment memo",
       "prompt": "Give me deep research on PLUG and tell me whether now is a good time to buy.",
       "require_contract": true,
+      "require_actions": true,
+      "require_dual_horizon": true,
+      "require_expectations": true,
+      "require_evidence_chips": true,
+      "require_source_tiers": true,
+      "require_scan_first": true,
+      "require_opportunity_cost": true,
       "allowed_confidence": [
         "low",
         "medium"

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/structured_scan_first_email.html
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/structured_scan_first_email.html
@@ -1,0 +1,126 @@
+<section>
+  <h2>Request Framing</h2>
+  <ul>
+    <li><strong>Ticker:</strong> NOK</li>
+    <li><strong>Name:</strong> Nokia</li>
+    <li><strong>Type:</strong> Stock</li>
+    <li><strong>Research Mode:</strong> Deep research</li>
+    <li><strong>User Objective:</strong> Decide whether initiating now is attractive (stated)</li>
+    <li><strong>Horizon Basis:</strong> Dual-horizon default because the user did not specify one (inferred)</li>
+    <li><strong>Question Type:</strong> Long-term accumulation</li>
+  </ul>
+</section>
+<section class="dw-investment-card">
+  <div class="dw-investment-kicker">Decision-ready memo</div>
+  <h2>Decision Card</h2>
+  <ul class="dw-investment-list">
+    <li><strong>New Money Action:</strong> Starter Only</li>
+    <li><strong>Existing Holder Action:</strong> Hold / Do not add</li>
+    <li><strong>Near-Term Timing View:</strong> Wait unless order momentum and margin durability improve.</li>
+    <li><strong>Long-Term Ownership View:</strong> Ownable only if the multi-year network upgrade cycle turns into clearer operating leverage.</li>
+    <li><strong>Confidence:</strong> Medium</li>
+    <li><strong>One-Line Rationale:</strong> The stock is cheaper than mega-cap AI names, but it still needs better proof of earnings power to justify a clean Buy now verdict.</li>
+  </ul>
+</section>
+<section>
+  <h2>Why in 3 bullets</h2>
+  <ul>
+    <li><strong>What Is Priced In:</strong> Some margin recovery and a steadier telecom-spending backdrop.</li>
+    <li><strong>What Keeps This From Being Stronger:</strong> The market still needs more proof that profitability can improve without relying on optimistic cycle assumptions.</li>
+    <li><strong>What Would Change The View:</strong> Clearer order growth, cleaner free-cash-flow conversion, and fewer signs of operator budget hesitation.</li>
+  </ul>
+</section>
+<section class="dw-trigger-grid">
+  <h2>Trigger Block</h2>
+  <ul class="dw-trigger-list">
+    <li><strong>Upgrade / Add Triggers:</strong> Better margin execution plus evidence that carrier demand is improving rather than just stabilizing.</li>
+    <li><strong>Stay Wait Unless:</strong> The next report shows both operating leverage and healthier end-market demand.</li>
+    <li><strong>Invalidation Criteria:</strong> Margin recovery stalls, free cash flow weakens again, or operator spending softness deepens.</li>
+  </ul>
+</section>
+<section>
+  <h2>Verified Facts</h2>
+  <ul>
+    <li>
+      Nokia's most recent reporting still shows a business tied closely to telecom operator capex and network-cycle timing.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="primary" href="https://www.nokia.com/about-us/investors/">IR</a>
+        <a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com/">Reuters</a>
+      </div>
+    </li>
+    <li>
+      Quote cross-checks show the stock is not priced like a high-growth software name.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com/">Quote</a>
+      </div>
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Derived Metrics</h2>
+  <ul>
+    <li>
+      EV / EBIT remains easier to justify than pure sales multiples, but the setup still depends on how much margin recovery is actually achievable.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="primary" href="https://www.sec.gov/">Filing</a>
+        <a class="dw-evidence-chip" data-source-tier="reference" href="https://www.nasdaq.com/">Quote</a>
+      </div>
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Expectations</h2>
+  <ul>
+    <li>
+      <strong>What the Next Catalyst Must Show:</strong> Better network order momentum, not just cost discipline.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="primary" href="https://www.nokia.com/about-us/investors/">IR</a>
+        <a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com/">Reuters</a>
+      </div>
+    </li>
+    <li>
+      <strong>What Could Disappoint Even If Fundamentals Are Fine:</strong> A report that is acceptable on profit but too soft on demand to change the narrative.
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Opportunity-Cost / Peer Check</h2>
+  <ul>
+    <li>
+      Versus simply buying the index, Nokia offers more upside if telecom spending recovers, but it also offers less structural certainty than higher-quality compounders.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com/">Reuters</a>
+        <a class="dw-evidence-chip" data-source-tier="reference" href="https://www.marketwatch.com/">Quote</a>
+      </div>
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Inference / Judgment</h2>
+  <ul>
+    <li>Judgment: the stock is plausible as a starter position, but not clean enough yet for a confident full Buy call.</li>
+  </ul>
+</section>
+<section>
+  <h2>Scenario Analysis</h2>
+  <p><strong>Bull Case:</strong> Operator budgets improve and margin recovery arrives faster than expected.</p>
+  <p><strong>Base Case:</strong> Demand stabilizes but re-rating is limited because improvement is only gradual.</p>
+  <p><strong>Bear Case:</strong> Capex pressure persists and the market stops paying for a margin-recovery story.</p>
+</section>
+<section class="dw-source-note">
+  <h2>Source Notes</h2>
+  <ul>
+    <li>
+      Primary, independent, and reference sources were cross-checked instead of relying only on company-controlled material.
+      <div class="dw-evidence-row">
+        <a class="dw-evidence-chip" data-source-tier="primary" href="https://www.nokia.com/about-us/investors/">IR</a>
+        <a class="dw-evidence-chip" data-source-tier="independent" href="https://www.reuters.com/">Reuters</a>
+        <a class="dw-evidence-chip" data-source-tier="reference" href="https://finance.yahoo.com/">Quote</a>
+      </div>
+    </li>
+  </ul>
+</section>
+<section>
+  <h2>Disclaimer</h2>
+  <p>Public-information-based research only, not personalized investment advice or trade execution.</p>
+</section>

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py
@@ -26,22 +26,74 @@ from typing import Any
 
 SERVICE_ROOT = Path(__file__).resolve().parents[3]
 SKILL_ROOT = Path(__file__).resolve().parents[1]
+EVALS_ROOT = SKILL_ROOT / "evals"
 WORKSPACE_ROOT = SKILL_ROOT.parent.parent / "us-equity-daily-monitor-workspace"
 REQUIRED_LABELS = [
-    "rating:",
-    "horizon:",
+    "request framing",
+    "ticker:",
+    "name:",
+    "type:",
+    "research mode:",
+    "user objective:",
+    "horizon basis:",
+    "question type:",
+    "decision card",
+    "new money action:",
+    "existing holder action:",
+    "near-term timing view:",
+    "long-term ownership view:",
     "confidence:",
-    "timing verdict:",
+    "one-line rationale:",
+    "why in 3 bullets",
+    "what is priced in:",
+    "what keeps this from being stronger:",
+    "what would change the view:",
+    "trigger block",
+    "upgrade / add triggers:",
+    "stay wait unless:",
+    "invalidation criteria:",
     "verified facts",
     "derived metrics",
-    "bull case",
-    "base case",
-    "bear case",
-    "add criteria:",
-    "invalidation criteria:",
-    "biggest near-term risk:",
-    "biggest long-term strength:",
+    "expectations",
+    "what the next catalyst must show:",
+    "what could disappoint even if fundamentals are fine:",
+    "opportunity-cost / peer check",
+    "inference / judgment",
+    "bull case:",
+    "base case:",
+    "bear case:",
+    "source notes",
+    "disclaimer",
 ]
+SUMMARY_FIRST_HEADINGS = [
+    "request framing",
+    "decision card",
+    "why in 3 bullets",
+    "trigger block",
+    "verified facts",
+]
+SECTION_HEADINGS = [
+    "request framing",
+    "decision card",
+    "why in 3 bullets",
+    "trigger block",
+    "verified facts",
+    "derived metrics",
+    "expectations",
+    "opportunity-cost / peer check",
+    "inference / judgment",
+    "scenario analysis",
+    "source notes",
+    "disclaimer",
+]
+LINKED_EVIDENCE_SECTIONS = [
+    "verified facts",
+    "derived metrics",
+    "expectations",
+    "source notes",
+]
+NEW_MONEY_ACTIONS = ["buy", "wait", "starter only", "avoid for now"]
+EXISTING_HOLDER_ACTIONS = ["hold", "add", "trim", "exit", "hold / do not add"]
 
 
 def parse_args() -> argparse.Namespace:
@@ -52,7 +104,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_evals() -> list[dict[str, Any]]:
-    payload = json.loads((SKILL_ROOT / "evals" / "evals.json").read_text())
+    payload = json.loads((EVALS_ROOT / "evals.json").read_text())
     return payload["evals"]
 
 
@@ -67,6 +119,61 @@ def normalize_text(raw_html: str) -> str:
     return " ".join(text.split()).lower()
 
 
+def contains_in_order(text: str, markers: list[str]) -> bool:
+    start = 0
+    for marker in markers:
+        idx = text.find(marker, start)
+        if idx == -1:
+            return False
+        start = idx + len(marker)
+    return True
+
+
+def find_field_value(text: str, label: str, allowed: list[str]) -> str | None:
+    for value in allowed:
+        if f"{label}: {value}" in text:
+            return value
+    return None
+
+
+def extract_section(html_lower: str, heading: str) -> str | None:
+    start = find_heading_position(html_lower, heading)
+    if start is None:
+        return None
+    section_start = start + 1
+    end = len(html_lower)
+    for next_heading in SECTION_HEADINGS:
+        if next_heading == heading:
+            continue
+        idx = find_heading_position(html_lower[section_start:], next_heading)
+        if idx is not None:
+            end = min(end, section_start + idx)
+    return html_lower[start:end]
+
+
+def find_heading_position(html_lower: str, heading: str) -> int | None:
+    for marker in [f">{heading}</", f">{heading}<"]:
+        idx = html_lower.find(marker)
+        if idx != -1:
+            return idx
+    return None
+
+
+def section_contains_link(html_lower: str, heading: str) -> bool:
+    section = extract_section(html_lower, heading)
+    if not section:
+        return False
+    return 'href="http' in section or "href='http" in section
+
+
+def count_evidence_chips(html_lower: str) -> int:
+    return html_lower.count("dw-evidence-chip")
+
+
+def has_source_tier(html_lower: str, tier: str) -> bool:
+    return f'data-source-tier="{tier}"' in html_lower or f"data-source-tier='{tier}'" in html_lower
+
+
 def extract_field(text: str, label: str) -> str | None:
     pattern = re.compile(rf"{re.escape(label)}\s*:\s*([^<\n\r]+)", re.IGNORECASE)
     match = pattern.search(text)
@@ -75,8 +182,33 @@ def extract_field(text: str, label: str) -> str | None:
     return match.group(1).strip().lower()
 
 
-def grade_contract(text: str) -> list[str]:
-    return [label for label in REQUIRED_LABELS if label not in text]
+def audit_artifact(artifact_html: str) -> dict[str, Any]:
+    text = normalize_text(artifact_html)
+    html_lower = artifact_html.lower()
+    missing_labels = [label for label in REQUIRED_LABELS if label not in text]
+    decision_card_pos = text.find("decision card")
+
+    return {
+        "normalized_text": text,
+        "missing_labels": missing_labels,
+        "new_money_action": find_field_value(text, "new money action", NEW_MONEY_ACTIONS),
+        "existing_holder_action": find_field_value(
+            text, "existing holder action", EXISTING_HOLDER_ACTIONS
+        ),
+        "summary_first_ok": contains_in_order(text, SUMMARY_FIRST_HEADINGS),
+        "decision_card_near_top": decision_card_pos != -1 and decision_card_pos < 900,
+        "evidence_chip_count": count_evidence_chips(html_lower),
+        "source_tiers": {
+            tier: has_source_tier(html_lower, tier)
+            for tier in ["primary", "independent", "reference"]
+        },
+        "linked_evidence_sections": {
+            heading: section_contains_link(html_lower, heading)
+            for heading in LINKED_EVIDENCE_SECTIONS
+        },
+        "confidence": extract_field(text, "confidence"),
+        "html_lower": html_lower,
+    }
 
 
 def run_live_eval(case: dict[str, Any], eval_dir: Path) -> dict[str, Any]:
@@ -138,7 +270,10 @@ def run_live_eval(case: dict[str, Any], eval_dir: Path) -> dict[str, Any]:
 
 
 def run_fixture_eval(case: dict[str, Any], eval_dir: Path) -> dict[str, Any]:
-    artifact_html = case["artifact_html"]
+    if case.get("artifact_file"):
+        artifact_html = (EVALS_ROOT / case["artifact_file"]).read_text()
+    else:
+        artifact_html = case["artifact_html"]
     rendered_path = eval_dir / "final_rendered_email.html"
     rendered_path.write_text(artifact_html)
     return {
@@ -150,48 +285,120 @@ def run_fixture_eval(case: dict[str, Any], eval_dir: Path) -> dict[str, Any]:
 
 
 def grade_case(case: dict[str, Any], run_result: dict[str, Any]) -> dict[str, Any]:
-    artifact_html = run_result["artifact_html"]
-    text = normalize_text(artifact_html)
+    audit = audit_artifact(run_result["artifact_html"])
+    text = audit["normalized_text"]
     checks: list[dict[str, Any]] = []
 
-    missing_contract = grade_contract(text)
     if case.get("expected_failure"):
+        failed_reasons = []
+        if audit["missing_labels"]:
+            failed_reasons.append(f"missing labels: {', '.join(audit['missing_labels'])}")
+        if not audit["summary_first_ok"]:
+            failed_reasons.append("summary-first order missing")
+        if not audit["new_money_action"]:
+            failed_reasons.append("new money action missing or invalid")
+        if audit["evidence_chip_count"] < 4:
+            failed_reasons.append("evidence chips missing")
         checks.append(
             {
                 "name": "generic_commentary_fixture_rejected",
-                "passed": bool(missing_contract),
-                "detail": "grader rejected fixture" if missing_contract else "fixture unexpectedly passed",
+                "passed": bool(failed_reasons),
+                "detail": "; ".join(failed_reasons)
+                if failed_reasons
+                else "fixture unexpectedly passed the stronger contract",
             }
         )
     elif case.get("require_contract"):
         checks.append(
             {
                 "name": "required_contract_labels_present",
-                "passed": not missing_contract,
+                "passed": not audit["missing_labels"],
                 "detail": "ok"
-                if not missing_contract
-                else f"missing: {', '.join(missing_contract)}",
+                if not audit["missing_labels"]
+                else f"missing: {', '.join(audit['missing_labels'])}",
             }
         )
 
-    if case.get("expected_horizon_contains"):
-        horizon = extract_field(text, "horizon") or ""
+    if case.get("require_actions"):
         checks.append(
             {
-                "name": "horizon_awareness",
-                "passed": case["expected_horizon_contains"] in horizon,
-                "detail": f"horizon={horizon or '(missing)'}",
+                "name": "new_money_vs_existing_holder_actions",
+                "passed": bool(audit["new_money_action"] and audit["existing_holder_action"]),
+                "detail": (
+                    f"new_money={audit['new_money_action'] or '(missing)'} "
+                    f"existing_holder={audit['existing_holder_action'] or '(missing)'}"
+                ),
             }
         )
 
-    if case.get("expected_question_type_contains"):
+    if case.get("require_dual_horizon"):
         checks.append(
             {
-                "name": "question_type_alignment",
-                "passed": case["expected_question_type_contains"] in text,
+                "name": "dual_horizon_present",
+                "passed": "near-term timing view:" in text and "long-term ownership view:" in text,
                 "detail": "ok"
-                if case["expected_question_type_contains"] in text
-                else "question type missing from final artifact",
+                if "near-term timing view:" in text and "long-term ownership view:" in text
+                else "near-term or long-term view missing",
+            }
+        )
+
+    if case.get("require_expectations"):
+        expectations_ok = (
+            "what is priced in:" in text
+            and "what the next catalyst must show:" in text
+            and "what could disappoint even if fundamentals are fine:" in text
+        )
+        checks.append(
+            {
+                "name": "expectations_layer_present",
+                "passed": expectations_ok,
+                "detail": "ok" if expectations_ok else "expectations layer missing pieces",
+            }
+        )
+
+    if case.get("require_evidence_chips"):
+        linked_sections_ok = all(audit["linked_evidence_sections"].values())
+        checks.append(
+            {
+                "name": "clickable_evidence_present",
+                "passed": audit["evidence_chip_count"] >= 4 and linked_sections_ok,
+                "detail": (
+                    f"chips={audit['evidence_chip_count']} "
+                    f"linked_sections={audit['linked_evidence_sections']}"
+                ),
+            }
+        )
+
+    if case.get("require_source_tiers"):
+        tiers_ok = all(audit["source_tiers"].values())
+        checks.append(
+            {
+                "name": "tiered_sources_present",
+                "passed": tiers_ok,
+                "detail": f"tiers={audit['source_tiers']}",
+            }
+        )
+
+    if case.get("require_scan_first"):
+        checks.append(
+            {
+                "name": "scan_first_information_architecture",
+                "passed": audit["summary_first_ok"] and audit["decision_card_near_top"],
+                "detail": (
+                    f"summary_first_ok={audit['summary_first_ok']} "
+                    f"decision_card_near_top={audit['decision_card_near_top']}"
+                ),
+            }
+        )
+
+    if case.get("require_opportunity_cost"):
+        checks.append(
+            {
+                "name": "opportunity_cost_present",
+                "passed": "opportunity-cost / peer check" in text,
+                "detail": "ok"
+                if "opportunity-cost / peer check" in text
+                else "opportunity-cost block missing",
             }
         )
 
@@ -206,7 +413,7 @@ def grade_case(case: dict[str, Any], run_result: dict[str, Any]) -> dict[str, An
         )
 
     if case.get("must_contain_any"):
-        passed = any(s.lower() in artifact_html.lower() for s in case["must_contain_any"])
+        passed = any(s.lower() in run_result["artifact_html"].lower() for s in case["must_contain_any"])
         checks.append(
             {
                 "name": "required_correction_or_phrase_present",
@@ -216,7 +423,7 @@ def grade_case(case: dict[str, Any], run_result: dict[str, Any]) -> dict[str, An
         )
 
     if case.get("allowed_confidence"):
-        confidence = extract_field(text, "confidence") or ""
+        confidence = audit["confidence"] or ""
         allowed = [value.lower() for value in case["allowed_confidence"]]
         checks.append(
             {
@@ -259,17 +466,15 @@ def main() -> None:
                 "id": case["id"],
                 "name": case["name"],
                 "passed": grading["passed"],
+                "checks": grading["checks"],
                 "artifact_path": grading["artifact_path"],
                 "reply_draft_path": grading["reply_draft_path"],
             }
         )
 
     summary_path = iteration_dir / "summary.json"
-    summary_path.write_text(json.dumps(summary, indent=2))
-    failed = [item for item in summary if not item["passed"]]
-    print(json.dumps({"summary_path": str(summary_path), "failed": failed}, indent=2))
-    if failed:
-        raise SystemExit(1)
+    summary_path.write_text(json.dumps({"results": summary}, indent=2))
+    print(summary_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- upgrade the live Oliver investment email contract from the older rating/timing memo into a scan-first decision memo
- distinguish new-money vs existing-holder actions, dual-horizon views, expectations, triggers, opportunity cost, and inline evidence chips with source tiers
- hard-enforce the final artifact contract in `run_task`, update renderer-safe email styling, and strengthen final-artifact fixture grading

## What changed
- rewrote the runtime investment skill contract and prompt guidance
- replaced the old label-only reply validator with stronger final-artifact checks for action tracks, summary-first ordering, evidence chips, clickable links, and primary/independent/reference tiers
- updated the final email shell styling for decision cards, trigger blocks, and evidence chips
- updated fake agent outputs, integration tests, and final-artifact eval grading to the new contract

## Validation
- `cargo fmt --all`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p run_task_module --lib investment -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p run_task_module --test run_task_tests investment -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p send_emails_module normalize_email_html_preserves_investment_contract_labels -- --nocapture`
- `python3 -m py_compile DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py`
- `python3 -m json.tool DoWhiz_service/skills/us-equity-daily-monitor/evals/evals.json >/dev/null`
- `python3 DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py --iteration iteration-round4-fixture --eval-ids 1 2`

## Remaining gaps
- this pass does not add a live chart-generation pipeline; chart support remains optional and renderer-safe only
- a local live `investment_eval` attempt through the real runtime path was started, but it stayed in a long cold build on this machine and did not reach a model result during the session
