### PR TITLE
Add Oliver launch execution v1

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -2011,7 +2011,11 @@ fn read_latest_azcopy_log_tail(secrets: &[&str]) -> Option<String> {
     let log_dir = env::var("AZCOPY_LOG_LOCATION")
         .ok()
         .map(PathBuf::from)
-        .or_else(|| env::var("HOME").ok().map(|h| PathBuf::from(h).join(".azcopy")))?;
+        .or_else(|| {
+            env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".azcopy"))
+        })?;
 
     let mut latest: Option<(std::time::SystemTime, PathBuf)> = None;
     for entry in fs::read_dir(&log_dir).ok()? {
@@ -2021,10 +2025,7 @@ fn read_latest_azcopy_log_tail(secrets: &[&str]) -> Option<String> {
             continue;
         }
         let modified = entry.metadata().ok().and_then(|m| m.modified().ok())?;
-        if latest
-            .as_ref()
-            .is_none_or(|(ts, _)| modified > *ts)
-        {
+        if latest.as_ref().is_none_or(|(ts, _)| modified > *ts) {
             latest = Some((modified, path));
         }
     }
@@ -2052,7 +2053,11 @@ fn read_latest_azcopy_log_tail(secrets: &[&str]) -> Option<String> {
             .collect();
     }
     let header = format!("(from {}):\n", log_path.display());
-    Some(format!("{}{}", header, redact_sensitive_text(&trimmed, secrets)))
+    Some(format!(
+        "{}{}",
+        header,
+        redact_sensitive_text(&trimmed, secrets)
+    ))
 }
 
 fn promote_downloaded_entry(source: &Path, dest: &Path) -> Result<(), RunTaskError> {

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -2021,7 +2021,7 @@ fn read_latest_azcopy_log_tail(secrets: &[&str]) -> Option<String> {
     for entry in fs::read_dir(&log_dir).ok()? {
         let entry = entry.ok()?;
         let path = entry.path();
-        if !path.extension().is_some_and(|e| e == "log") {
+        if path.extension().is_none_or(|e| e != "log") {
             continue;
         }
         let modified = entry.metadata().ok().and_then(|m| m.modified().ok())?;

--- a/DoWhiz_service/scheduler_module/src/service.rs
+++ b/DoWhiz_service/scheduler_module/src/service.rs
@@ -10,6 +10,7 @@ pub mod grocery;
 mod html;
 mod inbound;
 mod ingestion;
+pub mod launch_execution;
 mod onboarding;
 mod postmark;
 mod recipients;

--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -27,8 +27,8 @@ use crate::scheduler::{
     append_task_execution_event, insert_scheduled_task, is_user_visible_routine_task,
     load_scheduled_task, persist_scheduled_task, prepare_task_for_resume,
     try_load_routines_with_status, try_load_task_executions, try_load_task_with_status,
-    try_load_tasks_with_status, try_load_tasks_with_status_shared, RoutineSummary, Schedule,
-    ScheduledTask, TaskExecutionSummary, TaskKind,
+    try_load_tasks_with_status_shared, RoutineSummary, Schedule, ScheduledTask,
+    TaskExecutionSummary, TaskKind,
 };
 use crate::slack_store::{SlackInstallation, SlackStore};
 use crate::thread_state::{
@@ -37,6 +37,7 @@ use crate::thread_state::{
 use crate::user_store::UserStore;
 use crate::{load_tasks_with_status, TaskStatusSummary};
 
+use super::launch_execution::{generate_launch_execution_response, LaunchExecutionRequest};
 use super::onboarding::{
     run_install_onboarding, AccountStoreInstallOnboardingStateStore,
     DiscordInstallOnboardingClient, InstallOnboardingConfig, InstallOnboardingRequest,
@@ -2535,6 +2536,33 @@ pub async fn startup_workspace_intake_chat(
         Err(error_message) => {
             let status = if error_message.contains("No conversation messages")
                 || error_message.contains("messages")
+            {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::BAD_GATEWAY
+            };
+
+            (
+                status,
+                Json(serde_json::json!({
+                    "error": error_message
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// POST /api/launch-execution/analyze
+/// Analyze one pasted launch thread into a narrow execution plan and readiness brief.
+pub async fn analyze_launch_execution(
+    Json(request): Json<LaunchExecutionRequest>,
+) -> impl IntoResponse {
+    match generate_launch_execution_response(request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error_message) => {
+            let status = if error_message.contains("context_text")
+                || error_message.contains("Unsupported source_type")
             {
                 StatusCode::BAD_REQUEST
             } else {
@@ -7161,6 +7189,10 @@ pub fn auth_router(state: AuthState) -> Router {
         .route(
             "/api/startup-workspace/intake-chat",
             post(startup_workspace_intake_chat),
+        )
+        .route(
+            "/api/launch-execution/analyze",
+            post(analyze_launch_execution),
         )
         .route(
             "/api/workspace/provider-state",

--- a/DoWhiz_service/scheduler_module/src/service/launch_execution.rs
+++ b/DoWhiz_service/scheduler_module/src/service/launch_execution.rs
@@ -1,0 +1,1718 @@
+use std::collections::{BTreeSet, HashSet};
+use std::env;
+use std::time::Duration;
+
+use chrono::Utc;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const DEFAULT_OPENAI_URL: &str = "https://api.openai.com/v1";
+const DEFAULT_MODEL: &str = "gpt-5.4";
+const LLM_TIMEOUT: Duration = Duration::from_secs(45);
+const DEFAULT_SOURCE_TYPE: &str = "pasted_thread";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchExecutionRequest {
+    #[serde(default)]
+    pub source_type: Option<String>,
+    #[serde(default)]
+    pub source_label: Option<String>,
+    pub context_text: String,
+    #[serde(default)]
+    pub update_text: Option<String>,
+    #[serde(default)]
+    pub prior_plan: Option<LaunchExecutionPlan>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchExecutionResponse {
+    pub launch_execution_plan: LaunchExecutionPlan,
+    #[serde(default)]
+    pub tracker_rows: Vec<LaunchTrackerRow>,
+    pub readiness_brief: LaunchReadinessBrief,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchExecutionPlan {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub objective: Option<String>,
+    #[serde(default)]
+    pub source_context: LaunchSourceContext,
+    #[serde(default)]
+    pub target_date: Option<String>,
+    #[serde(default)]
+    pub launch_window: Option<String>,
+    #[serde(default)]
+    pub milestones: Vec<LaunchMilestone>,
+    #[serde(default)]
+    pub owners: Vec<LaunchOwner>,
+    #[serde(default)]
+    pub dependencies: Vec<LaunchDependency>,
+    #[serde(default)]
+    pub critical_path: Vec<LaunchCriticalPathItem>,
+    #[serde(default)]
+    pub risks: Vec<LaunchRisk>,
+    #[serde(default)]
+    pub decisions: Vec<LaunchDecision>,
+    #[serde(default)]
+    pub readiness_status: String,
+    #[serde(default)]
+    pub readiness_reason: String,
+    #[serde(default)]
+    pub evidence: Vec<LaunchEvidence>,
+    #[serde(default)]
+    pub last_updated_at: String,
+    #[serde(default)]
+    pub follow_up_items: Vec<LaunchFollowUpItem>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchSourceContext {
+    #[serde(default)]
+    pub input_type: String,
+    #[serde(default)]
+    pub source_label: Option<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchMilestone {
+    pub title: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub target_date: Option<String>,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub notes: Option<String>,
+    #[serde(default)]
+    pub critical_path: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchOwner {
+    pub name: String,
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub responsibilities: Vec<String>,
+    #[serde(default)]
+    pub update_status: String,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchDependency {
+    pub title: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub target_date: Option<String>,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub notes: Option<String>,
+    #[serde(default)]
+    pub critical_path: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchCriticalPathItem {
+    pub title: String,
+    #[serde(default)]
+    pub item_type: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub target_date: Option<String>,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchRisk {
+    pub title: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub severity: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub blocker: bool,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchDecision {
+    pub title: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub due_date: Option<String>,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub launch_blocking: bool,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchEvidence {
+    pub label: String,
+    pub snippet: String,
+    #[serde(default)]
+    pub source_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchFollowUpItem {
+    pub kind: String,
+    pub target: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub priority: String,
+    pub reason: String,
+    pub suggested_message: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchTrackerRow {
+    pub category: String,
+    pub title: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub target_date: Option<String>,
+    pub status: String,
+    #[serde(default)]
+    pub risk_level: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchReadinessBrief {
+    #[serde(default)]
+    pub overall_readiness: String,
+    #[serde(default)]
+    pub critical_blockers: Vec<String>,
+    #[serde(default)]
+    pub at_risk_dependencies: Vec<String>,
+    #[serde(default)]
+    pub open_decisions: Vec<String>,
+    #[serde(default)]
+    pub missing_owner_updates: Vec<String>,
+    #[serde(default)]
+    pub what_changed_since_last_update: Vec<String>,
+    #[serde(default)]
+    pub evidence_summary: Vec<String>,
+    #[serde(default)]
+    pub next_follow_up_focus: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LlmLaunchExecutionOutput {
+    #[serde(default, alias = "plan")]
+    launch_execution_plan: LaunchExecutionPlan,
+    #[serde(default, alias = "brief")]
+    readiness_brief: LaunchReadinessBrief,
+}
+
+#[derive(Debug, Clone)]
+struct LaunchExecutionLlmConfig {
+    api_key: String,
+    api_url: String,
+    model: String,
+    use_azure_auth: bool,
+}
+
+impl LaunchExecutionLlmConfig {
+    fn from_env() -> Result<Self, String> {
+        let azure_api_key = env::var("AZURE_OPENAI_API_KEY_BACKUP")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let azure_endpoint = env::var("AZURE_OPENAI_ENDPOINT_BACKUP")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        if let (Some(api_key), Some(endpoint)) = (azure_api_key, azure_endpoint) {
+            let model = env::var("LAUNCH_EXECUTION_MODEL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+            return Ok(Self {
+                api_key,
+                api_url: normalize_azure_endpoint(&endpoint),
+                model,
+                use_azure_auth: true,
+            });
+        }
+
+        let api_key = env::var("OPENAI_API_KEY")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                "Launch execution LLM is not configured (set AZURE_OPENAI_API_KEY_BACKUP + AZURE_OPENAI_ENDPOINT_BACKUP, or OPENAI_API_KEY).".to_string()
+            })?;
+
+        let api_url = env::var("OPENAI_API_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_OPENAI_URL.to_string());
+        let model = env::var("LAUNCH_EXECUTION_MODEL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+        Ok(Self {
+            api_key,
+            api_url: api_url.trim_end_matches('/').to_string(),
+            model,
+            use_azure_auth: false,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ChatRequestBody {
+    model: String,
+    messages: Vec<ChatMessage>,
+    max_completion_tokens: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ChatResponseBody {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+
+pub async fn generate_launch_execution_response(
+    request: LaunchExecutionRequest,
+) -> Result<LaunchExecutionResponse, String> {
+    let source_type = normalize_source_type(request.source_type)?;
+    let context_text = request.context_text.trim().to_string();
+    if context_text.is_empty() {
+        return Err(
+            "context_text must contain a pasted launch thread or planning bundle".to_string(),
+        );
+    }
+
+    let config = LaunchExecutionLlmConfig::from_env()?;
+    let system_prompt = launch_execution_system_prompt();
+    let user_prompt = launch_execution_user_prompt(
+        &source_type,
+        request.source_label.as_deref(),
+        &context_text,
+        request.update_text.as_deref(),
+        request.prior_plan.as_ref(),
+    )?;
+    let raw = call_chat_completion(&config, &system_prompt, &user_prompt).await?;
+    let parsed = parse_llm_output(&raw)?;
+
+    let mut plan = normalize_launch_execution_plan(
+        parsed.launch_execution_plan,
+        &source_type,
+        request.source_label,
+        request.prior_plan.as_ref(),
+    );
+    plan.follow_up_items = derive_follow_up_items(&plan);
+    let (readiness_status, readiness_reason) = derive_readiness_status(&plan);
+    plan.readiness_status = readiness_status;
+    plan.readiness_reason = readiness_reason;
+
+    let tracker_rows = build_tracker_rows(&plan);
+    let change_summary = derive_change_summary(request.prior_plan.as_ref(), &plan);
+    let readiness_brief = build_readiness_brief(parsed.readiness_brief, &plan, change_summary);
+
+    Ok(LaunchExecutionResponse {
+        launch_execution_plan: plan,
+        tracker_rows,
+        readiness_brief,
+    })
+}
+
+fn normalize_source_type(value: Option<String>) -> Result<String, String> {
+    let trimmed = value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_SOURCE_TYPE)
+        .to_ascii_lowercase();
+
+    if trimmed == "pasted_thread"
+        || trimmed == "thread"
+        || trimmed == "message_bundle"
+        || trimmed.contains("paste")
+    {
+        return Ok(DEFAULT_SOURCE_TYPE.to_string());
+    }
+
+    Err(format!(
+        "Unsupported source_type '{}'. Oliver launch execution v1 currently supports pasted_thread only.",
+        trimmed
+    ))
+}
+
+fn launch_execution_system_prompt() -> String {
+    r#"You are Oliver's launch execution analyst.
+
+Your only job is to turn one launch-related thread or planning bundle into a narrow launch execution record.
+
+Scope rules:
+- Focus only on launch execution.
+- Do not generalize into a broad TPM system, generic project management, or broad automation advice.
+- Never invent owners, dates, milestones, or status.
+- If information is missing, leave the field null/empty and surface it through missing owner updates, decisions, risks, or other grounded fields.
+- Preserve uncertainty. If a date is only a window, use launch_window instead of target_date.
+- Evidence matters: every readiness judgment must be grounded in snippets from the provided context.
+
+Output requirements:
+- Return ONLY valid JSON.
+- No markdown, no code fences, no commentary outside the JSON object.
+- JSON shape:
+{
+  "launch_execution_plan": {
+    "id": "string",
+    "title": "string",
+    "objective": "string|null",
+    "source_context": {
+      "input_type": "pasted_thread",
+      "source_label": "string|null",
+      "summary": "string|null"
+    },
+    "target_date": "string|null",
+    "launch_window": "string|null",
+    "milestones": [
+      {
+        "title": "string",
+        "owner": "string|null",
+        "target_date": "string|null",
+        "status": "not_started|in_progress|at_risk|blocked|done|unknown",
+        "notes": "string|null",
+        "critical_path": true
+      }
+    ],
+    "owners": [
+      {
+        "name": "string",
+        "role": "string|null",
+        "responsibilities": ["string"],
+        "update_status": "current|stale|missing|unknown",
+        "notes": "string|null"
+      }
+    ],
+    "dependencies": [
+      {
+        "title": "string",
+        "owner": "string|null",
+        "target_date": "string|null",
+        "status": "ready|at_risk|blocked|done|unknown",
+        "notes": "string|null",
+        "critical_path": false
+      }
+    ],
+    "critical_path": [
+      {
+        "title": "string",
+        "item_type": "milestone|dependency|decision|risk",
+        "owner": "string|null",
+        "target_date": "string|null",
+        "status": "string",
+        "reason": "string|null"
+      }
+    ],
+    "risks": [
+      {
+        "title": "string",
+        "owner": "string|null",
+        "severity": "low|medium|high|critical",
+        "status": "open|watching|mitigated|resolved|unknown",
+        "blocker": true,
+        "notes": "string|null"
+      }
+    ],
+    "decisions": [
+      {
+        "title": "string",
+        "owner": "string|null",
+        "due_date": "string|null",
+        "status": "open|resolved|blocked|unknown",
+        "launch_blocking": true,
+        "notes": "string|null"
+      }
+    ],
+    "evidence": [
+      {
+        "label": "string",
+        "snippet": "string",
+        "source_ref": "primary_context|latest_update"
+      }
+    ]
+  },
+  "readiness_brief": {
+    "overall_readiness": "string",
+    "critical_blockers": ["string"],
+    "at_risk_dependencies": ["string"],
+    "open_decisions": ["string"],
+    "missing_owner_updates": ["string"],
+    "what_changed_since_last_update": ["string"],
+    "evidence_summary": ["string"],
+    "next_follow_up_focus": "string|null"
+  }
+}
+
+Interpretation rules:
+- Milestones are concrete launch checkpoints.
+- Dependencies are cross-functional or external gating items.
+- Critical path should contain only the few items most likely to move the launch date.
+- Risks should be explicit blockers or launch risks, not generic concerns.
+- Decisions should be unanswered choices or approvals.
+- Owners.update_status should be "missing" when no useful owner update is present, "stale" when the thread implies waiting/lagging/no recent update, "current" when there is a recent grounded update, otherwise "unknown".
+- Evidence snippets should be short, specific, and directly grounded in the provided text.
+"#
+    .to_string()
+}
+
+fn launch_execution_user_prompt(
+    source_type: &str,
+    source_label: Option<&str>,
+    context_text: &str,
+    update_text: Option<&str>,
+    prior_plan: Option<&LaunchExecutionPlan>,
+) -> Result<String, String> {
+    let prior_plan_json = serde_json::to_string_pretty(&prior_plan.cloned().unwrap_or_default())
+        .map_err(|err| format!("failed to serialize prior launch plan: {}", err))?;
+
+    let source_label = source_label
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("Untitled launch thread");
+
+    let latest_update = update_text
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("None");
+
+    Ok(format!(
+        "Current UTC timestamp: {timestamp}
+Supported source type for this request: {source_type}
+Source label: {source_label}
+
+Previous launch execution plan (may be empty on first run):
+{prior_plan_json}
+
+Primary launch context:
+{context_text}
+
+Latest incremental update:
+{latest_update}
+
+Instructions:
+1. Extract the narrowest believable launch execution record from the provided context.
+2. If a prior plan is provided, refresh it using the latest context and preserve stable titles when the same item still exists.
+3. Treat missing owners, missing dates, stale updates, unresolved blockers, and unresolved decisions as first-class output signals.
+4. Keep evidence visible and specific.",
+        timestamp = Utc::now().to_rfc3339(),
+        source_type = source_type,
+        source_label = source_label,
+        prior_plan_json = prior_plan_json,
+        context_text = context_text,
+        latest_update = latest_update
+    ))
+}
+
+async fn call_chat_completion(
+    config: &LaunchExecutionLlmConfig,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Result<String, String> {
+    let client = Client::builder()
+        .timeout(LLM_TIMEOUT)
+        .build()
+        .map_err(|err| format!("failed to build HTTP client: {}", err))?;
+
+    let url = format!("{}/chat/completions", config.api_url.trim_end_matches('/'));
+    let payload = ChatRequestBody {
+        model: config.model.clone(),
+        messages: vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: system_prompt.to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: user_prompt.to_string(),
+            },
+        ],
+        max_completion_tokens: 2600,
+    };
+
+    let mut request_builder = client.post(url).header("Content-Type", "application/json");
+
+    if config.use_azure_auth {
+        request_builder = request_builder.header("api-key", &config.api_key);
+    } else {
+        request_builder =
+            request_builder.header("Authorization", format!("Bearer {}", config.api_key));
+    }
+
+    let response = request_builder
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|err| format!("launch execution LLM request failed: {}", err))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "launch execution LLM returned {}: {}",
+            status, body
+        ));
+    }
+
+    let parsed: ChatResponseBody = response
+        .json()
+        .await
+        .map_err(|err| format!("failed to parse launch execution LLM response: {}", err))?;
+
+    let content = parsed
+        .choices
+        .first()
+        .map(|choice| choice.message.content.clone())
+        .unwrap_or_default();
+
+    if content.trim().is_empty() {
+        return Err("launch execution LLM returned an empty response".to_string());
+    }
+
+    Ok(content)
+}
+
+fn parse_llm_output(raw: &str) -> Result<LlmLaunchExecutionOutput, String> {
+    if let Ok(parsed) = serde_json::from_str::<LlmLaunchExecutionOutput>(raw) {
+        return Ok(parsed);
+    }
+
+    if let Some(extracted) = extract_json_object(raw) {
+        if let Ok(parsed) = serde_json::from_str::<LlmLaunchExecutionOutput>(&extracted) {
+            return Ok(parsed);
+        }
+    }
+
+    Err(format!(
+        "launch execution LLM response was not valid JSON. raw={}",
+        raw
+    ))
+}
+
+fn extract_json_object(input: &str) -> Option<String> {
+    let mut start_index = None;
+    let mut brace_depth: i32 = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (index, ch) in input.char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            continue;
+        }
+
+        if ch == '{' {
+            if start_index.is_none() {
+                start_index = Some(index);
+            }
+            brace_depth += 1;
+            continue;
+        }
+
+        if ch == '}' && brace_depth > 0 {
+            brace_depth -= 1;
+            if brace_depth == 0 {
+                if let Some(start) = start_index {
+                    return Some(input[start..=index].to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn normalize_launch_execution_plan(
+    mut plan: LaunchExecutionPlan,
+    source_type: &str,
+    source_label: Option<String>,
+    prior_plan: Option<&LaunchExecutionPlan>,
+) -> LaunchExecutionPlan {
+    plan.id = normalize_optional_string(Some(plan.id))
+        .or_else(|| prior_plan.map(|item| item.id.clone()))
+        .unwrap_or_else(|| format!("launch_{}", Uuid::new_v4()));
+    plan.title = normalize_optional_string(Some(plan.title))
+        .or_else(|| source_label.clone())
+        .or_else(|| prior_plan.map(|item| item.title.clone()))
+        .unwrap_or_else(|| "Launch execution plan".to_string());
+    plan.objective = normalize_optional_string(plan.objective);
+
+    plan.source_context.input_type = source_type.to_string();
+    plan.source_context.source_label = normalize_optional_string(plan.source_context.source_label)
+        .or(source_label)
+        .or_else(|| prior_plan.and_then(|item| item.source_context.source_label.clone()));
+    plan.source_context.summary = normalize_optional_string(plan.source_context.summary)
+        .or_else(|| prior_plan.and_then(|item| item.source_context.summary.clone()));
+
+    plan.target_date = normalize_optional_string(plan.target_date);
+    plan.launch_window = normalize_optional_string(plan.launch_window);
+    plan.milestones = normalize_milestones(plan.milestones);
+    let owners = std::mem::take(&mut plan.owners);
+    plan.owners = normalize_owners(owners, &plan);
+    plan.dependencies = normalize_dependencies(plan.dependencies);
+    let critical_path = std::mem::take(&mut plan.critical_path);
+    plan.critical_path = normalize_critical_path(critical_path, &plan);
+    plan.risks = normalize_risks(plan.risks);
+    plan.decisions = normalize_decisions(plan.decisions);
+    plan.evidence = normalize_evidence(plan.evidence);
+    plan.last_updated_at = normalize_optional_string(Some(plan.last_updated_at))
+        .unwrap_or_else(|| Utc::now().to_rfc3339());
+    plan.follow_up_items = Vec::new();
+    plan.readiness_status = String::new();
+    plan.readiness_reason = String::new();
+
+    plan
+}
+
+fn normalize_milestones(values: Vec<LaunchMilestone>) -> Vec<LaunchMilestone> {
+    dedupe_by_key(
+        values.into_iter().filter_map(|mut item| {
+            item.title = normalize_required_string(item.title)?;
+            item.owner = normalize_optional_string(item.owner);
+            item.target_date = normalize_optional_string(item.target_date);
+            item.status = normalize_milestone_status(item.status);
+            item.notes = normalize_optional_string(item.notes);
+            Some(item)
+        }),
+        |item| item.title.to_ascii_lowercase(),
+    )
+}
+
+fn normalize_owners(values: Vec<LaunchOwner>, plan: &LaunchExecutionPlan) -> Vec<LaunchOwner> {
+    let mut owners = dedupe_by_key(
+        values.into_iter().filter_map(|mut item| {
+            item.name = normalize_required_string(item.name)?;
+            item.role = normalize_optional_string(item.role);
+            item.responsibilities = normalize_string_list(item.responsibilities);
+            item.update_status = normalize_owner_update_status(item.update_status);
+            item.notes = normalize_optional_string(item.notes);
+            Some(item)
+        }),
+        |item| item.name.to_ascii_lowercase(),
+    );
+
+    let mut known = owners
+        .iter()
+        .map(|item| item.name.to_ascii_lowercase())
+        .collect::<HashSet<_>>();
+
+    for name in collect_owner_names(plan) {
+        let key = name.to_ascii_lowercase();
+        if known.insert(key) {
+            owners.push(LaunchOwner {
+                name,
+                update_status: "unknown".to_string(),
+                ..LaunchOwner::default()
+            });
+        }
+    }
+
+    owners
+}
+
+fn normalize_dependencies(values: Vec<LaunchDependency>) -> Vec<LaunchDependency> {
+    dedupe_by_key(
+        values.into_iter().filter_map(|mut item| {
+            item.title = normalize_required_string(item.title)?;
+            item.owner = normalize_optional_string(item.owner);
+            item.target_date = normalize_optional_string(item.target_date);
+            item.status = normalize_dependency_status(item.status);
+            item.notes = normalize_optional_string(item.notes);
+            Some(item)
+        }),
+        |item| item.title.to_ascii_lowercase(),
+    )
+}
+
+fn normalize_critical_path(
+    mut values: Vec<LaunchCriticalPathItem>,
+    plan: &LaunchExecutionPlan,
+) -> Vec<LaunchCriticalPathItem> {
+    values = dedupe_by_key(
+        values.into_iter().filter_map(|mut item| {
+            item.title = normalize_required_string(item.title)?;
+            item.item_type = normalize_critical_path_item_type(item.item_type);
+            item.owner = normalize_optional_string(item.owner);
+            item.target_date = normalize_optional_string(item.target_date);
+            item.status = normalize_optional_string(Some(item.status))
+                .unwrap_or_else(|| "unknown".to_string());
+            item.reason = normalize_optional_string(item.reason);
+            Some(item)
+        }),
+        |item| format!("{}:{}", item.item_type, item.title.to_ascii_lowercase()),
+    );
+
+    if !values.is_empty() {
+        return values;
+    }
+
+    let milestone_items = plan
+        .milestones
+        .iter()
+        .filter(|item| item.critical_path)
+        .map(|item| LaunchCriticalPathItem {
+            title: item.title.clone(),
+            item_type: "milestone".to_string(),
+            owner: item.owner.clone(),
+            target_date: item.target_date.clone(),
+            status: item.status.clone(),
+            reason: item.notes.clone(),
+        });
+    let dependency_items = plan
+        .dependencies
+        .iter()
+        .filter(|item| item.critical_path)
+        .map(|item| LaunchCriticalPathItem {
+            title: item.title.clone(),
+            item_type: "dependency".to_string(),
+            owner: item.owner.clone(),
+            target_date: item.target_date.clone(),
+            status: item.status.clone(),
+            reason: item.notes.clone(),
+        });
+
+    dedupe_by_key(milestone_items.chain(dependency_items), |item| {
+        format!("{}:{}", item.item_type, item.title.to_ascii_lowercase())
+    })
+}
+
+fn normalize_risks(values: Vec<LaunchRisk>) -> Vec<LaunchRisk> {
+    dedupe_by_key(
+        values.into_iter().filter_map(|mut item| {
+            item.title = normalize_required_string(item.title)?;
+            item.owner = normalize_optional_string(item.owner);
+            item.severity = normalize_risk_severity(item.severity);
+            item.status = normalize_risk_status(item.status);
+            item.notes = normalize_optional_string(item.notes);
+            Some(item)
+        }),
+        |item| item.title.to_ascii_lowercase(),
+    )
+}
+
+fn normalize_decisions(values: Vec<LaunchDecision>) -> Vec<LaunchDecision> {
+    dedupe_by_key(
+        values.into_iter().filter_map(|mut item| {
+            item.title = normalize_required_string(item.title)?;
+            item.owner = normalize_optional_string(item.owner);
+            item.due_date = normalize_optional_string(item.due_date);
+            item.status = normalize_decision_status(item.status);
+            item.notes = normalize_optional_string(item.notes);
+            Some(item)
+        }),
+        |item| item.title.to_ascii_lowercase(),
+    )
+}
+
+fn normalize_evidence(values: Vec<LaunchEvidence>) -> Vec<LaunchEvidence> {
+    let mut output = dedupe_by_key(
+        values.into_iter().filter_map(|mut item| {
+            item.label = normalize_required_string(item.label)?;
+            item.snippet = normalize_required_string(item.snippet)?;
+            item.source_ref = normalize_optional_string(item.source_ref);
+            Some(item)
+        }),
+        |item| {
+            format!(
+                "{}:{}",
+                item.label.to_ascii_lowercase(),
+                item.snippet.to_ascii_lowercase()
+            )
+        },
+    );
+
+    if output.len() > 8 {
+        output.truncate(8);
+    }
+    output
+}
+
+fn derive_follow_up_items(plan: &LaunchExecutionPlan) -> Vec<LaunchFollowUpItem> {
+    let mut items = Vec::new();
+    let mut seen = HashSet::new();
+
+    for owner in &plan.owners {
+        if owner.update_status == "missing" || owner.update_status == "stale" {
+            let kind = if owner.update_status == "missing" {
+                "missing_owner"
+            } else {
+                "stale_update"
+            };
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                LaunchFollowUpItem {
+                    kind: kind.to_string(),
+                    target: owner.name.clone(),
+                    owner: Some(owner.name.clone()),
+                    priority: "medium".to_string(),
+                    reason: owner.notes.clone().unwrap_or_else(|| {
+                        if owner.update_status == "missing" {
+                            "Owner is referenced in the launch but no concrete update is available.".to_string()
+                        } else {
+                            "Owner update appears stale relative to the launch thread.".to_string()
+                        }
+                    }),
+                    suggested_message: format!(
+                        "Can you send a launch status update for your area, including current risk, next step, and expected date?"
+                    ),
+                },
+            );
+        }
+    }
+
+    for item in &plan.milestones {
+        if item.status != "done" && item.owner.is_none() {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                build_missing_owner_follow_up(
+                    "milestone",
+                    &item.title,
+                    item.critical_path,
+                    item.notes.as_deref(),
+                ),
+            );
+        }
+        if item.status != "done" && item.target_date.is_none() {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                build_missing_date_follow_up(
+                    "milestone",
+                    &item.title,
+                    item.owner.as_deref(),
+                    item.critical_path,
+                ),
+            );
+        }
+    }
+
+    for item in &plan.dependencies {
+        if item.status != "done" && item.owner.is_none() {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                build_missing_owner_follow_up(
+                    "dependency",
+                    &item.title,
+                    item.critical_path,
+                    item.notes.as_deref(),
+                ),
+            );
+        }
+        if item.status != "done" && item.target_date.is_none() {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                build_missing_date_follow_up(
+                    "dependency",
+                    &item.title,
+                    item.owner.as_deref(),
+                    item.critical_path,
+                ),
+            );
+        }
+        if item.status == "blocked" {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                LaunchFollowUpItem {
+                    kind: "unresolved_blocker".to_string(),
+                    target: item.title.clone(),
+                    owner: item.owner.clone(),
+                    priority: if item.critical_path { "high" } else { "medium" }.to_string(),
+                    reason: item
+                        .notes
+                        .clone()
+                        .unwrap_or_else(|| "Dependency is currently blocked.".to_string()),
+                    suggested_message: format!(
+                        "What is blocking \"{}\", who owns the unblock, and what is the earliest credible resolution date?",
+                        item.title
+                    ),
+                },
+            );
+        }
+    }
+
+    for item in &plan.risks {
+        if item.blocker && !matches!(item.status.as_str(), "resolved" | "mitigated") {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                LaunchFollowUpItem {
+                    kind: "unresolved_blocker".to_string(),
+                    target: item.title.clone(),
+                    owner: item.owner.clone(),
+                    priority: if matches!(item.severity.as_str(), "high" | "critical") {
+                        "high"
+                    } else {
+                        "medium"
+                    }
+                    .to_string(),
+                    reason: item
+                        .notes
+                        .clone()
+                        .unwrap_or_else(|| "Launch blocker is still unresolved.".to_string()),
+                    suggested_message: format!(
+                        "What is the unblock plan for \"{}\", and what needs to happen next to clear it?",
+                        item.title
+                    ),
+                },
+            );
+        }
+    }
+
+    for item in &plan.decisions {
+        if item.status != "resolved" {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                LaunchFollowUpItem {
+                    kind: "unresolved_decision".to_string(),
+                    target: item.title.clone(),
+                    owner: item.owner.clone(),
+                    priority: if item.launch_blocking { "high" } else { "medium" }.to_string(),
+                    reason: item
+                        .notes
+                        .clone()
+                        .unwrap_or_else(|| "Launch decision is still unresolved.".to_string()),
+                    suggested_message: format!(
+                        "Who will decide \"{}\", and by when can the launch team expect a clear answer?",
+                        item.title
+                    ),
+                },
+            );
+        }
+        if item.status != "resolved" && item.due_date.is_none() {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                build_missing_date_follow_up(
+                    "decision",
+                    &item.title,
+                    item.owner.as_deref(),
+                    item.launch_blocking,
+                ),
+            );
+        }
+        if item.status != "resolved" && item.owner.is_none() {
+            push_follow_up(
+                &mut items,
+                &mut seen,
+                build_missing_owner_follow_up(
+                    "decision",
+                    &item.title,
+                    item.launch_blocking,
+                    item.notes.as_deref(),
+                ),
+            );
+        }
+    }
+
+    items
+}
+
+fn build_missing_owner_follow_up(
+    category: &str,
+    title: &str,
+    high_priority: bool,
+    notes: Option<&str>,
+) -> LaunchFollowUpItem {
+    LaunchFollowUpItem {
+        kind: "missing_owner".to_string(),
+        target: format!("{}: {}", category, title),
+        owner: None,
+        priority: if high_priority { "high" } else { "medium" }.to_string(),
+        reason: notes.map(str::to_string).unwrap_or_else(|| {
+            format!(
+                "{} is present in the launch plan but has no clear owner.",
+                title
+            )
+        }),
+        suggested_message: format!(
+            "Who owns \"{}\" for launch, and who should Oliver follow up with next?",
+            title
+        ),
+    }
+}
+
+fn build_missing_date_follow_up(
+    category: &str,
+    title: &str,
+    owner: Option<&str>,
+    high_priority: bool,
+) -> LaunchFollowUpItem {
+    let owner_phrase = owner.unwrap_or("the owner");
+    LaunchFollowUpItem {
+        kind: "missing_date".to_string(),
+        target: format!("{}: {}", category, title),
+        owner: owner.map(|value| value.to_string()),
+        priority: if high_priority { "high" } else { "medium" }.to_string(),
+        reason: format!("{} does not have a committed date or launch window.", title),
+        suggested_message: format!(
+            "Can {} commit a date or launch window for \"{}\" so the launch plan has a credible timeline?",
+            owner_phrase, title
+        ),
+    }
+}
+
+fn push_follow_up(
+    items: &mut Vec<LaunchFollowUpItem>,
+    seen: &mut HashSet<String>,
+    item: LaunchFollowUpItem,
+) {
+    let key = format!("{}:{}", item.kind, item.target.to_ascii_lowercase());
+    if seen.insert(key) {
+        items.push(item);
+    }
+}
+
+fn derive_readiness_status(plan: &LaunchExecutionPlan) -> (String, String) {
+    if plan.evidence.is_empty() {
+        return (
+            "red".to_string(),
+            "No credible readiness evidence was extracted from the source context.".to_string(),
+        );
+    }
+
+    if let Some(risk) = plan.risks.iter().find(|item| {
+        item.blocker
+            && matches!(item.severity.as_str(), "high" | "critical")
+            && !matches!(item.status.as_str(), "resolved" | "mitigated")
+    }) {
+        return (
+            "red".to_string(),
+            format!("Critical blocker still open: {}.", risk.title),
+        );
+    }
+
+    if let Some(decision) = plan
+        .decisions
+        .iter()
+        .find(|item| item.launch_blocking && item.status != "resolved")
+    {
+        return (
+            "red".to_string(),
+            format!(
+                "Launch-blocking decision still unresolved: {}.",
+                decision.title
+            ),
+        );
+    }
+
+    if let Some(item) = plan.critical_path.iter().find(|item| {
+        item.owner
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+    }) {
+        return (
+            "red".to_string(),
+            format!("Critical path item lacks a clear owner: {}.", item.title),
+        );
+    }
+
+    let has_yellow_signals = plan.follow_up_items.iter().any(|item| {
+        matches!(
+            item.kind.as_str(),
+            "missing_date"
+                | "missing_owner"
+                | "stale_update"
+                | "unresolved_blocker"
+                | "unresolved_decision"
+        )
+    }) || plan
+        .dependencies
+        .iter()
+        .any(|item| matches!(item.status.as_str(), "at_risk" | "blocked"))
+        || plan
+            .risks
+            .iter()
+            .any(|item| matches!(item.status.as_str(), "open" | "watching"))
+        || plan.target_date.is_none() && plan.launch_window.is_none();
+
+    if has_yellow_signals {
+        return (
+            "yellow".to_string(),
+            "Launch has meaningful open follow-ups, at-risk dependencies, or timeline gaps."
+                .to_string(),
+        );
+    }
+
+    (
+        "green".to_string(),
+        "Critical blockers are cleared, owners are assigned, dates are present, and evidence supports readiness.".to_string(),
+    )
+}
+
+fn build_tracker_rows(plan: &LaunchExecutionPlan) -> Vec<LaunchTrackerRow> {
+    let milestones = plan.milestones.iter().map(|item| LaunchTrackerRow {
+        category: "milestone".to_string(),
+        title: item.title.clone(),
+        owner: item.owner.clone(),
+        target_date: item.target_date.clone(),
+        status: item.status.clone(),
+        risk_level: Some(if item.critical_path {
+            "critical_path".to_string()
+        } else {
+            "normal".to_string()
+        }),
+    });
+
+    let dependencies = plan.dependencies.iter().map(|item| LaunchTrackerRow {
+        category: "dependency".to_string(),
+        title: item.title.clone(),
+        owner: item.owner.clone(),
+        target_date: item.target_date.clone(),
+        status: item.status.clone(),
+        risk_level: Some(if item.critical_path || item.status == "blocked" {
+            "high".to_string()
+        } else if item.status == "at_risk" {
+            "medium".to_string()
+        } else {
+            "normal".to_string()
+        }),
+    });
+
+    let decisions = plan.decisions.iter().map(|item| LaunchTrackerRow {
+        category: "decision".to_string(),
+        title: item.title.clone(),
+        owner: item.owner.clone(),
+        target_date: item.due_date.clone(),
+        status: item.status.clone(),
+        risk_level: Some(if item.launch_blocking {
+            "high".to_string()
+        } else {
+            "medium".to_string()
+        }),
+    });
+
+    let risks = plan.risks.iter().map(|item| LaunchTrackerRow {
+        category: "risk".to_string(),
+        title: item.title.clone(),
+        owner: item.owner.clone(),
+        target_date: None,
+        status: item.status.clone(),
+        risk_level: Some(item.severity.clone()),
+    });
+
+    milestones
+        .chain(dependencies)
+        .chain(decisions)
+        .chain(risks)
+        .collect()
+}
+
+fn derive_change_summary(
+    prior_plan: Option<&LaunchExecutionPlan>,
+    current_plan: &LaunchExecutionPlan,
+) -> Vec<String> {
+    let Some(prior_plan) = prior_plan else {
+        return vec!["Initial launch execution brief created from the pasted thread.".to_string()];
+    };
+
+    let mut changes = Vec::new();
+
+    if prior_plan.readiness_status != current_plan.readiness_status
+        && !prior_plan.readiness_status.is_empty()
+        && !current_plan.readiness_status.is_empty()
+    {
+        changes.push(format!(
+            "Readiness changed from {} to {}.",
+            prior_plan.readiness_status, current_plan.readiness_status
+        ));
+    }
+
+    let prior_open_blockers = blocker_titles(prior_plan);
+    let current_open_blockers = blocker_titles(current_plan);
+    for added in current_open_blockers
+        .difference(&prior_open_blockers)
+        .take(3)
+    {
+        changes.push(format!("New blocker surfaced: {}.", added));
+    }
+    for resolved in prior_open_blockers
+        .difference(&current_open_blockers)
+        .take(3)
+    {
+        changes.push(format!("Blocker cleared or downgraded: {}.", resolved));
+    }
+
+    let prior_open_decisions = open_decision_titles(prior_plan);
+    let current_open_decisions = open_decision_titles(current_plan);
+    for added in current_open_decisions
+        .difference(&prior_open_decisions)
+        .take(3)
+    {
+        changes.push(format!("New open decision: {}.", added));
+    }
+    for resolved in prior_open_decisions
+        .difference(&current_open_decisions)
+        .take(3)
+    {
+        changes.push(format!("Decision resolved: {}.", resolved));
+    }
+
+    let prior_milestones = milestone_status_map(prior_plan);
+    let current_milestones = milestone_status_map(current_plan);
+    for (title, status) in &current_milestones {
+        if let Some(previous_status) = prior_milestones.get(title) {
+            if previous_status != status {
+                changes.push(format!(
+                    "Milestone status changed for {}: {} -> {}.",
+                    title, previous_status, status
+                ));
+            }
+        }
+    }
+
+    if changes.is_empty() {
+        changes.push("No material change was detected from the latest update.".to_string());
+    }
+
+    if changes.len() > 6 {
+        changes.truncate(6);
+    }
+
+    changes
+}
+
+fn blocker_titles(plan: &LaunchExecutionPlan) -> BTreeSet<String> {
+    let risk_titles = plan.risks.iter().filter_map(|item| {
+        if item.blocker && !matches!(item.status.as_str(), "resolved" | "mitigated") {
+            Some(item.title.clone())
+        } else {
+            None
+        }
+    });
+    let dependency_titles = plan.dependencies.iter().filter_map(|item| {
+        if item.status == "blocked" {
+            Some(item.title.clone())
+        } else {
+            None
+        }
+    });
+
+    risk_titles.chain(dependency_titles).collect()
+}
+
+fn open_decision_titles(plan: &LaunchExecutionPlan) -> BTreeSet<String> {
+    plan.decisions
+        .iter()
+        .filter(|item| item.status != "resolved")
+        .map(|item| item.title.clone())
+        .collect()
+}
+
+fn milestone_status_map(plan: &LaunchExecutionPlan) -> std::collections::BTreeMap<String, String> {
+    plan.milestones
+        .iter()
+        .map(|item| (item.title.clone(), item.status.clone()))
+        .collect()
+}
+
+fn build_readiness_brief(
+    mut brief: LaunchReadinessBrief,
+    plan: &LaunchExecutionPlan,
+    change_summary: Vec<String>,
+) -> LaunchReadinessBrief {
+    brief.overall_readiness = normalize_optional_string(Some(brief.overall_readiness))
+        .unwrap_or_else(|| {
+            format!(
+                "{} readiness. {}",
+                title_case(&plan.readiness_status),
+                plan.readiness_reason
+            )
+        });
+
+    if brief.critical_blockers.is_empty() {
+        brief.critical_blockers = blocker_titles(plan).into_iter().collect();
+    } else {
+        brief.critical_blockers = normalize_string_list(brief.critical_blockers);
+    }
+
+    if brief.at_risk_dependencies.is_empty() {
+        brief.at_risk_dependencies = plan
+            .dependencies
+            .iter()
+            .filter(|item| matches!(item.status.as_str(), "at_risk" | "blocked"))
+            .map(|item| item.title.clone())
+            .collect();
+    } else {
+        brief.at_risk_dependencies = normalize_string_list(brief.at_risk_dependencies);
+    }
+
+    if brief.open_decisions.is_empty() {
+        brief.open_decisions = plan
+            .decisions
+            .iter()
+            .filter(|item| item.status != "resolved")
+            .map(|item| item.title.clone())
+            .collect();
+    } else {
+        brief.open_decisions = normalize_string_list(brief.open_decisions);
+    }
+
+    if brief.missing_owner_updates.is_empty() {
+        brief.missing_owner_updates = plan
+            .owners
+            .iter()
+            .filter(|item| matches!(item.update_status.as_str(), "missing" | "stale"))
+            .map(|item| item.name.clone())
+            .collect();
+    } else {
+        brief.missing_owner_updates = normalize_string_list(brief.missing_owner_updates);
+    }
+
+    brief.what_changed_since_last_update = change_summary;
+
+    if brief.evidence_summary.is_empty() {
+        brief.evidence_summary = plan
+            .evidence
+            .iter()
+            .take(4)
+            .map(|item| format!("{}: {}", item.label, item.snippet))
+            .collect();
+    } else {
+        brief.evidence_summary = normalize_string_list(brief.evidence_summary);
+    }
+
+    brief.next_follow_up_focus =
+        normalize_optional_string(brief.next_follow_up_focus).or_else(|| {
+            plan.follow_up_items
+                .iter()
+                .find(|item| item.priority == "high")
+                .or_else(|| plan.follow_up_items.first())
+                .map(|item| item.target.clone())
+        });
+
+    brief
+}
+
+fn collect_owner_names(plan: &LaunchExecutionPlan) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut seen = HashSet::new();
+    for name in plan
+        .milestones
+        .iter()
+        .filter_map(|item| item.owner.clone())
+        .chain(
+            plan.dependencies
+                .iter()
+                .filter_map(|item| item.owner.clone()),
+        )
+        .chain(plan.risks.iter().filter_map(|item| item.owner.clone()))
+        .chain(plan.decisions.iter().filter_map(|item| item.owner.clone()))
+    {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let key = trimmed.to_ascii_lowercase();
+        if seen.insert(key) {
+            names.push(trimmed.to_string());
+        }
+    }
+    names
+}
+
+fn normalize_required_string(value: String) -> Option<String> {
+    normalize_optional_string(Some(value))
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|item| item.trim().to_string())
+        .filter(|item| !item.is_empty())
+}
+
+fn normalize_string_list(values: Vec<String>) -> Vec<String> {
+    let mut output = Vec::new();
+    let mut seen = HashSet::new();
+
+    for value in values {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let key = trimmed.to_ascii_lowercase();
+        if seen.insert(key) {
+            output.push(trimmed.to_string());
+        }
+    }
+
+    output
+}
+
+fn dedupe_by_key<I, T, F>(values: I, key_fn: F) -> Vec<T>
+where
+    I: IntoIterator<Item = T>,
+    F: Fn(&T) -> String,
+{
+    let mut output = Vec::new();
+    let mut seen = HashSet::new();
+
+    for value in values {
+        let key = key_fn(&value);
+        if seen.insert(key) {
+            output.push(value);
+        }
+    }
+
+    output
+}
+
+fn normalize_milestone_status(value: String) -> String {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "done" | "complete" | "completed" => "done",
+        "in_progress" | "in progress" | "active" => "in_progress",
+        "at_risk" | "at risk" | "risk" => "at_risk",
+        "blocked" => "blocked",
+        "not_started" | "not started" | "todo" | "planned" => "not_started",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn normalize_dependency_status(value: String) -> String {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "ready" | "on_track" | "on track" => "ready",
+        "at_risk" | "at risk" => "at_risk",
+        "blocked" => "blocked",
+        "done" | "complete" | "completed" => "done",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn normalize_owner_update_status(value: String) -> String {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "current" | "fresh" | "updated" => "current",
+        "stale" | "waiting" | "lagging" => "stale",
+        "missing" | "none" => "missing",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn normalize_critical_path_item_type(value: String) -> String {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "milestone" | "dependency" | "decision" | "risk" => normalized,
+        _ => "milestone".to_string(),
+    }
+}
+
+fn normalize_risk_severity(value: String) -> String {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "low" | "medium" | "high" | "critical" => normalized,
+        _ => "medium".to_string(),
+    }
+}
+
+fn normalize_risk_status(value: String) -> String {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "open" | "watching" | "mitigated" | "resolved" => normalized,
+        _ => "unknown".to_string(),
+    }
+}
+
+fn normalize_decision_status(value: String) -> String {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "open" | "resolved" | "blocked" => normalized,
+        _ => "unknown".to_string(),
+    }
+}
+
+fn normalize_azure_endpoint(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.ends_with("/openai/v1") {
+        trimmed.to_string()
+    } else {
+        format!("{}/openai/v1", trimmed)
+    }
+}
+
+fn title_case(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return "Unknown".to_string();
+    }
+
+    let mut chars = trimmed.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => "Unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_plan() -> LaunchExecutionPlan {
+        LaunchExecutionPlan {
+            title: "Mobile app launch".to_string(),
+            evidence: vec![LaunchEvidence {
+                label: "timeline".to_string(),
+                snippet: "Launch target is June 14".to_string(),
+                source_ref: Some("primary_context".to_string()),
+            }],
+            ..LaunchExecutionPlan::default()
+        }
+    }
+
+    #[test]
+    fn extract_json_object_finds_first_valid_object() {
+        let raw =
+            "noise {\"launch_execution_plan\":{\"title\":\"hi\"},\"readiness_brief\":{}} trailing";
+        let extracted = extract_json_object(raw).expect("json object should be extracted");
+        assert!(extracted.contains("\"title\":\"hi\""));
+    }
+
+    #[test]
+    fn readiness_turns_red_without_evidence() {
+        let plan = LaunchExecutionPlan::default();
+        let (status, reason) = derive_readiness_status(&plan);
+        assert_eq!(status, "red");
+        assert!(reason.contains("No credible readiness evidence"));
+    }
+
+    #[test]
+    fn readiness_turns_red_for_launch_blocking_decision() {
+        let mut plan = base_plan();
+        plan.decisions.push(LaunchDecision {
+            title: "Approve pricing page copy".to_string(),
+            status: "open".to_string(),
+            launch_blocking: true,
+            ..LaunchDecision::default()
+        });
+
+        let (status, reason) = derive_readiness_status(&plan);
+        assert_eq!(status, "red");
+        assert!(reason.contains("Launch-blocking decision"));
+    }
+
+    #[test]
+    fn follow_up_generation_surfaces_missing_owners_dates_and_stale_updates() {
+        let mut plan = base_plan();
+        plan.owners.push(LaunchOwner {
+            name: "Dana".to_string(),
+            update_status: "stale".to_string(),
+            ..LaunchOwner::default()
+        });
+        plan.milestones.push(LaunchMilestone {
+            title: "Finish QA signoff".to_string(),
+            critical_path: true,
+            status: "in_progress".to_string(),
+            ..LaunchMilestone::default()
+        });
+        plan.decisions.push(LaunchDecision {
+            title: "Pick rollback threshold".to_string(),
+            status: "open".to_string(),
+            ..LaunchDecision::default()
+        });
+
+        let items = derive_follow_up_items(&plan);
+        assert!(items.iter().any(|item| item.kind == "stale_update"));
+        assert!(items.iter().any(|item| item.kind == "missing_owner"));
+        assert!(items.iter().any(|item| item.kind == "missing_date"));
+        assert!(items.iter().any(|item| item.kind == "unresolved_decision"));
+    }
+
+    #[test]
+    fn change_summary_reports_readiness_and_new_blockers() {
+        let mut prior = base_plan();
+        prior.readiness_status = "yellow".to_string();
+
+        let mut current = base_plan();
+        current.readiness_status = "red".to_string();
+        current.risks.push(LaunchRisk {
+            title: "Payments callback still failing".to_string(),
+            blocker: true,
+            severity: "critical".to_string(),
+            status: "open".to_string(),
+            ..LaunchRisk::default()
+        });
+
+        let summary = derive_change_summary(Some(&prior), &current);
+        assert!(summary
+            .iter()
+            .any(|item| item.contains("Readiness changed")));
+        assert!(summary
+            .iter()
+            .any(|item| item.contains("New blocker surfaced")));
+    }
+
+    #[test]
+    fn normalize_source_type_rejects_non_v1_sources() {
+        let err =
+            normalize_source_type(Some("google_docs".to_string())).expect_err("should reject");
+        assert!(err.contains("pasted_thread only"));
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/tpm_cron.rs
+++ b/DoWhiz_service/scheduler_module/src/tpm_cron.rs
@@ -190,7 +190,9 @@ pub fn setup_tpm_cron(
 
     // Use unique workspace per cron setup to avoid collisions
     let cron_id = Uuid::new_v4();
-    let workspace_dir = user_paths.workspaces_root.join(format!("tpm_cron_{}", cron_id));
+    let workspace_dir = user_paths
+        .workspaces_root
+        .join(format!("tpm_cron_{}", cron_id));
 
     // Create all workspace directories required by RunTaskTask validation
     for subdir in [

--- a/docs/oliver-launch-execution-v1.md
+++ b/docs/oliver-launch-execution-v1.md
@@ -1,0 +1,142 @@
+# Oliver Launch Execution V1
+
+- Status: implemented
+- Last updated: 2026-04-24
+- Audience: product, design, frontend, backend
+
+## Summary
+
+Oliver v1 is now a narrow launch execution copilot instead of a broad AI TPM surface.
+
+The shipped promise is:
+
+- Turn one messy launch thread into an accountable execution plan.
+- Keep that plan refreshable with pasted updates.
+- Produce a launch-readiness brief backed by visible evidence.
+
+## Scope shipped
+
+### Input
+
+V1 supports one starting path only:
+
+- pasted thread or pasted message bundle
+
+This is intentional. We did not try to make Google Docs, email references, or broad multi-surface ingestion equally complete in this first slice.
+
+### Output
+
+The analyzer returns a `LaunchExecutionPlan` with:
+
+- title
+- objective
+- source context summary
+- target date or launch window
+- milestones
+- owners
+- dependencies
+- critical path candidates
+- risks
+- decisions
+- evidence
+- readiness status
+- readiness reason
+- follow-up items
+
+The response also returns:
+
+- tracker rows for owner/date/risk scanning
+- a readiness brief with blockers, at-risk dependencies, open decisions, missing owner updates, and change summary
+
+## Current product surface
+
+### Frontend
+
+- New route: `website/src/pages/OliverLaunchExecutionPage.jsx`
+- New API client: `website/src/domain/launchExecutionApi.js`
+- Demo thread seed: `website/src/data/launchExecutionDemo.js`
+- New styling: `website/src/styles/launch-execution.css`
+
+### Backend
+
+- New analyzer module: `DoWhiz_service/scheduler_module/src/service/launch_execution.rs`
+- New endpoint: `POST /api/launch-execution/analyze`
+- Router wiring: `DoWhiz_service/scheduler_module/src/service/auth.rs`
+
+## Readiness model
+
+The readiness model is deliberately explicit in code.
+
+### Green
+
+- Evidence is present
+- no critical blockers are open
+- no launch-blocking decision is unresolved
+- no critical-path item lacks ownership
+- dates and follow-through are credible enough to support readiness
+
+### Yellow
+
+- Evidence exists, but there are still material follow-ups
+- common causes include missing dates, stale updates, at-risk dependencies, or unresolved non-blocking issues
+
+### Red
+
+- No credible evidence was extracted
+- or a high/critical blocker is still open
+- or a launch-blocking decision is unresolved
+- or a critical-path item lacks a clear owner
+
+## Follow-through loop
+
+We intentionally shipped the lightest real loop:
+
+- user pastes initial launch context
+- Oliver extracts a plan and brief
+- user pastes the newest update
+- Oliver refreshes the same plan and highlights what changed
+
+The backend currently generates follow-up prompts for:
+
+- missing owner
+- missing date
+- stale update
+- unresolved blocker
+- unresolved decision
+
+We did not ship autonomous background outreach in v1.
+
+## Why this matches the product thesis
+
+This version keeps the strongest parts of Oliver:
+
+- thread-native start
+- continuity across updates
+- follow-through into a structured execution layer
+
+And it cuts the weak parts:
+
+- no generic “works anywhere” positioning
+- no broad task automation platform
+- no attempt to become full PM software
+
+## Intentional non-goals
+
+Not built in this iteration:
+
+- broad channel ingestion parity
+- persistent launch-plan storage
+- autonomous owner messaging
+- generic workflow abstractions
+- dashboards beyond the launch execution slice
+- broad GitHub or engineering execution flows
+
+## Next iteration
+
+If this v1 proves useful, the most natural next steps are:
+
+1. Persist `LaunchExecutionPlan` by thread so refreshes do not depend on browser state.
+2. Add one more ingestion path, most likely email thread or Google Docs note.
+3. Add approved follow-up send actions instead of draft-only messages.
+4. Add evidence lineage to exact message timestamps or channel references.
+5. Add a lightweight launch archive/history so “what changed” survives across sessions.

--- a/website/src/app/AppRouter.jsx
+++ b/website/src/app/AppRouter.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import LandingPage from '../pages/LandingPage';
 import OliverLandingPage from '../pages/OliverLandingPage';
+import OliverLaunchExecutionPage from '../pages/OliverLaunchExecutionPage';
 import StartupIntakePage from '../pages/StartupIntakePage';
 import WorkspaceDemoPage from '../pages/WorkspaceDemoPage';
 import WorkspaceHomePage from '../pages/WorkspaceHomePage';
@@ -13,6 +14,7 @@ function AppRouter() {
       <Routes>
         <Route path="/" element={<LandingPage locale="en-US" />} />
         <Route path="/oliver" element={<OliverLandingPage />} />
+        <Route path="/oliver/launch" element={<OliverLaunchExecutionPage />} />
         <Route path="/cn" element={<LandingPage locale="zh-CN" />} />
         <Route path="/cn/*" element={<LandingPage locale="zh-CN" />} />
         <Route path="/start" element={<StartupIntakePage />} />

--- a/website/src/data/launchExecutionDemo.js
+++ b/website/src/data/launchExecutionDemo.js
@@ -1,0 +1,39 @@
+export const launchExecutionDemo = {
+  sourceLabel: 'Q2 mobile checkout launch thread',
+  contextText: `Slack thread: #launch-war-room
+
+Maya (PM) - Apr 16
+We still want to launch the mobile checkout refresh before the partner webinar on June 14. Goal is to reduce drop-off and have the webinar point to the new flow.
+
+Jon (Eng) - Apr 16
+Implementation is mostly done. Payments callback retries are still failing in staging after about 20 minutes, and that blocks QA from signing off.
+
+Priya (Design) - Apr 17
+Final screenshots are ready once Product approves the fallback copy for the payment error state.
+
+Lena (Lifecycle) - Apr 17
+Email + in-app launch comms draft is 80% there. I need the final launch date and approved screenshots.
+
+Maya (PM) - Apr 18
+We need a go/no-go review by June 11. Owners should come with status, blockers, and what they need from others.
+
+Jon (Eng) - Apr 19
+I can own the callback fix, but I need infra to confirm whether the retry queue config can change before code freeze.
+
+Sam (Infra) - Apr 19
+I haven't checked the retry queue setting yet. I should know by Tuesday.
+
+QA note - Apr 20
+Regression pass is blocked until callback retries are stable in staging.
+
+Product comment - Apr 20
+Fallback copy still needs approval from legal because of the refund language.
+
+Launch checklist excerpt
+- Engineering fix callback retries in staging
+- QA regression pass
+- Final screenshots approved
+- Lifecycle email + in-app message scheduled
+- Webinar deck updated
+- Go/no-go review on June 11`
+};

--- a/website/src/domain/launchExecutionApi.js
+++ b/website/src/domain/launchExecutionApi.js
@@ -1,0 +1,51 @@
+import { getDoWhizApiBaseUrl } from '../analytics';
+
+export const LAUNCH_EXECUTION_API_PATH = '/api/launch-execution/analyze';
+
+export async function analyzeLaunchExecution({
+  contextText,
+  updateText,
+  sourceLabel,
+  priorPlan
+}) {
+  const response = await fetch(`${getDoWhizApiBaseUrl()}${LAUNCH_EXECUTION_API_PATH}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      source_type: 'pasted_thread',
+      source_label: sourceLabel,
+      context_text: contextText,
+      update_text: updateText,
+      prior_plan: priorPlan || null
+    })
+  });
+
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(body?.error || `Launch execution request failed (${response.status})`);
+  }
+
+  return body;
+}
+
+export function getReadinessTone(status) {
+  const normalized = String(status || '').trim().toLowerCase();
+  if (normalized === 'green') {
+    return 'green';
+  }
+  if (normalized === 'red') {
+    return 'red';
+  }
+  return 'yellow';
+}
+
+export function formatReadinessLabel(status) {
+  const tone = getReadinessTone(status);
+  return tone.charAt(0).toUpperCase() + tone.slice(1);
+}
+
+export function formatLaunchDate(targetDate, launchWindow) {
+  return targetDate || launchWindow || 'Needs date';
+}

--- a/website/src/pages/OliverLandingPage.jsx
+++ b/website/src/pages/OliverLandingPage.jsx
@@ -8,9 +8,9 @@ import { getThemeForLocalTime, LOCAL_THEME_CHANGE_EVENT, THEME_META_COLORS } fro
 import oliverAvatar from '../assets/Oliver-Avatar-Apr-23-2026.png';
 import {
   OLIVER_AUTH_SIGN_IN_HREF,
-  OLIVER_AUTH_OVERVIEW_HREF,
   OLIVER_ENTRY_SURFACE,
   OLIVER_HOME_HREF,
+  OLIVER_LAUNCH_HREF,
   OLIVER_LANDING_VARIANT,
   oliverLandingContent
 } from './oliverLandingContent';
@@ -219,9 +219,9 @@ function OliverLandingPage() {
       'landing_page_view',
       {
         landing_page_variant: OLIVER_LANDING_VARIANT,
-        landing_story: 'tpm_hook',
+        landing_story: 'launch_execution',
         entry_surface: OLIVER_ENTRY_SURFACE,
-        role_focus: 'tpm'
+        role_focus: 'launch_execution'
       },
       {
         eventKey: `landing_page_view:${sessionId}:/oliver`,
@@ -280,7 +280,7 @@ function OliverLandingPage() {
   const trackLandingInteraction = (eventName, properties = {}) => {
     trackAnalyticsEvent(eventName, {
       landing_page_variant: OLIVER_LANDING_VARIANT,
-      landing_story: 'tpm_hook',
+      landing_story: 'launch_execution',
       entry_surface: OLIVER_ENTRY_SURFACE,
       ...properties
     });
@@ -322,7 +322,7 @@ function OliverLandingPage() {
                 {content.nav.signInLabel}
               </a>
               <a
-                href={OLIVER_AUTH_OVERVIEW_HREF}
+                href={OLIVER_LAUNCH_HREF}
                 className="btn btn-primary oliver-clarity-primary-button"
                 onClick={() =>
                   trackLandingInteraction('primary_cta_click', {
@@ -368,7 +368,7 @@ function OliverLandingPage() {
                 <div className="oliver-clarity-cta-row">
                   <a
                     className="btn btn-primary oliver-clarity-primary-button"
-                    href={OLIVER_AUTH_OVERVIEW_HREF}
+                    href={OLIVER_LAUNCH_HREF}
                     onClick={() =>
                       trackLandingInteraction('primary_cta_click', {
                         cta_location: 'hero_primary',
@@ -492,7 +492,7 @@ function OliverLandingPage() {
                 <div className="oliver-clarity-trust-actions">
                   <a
                     className="btn btn-primary oliver-clarity-primary-button"
-                    href={OLIVER_AUTH_OVERVIEW_HREF}
+                    href={OLIVER_LAUNCH_HREF}
                     onClick={() =>
                       trackLandingInteraction('primary_cta_click', {
                         cta_location: 'trust_primary',

--- a/website/src/pages/OliverLaunchExecutionPage.jsx
+++ b/website/src/pages/OliverLaunchExecutionPage.jsx
@@ -1,0 +1,519 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { analyzeLaunchExecution, formatLaunchDate, formatReadinessLabel, getReadinessTone } from '../domain/launchExecutionApi';
+import { launchExecutionDemo } from '../data/launchExecutionDemo';
+
+function LaunchReadinessPill({ status }) {
+  const tone = getReadinessTone(status);
+  return <span className={`launch-readiness-pill is-${tone}`}>{formatReadinessLabel(status)}</span>;
+}
+
+function LaunchList({ items, emptyLabel, renderItem }) {
+  if (!items?.length) {
+    return <p className="launch-empty-state">{emptyLabel}</p>;
+  }
+
+  return (
+    <div className="launch-list">
+      {items.map((item, index) => (
+        <article
+          key={`${item.title || item.name || item.target || item.label || 'item'}-${index}`}
+          className="launch-list-item"
+        >
+          {renderItem(item)}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function LaunchExecutionPage() {
+  const [sourceLabel, setSourceLabel] = useState('');
+  const [contextText, setContextText] = useState('');
+  const [updateText, setUpdateText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [response, setResponse] = useState(null);
+
+  const plan = response?.launch_execution_plan || null;
+  const trackerRows = response?.tracker_rows || [];
+  const readinessBrief = response?.readiness_brief || null;
+
+  async function handleAnalyze(event) {
+    event.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      const result = await analyzeLaunchExecution({
+        sourceLabel,
+        contextText,
+        updateText,
+        priorPlan: plan
+      });
+      setResponse(result);
+    } catch (requestError) {
+      setError(requestError.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function loadDemoThread() {
+    setSourceLabel(launchExecutionDemo.sourceLabel);
+    setContextText(launchExecutionDemo.contextText);
+    setUpdateText('');
+    setError('');
+  }
+
+  return (
+    <main className="route-shell launch-execution-shell">
+      <div className="route-card launch-execution-card">
+        <header className="launch-hero">
+          <div className="launch-hero-copy">
+            <p className="route-kicker">Oliver v1</p>
+            <h1>Turn one messy launch thread into accountable execution.</h1>
+            <p className="launch-hero-summary">
+              Paste one launch-related thread or planning bundle. Oliver extracts owners, dates,
+              dependencies, blockers, open decisions, and a live readiness brief backed by
+              evidence.
+            </p>
+            <p className="workspace-inline-note">
+              Narrow v1 scope: pasted thread or message bundle only. No autonomous outreach, no
+              generic workflow platform, no broad “AI employee” positioning.
+            </p>
+          </div>
+
+          <div className="launch-hero-aside">
+            <div className="launch-hero-note">
+              <span>Start</span>
+              <strong>Thread-native</strong>
+            </div>
+            <div className="launch-hero-note">
+              <span>Output</span>
+              <strong>Execution layer + readiness brief</strong>
+            </div>
+            <div className="launch-hero-note">
+              <span>Loop</span>
+              <strong>Paste updates, refresh the brief</strong>
+            </div>
+          </div>
+        </header>
+
+        <div className="route-actions">
+          <Link className="btn btn-secondary" to="/oliver">
+            View Oliver positioning
+          </Link>
+          <button type="button" className="btn btn-primary" onClick={loadDemoThread}>
+            Load demo launch thread
+          </button>
+        </div>
+
+        <section className="launch-input-layout">
+          <form className="launch-input-card" onSubmit={handleAnalyze}>
+            <div className="launch-field">
+              <label htmlFor="launch-source-label">Launch label</label>
+              <input
+                id="launch-source-label"
+                value={sourceLabel}
+                onChange={(event) => setSourceLabel(event.target.value)}
+                placeholder="Q2 launch thread, June webinar launch, release war room..."
+              />
+            </div>
+
+            <div className="launch-field">
+              <label htmlFor="launch-context">Pasted launch thread or planning bundle</label>
+              <textarea
+                id="launch-context"
+                value={contextText}
+                onChange={(event) => setContextText(event.target.value)}
+                placeholder="Paste the thread, planning note, or message bundle here."
+                required
+              />
+            </div>
+
+            <div className="launch-field">
+              <label htmlFor="launch-update">Latest update for refresh loop (optional)</label>
+              <textarea
+                id="launch-update"
+                value={updateText}
+                onChange={(event) => setUpdateText(event.target.value)}
+                placeholder="Paste the newest owner reply or status update when you want Oliver to refresh the plan."
+              />
+            </div>
+
+            {error ? <p className="launch-error-banner">{error}</p> : null}
+
+            <div className="launch-submit-row">
+              <button type="submit" className="btn btn-primary" disabled={loading}>
+                {loading
+                  ? 'Analyzing launch...'
+                  : plan
+                    ? 'Refresh readiness brief'
+                    : 'Build launch execution plan'}
+              </button>
+              <p className="launch-submit-note">
+                {plan
+                  ? 'The existing plan is sent back with the latest update so Oliver can show what changed.'
+                  : 'First run extracts the plan, tracker, follow-ups, and readiness brief.'}
+              </p>
+            </div>
+          </form>
+
+          <aside className="launch-scope-card">
+            <h2>Readiness model</h2>
+            <div className="launch-model-list">
+              <div>
+                <strong>Green</strong>
+                <p>Owners and dates are present, no critical blockers remain, and the evidence is credible.</p>
+              </div>
+              <div>
+                <strong>Yellow</strong>
+                <p>There are missing updates, at-risk dependencies, unresolved follow-ups, or timeline gaps.</p>
+              </div>
+              <div>
+                <strong>Red</strong>
+                <p>There is no credible evidence, a critical blocker is open, a launch-blocking decision is unresolved, or the critical path lacks ownership.</p>
+              </div>
+            </div>
+
+            <div className="launch-scope-divider"></div>
+
+            <h2>What this v1 does</h2>
+            <div className="launch-model-list">
+              <div>
+                <strong>Extract</strong>
+                <p>Launch goal, target date or window, milestones, owners, risks, dependencies, and decisions.</p>
+              </div>
+              <div>
+                <strong>Track</strong>
+                <p>Critical path candidates, missing updates, missing dates, unresolved blockers, and follow-up prompts.</p>
+              </div>
+              <div>
+                <strong>Refresh</strong>
+                <p>Paste the newest update and Oliver will refresh the plan and call out what changed.</p>
+              </div>
+            </div>
+          </aside>
+        </section>
+
+        {plan ? (
+          <>
+            <section className="launch-summary-card">
+              <div className="launch-summary-head">
+                <div>
+                  <p className="route-kicker">Launch execution plan</p>
+                  <h2>{plan.title}</h2>
+                  <p className="launch-summary-objective">
+                    {plan.objective || 'Objective not explicitly stated in the source context.'}
+                  </p>
+                </div>
+                <div className="launch-summary-status">
+                  <LaunchReadinessPill status={plan.readiness_status} />
+                  <span>{formatLaunchDate(plan.target_date, plan.launch_window)}</span>
+                  <span>{plan.last_updated_at}</span>
+                </div>
+              </div>
+
+              <div className="launch-summary-grid">
+                <div className="launch-summary-cell">
+                  <span>Why this status</span>
+                  <strong>{plan.readiness_reason}</strong>
+                </div>
+                <div className="launch-summary-cell">
+                  <span>Source</span>
+                  <strong>{plan.source_context?.source_label || 'Pasted thread'}</strong>
+                </div>
+                <div className="launch-summary-cell">
+                  <span>Evidence</span>
+                  <strong>{plan.evidence?.length || 0} supporting snippets</strong>
+                </div>
+                <div className="launch-summary-cell">
+                  <span>Follow-ups</span>
+                  <strong>{plan.follow_up_items?.length || 0} next asks ready</strong>
+                </div>
+              </div>
+            </section>
+
+            <section className="launch-results-grid">
+              <article className="launch-section-card">
+                <div className="launch-section-head">
+                  <h2>Milestones</h2>
+                  <p>Execution layer extracted from the thread.</p>
+                </div>
+                <LaunchList
+                  items={plan.milestones}
+                  emptyLabel="No milestones were clearly grounded in the source context."
+                  renderItem={(item) => (
+                    <>
+                      <div className="launch-item-row">
+                        <strong>{item.title}</strong>
+                        <span className={`launch-mini-pill is-${item.status}`}>{item.status.replace('_', ' ')}</span>
+                      </div>
+                      <p>
+                        Owner: {item.owner || 'Unassigned'}
+                        {' · '}
+                        Date: {item.target_date || 'Needs date'}
+                        {item.critical_path ? ' · Critical path' : ''}
+                      </p>
+                      {item.notes ? <p>{item.notes}</p> : null}
+                    </>
+                  )}
+                />
+              </article>
+
+              <article className="launch-section-card">
+                <div className="launch-section-head">
+                  <h2>Critical path</h2>
+                  <p>The few items most likely to move the launch date.</p>
+                </div>
+                <LaunchList
+                  items={plan.critical_path}
+                  emptyLabel="No critical path candidate was explicitly extracted yet."
+                  renderItem={(item) => (
+                    <>
+                      <div className="launch-item-row">
+                        <strong>{item.title}</strong>
+                        <span className="launch-mini-pill is-critical">{item.item_type}</span>
+                      </div>
+                      <p>
+                        Owner: {item.owner || 'Unassigned'}
+                        {' · '}
+                        Date: {item.target_date || 'Needs date'}
+                        {' · '}
+                        Status: {item.status}
+                      </p>
+                      {item.reason ? <p>{item.reason}</p> : null}
+                    </>
+                  )}
+                />
+              </article>
+
+              <article className="launch-section-card launch-tracker-card">
+                <div className="launch-section-head">
+                  <h2>Owner / date / risk tracker</h2>
+                  <p>One compact view of what needs attention.</p>
+                </div>
+                {trackerRows.length ? (
+                  <div className="launch-tracker-table" role="table" aria-label="Launch tracker">
+                    <div className="launch-tracker-row launch-tracker-head" role="row">
+                      <span>Type</span>
+                      <span>Item</span>
+                      <span>Owner</span>
+                      <span>Date</span>
+                      <span>Status</span>
+                      <span>Risk</span>
+                    </div>
+                    {trackerRows.map((row, index) => (
+                      <div key={`${row.category}-${row.title}-${index}`} className="launch-tracker-row" role="row">
+                        <span>{row.category}</span>
+                        <strong>{row.title}</strong>
+                        <span>{row.owner || 'Unassigned'}</span>
+                        <span>{row.target_date || 'Needs date'}</span>
+                        <span>{row.status}</span>
+                        <span>{row.risk_level || 'n/a'}</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="launch-empty-state">Tracker rows will appear once execution items are extracted.</p>
+                )}
+              </article>
+
+              <article className="launch-section-card">
+                <div className="launch-section-head">
+                  <h2>Dependencies</h2>
+                  <p>Cross-functional or external items that can gate launch.</p>
+                </div>
+                <LaunchList
+                  items={plan.dependencies}
+                  emptyLabel="No dependencies were explicitly grounded in the source context."
+                  renderItem={(item) => (
+                    <>
+                      <div className="launch-item-row">
+                        <strong>{item.title}</strong>
+                        <span className={`launch-mini-pill is-${item.status}`}>{item.status.replace('_', ' ')}</span>
+                      </div>
+                      <p>
+                        Owner: {item.owner || 'Unassigned'}
+                        {' · '}
+                        Date: {item.target_date || 'Needs date'}
+                        {item.critical_path ? ' · Critical path' : ''}
+                      </p>
+                      {item.notes ? <p>{item.notes}</p> : null}
+                    </>
+                  )}
+                />
+              </article>
+
+              <article className="launch-section-card">
+                <div className="launch-section-head">
+                  <h2>Risks and blockers</h2>
+                  <p>Explicit launch risks, not generic concerns.</p>
+                </div>
+                <LaunchList
+                  items={plan.risks}
+                  emptyLabel="No explicit risks or blockers were extracted."
+                  renderItem={(item) => (
+                    <>
+                      <div className="launch-item-row">
+                        <strong>{item.title}</strong>
+                        <span className={`launch-mini-pill is-${item.severity}`}>{item.severity}</span>
+                      </div>
+                      <p>
+                        Owner: {item.owner || 'Unassigned'}
+                        {' · '}
+                        Status: {item.status}
+                        {item.blocker ? ' · Blocker' : ''}
+                      </p>
+                      {item.notes ? <p>{item.notes}</p> : null}
+                    </>
+                  )}
+                />
+              </article>
+
+              <article className="launch-section-card">
+                <div className="launch-section-head">
+                  <h2>Open decisions</h2>
+                  <p>Unanswered choices or approvals still needed for launch.</p>
+                </div>
+                <LaunchList
+                  items={plan.decisions}
+                  emptyLabel="No unresolved decisions were extracted."
+                  renderItem={(item) => (
+                    <>
+                      <div className="launch-item-row">
+                        <strong>{item.title}</strong>
+                        <span className={`launch-mini-pill is-${item.status}`}>{item.status}</span>
+                      </div>
+                      <p>
+                        Owner: {item.owner || 'Unassigned'}
+                        {' · '}
+                        Due: {item.due_date || 'Needs date'}
+                        {item.launch_blocking ? ' · Launch blocking' : ''}
+                      </p>
+                      {item.notes ? <p>{item.notes}</p> : null}
+                    </>
+                  )}
+                />
+              </article>
+
+              <article className="launch-section-card">
+                <div className="launch-section-head">
+                  <h2>Recommended follow-ups</h2>
+                  <p>Generated from missing owners, missing dates, stale updates, blockers, and decisions.</p>
+                </div>
+                <LaunchList
+                  items={plan.follow_up_items}
+                  emptyLabel="No immediate follow-up prompt was generated."
+                  renderItem={(item) => (
+                    <>
+                      <div className="launch-item-row">
+                        <strong>{item.target}</strong>
+                        <span className={`launch-mini-pill is-${item.priority}`}>{item.priority}</span>
+                      </div>
+                      <p>{item.reason}</p>
+                      <div className="launch-message-box">{item.suggested_message}</div>
+                    </>
+                  )}
+                />
+              </article>
+
+              <article className="launch-section-card">
+                <div className="launch-section-head">
+                  <h2>Evidence</h2>
+                  <p>Visible grounding for the readiness state.</p>
+                </div>
+                <LaunchList
+                  items={plan.evidence}
+                  emptyLabel="No evidence snippets were returned."
+                  renderItem={(item) => (
+                    <>
+                      <div className="launch-item-row">
+                        <strong>{item.label}</strong>
+                        <span className="launch-mini-pill is-evidence">{item.source_ref || 'context'}</span>
+                      </div>
+                      <div className="launch-evidence-quote">“{item.snippet}”</div>
+                    </>
+                  )}
+                />
+              </article>
+
+              <article className="launch-section-card">
+                <div className="launch-section-head">
+                  <h2>Readiness brief</h2>
+                  <p>Concise status readout with visible rationale.</p>
+                </div>
+                {readinessBrief ? (
+                  <div className="launch-brief-grid">
+                    <div className="launch-brief-block">
+                      <span>Overall readiness</span>
+                      <strong>{readinessBrief.overall_readiness}</strong>
+                    </div>
+                    <div className="launch-brief-block">
+                      <span>Critical blockers</span>
+                      <LaunchList
+                        items={readinessBrief.critical_blockers.map((item) => ({ title: item }))}
+                        emptyLabel="No critical blockers listed."
+                        renderItem={(item) => <p>{item.title}</p>}
+                      />
+                    </div>
+                    <div className="launch-brief-block">
+                      <span>At-risk dependencies</span>
+                      <LaunchList
+                        items={readinessBrief.at_risk_dependencies.map((item) => ({ title: item }))}
+                        emptyLabel="No at-risk dependencies listed."
+                        renderItem={(item) => <p>{item.title}</p>}
+                      />
+                    </div>
+                    <div className="launch-brief-block">
+                      <span>Open decisions</span>
+                      <LaunchList
+                        items={readinessBrief.open_decisions.map((item) => ({ title: item }))}
+                        emptyLabel="No open decisions listed."
+                        renderItem={(item) => <p>{item.title}</p>}
+                      />
+                    </div>
+                    <div className="launch-brief-block">
+                      <span>Missing owner updates</span>
+                      <LaunchList
+                        items={readinessBrief.missing_owner_updates.map((item) => ({ title: item }))}
+                        emptyLabel="No missing owner updates listed."
+                        renderItem={(item) => <p>{item.title}</p>}
+                      />
+                    </div>
+                    <div className="launch-brief-block">
+                      <span>What changed since last update</span>
+                      <LaunchList
+                        items={readinessBrief.what_changed_since_last_update.map((item) => ({ title: item }))}
+                        emptyLabel="No change summary available yet."
+                        renderItem={(item) => <p>{item.title}</p>}
+                      />
+                    </div>
+                    <div className="launch-brief-block">
+                      <span>Evidence summary</span>
+                      <LaunchList
+                        items={readinessBrief.evidence_summary.map((item) => ({ title: item }))}
+                        emptyLabel="No evidence summary available."
+                        renderItem={(item) => <p>{item.title}</p>}
+                      />
+                    </div>
+                    <div className="launch-brief-block">
+                      <span>Next follow-up focus</span>
+                      <strong>{readinessBrief.next_follow_up_focus || 'No follow-up target selected.'}</strong>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="launch-empty-state">Readiness brief will appear after analysis.</p>
+                )}
+              </article>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </main>
+  );
+}
+
+export default LaunchExecutionPage;

--- a/website/src/pages/oliverLandingContent.js
+++ b/website/src/pages/oliverLandingContent.js
@@ -1,57 +1,57 @@
-export const OLIVER_ENTRY_SURFACE = 'oliver_tpm';
-export const OLIVER_LANDING_VARIANT = 'oliver_tpm_hook_v5_cta_avatar';
-export const OLIVER_AUTH_OVERVIEW_HREF = '/auth/index.html?loggedIn=true&entry=oliver_tpm#section-overview';
-export const OLIVER_AUTH_SIGN_IN_HREF = '/auth/index.html?entry=oliver_tpm';
+export const OLIVER_ENTRY_SURFACE = 'oliver_launch_execution';
+export const OLIVER_LANDING_VARIANT = 'oliver_launch_execution_hook_v1';
+export const OLIVER_LAUNCH_HREF = '/oliver/launch';
+export const OLIVER_AUTH_SIGN_IN_HREF = '/auth/index.html?entry=oliver_launch_execution';
 export const OLIVER_HOME_HREF = '/';
 
 export const oliverLandingContent = {
   metadata: {
-    title: 'Oliver by DoWhiz | AI TPM for product and engineering teams',
+    title: 'Oliver by DoWhiz | Launch Execution Copilot',
     description:
-      'Oliver is the AI TPM for product and engineering teams. Sign in, point him at one program, and get the weekly update, current risks, and next owners.',
+      'Turn one messy launch thread into an accountable execution plan and a live readiness brief backed by evidence.',
     canonicalUrl: 'https://dowhiz.com/oliver',
     robots: 'noindex, nofollow',
     htmlLang: 'en',
     ogLocale: 'en_US',
     themeColor: '#050816',
     ogImage: 'https://dowhiz.com/assets/DoWhiz.svg',
-    ogImageAlt: 'Oliver landing page for product and engineering teams'
+    ogImageAlt: 'Oliver landing page for launch execution'
   },
   nav: {
     homeLabel: 'Home',
     signInLabel: 'Sign in',
-    primaryCta: 'Open Oliver'
+    primaryCta: 'Try Launch Flow'
   },
   hero: {
-    badge: 'AI TPM',
-    eyebrow: 'For launches, releases, and cross-functional work',
-    title: 'Oliver is your AI TPM.',
+    badge: 'Launch Execution Copilot',
+    eyebrow: 'For one launch thread at a time',
+    title: 'Turn one messy launch thread into accountable execution.',
     subtitle:
-      'Sign in, point him at one program, and get the update, current risks, and next owners.',
-    activity: 'Weekly review ready to send.',
-    primaryCta: 'Open Oliver',
+      'Paste the thread. Oliver extracts owners, dates, dependencies, blockers, open decisions, and a readiness brief backed by evidence.',
+    activity: 'Readiness brief refreshed from the latest owner update.',
+    primaryCta: 'Try Launch Flow',
     secondaryCta: 'See output samples',
-    proofPills: ['Weekly update', 'Current risks', 'Next owners'],
-    orbitSignals: ['Slack', 'GitHub', 'Docs', 'Meetings']
+    proofPills: ['Owners + dates', 'Blockers + decisions', 'Readiness brief'],
+    orbitSignals: ['Thread', 'Milestones', 'Risks', 'Owners']
   },
   workflow: {
     eyebrow: 'How to start',
-    title: 'Connect one program.',
-    subtitle: 'Oliver watches the signals and drafts the output.',
+    title: 'Paste one launch thread.',
+    subtitle: 'Oliver turns the thread into a narrow execution layer instead of a generic project dashboard.',
     signalsLabel: 'Signals in',
     signals: [
-      { title: 'Slack blocker thread', meta: '#launch-ops', tone: 'teal' },
-      { title: 'GitHub regression', meta: 'payments/callback', tone: 'violet' },
-      { title: 'Launch notes', meta: 'decision recap', tone: 'gold' }
+      { title: 'Launch thread bundle', meta: 'Slack or email paste', tone: 'teal' },
+      { title: 'Planning note', meta: 'milestones + dependencies', tone: 'gold' },
+      { title: 'Latest owner reply', meta: 'refresh the brief', tone: 'sky' }
     ],
     coreLabel: 'Oliver',
-    coreTitle: 'Reviews the week',
-    coreSubtitle: 'Builds one operating picture.',
+    coreTitle: 'Builds the execution layer',
+    coreSubtitle: 'Extracts ownership, dates, risks, decisions, and follow-ups.',
     outputsLabel: 'What you get',
     outputs: [
-      { title: 'Weekly update', meta: 'Ready to review', tone: 'emerald' },
-      { title: 'Current risks', meta: '2 need decisions', tone: 'amber' },
-      { title: 'Next owners', meta: '3 follow-ups ready', tone: 'sky' }
+      { title: 'Launch plan', meta: 'Milestones + owners', tone: 'emerald' },
+      { title: 'Readiness brief', meta: 'Evidence-backed status', tone: 'amber' },
+      { title: 'Follow-ups', meta: 'Missing owners and blockers', tone: 'sky' }
     ]
   },
   proof: {
@@ -60,47 +60,51 @@ export const oliverLandingContent = {
     cards: [
       {
         key: 'update',
-        eyebrow: 'Weekly update',
-        title: 'Send-ready draft',
-        description: 'Health, blockers, and next asks.',
+        eyebrow: 'Readiness brief',
+        title: 'One accountable launch view',
+        description: 'Overall readiness, blockers, and what changed since the last update.',
         visual: {
           type: 'update',
-          windowTitle: 'Mobile release weekly update',
-          status: 'At risk',
-          metrics: ['2 blockers', '3 owners', 'Fri review'],
+          windowTitle: 'Mobile checkout launch readiness',
+          status: 'Yellow',
+          metrics: ['1 blocker', '4 owners', 'June 11 review'],
           lines: [
-            { label: 'Build', value: 86 },
-            { label: 'QA', value: 52 },
-            { label: 'Comms', value: 74 }
+            { label: 'Build', value: 82 },
+            { label: 'QA', value: 45 },
+            { label: 'Comms', value: 68 }
           ],
-          bullets: ['Checkout is code-complete', 'QA waits on callback fix', 'Fallback copy needs approval']
+          bullets: [
+            'Payments callback still blocks QA signoff',
+            'Fallback copy approval is unresolved',
+            'Lifecycle needs final date and screenshots'
+          ]
         }
       },
       {
         key: 'risks',
-        eyebrow: 'Risk register',
-        title: 'Live risk list',
-        description: 'Severity, owner, and next review.',
+        eyebrow: 'Owner / date / risk tracker',
+        title: 'Tracker, not task sprawl',
+        description: 'The smallest useful layer for launch accountability.',
         visual: {
           type: 'risks',
           rows: [
-            { tone: 'high', label: 'Callback regression', owner: 'Eng', review: 'Today' },
-            { tone: 'medium', label: 'Fallback copy approval', owner: 'Product', review: 'Today' },
-            { tone: 'low', label: 'Release note timing', owner: 'Ops', review: 'Fri' }
+            { tone: 'high', label: 'Callback retries stable in staging', owner: 'Jon', review: 'Needs date' },
+            { tone: 'medium', label: 'Fallback copy legal approval', owner: 'Product', review: 'Open' },
+            { tone: 'low', label: 'Lifecycle comms scheduled', owner: 'Lena', review: 'After screenshots' }
           ]
         }
       },
       {
         key: 'follow-up',
-        eyebrow: 'Owner follow-through',
-        title: 'Next owners',
-        description: 'Who moves next, in one place.',
+        eyebrow: 'Next follow-ups',
+        title: 'Keep the loop moving',
+        description: 'The next asks are generated from missing owners, dates, blockers, and stale updates.',
         visual: {
           type: 'follow-up',
           rows: [
-            { tool: 'Slack', owner: 'Engineering', action: 'Confirm ETA', state: 'Queued' },
-            { tool: 'GitHub', owner: 'Product', action: 'Approve fallback copy', state: 'Waiting' },
-            { tool: 'Docs', owner: 'Ops', action: 'Send release note', state: 'Ready' }
+            { tool: 'Thread', owner: 'Infra', action: 'Confirm retry queue ETA', state: 'Queued' },
+            { tool: 'Thread', owner: 'Product', action: 'Name owner for copy approval', state: 'Waiting' },
+            { tool: 'Thread', owner: 'Lifecycle', action: 'Request final launch date', state: 'Ready' }
           ]
         }
       }
@@ -108,13 +112,13 @@ export const oliverLandingContent = {
   },
   trust: {
     eyebrow: 'Stay In Control',
-    title: 'Review before send.',
+    title: 'Keep the launch loop tight.',
     items: [
-      'Review before send',
-      'Only connected scopes',
-      'Shared DoWhiz setup'
+      'Evidence stays visible',
+      'Follow-up drafts first',
+      'One launch at a time'
     ],
-    primaryCta: 'Open Oliver',
+    primaryCta: 'Try Launch Flow',
     secondaryCta: 'Sign in'
   }
 };

--- a/website/src/styles/index.css
+++ b/website/src/styles/index.css
@@ -2,5 +2,6 @@
 @import './base.css';
 @import './landing.css';
 @import './oliver-landing.css';
+@import './launch-execution.css';
 @import './layout.css';
 @import './responsive.css';

--- a/website/src/styles/launch-execution.css
+++ b/website/src/styles/launch-execution.css
@@ -1,0 +1,469 @@
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap');
+
+.launch-execution-shell {
+  background:
+    radial-gradient(circle at top left, rgba(212, 79, 54, 0.15), transparent 30rem),
+    radial-gradient(circle at 85% 20%, rgba(220, 169, 61, 0.18), transparent 28rem),
+    linear-gradient(180deg, #fbf4e7 0%, #f6eedf 52%, #efe6d5 100%);
+}
+
+.launch-execution-card {
+  --launch-ink: #23190f;
+  --launch-copy: #5b4b3d;
+  --launch-border: rgba(93, 72, 50, 0.22);
+  --launch-surface: rgba(255, 251, 244, 0.94);
+  --launch-surface-strong: rgba(255, 247, 235, 0.98);
+  --launch-accent: #c4552c;
+  --launch-accent-soft: rgba(196, 85, 44, 0.12);
+  --launch-gold: #b6881f;
+  --launch-green: #27795b;
+  --launch-yellow: #a46811;
+  --launch-red: #a03f33;
+  --launch-shadow: 0 28px 70px rgba(73, 49, 27, 0.12);
+  width: min(1320px, 100%);
+  gap: 1.4rem;
+  border-radius: 28px;
+  border-color: rgba(122, 93, 58, 0.22);
+  background:
+    linear-gradient(180deg, rgba(255, 253, 248, 0.92), rgba(255, 249, 239, 0.97)),
+    repeating-linear-gradient(
+      180deg,
+      rgba(149, 122, 88, 0.045) 0,
+      rgba(149, 122, 88, 0.045) 1px,
+      transparent 1px,
+      transparent 30px
+    );
+  box-shadow: var(--launch-shadow);
+  color: var(--launch-ink);
+}
+
+.launch-execution-card h1,
+.launch-execution-card h2,
+.launch-execution-card h3,
+.launch-execution-card strong {
+  color: var(--launch-ink);
+}
+
+.launch-execution-card h1,
+.launch-execution-card h2,
+.launch-execution-card h3 {
+  font-family: 'Fraunces', Georgia, serif;
+  letter-spacing: -0.04em;
+}
+
+.launch-execution-card p,
+.launch-execution-card label,
+.launch-execution-card span {
+  color: var(--launch-copy);
+}
+
+.launch-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.9fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.launch-hero-copy {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.launch-hero-copy h1 {
+  font-size: clamp(2.7rem, 5vw, 4.6rem);
+  line-height: 0.94;
+  max-width: 12ch;
+}
+
+.launch-hero-summary {
+  max-width: 65ch;
+  font-size: 1.02rem;
+}
+
+.launch-hero-aside {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.launch-hero-note,
+.launch-input-card,
+.launch-scope-card,
+.launch-summary-card,
+.launch-section-card {
+  border: 1px solid var(--launch-border);
+  background: var(--launch-surface);
+  border-radius: 18px;
+  box-shadow: 0 12px 30px rgba(73, 49, 27, 0.05);
+}
+
+.launch-hero-note {
+  padding: 1rem 1.05rem;
+  display: grid;
+  gap: 0.2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.launch-hero-note::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: linear-gradient(180deg, var(--launch-accent), #efc46e);
+}
+
+.launch-hero-note span {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.launch-hero-note strong {
+  font-size: 1.02rem;
+}
+
+.launch-input-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
+  gap: 1rem;
+}
+
+.launch-input-card,
+.launch-scope-card,
+.launch-summary-card,
+.launch-section-card {
+  padding: 1.1rem 1.1rem 1.15rem;
+}
+
+.launch-input-card {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.launch-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.launch-field label {
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.launch-field input,
+.launch-field textarea {
+  width: 100%;
+  border: 1px solid rgba(107, 83, 58, 0.2);
+  border-radius: 14px;
+  background: var(--launch-surface-strong);
+  color: var(--launch-ink);
+  font: inherit;
+  padding: 0.78rem 0.86rem;
+}
+
+.launch-field input::placeholder,
+.launch-field textarea::placeholder {
+  color: rgba(91, 75, 61, 0.72);
+}
+
+.launch-field textarea {
+  min-height: 190px;
+  resize: vertical;
+}
+
+.launch-submit-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.launch-submit-note {
+  flex: 1 1 240px;
+  font-size: 0.92rem;
+}
+
+.launch-error-banner {
+  border: 1px solid rgba(160, 63, 51, 0.2);
+  background: rgba(160, 63, 51, 0.08);
+  color: var(--launch-red);
+  border-radius: 14px;
+  padding: 0.8rem 0.9rem;
+}
+
+.launch-scope-card h2,
+.launch-section-head h2,
+.launch-summary-head h2 {
+  font-size: 1.55rem;
+  margin-bottom: 0.25rem;
+}
+
+.launch-model-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.launch-model-list div {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.launch-model-list strong {
+  font-size: 0.98rem;
+}
+
+.launch-scope-divider {
+  height: 1px;
+  margin: 1rem 0;
+  background: linear-gradient(90deg, transparent, rgba(93, 72, 50, 0.24), transparent);
+}
+
+.launch-summary-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.launch-summary-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: start;
+}
+
+.launch-summary-objective {
+  max-width: 58ch;
+}
+
+.launch-summary-status {
+  min-width: 210px;
+  display: grid;
+  gap: 0.35rem;
+  justify-items: end;
+  text-align: right;
+}
+
+.launch-readiness-pill,
+.launch-mini-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0.28rem 0.68rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.launch-readiness-pill.is-green,
+.launch-mini-pill.is-done,
+.launch-mini-pill.is-ready,
+.launch-mini-pill.is-current {
+  background: rgba(39, 121, 91, 0.12);
+  color: var(--launch-green);
+}
+
+.launch-readiness-pill.is-yellow,
+.launch-mini-pill.is-yellow,
+.launch-mini-pill.is-at_risk,
+.launch-mini-pill.is-medium,
+.launch-mini-pill.is-open {
+  background: rgba(182, 136, 31, 0.14);
+  color: var(--launch-yellow);
+}
+
+.launch-readiness-pill.is-red,
+.launch-mini-pill.is-red,
+.launch-mini-pill.is-blocked,
+.launch-mini-pill.is-critical,
+.launch-mini-pill.is-high,
+.launch-mini-pill.is-missing {
+  background: rgba(160, 63, 51, 0.13);
+  color: var(--launch-red);
+}
+
+.launch-mini-pill.is-low,
+.launch-mini-pill.is-evidence,
+.launch-mini-pill.is-unknown,
+.launch-mini-pill.is-normal,
+.launch-mini-pill.is-not_started {
+  background: rgba(50, 46, 39, 0.08);
+  color: var(--launch-copy);
+}
+
+.launch-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.launch-summary-cell {
+  border: 1px dashed rgba(107, 83, 58, 0.24);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.42);
+  padding: 0.85rem 0.9rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.launch-summary-cell span,
+.launch-brief-block span {
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.launch-results-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.launch-section-head {
+  display: grid;
+  gap: 0.2rem;
+  margin-bottom: 0.9rem;
+}
+
+.launch-section-head p {
+  font-size: 0.94rem;
+}
+
+.launch-list {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.launch-list-item {
+  border: 1px solid rgba(93, 72, 50, 0.14);
+  background: rgba(255, 255, 255, 0.52);
+  border-radius: 16px;
+  padding: 0.85rem 0.9rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.launch-item-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.launch-empty-state {
+  padding: 0.95rem 1rem;
+  border: 1px dashed rgba(107, 83, 58, 0.24);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.42);
+}
+
+.launch-message-box,
+.launch-evidence-quote {
+  border-left: 3px solid var(--launch-accent);
+  background: rgba(196, 85, 44, 0.07);
+  border-radius: 12px;
+  padding: 0.8rem 0.9rem;
+  color: var(--launch-ink);
+}
+
+.launch-tracker-card {
+  grid-column: 1 / -1;
+}
+
+.launch-tracker-table {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.launch-tracker-row {
+  display: grid;
+  grid-template-columns: 0.8fr 1.7fr 1fr 1fr 0.9fr 0.8fr;
+  gap: 0.75rem;
+  align-items: start;
+  border: 1px solid rgba(93, 72, 50, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.54);
+  padding: 0.72rem 0.8rem;
+}
+
+.launch-tracker-head {
+  background: rgba(35, 25, 15, 0.04);
+  border-style: dashed;
+  font-size: 0.79rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.launch-brief-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.launch-brief-block {
+  border: 1px solid rgba(93, 72, 50, 0.14);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.52);
+  padding: 0.9rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.launch-brief-block .launch-list,
+.launch-brief-block .launch-list-item {
+  gap: 0.5rem;
+}
+
+.launch-brief-block .launch-list-item {
+  background: rgba(255, 249, 239, 0.94);
+  padding: 0.7rem 0.75rem;
+}
+
+@media (max-width: 1080px) {
+  .launch-hero,
+  .launch-input-layout,
+  .launch-results-grid,
+  .launch-summary-grid,
+  .launch-brief-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .launch-summary-status {
+    justify-items: start;
+    text-align: left;
+  }
+}
+
+@media (max-width: 860px) {
+  .launch-tracker-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .launch-execution-card {
+    padding: 1rem;
+    border-radius: 22px;
+  }
+
+  .launch-hero-copy h1 {
+    max-width: none;
+    font-size: clamp(2.2rem, 11vw, 3.1rem);
+  }
+
+  .launch-submit-row {
+    align-items: stretch;
+  }
+
+  .launch-submit-row .btn {
+    width: 100%;
+  }
+
+  .launch-tracker-row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a narrow launch-execution backend contract and analyzer for pasted launch threads
- add the first Oliver launch execution UI, including readiness brief, tracker, evidence, and refresh loop
- tighten Oliver landing copy around launch execution and document the v1 scope and tradeoffs

## Testing
- cargo test --manifest-path DoWhiz_service/Cargo.toml -p scheduler_module launch_execution
- npm run lint
- npm run build

## Notes
- intentionally scoped to pasted thread input for v1
- excludes unrelated local artifact directories from this PR