### PR TITLE
Refocus landing page around launch execution

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -1744,6 +1744,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
         let section = build_user_identities_section(&identities);
 
@@ -2072,6 +2073,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
 
         let prompt = build_prompt(
@@ -2117,6 +2119,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
 
         let prompt = build_prompt(
@@ -2171,6 +2174,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
 
         let prompt = build_prompt(
@@ -2217,6 +2221,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
 
         let prompt = build_prompt(
@@ -2358,6 +2363,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
 
         let prompt = build_prompt(
@@ -2412,6 +2418,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
 
         let prompt = build_prompt(
@@ -2470,6 +2477,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
 
         let prompt = build_prompt(
@@ -2516,6 +2524,7 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            organization_members: vec![],
         };
 
         let prompt = build_prompt(

--- a/DoWhiz_service/scheduler_module/src/scheduler/utils.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/utils.rs
@@ -150,7 +150,10 @@ pub fn load_notion_access_token_for_account(account_id: Option<Uuid>) -> Option<
                 );
                 Some(cred.access_token.clone())
             } else {
-                tracing::debug!("No Notion credentials found for account {}", effective_account_id);
+                tracing::debug!(
+                    "No Notion credentials found for account {}",
+                    effective_account_id
+                );
                 None
             }
         }

--- a/website/src/pages/LandingPage.jsx
+++ b/website/src/pages/LandingPage.jsx
@@ -25,7 +25,7 @@ const LANDING_PAGE_OVERRIDE_VALUE = 'landing';
 const LANDING_DASHBOARD_SUFFIX = '?loggedIn=true#section-overview';
 const LANDING_SETTINGS_SUFFIX = '#section-settings';
 const AUTHENTICATED_SETTINGS_SUFFIX = '?loggedIn=true#section-settings';
-const LANDING_PAGE_VARIANT = 'oliver_channel_native_stages_v3';
+const LANDING_PAGE_VARIANT = 'launch_execution_workspace_v1';
 const HERO_SHOWCASE_INTERVAL_MS = 4200;
 const PUBLIC_CHANNEL_URLS = {
   slack:
@@ -569,7 +569,7 @@ function SlackHeroStage({ tool }) {
         </div>
 
         <div className="hero-stage-slack-composer">
-          <span className="hero-stage-slack-composer-pill">@Oliver</span>
+          <span className="hero-stage-slack-composer-pill">@DoWhiz</span>
           <div className="hero-stage-slack-composer-copy">
             <strong>{stage.composerPlaceholder}</strong>
             <span>{stage.composerHint}</span>
@@ -1277,9 +1277,9 @@ function LandingPage({ locale }) {
 
   const buildToolTrialMailto = (tool) => {
     const englishContext = {
-      github: 'repo, issue, or code-adjacent task',
-      notion: 'docs, notes, or knowledge work',
-      lark: 'ops coordination or follow-through work'
+      github: 'launch issue, blocker, or code-adjacent follow-through',
+      notion: 'launch brief, decision log, or planning doc',
+      lark: 'cross-team follow-through work'
     };
     const chineseContext = {
       github: 'repo、issue 或代码周边任务',
@@ -1287,10 +1287,10 @@ function LandingPage({ locale }) {
       lark: '协作运营或持续跟进任务'
     };
     const chineseTaskContext = chineseContext[tool.key] || `${tool.label} 相关任务`;
-    const subject = isChinesePage ? `想通过 ${tool.label} 试用 Oliver` : `Trying Oliver with ${tool.label}`;
+    const subject = isChinesePage ? `想通过 ${tool.label} 试用 DoWhiz` : `Trying DoWhiz with ${tool.label}`;
     const body = isChinesePage
-      ? `你好 Oliver，\n\n我想先试一个和 ${tool.label} 有关的 ${chineseTaskContext}。\n\n- 我需要你处理什么：\n- 相关链接或上下文：\n- 希望最后拿到什么结果：\n- 如果后续更顺手，我是否愿意再连接 ${tool.label}：\n\n如果 setup 或绑定真的有帮助，也请你在回复里告诉我下一步。\n\n谢谢！`
-      : `Hi Oliver,\n\nI want to try Oliver with a ${englishContext[tool.key] || tool.label} request.\n\n- What I need done:\n- Relevant links or context:\n- What a good result looks like:\n- If it helps later, should we connect ${tool.label} after this:\n\nIf setup or linking would actually help, please guide me in your reply.\n\nThanks!`;
+      ? `你好 DoWhiz，\n\n我想先试一个和 ${tool.label} 有关的 ${chineseTaskContext}。\n\n- 我需要你处理什么：\n- 相关链接或上下文：\n- 希望最后拿到什么结果：\n- 如果后续更顺手，我是否愿意再连接 ${tool.label}：\n\n如果 setup 或绑定真的有帮助，也请你在回复里告诉我下一步。\n\n谢谢！`
+      : `Hi DoWhiz,\n\nI want to try DoWhiz with a ${englishContext[tool.key] || tool.label} request.\n\n- What I need done:\n- Relevant links or context:\n- What a good result looks like:\n- If it helps later, should we connect ${tool.label} after this:\n\nIf setup or linking would actually help, please guide me in your reply.\n\nThanks!`;
 
     return buildMailtoLink('oliver@dowhiz.com', subject, body);
   };
@@ -1644,21 +1644,8 @@ function LandingPage({ locale }) {
                 >
                   {content.hero.primaryCta}
                 </a>
-                <a
-                  className="btn btn-secondary hero-secondary-cta"
-                  href="#watch"
-                  onClick={() =>
-                    trackCtaClick('secondary_cta_click', {
-                      cta_location: 'hero_secondary_watch',
-                      cta_text: content.hero.secondaryCta,
-                      landing_page_variant: LANDING_PAGE_VARIANT
-                    })
-                  }
-                >
-                  {content.hero.secondaryCta}
-                </a>
               </div>
-              <p className="hero-support-note">{content.hero.toolsFootnote}</p>
+              <p className="hero-support-note">{content.hero.supportNote || content.hero.toolsFootnote}</p>
             </div>
 
             <div
@@ -1679,11 +1666,11 @@ function LandingPage({ locale }) {
                 </div>
                 <div className="hero-operator-chip">
                   <div className="hero-operator-portrait">
-                    <img src={oliverImg} alt="Oliver" className="hero-portrait" />
+                    <img src={oliverImg} alt={content.hero.operatorName || 'Oliver'} className="hero-portrait" />
                   </div>
                   <div className="hero-operator-copy">
-                    <strong>Oliver</strong>
-                    <span>{isChinesePage ? '可信 AI operator' : 'Trusted AI operator'}</span>
+                    <strong>{content.hero.operatorName || 'Oliver'}</strong>
+                    <span>{content.hero.operatorRole || (isChinesePage ? '可信 AI operator' : 'Trusted AI operator')}</span>
                   </div>
                 </div>
               </div>
@@ -1807,143 +1794,202 @@ function LandingPage({ locale }) {
           </div>
         </section>
 
-          <section id="watch" className="section demo-showcase-section">
-          <div className="container">
-            <div className="section-heading-shell">
-              <span className="section-kicker">{content.demo.eyebrow}</span>
-              <h2 className="section-title section-title-left">{content.demo.title}</h2>
-              <p className="section-intro section-intro-left">{content.demo.intro}</p>
-            </div>
-
-            <div className="demo-showcase-grid">
-              <article className="demo-feature-card">
-                <div className="demo-card-head">
-                  <div>
-                    <h3>{content.demo.desktopTitle}</h3>
-                    <p>{content.demo.desktopDescription}</p>
+          {isChinesePage ? (
+            <>
+              <section id="watch" className="section demo-showcase-section">
+                <div className="container">
+                  <div className="section-heading-shell">
+                    <span className="section-kicker">{content.demo.eyebrow}</span>
+                    <h2 className="section-title section-title-left">{content.demo.title}</h2>
+                    <p className="section-intro section-intro-left">{content.demo.intro}</p>
                   </div>
-                  <a
-                    className="demo-inline-link"
-                    href={content.demo.desktopVideoHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {content.demo.desktopCta}
-                  </a>
-                </div>
-                <div className="frame-shell frame-landscape">
-                  <iframe
-                    src={`https://www.youtube.com/embed/${content.demo.desktopVideoId}?rel=0`}
-                    title={content.demo.desktopTitle}
-                    loading="lazy"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerPolicy="strict-origin-when-cross-origin"
-                    allowFullScreen
-                  ></iframe>
-                </div>
-              </article>
 
-              <aside className="demo-short-rail">
-                <div className="demo-short-head">
-                  <h3>{content.demo.shortsTitle}</h3>
-                  <p>{content.demo.shortsDescription}</p>
-                </div>
-                <div className="demo-short-grid">
-                  {content.demo.shorts.map((item) => (
-                    <article key={item.videoId} className="demo-short-card">
-                      <div className="frame-shell frame-portrait">
+                  <div className="demo-showcase-grid">
+                    <article className="demo-feature-card">
+                      <div className="demo-card-head">
+                        <div>
+                          <h3>{content.demo.desktopTitle}</h3>
+                          <p>{content.demo.desktopDescription}</p>
+                        </div>
+                        <a
+                          className="demo-inline-link"
+                          href={content.demo.desktopVideoHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {content.demo.desktopCta}
+                        </a>
+                      </div>
+                      <div className="frame-shell frame-landscape">
                         <iframe
-                          src={`https://www.youtube.com/embed/${item.videoId}?rel=0`}
-                          title={item.title}
+                          src={`https://www.youtube.com/embed/${content.demo.desktopVideoId}?rel=0`}
+                          title={content.demo.desktopTitle}
                           loading="lazy"
                           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                           referrerPolicy="strict-origin-when-cross-origin"
                           allowFullScreen
                         ></iframe>
                       </div>
-                      <a
-                        className="demo-short-link"
-                        href={item.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {item.title}
-                      </a>
                     </article>
-                  ))}
-                </div>
-              </aside>
-            </div>
-          </div>
-        </section>
 
-          <section id="examples" className="section example-showcase-section">
-          <div className="container story-stack">
-            <div className="section-heading-shell">
-              <span className="section-kicker">{content.examples.eyebrow}</span>
-              <h2 className="section-title section-title-left">{content.examples.title}</h2>
-              <p className="section-intro section-intro-left">{content.examples.intro}</p>
-            </div>
-
-            <div className="example-card-grid">
-              {content.examples.cards.map((item) => (
-                <a
-                  key={item.title}
-                  className={`example-card${item.href ? ' example-card-link' : ''}`}
-                  href={item.href || undefined}
-                >
-                  <span className="example-card-tag">{item.tag}</span>
-                  <h3>{item.title}</h3>
-                  <p>{item.description}</p>
-                  {item.ctaLabel ? <span className="example-card-cta">{item.ctaLabel}</span> : null}
-                </a>
-              ))}
-            </div>
-          </div>
-        </section>
-
-          <section id="faq" className="section faq-section">
-            <div className="container">
-              <div className="section-heading-shell">
-                <span className="section-kicker">{content.labels.faqEyebrow}</span>
-                <h2 className="section-title section-title-left">{content.labels.faqTitle}</h2>
-                <p className="section-intro section-intro-left">{content.labels.faqIntro}</p>
-              </div>
-              <div className="faq-accordion faq-compact">
-                {content.faqItems.map((item, idx) => {
-                  const isOpen = openFaq === idx;
-                  return (
-                    <article key={item.question} className={`faq-accordion-item ${isOpen ? 'open' : ''}`}>
-                      <button
-                        type="button"
-                        className="faq-accordion-header"
-                        onClick={() => toggleFaq(idx)}
-                        aria-expanded={isOpen}
-                        aria-controls={`faq-panel-${idx}`}
-                      >
-                        <span className="faq-question">{item.question}</span>
-                        <span className="faq-toggle" aria-hidden="true">
-                          {isOpen ? '−' : '+'}
-                        </span>
-                      </button>
-                      <div
-                        id={`faq-panel-${idx}`}
-                        className="faq-accordion-panel"
-                        style={{ display: isOpen ? 'block' : 'none' }}
-                      >
-                        <p>{item.answer}</p>
+                    <aside className="demo-short-rail">
+                      <div className="demo-short-head">
+                        <h3>{content.demo.shortsTitle}</h3>
+                        <p>{content.demo.shortsDescription}</p>
                       </div>
-                    </article>
-                  );
-                })}
+                      <div className="demo-short-grid">
+                        {content.demo.shorts.map((item) => (
+                          <article key={item.videoId} className="demo-short-card">
+                            <div className="frame-shell frame-portrait">
+                              <iframe
+                                src={`https://www.youtube.com/embed/${item.videoId}?rel=0`}
+                                title={item.title}
+                                loading="lazy"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                referrerPolicy="strict-origin-when-cross-origin"
+                                allowFullScreen
+                              ></iframe>
+                            </div>
+                            <a
+                              className="demo-short-link"
+                              href={item.href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {item.title}
+                            </a>
+                          </article>
+                        ))}
+                      </div>
+                    </aside>
+                  </div>
+                </div>
+              </section>
+
+              <section id="examples" className="section example-showcase-section">
+                <div className="container story-stack">
+                  <div className="section-heading-shell">
+                    <span className="section-kicker">{content.examples.eyebrow}</span>
+                    <h2 className="section-title section-title-left">{content.examples.title}</h2>
+                    <p className="section-intro section-intro-left">{content.examples.intro}</p>
+                  </div>
+
+                  <div className="example-card-grid">
+                    {content.examples.cards.map((item) => (
+                      <a
+                        key={item.title}
+                        className={`example-card${item.href ? ' example-card-link' : ''}`}
+                        href={item.href || undefined}
+                      >
+                        <span className="example-card-tag">{item.tag}</span>
+                        <h3>{item.title}</h3>
+                        <p>{item.description}</p>
+                        {item.ctaLabel ? <span className="example-card-cta">{item.ctaLabel}</span> : null}
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              </section>
+            </>
+          ) : (
+            <>
+              <section id="workflow" className="section workflow-visual-section">
+                <div className="container story-stack">
+                  <div className="section-heading-shell">
+                    <span className="section-kicker">{content.workflowVisual.eyebrow}</span>
+                    <h2 className="section-title section-title-left">{content.workflowVisual.title}</h2>
+                    <p className="section-intro section-intro-left">{content.workflowVisual.subtitle}</p>
+                  </div>
+
+                  <div className="workflow-visual-flow">
+                    {content.workflowVisual.stages.map((stage, index) => (
+                      <article
+                        key={stage.key}
+                        className="workflow-visual-step"
+                        data-app={stage.key}
+                      >
+                        <div className="workflow-visual-card">
+                          <div className="workflow-visual-card-head">
+                            <span className="workflow-visual-app">{stage.app}</span>
+                            <span className="workflow-visual-index">{String(index + 1).padStart(2, '0')}</span>
+                          </div>
+                          <h3>{stage.title}</h3>
+                          <p className="workflow-visual-copy">{stage.copy}</p>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+
+                  <p className="workflow-visual-note">{content.workflowVisual.note}</p>
+                </div>
+              </section>
+
+              <section id="outputs" className="section outputs-compact-section">
+                <div className="container story-stack">
+                  <div className="section-heading-shell">
+                    <span className="section-kicker">{content.artifactRail.eyebrow}</span>
+                    <h2 className="section-title section-title-left">{content.artifactRail.title}</h2>
+                    <p className="section-intro section-intro-left">{content.artifactRail.subtitle}</p>
+                  </div>
+
+                  <div className="artifact-rail">
+                    {content.artifactRail.items.map((item) => (
+                      <article key={item.title} className="example-card artifact-card">
+                        <h3>{item.title}</h3>
+                        <p>{item.description}</p>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              </section>
+            </>
+          )}
+
+          {isChinesePage ? (
+            <section id="faq" className="section faq-section">
+              <div className="container">
+                <div className="section-heading-shell">
+                  <span className="section-kicker">{content.labels.faqEyebrow}</span>
+                  <h2 className="section-title section-title-left">{content.labels.faqTitle}</h2>
+                  <p className="section-intro section-intro-left">{content.labels.faqIntro}</p>
+                </div>
+                <div className="faq-accordion faq-compact">
+                  {content.faqItems.map((item, idx) => {
+                    const isOpen = openFaq === idx;
+                    return (
+                      <article key={item.question} className={`faq-accordion-item ${isOpen ? 'open' : ''}`}>
+                        <button
+                          type="button"
+                          className="faq-accordion-header"
+                          onClick={() => toggleFaq(idx)}
+                          aria-expanded={isOpen}
+                          aria-controls={`faq-panel-${idx}`}
+                        >
+                          <span className="faq-question">{item.question}</span>
+                          <span className="faq-toggle" aria-hidden="true">
+                            {isOpen ? '−' : '+'}
+                          </span>
+                        </button>
+                        <div
+                          id={`faq-panel-${idx}`}
+                          className="faq-accordion-panel"
+                          style={{ display: isOpen ? 'block' : 'none' }}
+                        >
+                          <p>{item.answer}</p>
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+                <div className="faq-link-row">
+                  <a className="faq-text-link" href="/help-center/">
+                    {content.labels.faqLinkLabel}
+                  </a>
+                </div>
               </div>
-              <div className="faq-link-row">
-                <a className="faq-text-link" href="/help-center/">
-                  {content.labels.faqLinkLabel}
-                </a>
-              </div>
-            </div>
-          </section>
+            </section>
+          ) : null}
+
         </main>
 
         <footer className="site-footer">
@@ -1965,7 +2011,7 @@ function LandingPage({ locale }) {
                   </a>
                 ))}
                 <a href={`mailto:${SUPPORT_EMAIL}`} className="footer-link">
-                  {isChinesePage ? '联系 Oliver' : 'Contact Oliver'}
+                  {content.labels.footerContactLabel || (isChinesePage ? '联系 Oliver' : 'Contact Oliver')}
                 </a>
               </div>
             </div>

--- a/website/src/pages/landingContent.js
+++ b/website/src/pages/landingContent.js
@@ -1,8 +1,10 @@
+import { buildEnglishHomepageContent } from './landingExecutionContent';
+
 const EN_LANDING_CONTENT = {
   metadata: {
-    title: 'DoWhiz | AI digital employees in email, Slack, and GitHub',
+    title: 'DoWhiz | Keep launches from drifting',
     description:
-      'Start with Oliver in email, Slack, or Discord. DoWhiz turns real requests into finished work across GitHub, docs, and shared tools.',
+      'Turn messy planning threads into owners, dates, blockers, decisions, and evidence-backed readiness across Slack, email, GitHub, docs, and your systems of record.',
     canonicalUrl: 'https://dowhiz.com/',
     ogLocale: 'en_US',
     themeColor: '#2C2C2E',
@@ -1156,5 +1158,5 @@ const ZH_LANDING_CONTENT = {
 };
 
 export function getLandingContent(locale = 'en-US') {
-  return locale === 'zh-CN' ? ZH_LANDING_CONTENT : EN_LANDING_CONTENT;
+  return locale === 'zh-CN' ? ZH_LANDING_CONTENT : buildEnglishHomepageContent(EN_LANDING_CONTENT);
 }

--- a/website/src/pages/landingExecutionContent.js
+++ b/website/src/pages/landingExecutionContent.js
@@ -1,0 +1,781 @@
+const EN_HOMEPAGE_OVERRIDES = {
+  metadata: {
+    title: 'DoWhiz | Keep launches from drifting',
+    description:
+      'Turn messy planning threads into owners, dates, blockers, decisions, and evidence-backed readiness across Slack, email, GitHub, docs, and your systems of record.'
+  },
+  nav: {
+    links: [
+      { href: '#workflow', label: 'How it works' },
+      { href: '#outputs', label: 'What you get' }
+    ],
+    signIn: 'Open workspace',
+    dashboard: 'Workspace',
+    contactAriaLabel: 'Email DoWhiz'
+  },
+  hero: {
+    eyebrow: 'For PMs and product leads running launches',
+    title: 'DoWhiz keeps launches from drifting',
+    subtitle:
+      'Start with the thread. Get owners, blockers, proof, and updates across Slack, Discord, GitHub, docs, and Notion.',
+    primaryCta: 'Start with a thread',
+    secondaryCta: 'See the workflow',
+    secondaryHref: '#workflow',
+    manageAnonymous: 'Open workspace',
+    manageAuthenticated: 'Open your workspace',
+    contactSubject: 'Help me turn this launch thread into a plan',
+    contactBody:
+      'Hi DoWhiz,\n\nPlease turn this launch thread into an execution plan.\n\n- Launch or rollout:\n- Current thread or notes:\n- Owners already in motion:\n- What is blocked right now:\n- What done looks like:\n\nThanks!',
+    toolsEyebrow: 'Where the work starts',
+    toolsFootnote:
+      'DoWhiz starts in the thread, turns it into a live plan, and keeps follow-through tied to your system of record.',
+    previewLabel: 'Thread-native preview',
+    primaryChannelsLabel: 'Starts in the thread',
+    secondaryChannelsLabel: 'Follows through into systems of record',
+    showcaseSummary:
+      'The thread is where the work starts. The output is a plan, tracked follow-through, and linked evidence.',
+    proofPills: ['Thread in', 'Plan out', 'Updates synced'],
+    supportNote:
+      'For PMs and product leads running launches.',
+    operatorName: 'Oliver',
+    operatorRole: 'Representative coordination agent',
+    tools: {
+      email: {
+        anonymousStatus: 'Direct thread start',
+        authenticatedStatus: 'Direct thread start',
+        anonymousActionLabel: 'Forward thread',
+        authenticatedActionLabel: 'Forward thread',
+        description: 'Forward the thread or launch recap you already have',
+        samplePrompt: 'Turn this launch thread into an execution plan with owners, blockers, and next steps',
+        sampleReply: 'I can extract owners, dates, blockers, open decisions, and missing readiness evidence.',
+        stage: {
+          appMeta: 'Launch follow-through',
+          threads: [
+            {
+              from: 'Launch core thread',
+              subject: 'Friday release review',
+              preview: 'Docs owner is still open and QA sign-off order is unclear.',
+              time: '2m',
+              active: true
+            },
+            {
+              from: 'Support lead',
+              subject: 'Macro and escalation check',
+              preview: 'Need final owner plus evidence before launch-day handoff.',
+              time: '48m'
+            },
+            {
+              from: 'Eng manager',
+              subject: 'Rollback note gap',
+              preview: 'We still need the linked staging proof before go-live.',
+              time: '2h'
+            }
+          ],
+          composeTitle: 'Forward thread',
+          draftBadge: 'Forward',
+          ccLabel: 'Thread',
+          ccValue: 'launch-core@acme.com',
+          subjectValue: 'Turn Friday release thread into an execution plan',
+          tags: ['Launch', 'Needs owners'],
+          bodyLines: [
+            'Hi DoWhiz,',
+            'Please turn this thread into a live launch plan.',
+            '- docs owner is still unclear',
+            '- QA sign-off order is not locked',
+            '- support macro and rollback proof are still missing'
+          ],
+          footerNote: 'DoWhiz extracts owners, blockers, and missing evidence before the next meeting',
+          footerValue: 'Forward thread',
+          resultLabel: 'DoWhiz output',
+          resultTitle: 'Execution plan ready',
+          resultItems: [
+            'Owner, date, and blocker table',
+            'Unresolved decision log',
+            'Readiness gaps to chase before launch'
+          ]
+        }
+      },
+      slack: {
+        description: 'Read the thread where launch coordination is already happening',
+        samplePrompt: 'Read this launch thread and pull owners, dates, blockers, and missing evidence',
+        sampleReply: 'I can turn the thread into a reviewable plan and post the follow-through back to the channel.',
+        stage: {
+          workspace: 'launch-core',
+          workspaceMeta: '11 teammates online',
+          channels: ['#launch-ops', '#release-room', '#support-handoff'],
+          roomMeta: '41 messages today',
+          threadPills: ['launch', 'needs owner', 'readiness'],
+          threadActivity: '7 replies in thread',
+          messages: [
+            {
+              author: 'Mina',
+              meta: 'PM',
+              time: '10:14 AM',
+              text: 'We still need one owner for docs, support macros, and the launch email.',
+              reactions: ['eyes 4', 'check 1']
+            },
+            {
+              author: 'Theo',
+              meta: 'Eng',
+              time: '10:19 AM',
+              text: 'QA can validate today, but only if rollback notes and staging proof are linked first.',
+              reactions: ['warning 2']
+            },
+            {
+              author: 'You',
+              meta: 'Ask DoWhiz',
+              time: '10:23 AM',
+              text: 'Turn this thread into owners, blockers, dates, and what is still missing for readiness.',
+              tone: 'user'
+            }
+          ],
+          threadLabel: 'Launch thread summary',
+          threadTitle: 'Release blockers',
+          threadText:
+            'Docs owner is still missing. QA order is not final. Launch email, support macro, and rollback evidence still need owners and proof.',
+          cardLabel: 'Execution plan',
+          cardTitle: 'Reviewable next steps',
+          cardSummary: 'One clean update, owners, blockers, and next actions',
+          cardItems: [
+            'Assign docs owner before 3 PM',
+            'Lock QA sign-off order with linked staging proof',
+            'Attach support macro and rollback evidence to the launch brief'
+          ],
+          cardFooter: 'Ready to post back into the thread',
+          cardActions: ['Post update', 'Open brief']
+        }
+      },
+      discord: {
+        description: 'Turn a customer blocker thread into tracked follow-through',
+        samplePrompt: 'Read this blocker report and turn it into owner, severity, and follow-through',
+        sampleReply: 'I can pull the repro gaps, open the task, and keep the original thread updated.',
+        stage: {
+          server: 'beta-customers',
+          onlineLabel: '52 online',
+          channels: ['announcements', 'launch-blockers', 'release-notes'],
+          room: '#launch-blockers',
+          roomTopic: 'Customer blocker follow-through',
+          roomMeta: '3 active threads',
+          messages: [
+            {
+              author: 'Avery',
+              meta: 'Customer',
+              time: 'Today at 9:12 AM',
+              accent: '#f2b4ff',
+              text: 'Upgrade still blocks checkout for EU testers after the last release.'
+            },
+            {
+              author: 'Mina',
+              meta: 'Launch lead',
+              time: 'Today at 9:14 AM',
+              accent: '#8ec5ff',
+              text: 'We need severity, owner, acceptance criteria, and staging validation before relaunch.'
+            },
+            {
+              author: 'You',
+              meta: 'Prompt DoWhiz',
+              time: 'Today at 9:16 AM',
+              accent: '#9aa4ff',
+              text: 'Turn this blocker thread into tracked follow-through and prep the handoff.',
+              tone: 'user'
+            }
+          ],
+          planLabel: 'DoWhiz follow-through',
+          planTitle: 'Customer blocker loop',
+          planItems: [
+            'Ask for missing repro details and affected segment',
+            'Open the tracked task with owner, priority, and acceptance criteria',
+            'Return staging evidence and status back to the original thread'
+          ],
+          planActions: ['Open task', 'Reply in thread'],
+          botLabel: 'DoWhiz follow-through',
+          botTitle: 'Hotfix handoff',
+          botDescription: 'Here is the execution loop pulled from the blocker thread.',
+          botFields: [
+            { label: 'Owner', value: 'Payments engineer plus launch lead' },
+            { label: 'Now', value: 'Confirm repro details and affected customers' },
+            { label: 'Before relaunch', value: 'Link staging proof and validation back to the thread' }
+          ],
+          composerValue: '/dowhiz turn this blocker into tracked follow-through',
+          membersTitle: 'Online now',
+          members: [
+            { name: 'DoWhiz', role: 'Bot', accent: true },
+            { name: 'Avery', role: 'Customer' },
+            { name: 'Mina', role: 'Launch lead' }
+          ]
+        }
+      },
+      github: {
+        anonymousStatus: 'Follow through from the thread',
+        authenticatedStatus: 'Connected repo context',
+        anonymousActionLabel: 'Start in thread',
+        authenticatedActionLabel: 'Connect',
+        description: 'Carry launch blockers into tracked repo follow-through',
+        samplePrompt: 'Prepare the GitHub issue from this blocker thread and show what still needs proof',
+        sampleReply: 'I can open the issue context, flag review steps, and keep readiness evidence attached.',
+        stage: {
+          repo: 'acme/launch-app',
+          repoMeta: 'release branch',
+          filters: ['is:open', 'label:launch', 'sort:updated-desc'],
+          overview: { open: '9 Open', closed: '214 Closed' },
+          issues: [
+            {
+              id: '#482',
+              title: 'Checkout banner blocks EU upgrade during launch window',
+              meta: 'mina opened 24m ago',
+              status: 'Open',
+              labels: ['launch', 'checkout'],
+              comments: '6',
+              active: true
+            },
+            {
+              id: '#479',
+              title: 'Support macro approval still missing',
+              meta: 'sam updated 1h ago',
+              status: 'Open',
+              labels: ['launch', 'support'],
+              comments: '3'
+            },
+            {
+              id: '#477',
+              title: 'Rollback evidence not linked in readiness brief',
+              meta: 'tina updated yesterday',
+              status: 'Open',
+              labels: ['launch', 'risk'],
+              comments: '4'
+            }
+          ],
+          detailLabel: 'Tracked issue',
+          detailTitle: 'Checkout banner blocks EU upgrade during launch window',
+          detailSummary:
+            'Customer report is confirmed. Owner is assigned. Relaunch still depends on staging proof, support readiness, and go or no-go review.',
+          detailMeta: ['launch', 'customer blocker', 'priority: high'],
+          detailItems: [
+            'Capture repro, owner, and acceptance criteria from the original thread',
+            'Attach staging validation evidence before relaunch',
+            'Post the status back to launch ops and support'
+          ],
+          detailChecklist: [
+            { title: 'Owner and acceptance criteria captured', meta: 'In progress', state: 'progress' },
+            { title: 'Staging proof linked', meta: 'Waiting on validation', state: 'todo' },
+            { title: 'Support handoff updated', meta: 'Queued after review', state: 'todo' }
+          ],
+          detailCommentTitle: 'DoWhiz coordination note',
+          detailComment:
+            'Human approval and staging validation are still required before relaunch. Keep the original thread and readiness brief in sync.',
+          detailActivity: [
+            {
+              actor: 'DoWhiz',
+              text: 'Attached owner, blocker, and evidence checklist from the launch thread.',
+              meta: 'commented 3m ago'
+            },
+            {
+              actor: 'mina',
+              text: 'Marked relaunch decision as blocked on staging proof and support confirmation.',
+              meta: 'updated 21m ago'
+            }
+          ],
+          detailFooter: 'Ready to review before posting back to GitHub'
+        }
+      },
+      notion: {
+        anonymousStatus: 'Draft from the thread',
+        authenticatedStatus: 'Connected docs context',
+        anonymousActionLabel: 'Start in thread',
+        authenticatedActionLabel: 'Connect',
+        description: 'Keep a readiness brief synced to the original launch thread',
+        samplePrompt: 'Turn this planning thread into a launch-readiness brief',
+        sampleReply: 'I can create the brief, list missing evidence, and keep it updated as status changes.',
+        stage: {
+          breadcrumb: 'Product / Launches / Friday release',
+          collaborators: ['You', 'DoWhiz', 'Launch team'],
+          pageTitle: 'Friday launch readiness',
+          pageIntro: 'Owner, blocker, decision, and evidence brief',
+          properties: [
+            { label: 'Launch', value: 'EU upgrade release' },
+            { label: 'Status', value: 'Needs proof' },
+            { label: 'Owner', value: 'Launch lead + DoWhiz' }
+          ],
+          blocks: [
+            { type: 'heading', text: 'Open blockers' },
+            { type: 'bullet', text: 'Docs owner still missing' },
+            { type: 'bullet', text: 'Support macro needs final approval' },
+            { type: 'todo', text: 'Link staging proof for checkout hotfix' },
+            { type: 'callout', text: 'DoWhiz keeps this brief tied to the original thread and linked evidence' }
+          ],
+          databaseLabel: 'Readiness tracker',
+          databaseColumns: ['Item', 'Owner', 'Status'],
+          rows: [
+            { name: 'Docs owner', meta: 'PMM', status: 'Missing' },
+            { name: 'Support macro', meta: 'Support lead', status: 'Awaiting approval' },
+            { name: 'Staging proof', meta: 'QA', status: 'In progress' }
+          ],
+          sideLabel: 'Readiness brief',
+          sideTitle: 'What still needs proof',
+          sideItems: [
+            'One accountable docs owner',
+            'Support handoff approval',
+            'Linked staging validation before go-live'
+          ],
+          sideFootnote: 'Ready to review in the go or no-go meeting'
+        }
+      },
+      lark: {
+        anonymousStatus: 'Continue from the thread',
+        authenticatedStatus: 'Connected workspace',
+        anonymousActionLabel: 'Start in thread',
+        authenticatedActionLabel: 'Connect',
+        description: 'Carry launch follow-through into the workspace your team already uses',
+        samplePrompt: 'Turn this launch sync into owners, dates, and a sendable update',
+        sampleReply: 'I can keep the sync actionable and return a clean update card with the latest blockers.',
+        stage: {
+          workspace: 'Launch sync',
+          workspaceMeta: '7 participants',
+          chatTitle: 'Launch sync',
+          chatMeta: '7 participants',
+          participants: ['Nina', 'Sam', 'DoWhiz'],
+          recapLabel: 'Sync recap',
+          recapTitle: 'Launch email, support handoff, and final readiness proof',
+          recapText:
+            'Need final owners for the launch email, support staffing confirmation, and one clean readiness update before Friday.',
+          messages: [
+            {
+              author: 'Nina',
+              meta: 'PM',
+              time: '10:02',
+              text: 'We have the checklist, but the final owners and send order are still fuzzy.'
+            },
+            {
+              author: 'Sam',
+              meta: 'Support',
+              time: '10:07',
+              badge: 'Needs update',
+              text: 'I also need the final macro approval and the evidence link before handoff.'
+            }
+          ],
+          trackerLabel: 'DoWhiz follow-through',
+          trackerTitle: 'Owners and timing',
+          ownerColumns: ['Owner', 'Task', 'Due'],
+          owners: [
+            { owner: 'Nina', task: 'Launch email timing', due: 'Thu 3 PM', status: 'In progress' },
+            { owner: 'Sam', task: 'Support macro approval', due: 'Thu 5 PM', status: 'Queued' },
+            { owner: 'DoWhiz', task: 'Readiness update card', due: 'Now', status: 'Ready' }
+          ],
+          updateLabel: 'Sendable update',
+          updateText:
+            'Launch email timing locks Thursday. Support handoff closes after approval and linked proof. Readiness brief updates automatically.',
+          updateActions: ['Share update', 'Open brief']
+        }
+      }
+    }
+  },
+  workflowVisual: {
+    eyebrow: 'How it works',
+    title: 'How DoWhiz drives one item',
+    subtitle: 'Thread to task to deploy to update.',
+    note: 'Human review stays visible.',
+    stages: [
+      {
+        key: 'discord',
+        app: 'Slack / Discord',
+        title: 'Reply in thread',
+        copy: 'Ask repro. Confirm blocker.'
+      },
+      {
+        key: 'notion',
+        app: 'Notion',
+        title: 'Create task',
+        copy: 'Set owner. Track priority.'
+      },
+      {
+        key: 'github',
+        app: 'GitHub',
+        title: 'Open issue',
+        copy: 'Link context. Route engineering.'
+      },
+      {
+        key: 'devin',
+        app: 'Devin',
+        title: 'Route fix',
+        copy: 'Assign Devin or teammate.'
+      },
+      {
+        key: 'review',
+        app: 'Review',
+        title: 'Review fix',
+        copy: 'Keep approval visible.'
+      },
+      {
+        key: 'deploy',
+        app: 'GitHub Action',
+        title: 'Deploy build',
+        copy: 'Run staging deploy.'
+      },
+      {
+        key: 'staging',
+        app: 'Staging',
+        title: 'Link proof',
+        copy: 'Verify fix in staging.'
+      },
+      {
+        key: 'thread',
+        app: 'Thread update',
+        title: 'Post update',
+        copy: 'Sync thread and record.'
+      }
+    ]
+  },
+  artifactRail: {
+    eyebrow: 'What you get',
+    title: 'What DoWhiz delivers',
+    subtitle: 'Plan, issue, proof, and update.',
+    items: [
+      {
+        title: 'Execution plan',
+        description: 'Owners, dates, blockers, and decisions.'
+      },
+      {
+        title: 'Task + issue',
+        description: 'Tracked handoff with linked context.'
+      },
+      {
+        title: 'Readiness brief',
+        description: 'Go or no-go with linked proof.'
+      },
+      {
+        title: 'Thread update',
+        description: 'Clean status back to the source.'
+      }
+    ]
+  },
+  controlRail: {
+    items: [
+      {
+        kicker: 'Not chat',
+        title: 'Drives the work',
+        description: 'Turns the thread into owned follow-through.'
+      },
+      {
+        kicker: 'Not a dashboard',
+        title: 'Starts in thread',
+        description: 'Carries source context into the tools that matter.'
+      },
+      {
+        kicker: 'Not a black box',
+        title: 'Keeps review visible',
+        description: 'Human review and evidence stay explicit.'
+      }
+    ]
+  },
+  problems: {
+    eyebrow: 'Why launches drift',
+    title: 'The thread gets longer. The plan gets fuzzier.',
+    intro:
+      'When launch coordination lives across chat, docs, tickets, and status meetings, the work stops being obvious long before the launch is actually ready.',
+    items: [
+      {
+        title: 'Ownership stays fuzzy',
+        description: 'Launch threads get long, but nobody is clearly accountable for the next move.'
+      },
+      {
+        title: 'Status goes stale',
+        description: 'By the next meeting, the update is already outdated or missing the latest blocker.'
+      },
+      {
+        title: 'Blockers hide in chat',
+        description: 'Critical dependencies and unresolved decisions disappear inside Slack, email, and side threads.'
+      },
+      {
+        title: 'Readiness runs on vibes',
+        description: 'Go or no-go calls happen without linked evidence, clear owners, or explicit open risks.'
+      },
+      {
+        title: 'PMs become the glue',
+        description: 'Product leads spend their time chasing updates across tools instead of driving the launch.'
+      }
+    ]
+  },
+  workflow: {
+    eyebrow: 'From thread to plan',
+    title: 'From messy thread to execution plan',
+    subtitle:
+      'DoWhiz reads the thread where the work already lives, pulls the execution objects out of it, and keeps follow-through moving across tools.',
+    steps: [
+      {
+        title: 'Start in the thread',
+        description: 'DoWhiz reads the launch thread, recap, or blocker conversation where the work already exists.'
+      },
+      {
+        title: 'Extract the work',
+        description: 'It identifies owners, dates, blockers, dependencies, unresolved decisions, and missing evidence.'
+      },
+      {
+        title: 'Create the execution plan',
+        description: 'DoWhiz turns the thread into a live plan with clear next steps and reviewable artifacts.'
+      },
+      {
+        title: 'Follow through across tools',
+        description: 'Context carries into docs, tickets, GitHub, Notion, and other systems of record.'
+      },
+      {
+        title: 'Chase what is missing',
+        description: 'DoWhiz asks for stale updates, unresolved decisions, and blocked dependencies before they drift.'
+      },
+      {
+        title: 'Produce readiness evidence',
+        description: 'You get a launch-readiness brief backed by linked evidence instead of status vibes.'
+      }
+    ]
+  },
+  exampleLoop: {
+    eyebrow: 'Concrete example',
+    title: 'From customer feedback to shipped follow-through',
+    subtitle:
+      'A blocker lands in Slack or Discord. DoWhiz keeps the loop moving without losing the original thread or overclaiming autonomy.',
+    summaryTitle: 'Example thread',
+    summaryItems: [
+      'A customer reports a launch blocker in a public or internal thread.',
+      'The team needs severity, owner, acceptance criteria, and the next validation step.',
+      'The original thread still needs clean follow-up after implementation and review.'
+    ],
+    steps: [
+      {
+        title: 'Acknowledge the thread',
+        description: 'DoWhiz asks for missing repro details, scope, and what still blocks the launch.'
+      },
+      {
+        title: 'Track the work',
+        description: 'It turns the blocker into a tracked task with priority, owner, and acceptance criteria.'
+      },
+      {
+        title: 'Prepare the handoff',
+        description: 'DoWhiz opens or drafts the GitHub issue with the relevant context from the original thread.'
+      },
+      {
+        title: 'Keep specialists unblocked',
+        description: 'A teammate or specialist agent can take implementation, review, or validation work from there.'
+      },
+      {
+        title: 'Summarize evidence',
+        description: 'DoWhiz keeps review status, risk, and validation evidence tied back to the execution thread.'
+      },
+      {
+        title: 'Close the loop',
+        description: 'After human approval and staging validation, DoWhiz updates the original thread and system of record.'
+      }
+    ],
+    calloutTitle: 'Oliver can coordinate this loop',
+    calloutCopy:
+      'Oliver coordinates the launch thread. Specialist agents or teammates can take over implementation, review, or follow-through when needed.'
+  },
+  outputs: {
+    eyebrow: 'Outputs',
+    title: 'What DoWhiz produces',
+    subtitle:
+      'The homepage promise is not smart chat. It is concrete execution artifacts your team can review, update, and use.',
+    items: [
+      {
+        title: 'Execution plan',
+        description: 'A live plan with clear next steps instead of an unstructured thread.'
+      },
+      {
+        title: 'Owner, date, blocker table',
+        description: 'Who owns what, when it is due, and what is currently blocked.'
+      },
+      {
+        title: 'Decision log',
+        description: 'The unresolved calls that still need answers before launch.'
+      },
+      {
+        title: 'Dependency map',
+        description: 'The blockers, prerequisites, and handoffs that are easy to miss in chat.'
+      },
+      {
+        title: 'Launch-readiness brief',
+        description: 'A reviewable go or no-go summary backed by linked evidence.'
+      },
+      {
+        title: 'Follow-up messages',
+        description: 'Clean updates ready to post back into the original thread or channel.'
+      },
+      {
+        title: 'System-of-record updates',
+        description: 'Docs, tickets, and issue trackers updated without losing the original context.'
+      },
+      {
+        title: 'Evidence-backed status summary',
+        description: 'Status with proof attached, not memory, hearsay, or stale meeting notes.'
+      }
+    ]
+  },
+  useCases: {
+    eyebrow: 'Use cases',
+    title: 'Built for execution-critical threads',
+    subtitle:
+      'Launch is the hero use case, but the same thread-to-plan loop helps anywhere cross-team follow-through can drift.',
+    items: [
+      {
+        tag: 'Hero use case',
+        title: 'Product launch',
+        description: 'Turn launch chatter into owners, blockers, readiness, and launch-day follow-through.'
+      },
+      {
+        tag: 'Customer-facing',
+        title: 'Customer rollout',
+        description: 'Keep rollout blockers, approvals, and evidence tied to the customer thread.'
+      },
+      {
+        tag: 'Infra',
+        title: 'Infrastructure migration',
+        description: 'Track dependencies, unresolved risks, and readiness across teams and systems.'
+      },
+      {
+        tag: 'Partner',
+        title: 'Partner integration',
+        description: 'Turn fragmented follow-up across email, docs, and tickets into one execution loop.'
+      },
+      {
+        tag: 'Incident',
+        title: 'Incident follow-through',
+        description: 'Carry decisions, owners, fixes, and post-incident actions across the tools already in use.'
+      },
+      {
+        tag: 'Review',
+        title: 'Release readiness review',
+        description: 'Create evidence-backed readiness instead of relying on whichever update was heard last.'
+      }
+    ]
+  },
+  continuity: {
+    eyebrow: 'Cross-tool continuity',
+    title: 'Start in the thread. Follow through across tools.',
+    subtitle:
+      'DoWhiz carries context from the original thread into the tools your team already maintains, so nobody has to keep a second dashboard manually in sync.',
+    pillars: [
+      {
+        title: 'Thread-native start',
+        description: 'The work begins in Slack, email, Discord, or the thread where the discussion already exists.'
+      },
+      {
+        title: 'Reviewable artifacts',
+        description: 'Docs, issues, briefs, and follow-up messages stay tied to the source thread and linked evidence.'
+      },
+      {
+        title: 'System-of-record updates',
+        description: 'DoWhiz keeps GitHub, docs, Notion, tickets, and status updates aligned as the work moves.'
+      }
+    ],
+    threadStarts: ['Slack', 'Email', 'Discord'],
+    systems: ['GitHub', 'Docs', 'Notion', 'Tickets', 'Launch updates']
+  },
+  trust: {
+    eyebrow: 'Safety and control',
+    title: 'Reviewable by default',
+    subtitle:
+      'Execution is only credible if sensitive actions stay visible, scoped, and attributable. The homepage should say that plainly.',
+    items: [
+      {
+        title: 'Human review before sensitive changes',
+        description: 'Sensitive code, release, and production decisions stay reviewable instead of happening in the background.'
+      },
+      {
+        title: 'Scoped tool permissions',
+        description: 'Teams decide which tools DoWhiz can access and how deep those permissions should go.'
+      },
+      {
+        title: 'Linked evidence',
+        description: 'Readiness and status summaries can point back to the thread, issue, doc, or validation proof behind them.'
+      },
+      {
+        title: 'Clear audit trail',
+        description: 'Updates, artifacts, and follow-through stay attributable instead of disappearing inside hidden automation.'
+      }
+    ],
+    note: 'No hidden autonomous PR approvals. No silent production merges. No invisible code changes.'
+  },
+  faqItems: [
+    {
+      question: 'Who is DoWhiz for on the homepage?',
+      answer:
+        'The main homepage is for PMs, product leads, founders, engineering leads, operations leads, and launch owners running execution-critical threads. It is not positioned as a generic chatbot or a TPM-only tool.'
+    },
+    {
+      question: 'Where does the work start?',
+      answer:
+        'Usually in the messy thread you already have: Slack, email, Discord, or the planning recap nobody wants to manually turn into a plan.'
+    },
+    {
+      question: 'What does DoWhiz actually produce?',
+      answer:
+        'Execution plans, owner and blocker tables, decision logs, readiness briefs, follow-up messages, and linked system-of-record updates that stay reviewable.'
+    },
+    {
+      question: 'Is this only for launches?',
+      answer:
+        'Launch is the hero use case, but the same workflow helps with rollouts, migrations, partner integrations, incident follow-through, and other execution-critical threads.'
+    },
+    {
+      question: 'Does DoWhiz make hidden code or production changes?',
+      answer:
+        'No. The page now states the opposite. Sensitive implementation, review, and production actions still require human review and visible approval.'
+    }
+  ],
+  labels: {
+    faqEyebrow: 'Questions',
+    faqTitle: 'Before you start',
+    faqIntro: 'Short answers before you drop a real thread into the workflow.',
+    footerTagline: 'DoWhiz keeps launch work from drifting.',
+    footerPill: 'Starts in the thread. Stays reviewable.',
+    footerBottomSecondary: 'Thread in. Plan out. Tools stay aligned.',
+    footerContactLabel: 'Contact DoWhiz'
+  },
+  finalCta: {
+    title: 'Start with the thread',
+    description: 'DoWhiz turns the thread into a live execution plan and keeps follow-through moving across tools.',
+    support: 'Best first input: a launch thread, blocker thread, rollout recap, or release-readiness thread.'
+  }
+};
+
+function mergeHeroTools(baseTools = [], overrides = {}) {
+  return baseTools.map((tool) => {
+    const override = overrides[tool.key];
+    if (!override) {
+      return tool;
+    }
+
+    return {
+      ...tool,
+      ...override,
+      stage: override.stage ? { ...tool.stage, ...override.stage } : tool.stage
+    };
+  });
+}
+
+export function buildEnglishHomepageContent(base) {
+  const heroOverrides = EN_HOMEPAGE_OVERRIDES.hero || {};
+
+  return {
+    ...base,
+    metadata: { ...base.metadata, ...EN_HOMEPAGE_OVERRIDES.metadata },
+    nav: { ...base.nav, ...EN_HOMEPAGE_OVERRIDES.nav },
+    hero: {
+      ...base.hero,
+      ...heroOverrides,
+      actionLabels: { ...base.hero.actionLabels, ...(heroOverrides.actionLabels || {}) },
+      tools: mergeHeroTools(base.hero.tools, heroOverrides.tools)
+    },
+    workflowVisual: EN_HOMEPAGE_OVERRIDES.workflowVisual,
+    artifactRail: EN_HOMEPAGE_OVERRIDES.artifactRail,
+    controlRail: EN_HOMEPAGE_OVERRIDES.controlRail,
+    problems: EN_HOMEPAGE_OVERRIDES.problems,
+    workflow: EN_HOMEPAGE_OVERRIDES.workflow,
+    exampleLoop: EN_HOMEPAGE_OVERRIDES.exampleLoop,
+    outputs: EN_HOMEPAGE_OVERRIDES.outputs,
+    useCases: EN_HOMEPAGE_OVERRIDES.useCases,
+    continuity: EN_HOMEPAGE_OVERRIDES.continuity,
+    trust: EN_HOMEPAGE_OVERRIDES.trust,
+    finalCta: EN_HOMEPAGE_OVERRIDES.finalCta,
+    faqItems: EN_HOMEPAGE_OVERRIDES.faqItems,
+    labels: { ...base.labels, ...EN_HOMEPAGE_OVERRIDES.labels }
+  };
+}

--- a/website/src/pages/oliverLandingContent.js
+++ b/website/src/pages/oliverLandingContent.js
@@ -25,7 +25,7 @@ export const oliverLandingContent = {
   hero: {
     badge: 'Launch Execution Copilot',
     eyebrow: 'For one launch thread at a time',
-    title: 'Turn one messy launch thread into accountable execution.',
+    title: 'Turn one launch thread into accountable execution',
     subtitle:
       'Paste the thread. Oliver extracts owners, dates, dependencies, blockers, open decisions, and a readiness brief backed by evidence.',
     activity: 'Readiness brief refreshed from the latest owner update.',

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -376,7 +376,8 @@
 .hero-secondary-cta {
   min-height: 2.8rem;
   min-width: 230px;
-  border-color: var(--color-border);
+  border-color: color-mix(in srgb, var(--brand-primary) 16%, var(--color-border));
+  background: color-mix(in srgb, var(--surface-elevated) 92%, rgba(255, 255, 255, 0.72));
 }
 
 .landing-page-cn .hero-copy {
@@ -2191,7 +2192,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 0.6rem;
+  gap: 0.25rem 0.7rem;
   max-width: 48rem;
   margin: 0 auto;
 }
@@ -2199,28 +2200,37 @@
 .hero-value-pill {
   display: inline-flex;
   align-items: center;
-  min-height: 2.1rem;
-  padding: 0.45rem 0.8rem;
-  border-radius: var(--radius-full);
-  border: 1px solid color-mix(in srgb, var(--glass-border) 84%, transparent);
-  background: color-mix(in srgb, var(--surface-primary) 84%, transparent);
+  min-height: auto;
+  padding: 0;
+  border: none;
+  background: none;
   color: var(--text-secondary);
   font-size: 0.84rem;
   font-weight: 600;
   letter-spacing: 0.01em;
 }
 
+.hero-value-pill:not(:first-child)::before {
+  content: '•';
+  margin-right: 0.7rem;
+  color: color-mix(in srgb, var(--brand-primary) 45%, var(--text-secondary));
+}
+
 .hero-primary-cta {
-  min-width: 13.75rem;
-  box-shadow: 0 18px 45px -32px rgba(28, 28, 30, 0.32);
+  min-width: 15rem;
+  min-height: 3.2rem;
+  font-weight: 700;
+  box-shadow:
+    0 22px 48px -30px rgba(28, 28, 30, 0.36),
+    0 0 0 1px color-mix(in srgb, var(--brand-primary) 18%, transparent);
 }
 
 .hero-support-note {
   margin: 0;
-  max-width: 42rem;
+  max-width: 34rem;
   color: var(--text-secondary);
-  font-size: 0.92rem;
-  line-height: 1.55;
+  font-size: 0.89rem;
+  line-height: 1.5;
 }
 
 .hero-channel-showcase {
@@ -2642,6 +2652,26 @@
 [data-theme="dark"] .demo-short-link,
 [data-theme="dark"] .example-card-link:hover,
 [data-theme="dark"] .example-card-link:focus-visible {
+  border-color: color-mix(in srgb, var(--glass-border) 90%, transparent);
+  background: color-mix(in srgb, var(--surface-secondary) 88%, transparent);
+}
+
+[data-theme="dark"] .example-loop-callout,
+[data-theme="dark"] .continuity-panel,
+[data-theme="dark"] .final-cta-panel {
+  border-color: color-mix(in srgb, var(--glass-border) 90%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--surface-secondary) 92%, transparent) 0%,
+      color-mix(in srgb, var(--surface-primary) 97%, transparent) 100%
+    );
+  box-shadow:
+    0 30px 62px -46px rgba(0, 0, 0, 0.54),
+    0 14px 24px -18px rgba(0, 0, 0, 0.34);
+}
+
+[data-theme="dark"] .trust-note {
   border-color: color-mix(in srgb, var(--glass-border) 90%, transparent);
   background: color-mix(in srgb, var(--surface-secondary) 88%, transparent);
 }
@@ -5115,6 +5145,382 @@
   color: var(--brand-primary);
 }
 
+.problem-section {
+  padding-top: 1.5rem;
+}
+
+.problem-card-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.problem-card,
+.workflow-step-card,
+.example-loop-step-card,
+.output-card,
+.use-case-card,
+.continuity-card,
+.trust-card {
+  min-height: 100%;
+}
+
+.workflow-section,
+.outputs-section,
+.use-case-section,
+.continuity-section,
+.trust-section {
+  padding-top: 0.9rem;
+}
+
+.workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.example-loop-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.example-loop-brief {
+  display: grid;
+  gap: 0.85rem;
+  align-content: start;
+}
+
+.example-loop-brief h3 {
+  margin: 0;
+  font-size: 1.08rem;
+  line-height: 1.24;
+}
+
+.example-loop-summary {
+  display: grid;
+  gap: 0.72rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.example-loop-summary li {
+  position: relative;
+  padding-left: 1rem;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.example-loop-summary li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.52rem;
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: var(--radius-full);
+  background: var(--brand-primary);
+}
+
+.example-loop-step-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.example-loop-callout {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1.35rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  background: color-mix(in srgb, var(--surface-elevated) 92%, rgba(255, 255, 255, 0.68));
+  box-shadow: 0 16px 32px -30px rgba(28, 28, 30, 0.22);
+}
+
+.example-loop-callout strong {
+  font-size: 0.98rem;
+  line-height: 1.3;
+}
+
+.example-loop-callout p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.output-card-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.continuity-panel,
+.final-cta-panel {
+  border: 1px solid color-mix(in srgb, var(--glass-border) 92%, transparent);
+  border-radius: 1.45rem;
+  background: color-mix(in srgb, var(--surface-elevated) 92%, rgba(255, 255, 255, 0.7));
+  box-shadow: 0 16px 32px -30px rgba(28, 28, 30, 0.22);
+}
+
+.continuity-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem;
+}
+
+.continuity-pill-groups {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.continuity-pill-group {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.continuity-pill-label {
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.continuity-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.continuity-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.trust-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.trust-note {
+  margin: 0;
+  padding: 0.92rem 1rem;
+  border-radius: 1.1rem;
+  border: 1px solid color-mix(in srgb, var(--brand-primary) 16%, var(--glass-border));
+  background: color-mix(in srgb, var(--brand-primary) 8%, var(--surface-elevated));
+  color: var(--text-primary);
+  font-size: 0.92rem;
+  font-weight: 600;
+  line-height: 1.55;
+}
+
+.final-cta-section {
+  padding-top: 0.5rem;
+}
+
+.final-cta-panel {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 1.25rem;
+}
+
+.final-cta-copy {
+  display: grid;
+  gap: 0.7rem;
+  max-width: 44rem;
+}
+
+.final-cta-support {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.final-cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.workflow-visual-section,
+.outputs-compact-section {
+  padding-top: 0.85rem;
+}
+
+.workflow-visual-card h3,
+.artifact-card h3 {
+  max-width: 14ch;
+  white-space: normal;
+  text-wrap: balance;
+}
+
+.workflow-visual-section .section-title,
+.outputs-compact-section .section-title {
+  max-width: none;
+  font-size: clamp(1.5rem, 3.4vw, 2.65rem);
+  white-space: nowrap;
+  text-wrap: nowrap;
+}
+
+.workflow-visual-section .section-intro,
+.outputs-compact-section .section-intro {
+  max-width: 30rem;
+  text-wrap: pretty;
+}
+
+.workflow-visual-card h3,
+.artifact-card h3 {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.24;
+}
+
+.workflow-visual-card p,
+.artifact-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.workflow-visual-flow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  max-width: 56rem;
+  align-items: stretch;
+}
+
+.workflow-visual-step {
+  display: grid;
+  min-height: 100%;
+}
+
+.workflow-visual-step:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  width: 100%;
+  max-width: calc((100% - 1rem) / 2);
+  justify-self: center;
+}
+
+.workflow-visual-card,
+.artifact-card {
+  min-height: 100%;
+  padding: 0.92rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 94%, transparent);
+  border-radius: 1.45rem;
+  background: color-mix(in srgb, var(--surface-elevated) 90%, rgba(255, 255, 255, 0.68));
+  box-shadow: 0 16px 32px -30px rgba(28, 28, 30, 0.22);
+}
+
+.workflow-visual-card {
+  display: grid;
+  gap: 0.68rem;
+}
+
+.workflow-visual-copy {
+  color: var(--text-primary);
+}
+
+.workflow-visual-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.workflow-visual-app,
+.workflow-visual-index {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: var(--radius-full);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.workflow-visual-app {
+  min-height: 1.9rem;
+  padding: 0.35rem 0.72rem;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 90%, transparent);
+  background: color-mix(in srgb, var(--surface-primary) 92%, transparent);
+  color: var(--text-primary);
+}
+
+.workflow-visual-index {
+  min-width: 2.2rem;
+  min-height: 2.2rem;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--brand-primary) 16%, var(--glass-border));
+  background: color-mix(in srgb, var(--surface-elevated) 96%, rgba(255, 255, 255, 0.88));
+  color: var(--text-secondary);
+  box-shadow: 0 8px 18px -14px rgba(28, 28, 30, 0.26);
+}
+
+.workflow-visual-note {
+  margin: 0;
+  max-width: 28rem;
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.workflow-visual-step[data-app='discord'] .workflow-visual-app {
+  background: color-mix(in srgb, #5865f2 12%, var(--surface-primary));
+  border-color: color-mix(in srgb, #5865f2 20%, var(--glass-border));
+}
+
+.workflow-visual-step[data-app='notion'] .workflow-visual-app {
+  background: color-mix(in srgb, #111111 10%, var(--surface-primary));
+}
+
+.workflow-visual-step[data-app='github'] .workflow-visual-app {
+  background: color-mix(in srgb, #24292f 10%, var(--surface-primary));
+}
+
+.workflow-visual-step[data-app='devin'] .workflow-visual-app {
+  background: color-mix(in srgb, #ff8a3d 14%, var(--surface-primary));
+  border-color: color-mix(in srgb, #ff8a3d 20%, var(--glass-border));
+}
+
+.workflow-visual-step[data-app='review'] .workflow-visual-app {
+  background: color-mix(in srgb, #1c9b6e 14%, var(--surface-primary));
+  border-color: color-mix(in srgb, #1c9b6e 18%, var(--glass-border));
+}
+
+.workflow-visual-step[data-app='deploy'] .workflow-visual-app {
+  background: color-mix(in srgb, #218bff 14%, var(--surface-primary));
+  border-color: color-mix(in srgb, #218bff 18%, var(--glass-border));
+}
+
+.workflow-visual-step[data-app='staging'] .workflow-visual-app {
+  background: color-mix(in srgb, #4d8dff 14%, var(--surface-primary));
+  border-color: color-mix(in srgb, #4d8dff 18%, var(--glass-border));
+}
+
+.workflow-visual-step[data-app='thread'] .workflow-visual-app {
+  background: color-mix(in srgb, #ff5b7c 14%, var(--surface-primary));
+  border-color: color-mix(in srgb, #ff5b7c 18%, var(--glass-border));
+}
+
+.artifact-rail {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  max-width: 42rem;
+}
+
 .landing-page-cn .section-kicker,
 .landing-page-cn .hero-stage-micro-label,
 .landing-page-cn .hero-preview-label,
@@ -5136,6 +5542,24 @@
 }
 
 @media (max-width: 1180px) {
+  .problem-card-grid,
+  .workflow-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .artifact-rail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .example-loop-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .output-card-grid,
+  .trust-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .demo-showcase-grid {
     grid-template-columns: 1fr;
   }
@@ -5169,6 +5593,35 @@
 }
 
 @media (max-width: 900px) {
+  .problem-card-grid,
+  .workflow-grid,
+  .continuity-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .workflow-visual-flow {
+    grid-template-columns: 1fr;
+    max-width: 40rem;
+  }
+
+  .workflow-visual-step:last-child:nth-child(odd) {
+    grid-column: auto;
+    max-width: none;
+    justify-self: stretch;
+  }
+
+  .artifact-rail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .artifact-rail {
+    gap: 0.85rem;
+  }
+
+  .example-loop-step-grid {
+    grid-template-columns: 1fr;
+  }
+
   .hero-stage-slack-layout,
   .hero-stage-discord-layout,
   .hero-stage-lark-layout {
@@ -5207,8 +5660,37 @@
   }
 
   .hero-copy-showcase .hero-title {
-    max-width: 11ch;
+    max-width: 13ch;
     white-space: normal;
+  }
+
+  .problem-card-grid,
+  .workflow-grid,
+  .output-card-grid,
+  .continuity-grid,
+  .trust-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .artifact-rail {
+    grid-template-columns: 1fr;
+  }
+
+  .workflow-visual-section .section-title,
+  .outputs-compact-section .section-title {
+    font-size: clamp(1.5rem, 6vw, 1.95rem);
+    max-width: none;
+    white-space: nowrap;
+  }
+
+  .workflow-visual-card,
+  .artifact-card {
+    padding: 1rem;
+  }
+
+  .workflow-visual-index {
+    min-width: 2rem;
+    min-height: 2rem;
   }
 
   .hero-channel-showcase,
@@ -5267,6 +5749,7 @@
   .section-title-left {
     max-width: none;
   }
+
 }
 
 @media (max-width: 560px) {

--- a/website/src/styles/oliver-landing.css
+++ b/website/src/styles/oliver-landing.css
@@ -223,7 +223,7 @@
   display: grid;
   justify-items: center;
   gap: 0.9rem;
-  max-width: 46rem;
+  max-width: 56rem;
 }
 
 .oliver-clarity-eyebrow {
@@ -238,11 +238,11 @@
 .oliver-clarity-title {
   margin: 0;
   max-width: none;
-  font-size: clamp(3rem, 5.4vw, 4.9rem);
-  line-height: 0.97;
+  font-size: clamp(2.8rem, 5vw, 4.5rem);
+  line-height: 0.98;
   letter-spacing: -0.06em;
   font-weight: 700;
-  text-wrap: pretty;
+  text-wrap: balance;
 }
 
 .oliver-clarity-accent {


### PR DESCRIPTION
## Summary
- refocus the main landing page around launch execution instead of generic AI employee positioning
- replace long explanatory sections with a scannable thread-to-plan workflow, outputs rail, and tighter CTA hierarchy
- tighten the Oliver landing hero headline so it lands in two lines without terminal punctuation

## Validation
- `npm run lint`
- `npm run build`
- `npm run test:responsive`
- manual desktop/mobile review of `/`
- manual review of `/oliver`

## Notes
- homepage work stays on `/`; `/oliver` was only touched for the later headline-wrap request
- screenshots were validated locally during review
