### PR TITLE
Free CI disk before Rust staging tests

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -103,14 +103,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ needs.prepare.outputs.deploy_sha }}
+
+      - name: Reclaim runner disk space before Rust restore
+        run: |
+          set -euo pipefail
+          echo "Disk usage before cleanup:"
+          df -h
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/local/.ghcup \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/dotnet \
+            /usr/share/swift
+          sudo apt-get clean
+          echo "Disk usage after cleanup:"
+          df -h
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             DoWhiz_service -> target
+
+      - name: Drop cached artifacts not needed for tests
+        run: |
+          set -euo pipefail
+          rm -rf target/debug/incremental target/release
+          echo "Disk usage after pruning Rust artifacts:"
+          df -h .
 
       - name: Run tests (scheduler_module)
         run: cargo test --locked -p scheduler_module
@@ -137,8 +160,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ needs.prepare.outputs.deploy_sha }}
+
+      - name: Reclaim runner disk space before Rust restore
+        run: |
+          set -euo pipefail
+          echo "Disk usage before cleanup:"
+          df -h
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/local/.ghcup \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/dotnet \
+            /usr/share/swift
+          sudo apt-get clean
+          echo "Disk usage after cleanup:"
+          df -h
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -103,14 +103,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ needs.prepare.outputs.deploy_sha }}
+
+      - name: Reclaim runner disk space before Rust restore
+        run: |
+          set -euo pipefail
+          echo "Disk usage before cleanup:"
+          df -h
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/local/.ghcup \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/dotnet \
+            /usr/share/swift
+          sudo apt-get clean
+          echo "Disk usage after cleanup:"
+          df -h
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             DoWhiz_service -> target
+
+      - name: Drop cached artifacts not needed for tests
+        run: |
+          set -euo pipefail
+          rm -rf target/debug/incremental target/release
+          echo "Disk usage after pruning Rust artifacts:"
+          df -h .
 
       - name: Run tests (scheduler_module)
         run: cargo test --locked -p scheduler_module
@@ -137,8 +160,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ needs.prepare.outputs.deploy_sha }}
+
+      - name: Reclaim runner disk space before Rust restore
+        run: |
+          set -euo pipefail
+          echo "Disk usage before cleanup:"
+          df -h
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/local/.ghcup \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/dotnet \
+            /usr/share/swift
+          sudo apt-get clean
+          echo "Disk usage after cleanup:"
+          df -h
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- reclaim disk space on GitHub-hosted runners before restoring Rust cache in staging and production workflows
- drop cached incremental/release artifacts before scheduler test runs
- reduce checkout depth in test/build jobs to avoid unnecessary repository history on CI

## Validation
- Ruby YAML parse for both workflow files
- git diff --check

## Notes
- this is a bounded CI-only fix for recent `No space left on device` failures in `CICD_staging` test jobs
- live staging validation still requires the workflow to run from `dev`