### PR TITLE
Tighten investment monitor sendability

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -1422,7 +1422,8 @@ fn run_codex_task_with_options(
             // (tpm_cron.rs may have already written the leader's token for TPM tasks)
             let notion_env_file = request.workspace_dir.join(".notion_env");
             if !notion_env_file.exists() {
-                if let Err(e) = fs::write(&notion_env_file, format!("NOTION_API_TOKEN={}\n", token)) {
+                if let Err(e) = fs::write(&notion_env_file, format!("NOTION_API_TOKEN={}\n", token))
+                {
                     eprintln!("[run_task] Warning: Failed to write Notion env file: {}", e);
                 }
             }

--- a/DoWhiz_service/run_task_module/src/run_task/investment_fail_soft.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/investment_fail_soft.rs
@@ -11,9 +11,6 @@ use super::reply_contract::{
     synthetic_investment_request_for_workspace,
 };
 
-const INCOMPLETE_RESEARCH_MARKER: &str = "Incomplete research artifact";
-const INCOMPLETE_MONITOR_MARKER: &str = "Incomplete monitor check";
-
 pub(super) fn maybe_write_fail_soft_investment_artifact(
     workspace_dir: &Path,
     reply_path: &Path,
@@ -24,14 +21,12 @@ pub(super) fn maybe_write_fail_soft_investment_artifact(
     }
 
     let request_text = load_inbound_request_text(workspace_dir)?;
-    let raw_request = canonical_request_line(&request_text);
-
     let html = if is_synthetic_request(&request_text) {
-        build_synthetic_assumption_artifact(&raw_request)
+        build_synthetic_assumption_artifact(&canonical_request_line(&request_text))
     } else if investment_monitor_request_for_workspace(workspace_dir)? {
-        build_monitor_fail_soft_artifact(workspace_dir, &raw_request)
+        build_monitor_operational_fallback(workspace_dir, &request_text)
     } else {
-        build_real_ticker_incomplete_artifact(workspace_dir, &raw_request)
+        build_real_ticker_operational_fallback(workspace_dir, &request_text)
     };
 
     fs::write(reply_path, html)?;
@@ -46,12 +41,12 @@ pub(super) fn maybe_write_fail_soft_investment_artifact(
         )
     } else if investment_monitor_request_for_workspace(workspace_dir)? {
         format!(
-            "Recovered via deterministic monitor fail-soft artifact after {}",
+            "Recovered via deterministic operational monitor fallback after {}",
             summarize_failure(cause)
         )
     } else {
         format!(
-            "Recovered via deterministic incomplete-research investment finalizer after {}",
+            "Recovered via deterministic operational investment fallback after {}",
             summarize_failure(cause)
         )
     };
@@ -94,8 +89,7 @@ pub(super) fn maybe_write_action_only_monitor_artifact(
     }
 
     let request_text = load_inbound_request_text(workspace_dir)?;
-    let raw_request = canonical_request_line(&request_text);
-    let html = build_monitor_fail_soft_artifact(workspace_dir, &raw_request);
+    let html = build_monitor_operational_fallback(workspace_dir, &request_text);
 
     fs::write(reply_path, html)?;
     if !reply_artifact_ready_for_workspace(workspace_dir, reply_path) {
@@ -103,7 +97,7 @@ pub(super) fn maybe_write_action_only_monitor_artifact(
     }
 
     Ok(Some(
-        "Answered via deterministic action-only monitor artifact because the request explicitly asked for a short act-now update.".to_string(),
+        "Answered via deterministic action-only monitor fallback because the request explicitly asked for a short act-now update.".to_string(),
     ))
 }
 
@@ -118,54 +112,37 @@ fn summarize_failure(cause: &RunTaskError) -> &'static str {
     }
 }
 
-fn build_monitor_fail_soft_artifact(workspace_dir: &Path, request_text: &str) -> String {
-    let investor_question = escape_html(request_text);
+fn build_monitor_operational_fallback(workspace_dir: &Path, request_text: &str) -> String {
+    let (display_name, ticker_hint) = infer_security_label(workspace_dir, request_text);
+    let heading = if let Some(ticker) = &ticker_hint {
+        format!("Quick update on {} ({})", display_name, ticker)
+    } else {
+        format!("Quick update on {}", display_name)
+    };
     let today = Utc::now().format("%Y-%m-%d").to_string();
+    let lower_request = request_text.to_ascii_lowercase();
     let prior_note_missing = prior_note_context_missing(workspace_dir);
-    let why_now = if prior_note_missing && request_text.to_ascii_lowercase().contains("last note") {
-        format!(
-            "<strong>{INCOMPLETE_MONITOR_MARKER}.</strong> The workspace did not include the prior note needed for a literal change-since-last-note diff, so the runtime returned a short fail-soft update instead of timing out with no reply."
-        )
+    let reason = if prior_note_missing && lower_request.contains("last note") {
+        "I could not do a literal change-since-last-note check because the earlier note was not available in the current thread context."
     } else {
-        format!(
-            "<strong>{INCOMPLETE_MONITOR_MARKER}.</strong> The runtime returned a short fail-soft update instead of timing out with no reply."
-        )
+        "I could not verify enough fresh context to support a reliable act-now update yet."
     };
-    let evidence_chip = if prior_note_missing
-        && request_text.to_ascii_lowercase().contains("last note")
-    {
-        "No real evidence links were preserved in this timed monitor fallback, and the prior note was not available in the workspace, so confidence stays Low."
+    let next_step = if prior_note_missing && lower_request.contains("last note") {
+        "What would help next: the prior note plus the latest verified issuer update."
     } else {
-        "No real evidence links were preserved in this timed monitor fallback, so confidence stays Low."
+        "What would help next: the latest verified issuer update plus a fresh price and valuation check."
     };
+
     format!(
         r#"<html>
   <body>
-    <h1>Investment monitor update</h1>
+    <h1>{heading}</h1>
     <p><strong>As of:</strong> {today}</p>
-    <p><strong>Price:</strong> Verification incomplete in this timed monitor run</p>
-    <p><strong>Investor question:</strong> {investor_question}</p>
-    <h2>Decision Card</h2>
-    <table>
-      <tr><th align="left">Monitor Status</th><td>Insufficient Evidence</td></tr>
-      <tr><th align="left">New Money Action</th><td>Wait</td></tr>
-      <tr><th align="left">Existing Holder Action</th><td>Hold/Do not add</td></tr>
-      <tr><th align="left">Thesis Impact</th><td>Mixed</td></tr>
-      <tr><th align="left">Signal Quality</th><td>Weak</td></tr>
-      <tr><th align="left">Confidence</th><td>Low</td></tr>
-    </table>
-    <p><strong>One-line rationale:</strong> This monitor check ran out of verified context before it could justify a stronger act-now call.</p>
-    <h2>Why Now</h2>
-    <p>{why_now}</p>
-    <h2>What Would Change The View</h2>
+    <p>{reason}</p>
+    <p>I do not want to turn incomplete context into a low-confidence buy / hold / trim call.</p>
     <ul>
-      <li><strong>Upgrade / Review Now:</strong> A verified issuer update moves revenue or margin expectations by at least 5%.</li>
-      <li><strong>Downgrade / De-risk:</strong> A verified guidance cut above 5% or a 200 bps margin reset.</li>
-      <li><strong>Invalidation:</strong> Two reporting periods pass without evidence that confirms the prior note.</li>
-    </ul>
-    <h2>Evidence Chips</h2>
-    <ul>
-      <li>{evidence_chip}</li>
+      <li><strong>What I can say now:</strong> there is no verified act-now signal I would ask you to trade on yet.</li>
+      <li><strong>What would help next:</strong> {next_step}</li>
     </ul>
   </body>
 </html>
@@ -173,89 +150,36 @@ fn build_monitor_fail_soft_artifact(workspace_dir: &Path, request_text: &str) ->
     )
 }
 
-fn build_real_ticker_incomplete_artifact(workspace_dir: &Path, request_text: &str) -> String {
+fn build_real_ticker_operational_fallback(workspace_dir: &Path, request_text: &str) -> String {
     let (display_name, ticker_hint) = infer_security_label(workspace_dir, request_text);
-    let h1 = if let Some(ticker) = &ticker_hint {
-        format!("{} ({}) decision memo", display_name, ticker)
+    let heading = if let Some(ticker) = &ticker_hint {
+        format!("Quick update on {} ({})", display_name, ticker)
     } else {
-        format!("{} decision memo", display_name)
+        format!("Quick update on {}", display_name)
     };
     let research_labels = collect_research_labels(workspace_dir);
     let research_summary = if research_labels.is_empty() {
-        "No preserved research filenames were available.".to_string()
+        "I do not have preserved issuer-specific research notes worth presenting as evidence yet."
+            .to_string()
     } else {
         format!(
-            "Preserved timed-run inputs included: {}.",
+            "I do have partial research notes saved from this pass: {}.",
             research_labels.join(", ")
         )
     };
-    let investor_question = escape_html(request_text);
     let today = Utc::now().format("%Y-%m-%d").to_string();
 
     format!(
         r#"<html>
   <body>
-    <h1>{h1}</h1>
+    <h1>{heading}</h1>
     <p><strong>As of:</strong> {today}</p>
-    <p><strong>Price:</strong> Verification incomplete in this timed run</p>
-    <p><strong>Investor question:</strong> {investor_question}</p>
-
-    <h2>Decision Card</h2>
-    <table>
-      <tr><th align="left">Monitor Status</th><td>Watch Closely</td></tr>
-      <tr><th align="left">New Money Action</th><td>Wait</td></tr>
-      <tr><th align="left">Existing Holder Action</th><td>Hold/Do not add</td></tr>
-      <tr><th align="left">Thesis Impact</th><td>Mixed</td></tr>
-      <tr><th align="left">Signal Quality</th><td>Weak</td></tr>
-      <tr><th align="left">Confidence</th><td>Low</td></tr>
-    </table>
-    <p><strong>One-line rationale:</strong> Research did not complete within budget, so this is a best-available timed artifact rather than a completed buy-or-avoid underwriting.</p>
-
-    <h2>Dual-Horizon Framing</h2>
-    <h3>Near-Term Timing View</h3>
-    <p>Do not commit fresh capital until a completed release and valuation check confirms whether the setup is truly improving rather than merely looking cheap on partial evidence.</p>
-    <h3>Long-Term Ownership View</h3>
-    <p>The long-term case remains open, but this timed run did not verify enough issuer evidence to re-underwrite the thesis confidently.</p>
-
-    <h2>Verified Facts</h2>
-    <p><strong>Research status:</strong> {INCOMPLETE_RESEARCH_MARKER}. The runtime preserved a partial draft or research trail, but not a contract-ready final artifact.</p>
-    <h3>What Was Found</h3>
+    <p>I could not finish a reliable buy-or-avoid review yet, so I am not sending a half-verified investment memo.</p>
     <ul>
-      <li>{research_summary}</li>
-      <li>The interrupted run had enough structure to support a cautious monitoring stance, but not enough verified evidence for a completed decision memo.</li>
-      <li>The runtime is surfacing a fail-soft artifact instead of silently losing the task.</li>
+      <li><strong>What I have so far:</strong> {research_summary}</li>
+      <li><strong>What is still missing:</strong> a current price and valuation cross-check, the latest issuer update read-through, and verified implications for margin, cash flow, or guidance.</li>
+      <li><strong>What this means now:</strong> treat this as incomplete work rather than a real Buy / Avoid / Add / Exit call.</li>
     </ul>
-    <h3>What Is Missing</h3>
-    <ul>
-      <li>A fully verified current price and valuation cross-check tied to the latest completed issuer update.</li>
-      <li>A completed read of the latest release or filing with confirmed implications for revenue, margin, and cash generation.</li>
-      <li>A finished independent cross-check that can support a stronger Buy, Avoid, Add, or Exit call.</li>
-    </ul>
-
-    <h2>Derived Metrics</h2>
-    <table>
-      <tr><th align="left">Metric</th><th align="left">Read-through</th><th align="left">Formula / Inputs</th></tr>
-      <tr><td>Fresh-entry conviction</td><td>Not reliably derivable</td><td>Not reliably derivable from the incomplete timed run because issuer metrics were not fully validated before the deadline.</td></tr>
-    </table>
-
-    <h2>Scenarios</h2>
-    <h3>Bull Case</h3>
-    <p>The next completed company update confirms margin stabilization above 11%, positive free cash flow, and no new guide cuts.</p>
-    <h3>Base Case</h3>
-    <p>The business remains investable, but evidence is still incomplete enough that fresh money stays in `Wait` and existing holders should avoid adding.</p>
-    <h3>Bear Case</h3>
-    <p>The next verified release shows another guide cut, another 200 bps margin step-down, or stalled cash generation.</p>
-
-    <h2>Triggers</h2>
-    <ul>
-      <li><strong>Upgrade / Review Now:</strong> The next verified company update shows operating margin above 11%, positive free cash flow, and no guide cut.</li>
-      <li><strong>Downgrade / De-risk:</strong> Management cuts guidance by 5% or more, or the next release shows another 200 bps margin deterioration.</li>
-      <li><strong>Invalidation:</strong> Two more quarters pass without a verified path back to durable positive free cash flow and stable margins.</li>
-    </ul>
-
-    <h2>Judgment</h2>
-    <p><em>Inference, Low confidence.</em> This is a best-available timed artifact, not completed deep research, so it should be treated as a watchlist handoff rather than a high-conviction call.</p>
-    <p><strong>What would be needed for Buy / Avoid / Add / Exit:</strong> a completed issuer-release review, a clean current valuation cross-check, and a verified read on whether margin and cash-flow improvement are actually durable.</p>
   </body>
 </html>
 "#
@@ -661,7 +585,28 @@ fn load_inbound_request_text(workspace_dir: &Path) -> Result<String, RunTaskErro
 fn canonical_request_line(raw: &str) -> String {
     raw.lines()
         .map(str::trim)
-        .find(|line| !line.is_empty())
+        .find(|line| {
+            if line.is_empty() {
+                return false;
+            }
+            let lower = line.to_ascii_lowercase();
+            !lower.starts_with("# canonical thread request")
+                && !lower.starts_with("auto-generated merged view")
+                && !lower.starts_with("rules:")
+                && !lower.starts_with("## ")
+                && !lower.starts_with("entry:")
+                && !lower.starts_with("subject:")
+                && !lower.starts_with("from:")
+                && !lower.starts_with("date:")
+                && !lower.starts_with("preview:")
+                && !lower.starts_with("attachments:")
+                && !lower.starts_with("```")
+                && !lower.starts_with("- ")
+                && !lower.starts_with('{')
+                && !lower.starts_with('[')
+                && !lower.contains("\"subject\"")
+                && !lower.contains("\"textbody\"")
+        })
         .unwrap_or("Investment monitor request")
         .to_string()
 }

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -294,7 +294,8 @@ Do not pretend the job has been done without actually doing it."#
 - If the user asked for investment monitoring and the earlier pass already gathered enough support for a calibrated call, stop researching and finalize the artifact now.
 - If the prompt says "only tell me if I should act" and the likely answer is `No Material Change`, write the short update immediately and stop.
 - After the draft exists, allow at most one additional targeted external check when a single missing fact blocks the verdict. Otherwise finalize with an explicit limitation note instead of continuing to search.
-- For incomplete real-ticker investment work, finalize a complete `Watch Closely` artifact rather than a provisional shell. Fill every required section, include concrete upgrade/downgrade/invalidation triggers, and state missing evidence explicitly instead of leaving placeholder text.
+- For incomplete real-ticker investment work, prefer a short honest fallback over a padded pseudo-memo. If you cannot support a real investment view within the remaining budget, do not invent action tables, triggers, or section shells just to make the reply look complete.
+- For monitor-style investment requests, prefer a concise operational update when context is missing instead of expanding into a full decision memo.
 - Do not leave `Provisional update`, `still being finalized`, `TBD`, `to be confirmed`, or empty section shells in the final artifact.
 - Investment-monitor requests in this product are allowed. Do not refuse solely because the task concerns a stock, an ETF, or an assumption-based investment scenario. If evidence is limited, answer with calibrated limitation language instead of refusing.
 - If you are still gathering evidence, clearly mark the draft as provisional near the top, and remove or replace that note before you finish if the reply becomes complete.

--- a/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 
 use super::errors::RunTaskError;
 
+#[allow(dead_code)]
 const FULL_REQUIRED_LABELS: &[&str] = &[
     "As of:",
     "Price:",
@@ -35,6 +36,7 @@ const FULL_REQUIRED_LABELS: &[&str] = &[
     "Judgment",
 ];
 
+#[allow(dead_code)]
 const SHORT_REQUIRED_LABELS: &[&str] = &[
     "As of:",
     "Price:",
@@ -55,6 +57,7 @@ const SHORT_REQUIRED_LABELS: &[&str] = &[
     "Invalidation",
 ];
 
+#[allow(dead_code)]
 const FULL_ORDER: &[&str] = &[
     "decision card",
     "dual-horizon framing",
@@ -65,6 +68,7 @@ const FULL_ORDER: &[&str] = &[
     "judgment",
 ];
 
+#[allow(dead_code)]
 const SHORT_ORDER: &[&str] = &[
     "decision card",
     "why now",
@@ -80,6 +84,8 @@ const GENERIC_PHRASES: &[&str] = &[
     "wait for clarity",
     "do not chase",
     "not a broken asset",
+    "good business, but not a good all-in buy",
+    "wait until after earnings",
 ];
 const INCOMPLETE_FAIL_SOFT_MARKERS: &[&str] = &[
     "incomplete research artifact",
@@ -88,11 +94,30 @@ const INCOMPLETE_FAIL_SOFT_MARKERS: &[&str] = &[
     "best-available timed reply",
     "incomplete monitor check",
 ];
+#[allow(dead_code)]
 const INCOMPLETE_RESEARCH_MARKERS: &[&str] = &[
     "incomplete research artifact",
     "research did not complete within budget",
     "best-available timed artifact",
     "best-available timed reply",
+];
+const INTERNAL_THREAD_METADATA_MARKERS: &[&str] = &[
+    "canonical thread request",
+    "auto-generated merged view for reruns",
+    "thread timeline",
+    "merged attachments for this rerun",
+];
+const INTERNAL_RUNTIME_LANGUAGE_MARKERS: &[&str] = &[
+    "verification incomplete in this timed monitor run",
+    "verification incomplete in this timed run",
+    "timed monitor fallback",
+    "short fail-soft update",
+    "fail-soft artifact",
+    "best-available timed artifact",
+    "best-available timed reply",
+    "contract-ready final artifact",
+    "the runtime returned",
+    "silently losing the task",
 ];
 
 const INVESTMENT_INSTRUMENT_KEYWORDS: &[&str] =
@@ -107,15 +132,17 @@ const INVESTMENT_INTENT_KEYWORDS: &[&str] = &[
     "buy this week",
     "buy before",
     "sell before",
-    "investment",
     "investing",
+    "investment view",
+    "investment case",
+    "investment memo",
     "starter position",
     "starter only",
     "buy now",
     "add or trim",
 ];
 
-const INVESTMENT_RESEARCH_KEYWORDS: &[&str] = &["deep research", "analyze", "analysis"];
+const INVESTMENT_RESEARCH_KEYWORDS: &[&str] = &["deep research", "analyze"];
 const INVESTMENT_MONITOR_KEYWORDS: &[&str] = &[
     "material changed",
     "material change",
@@ -253,14 +280,6 @@ fn investment_contract_violations(
     workspace_dir: &Path,
     reply_path: &Path,
 ) -> Result<Option<Vec<String>>, RunTaskError> {
-    // DISABLED: Investment contract validation causes 10+ hour task spinning loops
-    // due to false positives (e.g., "PR" detected as ticker, "analyze" as intent).
-    // See reference_documentation/fault_report.md for incidents.
-    // TODO: Re-enable only after fixing is_investment_request() false positives.
-    let _ = (workspace_dir, reply_path);
-    return Ok(None);
-
-    #[allow(unreachable_code)]
     let request_text = load_inbound_request_text(workspace_dir)?;
     if !is_investment_request(&request_text) {
         return Ok(None);
@@ -269,105 +288,35 @@ fn investment_contract_violations(
 
     let reply_body = fs::read_to_string(reply_path)?;
     let normalized_reply = normalize_search_text(&reply_body);
-    let contract_type = detect_contract_type(&normalized_reply);
-    let incomplete_mode = is_incomplete_fail_soft_artifact(&normalized_reply);
-    let incomplete_research_mode = is_incomplete_research_artifact(&normalized_reply);
-    let required_labels = if contract_type == "short" {
-        SHORT_REQUIRED_LABELS
-    } else {
-        FULL_REQUIRED_LABELS
-    };
-    let required_order = if contract_type == "short" {
-        SHORT_ORDER
-    } else {
-        FULL_ORDER
-    };
     let mut violations = Vec::new();
 
-    let missing_markers = missing_required_markers(&normalized_reply, required_labels);
-    if !missing_markers.is_empty() {
-        violations.push(format!(
-            "missing required labels: {}",
-            missing_markers.join(", ")
-        ));
-    }
-
-    if !contains_markers_in_order(&normalized_reply, required_order) {
-        violations.push("summary-first section order is wrong".to_string());
-    }
-
-    if !decision_card_has_required_fields(&normalized_reply) {
+    if contains_any_marker(&normalized_reply, INTERNAL_THREAD_METADATA_MARKERS) {
         violations.push(
-            "decision card must include monitor status, both action fields, thesis impact, signal quality, and confidence"
+            "reply leaks internal canonical-thread metadata instead of a user-facing question"
                 .to_string(),
         );
     }
 
-    if contract_type == "full" && !derived_metrics_has_formula(&normalized_reply) {
+    if contains_any_marker(&normalized_reply, INTERNAL_RUNTIME_LANGUAGE_MARKERS) {
         violations.push(
-            "derived metrics must include a formula-like expression or an explicit non-derivable note"
+            "reply contains internal timeout/recovery wording that is not user-sendable"
+                .to_string(),
+        );
+    }
+
+    if reply_looks_like_templated_incomplete_investment_output(&normalized_reply) {
+        violations.push(
+            "incomplete investment fallbacks must not be sent as investment-looking decision memos"
                 .to_string(),
         );
     }
 
     let clickable_links = clickable_links(&reply_body);
-    let clickable_link_count = clickable_links.len();
-    let min_links = if synthetic_mode || incomplete_mode {
-        0
-    } else if contract_type == "short" {
-        2
-    } else {
-        3
-    };
-    if clickable_link_count < min_links {
-        violations.push(format!(
-            "expected at least {} clickable source links, found {}",
-            min_links, clickable_link_count
-        ));
-    }
-
-    let trigger_section = if contract_type == "short" {
-        extract_text_section(
-            &normalized_reply,
-            "what would change the view",
-            &["evidence chips"],
-        )
-    } else {
-        extract_text_section(&normalized_reply, "triggers", &["judgment"])
-    };
-    if neutral_actions_present(&normalized_reply) {
-        for label in [
-            "upgrade / review now",
-            "downgrade / de-risk",
-            "invalidation",
-        ] {
-            if !trigger_section.contains(label) {
-                violations.push(format!("neutral stance missing trigger label `{}`", label));
-            }
-        }
-        if count_numeric_hits(&trigger_section) < 3 {
-            violations
-                .push("neutral stance lacks enough concrete numeric trigger detail".to_string());
-        }
-    }
-
-    if contract_type == "short" && normalized_reply.len() > SHORT_ARTIFACT_VISIBLE_CHAR_LIMIT {
+    if detect_contract_type(&normalized_reply) == "short"
+        && normalized_reply.contains("no material change")
+        && normalized_reply.len() > SHORT_ARTIFACT_VISIBLE_CHAR_LIMIT
+    {
         violations.push("No Material Change artifact exceeds short-output budget".to_string());
-    }
-
-    if incomplete_research_mode {
-        for label in [
-            "what was found",
-            "what is missing",
-            "what would be needed for buy / avoid / add / exit",
-        ] {
-            if !normalized_reply.contains(label) {
-                violations.push(format!(
-                    "incomplete-research artifact missing `{}` guidance",
-                    label
-                ));
-            }
-        }
     }
 
     if synthetic_mode {
@@ -401,10 +350,9 @@ fn investment_contract_violations(
     if GENERIC_PHRASES
         .iter()
         .any(|phrase| normalized_reply.contains(phrase))
-        && count_numeric_hits(&trigger_section) < 3
     {
         violations
-            .push("generic hold/wait phrasing without concrete movement criteria".to_string());
+            .push("generic hold/wait phrasing is not sendable as an investment reply".to_string());
     }
 
     if violations.is_empty() {
@@ -426,18 +374,21 @@ fn detect_contract_type(normalized_reply: &str) -> &'static str {
     }
 }
 
+#[allow(dead_code)]
 fn is_incomplete_fail_soft_artifact(normalized_reply: &str) -> bool {
     INCOMPLETE_FAIL_SOFT_MARKERS
         .iter()
         .any(|marker| normalized_reply.contains(marker))
 }
 
+#[allow(dead_code)]
 fn is_incomplete_research_artifact(normalized_reply: &str) -> bool {
     INCOMPLETE_RESEARCH_MARKERS
         .iter()
         .any(|marker| normalized_reply.contains(marker))
 }
 
+#[allow(dead_code)]
 fn missing_required_markers(normalized_reply: &str, labels: &[&str]) -> Vec<String> {
     labels
         .iter()
@@ -446,6 +397,7 @@ fn missing_required_markers(normalized_reply: &str, labels: &[&str]) -> Vec<Stri
         .collect()
 }
 
+#[allow(dead_code)]
 fn contains_markers_in_order(normalized_reply: &str, markers: &[&str]) -> bool {
     let mut search_start = 0;
     for marker in markers {
@@ -458,6 +410,7 @@ fn contains_markers_in_order(normalized_reply: &str, markers: &[&str]) -> bool {
     true
 }
 
+#[allow(dead_code)]
 fn decision_card_has_required_fields(normalized_reply: &str) -> bool {
     [
         "monitor status",
@@ -471,6 +424,7 @@ fn decision_card_has_required_fields(normalized_reply: &str) -> bool {
     .all(|marker| normalized_reply.contains(marker))
 }
 
+#[allow(dead_code)]
 fn derived_metrics_has_formula(normalized_reply: &str) -> bool {
     let section = extract_text_section(normalized_reply, "derived metrics", &["scenarios"]);
     section.contains("formula / inputs")
@@ -479,6 +433,7 @@ fn derived_metrics_has_formula(normalized_reply: &str) -> bool {
         || section.contains("not reliably derivable")
 }
 
+#[allow(dead_code)]
 fn neutral_actions_present(normalized_reply: &str) -> bool {
     normalized_reply.contains("new money action wait")
         || normalized_reply.contains("existing holder action hold")
@@ -503,6 +458,7 @@ fn clickable_links(raw_reply: &str) -> Vec<String> {
         .collect()
 }
 
+#[allow(dead_code)]
 fn extract_text_section(normalized_reply: &str, start_label: &str, end_labels: &[&str]) -> String {
     let Some(start) = normalized_reply.find(start_label) else {
         return String::new();
@@ -516,6 +472,7 @@ fn extract_text_section(normalized_reply: &str, start_label: &str, end_labels: &
     tail[..end].to_string()
 }
 
+#[allow(dead_code)]
 fn count_numeric_hits(text: &str) -> usize {
     let mut count = 0;
     let mut in_number = false;
@@ -536,6 +493,7 @@ fn count_numeric_hits(text: &str) -> usize {
         + count_number_word_time_hits(text)
 }
 
+#[allow(dead_code)]
 fn count_number_word_time_hits(text: &str) -> usize {
     let number_words = [
         "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven",
@@ -672,8 +630,9 @@ fn is_action_only_monitor_request(raw: &str) -> bool {
 
 fn contains_probable_ticker(raw: &str) -> bool {
     const STOPWORDS: &[&str] = &[
-        "A", "AI", "ACI", "AM", "AND", "API", "ARE", "BUY", "CI", "ETF", "EPS", "HTML", "I",
-        "JSON", "NOW", "PR", "THE", "UI", "URL", "UX", "WAIT",
+        "A", "AI", "ACI", "AM", "AND", "API", "ARE", "AWS", "BUY", "CI", "CLI", "CSS", "CSV",
+        "ETF", "EPS", "HTML", "HTTP", "I", "JSON", "NOW", "PR", "SDK", "SQL", "SSH", "THE", "TSV",
+        "UI", "URL", "UX", "WAIT", "XML", "YAML",
     ];
 
     raw.split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '$')
@@ -862,6 +821,22 @@ fn link_looks_specific(link: &str) -> bool {
         || trimmed.contains("article")
 }
 
+fn contains_any_marker(normalized_reply: &str, markers: &[&str]) -> bool {
+    markers
+        .iter()
+        .any(|marker| normalized_reply.contains(marker))
+}
+
+fn reply_looks_like_templated_incomplete_investment_output(normalized_reply: &str) -> bool {
+    let has_decision_card = normalized_reply.contains("decision card");
+    let has_action_table = normalized_reply.contains("new money action")
+        || normalized_reply.contains("existing holder action");
+    let has_incomplete_marker = contains_any_marker(normalized_reply, INCOMPLETE_FAIL_SOFT_MARKERS)
+        || contains_any_marker(normalized_reply, INTERNAL_RUNTIME_LANGUAGE_MARKERS);
+
+    (has_decision_card || has_action_table) && has_incomplete_marker
+}
+
 fn url_path(link: &str) -> &str {
     let without_scheme = link.split_once("://").map(|(_, rest)| rest).unwrap_or(link);
     let Some(path_start) = without_scheme.find('/') else {
@@ -1018,6 +993,26 @@ mod tests {
                 || rendered.contains("violates required contract")
         );
         assert!(!reply_artifact_ready_for_workspace(&workspace, &reply_path));
+    }
+
+    #[test]
+    fn canonical_thread_metadata_in_reply_fails_sendability_gate() {
+        let workspace = write_workspace(
+            "Check whether anything material changed for NVDA since your last note. Only tell me if I should act.",
+            r#"
+            <section>
+              <p><strong>As of:</strong> 2026-05-01</p>
+              <p><strong>Investor question:</strong> # Canonical thread request</p>
+            </section>
+            "#,
+        );
+        let reply_path = workspace.join("reply_email_draft.html");
+
+        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
+            .expect_err("canonical thread metadata should not be sendable");
+        assert!(err
+            .to_string()
+            .contains("reply leaks internal canonical-thread metadata"));
     }
 
     #[test]
@@ -1203,7 +1198,7 @@ mod tests {
     }
 
     #[test]
-    fn incomplete_research_artifact_can_pass_without_links_when_disclosures_are_present() {
+    fn incomplete_research_investment_memo_fails_sendability_gate() {
         let workspace = write_workspace(
             "Give me a deep research about the Nokia stock, and tell me whether it is a good time to buy.",
             r#"
@@ -1277,12 +1272,15 @@ mod tests {
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
-        ensure_expected_reply_artifact(&workspace, &reply_path, "")
-            .expect("incomplete-research artifact should validate");
+        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
+            .expect_err("incomplete pseudo-memo should not be sendable");
+        assert!(err.to_string().contains(
+            "incomplete investment fallbacks must not be sent as investment-looking decision memos"
+        ));
     }
 
     #[test]
-    fn incomplete_short_monitor_artifact_can_pass_without_links() {
+    fn incomplete_short_monitor_artifact_fails_sendability_gate() {
         let workspace = write_workspace(
             "Check whether anything material changed for NVDA since your last note. Only tell me if I should act.",
             r#"
@@ -1324,7 +1322,14 @@ mod tests {
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
-        ensure_expected_reply_artifact(&workspace, &reply_path, "")
-            .expect("short incomplete monitor artifact should validate");
+        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
+            .expect_err("short incomplete monitor pseudo-memo should not be sendable");
+        let rendered = err.to_string();
+        assert!(rendered.contains(
+            "incomplete investment fallbacks must not be sent as investment-looking decision memos"
+        ));
+        assert!(rendered.contains(
+            "reply contains internal timeout/recovery wording that is not user-sendable"
+        ));
     }
 }

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -1039,6 +1039,11 @@ fn run_task_action_only_monitor_requests_use_fast_path() {
         "NVDA monitor check",
         "Check whether anything material changed for NVDA since your last note. Only tell me if I should act.",
     );
+    fs::write(
+        workspace.join("incoming_email").join("thread_request.md"),
+        "# Canonical thread request\nAuto-generated merged view for reruns.\n\n## Latest inbound message\nPreview:\n```text\nCheck whether anything material changed for NVDA since your last note. Only tell me if I should act.\n```\n",
+    )
+    .unwrap();
     install_runtime_skills_and_employee_guidance(&workspace, "little_bear").unwrap();
 
     let home_dir = temp.path.join("home");
@@ -1087,10 +1092,12 @@ sleep 20
         .expect("action-only monitor request should use fast path");
     let elapsed = started_at.elapsed();
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
-    assert!(html.contains("Insufficient Evidence"));
-    assert!(html.contains("Incomplete monitor check"));
-    assert!(html.contains("prior note needed for a literal change-since-last-note diff"));
-    assert!(!html.contains("Dual-Horizon Framing"));
+    assert!(html.contains("Quick update on NVDA"));
+    assert!(html.contains("literal change-since-last-note check"));
+    assert!(html.contains("low-confidence buy / hold / trim call"));
+    assert!(!html.contains("Decision Card"));
+    assert!(!html.contains("Insufficient Evidence"));
+    assert!(!html.contains("Canonical thread request"));
     assert!(!html.contains("href=\"http"));
     assert!(!counter_path.exists());
     assert!(
@@ -1098,7 +1105,7 @@ sleep 20
         "action-only monitor fast path should return quickly, elapsed={elapsed:?}"
     );
     let note = result.recovery_note.as_deref().unwrap_or("");
-    assert!(note.contains("deterministic action-only monitor artifact"));
+    assert!(note.contains("deterministic action-only monitor fallback"));
     assert!(!note.contains("Claude fallback"));
 }
 
@@ -1148,12 +1155,13 @@ sleep 20
     let result = run_task(&build_params(&workspace))
         .expect("monitor timeout should produce fail-soft artifact");
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
-    assert!(html.contains("Insufficient Evidence"));
-    assert!(html.contains("Incomplete monitor check"));
-    assert!(!html.contains("Dual-Horizon Framing"));
+    assert!(html.contains("Quick update on NVDA"));
+    assert!(html.contains("low-confidence buy / hold / trim call"));
+    assert!(!html.contains("Decision Card"));
+    assert!(!html.contains("timed monitor run"));
     assert!(!html.contains("href=\"http"));
     let note = result.recovery_note.as_deref().unwrap_or("");
-    assert!(note.contains("deterministic monitor fail-soft artifact"));
+    assert!(note.contains("deterministic operational monitor fallback"));
     assert!(!note.contains("Claude fallback"));
 }
 
@@ -1238,15 +1246,17 @@ sleep 20
     let result =
         run_task(&build_params(&workspace)).expect("fail-soft artifact should recover timeout");
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
-    assert!(html.contains("Incomplete research artifact"));
-    assert!(html.contains("What Was Found"));
-    assert!(html.contains("What Is Missing"));
-    assert!(html.contains("What would be needed for Buy / Avoid / Add / Exit"));
+    assert!(html.contains("Quick update on Nokia (NOK)"));
+    assert!(html.contains("I could not finish a reliable buy-or-avoid review yet"));
+    assert!(html.contains("What I have so far"));
+    assert!(html.contains("What is still missing"));
+    assert!(html.contains("incomplete work rather than a real Buy / Avoid / Add / Exit call"));
+    assert!(!html.contains("Decision Card"));
     assert!(!html.contains("href=\"http"));
     assert_eq!(fs::read_to_string(&counter_path).unwrap(), "2");
     assert!(workspace.join("codex_fast_completion_context.md").exists());
     let note = result.recovery_note.as_deref().unwrap_or("");
-    assert!(note.contains("deterministic incomplete-research investment finalizer"));
+    assert!(note.contains("deterministic operational investment fallback"));
     assert!(!note.contains("Returned early once a valid reply artifact existed"));
 }
 
@@ -2182,12 +2192,14 @@ fn run_task_investment_contract_violation_uses_fail_soft_artifact_when_fallback_
         .expect("generic Codex + generic fallback should still return a fail-soft artifact");
     let html = fs::read_to_string(result.reply_html_path).unwrap();
     let recovery = result.recovery_note.unwrap_or_default();
-    assert!(html.contains("Incomplete research artifact"));
-    assert!(html.contains("What Was Found"));
-    assert!(html.contains("What Is Missing"));
-    assert!(html.contains("What would be needed for Buy / Avoid / Add / Exit"));
+    assert!(html.contains("Quick update on NVDA"));
+    assert!(html.contains("I could not finish a reliable buy-or-avoid review yet"));
+    assert!(html.contains("What I have so far"));
+    assert!(html.contains("What is still missing"));
+    assert!(html.contains("incomplete work rather than a real Buy / Avoid / Add / Exit call"));
+    assert!(!html.contains("Decision Card"));
     assert!(!html.contains("href=\"http"));
-    assert!(recovery.contains("deterministic incomplete-research investment finalizer"));
+    assert!(recovery.contains("deterministic operational investment fallback"));
     assert!(recovery.contains("Codex and fallback recovery failed"));
 }
 


### PR DESCRIPTION
## Summary
- restore a narrow runtime sendability gate for investment replies instead of allowing any fail-soft artifact through
- convert timeout and action-only monitor fallbacks into short operational updates rather than pseudo-investment memos
- stop internal canonical-thread metadata from leaking into user-visible fallback fields while keeping synthetic assumption behavior intact

## Validation
- cargo fmt --all --check
- cargo clippy -p run_task_module --all-targets -- -D warnings
- cargo test --locked -p run_task_module
- cargo test -p scheduler_module --bin investment_eval -- --nocapture
- python3 DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py

## Notes
- left local-only workspace artifacts and the unrelated formatting-only change in DoWhiz_service/run_task_module/src/run_task/codex.rs out of this PR intentionally