### PR TITLE
Simplify investment monitor runtime

### DIFF
--- a/.agents/skills/us-equity-daily-monitor/SKILL.md
+++ b/.agents/skills/us-equity-daily-monitor/SKILL.md
@@ -1,55 +1,44 @@
 ---
 name: us-equity-daily-monitor
-description: Produce a calibrated U.S. equity decision memo or monitor update for one stock or ETF. Use whenever the user wants a decision-useful view on a single U.S. stock or ETF, including prompts like "should I buy NVDA", "is XOM still a hold", "what changed on PLUG", "thoughts on AAPL into earnings", "do I add or trim", or "is there any edge here". This skill separates monitor status from new-money and existing-holder actions, shortens no-edge situations into concise `No Material Change` updates, and forces concrete upgrade, downgrade, and invalidation triggers for neutral stances. Do not use for portfolio construction, crypto, FX, fixed income, multi-asset allocation, or broad macro notes.
+description: Produce a simple, bounded U.S. equity monitor reply for one stock or ETF. Use whenever the user wants a concise decision-useful update on a single U.S. stock or ETF, such as "should I buy NVDA", "what changed on PLUG", "do I add or trim", or "is there any edge here". Do not use for portfolio construction, crypto, FX, fixed income, multi-asset allocation, or broad macro notes.
 ---
 
 # U.S. Equity Daily Monitor
 
-Use this skill to produce calibrated decision support, not safe commentary. Decide the monitor mode first, then choose separate actions for new money and existing holders.
+This skill is a simple bounded monitor, not a deep-research pipeline.
 
-## Workflow
+## Output modes
 
-1. Restate the investor's actual question in one line.
-2. Choose the monitor mode from [`references/action-taxonomy.md`](references/action-taxonomy.md):
-   - `No Material Change`
-   - `Watch Closely`
-   - `Review Now`
-3. Pick the output contract from [`references/output-contract.md`](references/output-contract.md):
-   - `No Material Change` uses the short update contract.
-   - `Watch Closely` and `Review Now` use the full memo contract.
-4. Decide the fields in the Decision Card:
-   - `Monitor Status`
-   - `New Money Action`
-   - `Existing Holder Action`
-   - `Thesis Impact`
-   - `Signal Quality`
+Use exactly one of these modes:
+
+1. `Actionable Update`
+   - `Status`
+   - `New Money Action`: `Buy` | `Wait` | `Avoid`
+   - `Existing Holder Action`: `Hold` | `Add` | `Trim` | `Exit`
+   - `Why now`
+   - `What changed`
+   - `What would change the view`
    - `Confidence`
-5. Build the factual spine and derived metrics. Follow [`references/source-policy.md`](references/source-policy.md), [`references/data-adapters.md`](references/data-adapters.md), and [`references/formulas.md`](references/formulas.md). Use `scripts/compute_metrics.py` when the inputs fit the canonical schema.
-6. Run the anti-waffle pass from [`references/anti-waffle.md`](references/anti-waffle.md) before finalizing. If the visible recommendation lands on `Wait`, `Hold`, or `Hold/Do not add`, the artifact must include explicit `Upgrade / Review Now`, `Downgrade / De-risk`, and `Invalidation` triggers with concrete thresholds.
-7. Check [`references/monitor-vs-deep-research.md`](references/monitor-vs-deep-research.md) for when to stay short versus when to produce the full memo.
-8. Check [`references/special-cases.md`](references/special-cases.md) when the name is an ETF, loss-maker, recent IPO, or spin-off.
 
-## Core rules
+2. `No Material Update`
+   - `Status`
+   - `Action`: `No new action`
+   - `Why`
+   - `What would matter next`
 
-- `No Material Change` means the output gets shorter, not safer.
-- If the user says "only tell me if I should act" and the right answer is `No Material Change`, use the ultra-short contract.
-- `Review Now` means the evidence justifies a decision or re-underwrite now. It does not automatically mean `Buy` or `Sell`.
-- `Watch Closely` is for mixed but relevant change with concrete confirmation triggers, not filler prose.
-- Separate monitor status from the audience-specific actions.
-- Every material fact is sourced, every derived metric shows a formula, and every neutral stance has measurable movement criteria.
-- Do not pad low-edge cases into essays. If there is no new edge, say so briefly and specify what would change the call.
+3. `Unable to Verify`
+   - `Status`
+   - `Action`: `No recommendation`
+   - `Why`
+   - `Next step`
 
-## Bundled resources
+## Rules
 
-- [`references/output-contract.md`](references/output-contract.md) — exact full-memo and short-update contracts.
-- [`references/action-taxonomy.md`](references/action-taxonomy.md) — monitor-mode definitions and allowed action combinations.
-- [`references/anti-waffle.md`](references/anti-waffle.md) — generic-language traps and final-artifact self-checks.
-- [`references/monitor-vs-deep-research.md`](references/monitor-vs-deep-research.md) — when to stay brief versus when to go full memo.
-- [`references/source-policy.md`](references/source-policy.md) — source-tier rules and citation minimums.
-- [`references/formulas.md`](references/formulas.md) — standard metric formulas.
-- [`references/data-adapters.md`](references/data-adapters.md) — how to coerce upstream data into the metrics script.
-- [`references/special-cases.md`](references/special-cases.md) — changes for ETFs, loss-makers, IPOs, and spin-offs.
-- [`references/task-adapter-skillsbench.md`](references/task-adapter-skillsbench.md) — fixed I/O paths for the SkillsBench fixture only.
-- [`assets/memo-template.md`](assets/memo-template.md) — fillable full-contract skeleton.
-- [`assets/example-memo-nvda.md`](assets/example-memo-nvda.md) — calibrated example that shows `Watch Closely` without generic hold/wait waffle.
-- [`scripts/compute_metrics.py`](scripts/compute_metrics.py) — deterministic derived-metrics helper.
+- Keep the reply short and scan-first.
+- Do not write a long memo.
+- Do not produce bull/base/bear framing, large tables, or charts.
+- Do not mine annual reports page by page in the email path.
+- Use `Actionable Update` only when there is clear verified information.
+- Use `No Material Update` when no verified new catalyst is found.
+- Use `Unable to Verify` when tools, sources, or time budget are insufficient.
+- If a deeper report would help, say that you can run it separately, but do not start it automatically.

--- a/DoWhiz_service/run_task_module/src/run_task/core.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/core.rs
@@ -11,10 +11,10 @@ use super::env::read_env_trimmed;
 use super::errors::RunTaskError;
 use super::investment_fail_soft::{
     maybe_write_action_only_monitor_artifact, maybe_write_fail_soft_investment_artifact,
-    maybe_write_synthetic_assumption_artifact,
 };
 use super::reply_contract::{
-    investment_monitor_request_for_workspace, investment_request_for_workspace,
+    action_only_monitor_request_for_workspace, investment_monitor_request_for_workspace,
+    investment_request_for_workspace,
 };
 use super::trace::RUN_TASK_TRACE_DIRNAME;
 use super::types::{RunTaskOutput, RunTaskParams, RunTaskRequest};
@@ -25,28 +25,31 @@ const MAX_INVESTMENT_MONITOR_PRIMARY_TIMEOUT_SECS: u64 = 30;
 const MAX_INVESTMENT_MONITOR_FAST_COMPLETION_TIMEOUT_SECS: u64 = 20;
 const MAX_INVESTMENT_RESEARCH_PRIMARY_TIMEOUT_SECS: u64 = 90;
 const MAX_INVESTMENT_RESEARCH_FAST_COMPLETION_TIMEOUT_SECS: u64 = 30;
+const SIMPLE_INVESTMENT_MONITOR_TIMEOUT_SECS: u64 = 20;
+const SIMPLE_INVESTMENT_RESEARCH_TIMEOUT_SECS: u64 = 45;
 
 pub fn run_task(params: &RunTaskParams) -> Result<RunTaskOutput, RunTaskError> {
     let workspace_dir = remap_workspace_dir(&params.workspace_dir)?;
     let runner = normalize_runner(&params.runner);
     let request = build_request(&workspace_dir, params, params.model_name.as_str());
+    let action_only_monitor_request = action_only_monitor_request_for_workspace(&workspace_dir)?;
+    let investment_request = investment_request_for_workspace(&workspace_dir)?;
+
+    if action_only_monitor_request {
+        if let Some(output) = maybe_finalize_action_only_monitor_artifact(
+            params,
+            &workspace_dir,
+            "action-only monitor fast path",
+        )? {
+            return Ok(output);
+        }
+    }
+
+    if investment_request && !params.reply_to.is_empty() {
+        return run_simple_investment_monitor_task(params, &workspace_dir, &runner);
+    }
+
     let (reply_html_path, reply_attachments_dir) = prepare_workspace(&request)?;
-
-    if let Some(output) = maybe_finalize_synthetic_investment_artifact(
-        params,
-        &workspace_dir,
-        "synthetic assumption-mode fast path",
-    )? {
-        return Ok(output);
-    }
-
-    if let Some(output) = maybe_finalize_action_only_monitor_artifact(
-        params,
-        &workspace_dir,
-        "action-only monitor fast path",
-    )? {
-        return Ok(output);
-    }
 
     if params.codex_disabled {
         if !params.reply_to.is_empty() {
@@ -137,6 +140,106 @@ pub fn run_task(params: &RunTaskParams) -> Result<RunTaskOutput, RunTaskError> {
     }
 }
 
+fn run_simple_investment_monitor_task(
+    params: &RunTaskParams,
+    workspace_dir: &Path,
+    runner: &str,
+) -> Result<RunTaskOutput, RunTaskError> {
+    let request = build_request(workspace_dir, params, params.model_name.as_str());
+    let (reply_html_path, reply_attachments_dir) = prepare_workspace(&request)?;
+
+    if params.codex_disabled {
+        let disabled_error = RunTaskError::CodexFailed {
+            status: None,
+            output: "Codex disabled for bounded investment monitor runtime.".to_string(),
+        };
+        if let Some(output) = finalize_simple_investment_fallback(
+            params,
+            workspace_dir,
+            &disabled_error,
+            &reply_html_path,
+            &reply_attachments_dir,
+        )? {
+            return Ok(output);
+        }
+        return Err(disabled_error);
+    }
+
+    let primary_result = match runner {
+        "claude" => run_claude_task(
+            build_request(workspace_dir, params, params.model_name.as_str()),
+            runner,
+            reply_html_path.clone(),
+            reply_attachments_dir.clone(),
+            false,
+        ),
+        _ => run_codex_task_with_timeout(
+            build_request(workspace_dir, params, params.model_name.as_str()),
+            runner,
+            reply_html_path.clone(),
+            reply_attachments_dir.clone(),
+            Some(simple_investment_timeout(workspace_dir)?),
+        ),
+    };
+
+    match primary_result {
+        Ok(output) => Ok(output),
+        Err(primary_err) => {
+            if let Some(output) = finalize_simple_investment_fallback(
+                params,
+                workspace_dir,
+                &primary_err,
+                &reply_html_path,
+                &reply_attachments_dir,
+            )? {
+                Ok(output)
+            } else {
+                Err(primary_err)
+            }
+        }
+    }
+}
+
+fn finalize_simple_investment_fallback(
+    params: &RunTaskParams,
+    workspace_dir: &Path,
+    primary_err: &RunTaskError,
+    reply_html_path: &Path,
+    reply_attachments_dir: &Path,
+) -> Result<Option<RunTaskOutput>, RunTaskError> {
+    if params.reply_to.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(recovery_note) =
+        maybe_write_fail_soft_investment_artifact(workspace_dir, reply_html_path, primary_err)?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(RunTaskOutput {
+        reply_html_path: reply_html_path.to_path_buf(),
+        reply_attachments_dir: reply_attachments_dir.to_path_buf(),
+        codex_output: primary_err.to_string(),
+        scheduled_tasks: Vec::new(),
+        scheduled_tasks_error: None,
+        scheduler_actions: Vec::new(),
+        scheduler_actions_error: None,
+        token_usage: None,
+        recovery_note: Some(recovery_note),
+    }))
+}
+
+fn simple_investment_timeout(workspace_dir: &Path) -> Result<Duration, RunTaskError> {
+    let cap_secs = if investment_monitor_request_for_workspace(workspace_dir)? {
+        SIMPLE_INVESTMENT_MONITOR_TIMEOUT_SECS
+    } else {
+        SIMPLE_INVESTMENT_RESEARCH_TIMEOUT_SECS
+    };
+
+    Ok(codex_command_timeout().min(Duration::from_secs(cap_secs)))
+}
+
 fn should_prefer_investment_fail_soft(
     params: &RunTaskParams,
     workspace_dir: &Path,
@@ -150,36 +253,6 @@ fn should_prefer_investment_fail_soft(
         primary_err,
         RunTaskError::CommandTimeout { .. } | RunTaskError::OutputMissing { .. }
     ))
-}
-
-fn maybe_finalize_synthetic_investment_artifact(
-    params: &RunTaskParams,
-    workspace_dir: &Path,
-    codex_output: &str,
-) -> Result<Option<RunTaskOutput>, RunTaskError> {
-    if params.reply_to.is_empty() {
-        return Ok(None);
-    }
-
-    let request = build_request(workspace_dir, params, params.model_name.as_str());
-    let (reply_html_path, reply_attachments_dir) = prepare_workspace(&request)?;
-    let Some(recovery_note) =
-        maybe_write_synthetic_assumption_artifact(workspace_dir, &reply_html_path)?
-    else {
-        return Ok(None);
-    };
-
-    Ok(Some(RunTaskOutput {
-        reply_html_path,
-        reply_attachments_dir,
-        codex_output: codex_output.to_string(),
-        scheduled_tasks: Vec::new(),
-        scheduled_tasks_error: None,
-        scheduler_actions: Vec::new(),
-        scheduler_actions_error: None,
-        token_usage: None,
-        recovery_note: Some(recovery_note),
-    }))
 }
 
 fn maybe_finalize_action_only_monitor_artifact(

--- a/DoWhiz_service/run_task_module/src/run_task/investment_fail_soft.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/investment_fail_soft.rs
@@ -22,7 +22,7 @@ pub(super) fn maybe_write_fail_soft_investment_artifact(
 
     let request_text = load_inbound_request_text(workspace_dir)?;
     let html = if is_synthetic_request(&request_text) {
-        build_synthetic_assumption_artifact(&canonical_request_line(&request_text))
+        build_real_ticker_operational_fallback(workspace_dir, &request_text)
     } else if investment_monitor_request_for_workspace(workspace_dir)? {
         build_monitor_operational_fallback(workspace_dir, &request_text)
     } else {
@@ -34,12 +34,7 @@ pub(super) fn maybe_write_fail_soft_investment_artifact(
         return Ok(None);
     }
 
-    let note = if is_synthetic_request(&request_text) {
-        format!(
-            "Recovered via deterministic assumption-based investment finalizer after {}",
-            summarize_failure(cause)
-        )
-    } else if investment_monitor_request_for_workspace(workspace_dir)? {
+    let note = if investment_monitor_request_for_workspace(workspace_dir)? {
         format!(
             "Recovered via deterministic operational monitor fallback after {}",
             summarize_failure(cause)
@@ -54,6 +49,7 @@ pub(super) fn maybe_write_fail_soft_investment_artifact(
     Ok(Some(note))
 }
 
+#[allow(dead_code)]
 pub(super) fn maybe_write_synthetic_assumption_artifact(
     workspace_dir: &Path,
     reply_path: &Path,
@@ -123,14 +119,14 @@ fn build_monitor_operational_fallback(workspace_dir: &Path, request_text: &str) 
     let lower_request = request_text.to_ascii_lowercase();
     let prior_note_missing = prior_note_context_missing(workspace_dir);
     let reason = if prior_note_missing && lower_request.contains("last note") {
-        "I could not do a literal change-since-last-note check because the earlier note was not available in the current thread context."
+        "I could not compare against the prior note because that earlier note was not available in the current thread context."
     } else {
-        "I could not verify enough fresh context to support a reliable act-now update yet."
+        "I could not verify enough fresh context within the monitor budget to support a reliable act-now update."
     };
     let next_step = if prior_note_missing && lower_request.contains("last note") {
-        "What would help next: the prior note plus the latest verified issuer update."
+        "Send the earlier note again or ask for a deeper report separately."
     } else {
-        "What would help next: the latest verified issuer update plus a fresh price and valuation check."
+        "If you want more than a quick monitor check, I can run a deeper report separately."
     };
 
     format!(
@@ -138,12 +134,10 @@ fn build_monitor_operational_fallback(workspace_dir: &Path, request_text: &str) 
   <body>
     <h1>{heading}</h1>
     <p><strong>As of:</strong> {today}</p>
-    <p>{reason}</p>
-    <p>I do not want to turn incomplete context into a low-confidence buy / hold / trim call.</p>
-    <ul>
-      <li><strong>What I can say now:</strong> there is no verified act-now signal I would ask you to trade on yet.</li>
-      <li><strong>What would help next:</strong> {next_step}</li>
-    </ul>
+    <p><strong>Status:</strong> Unable to Verify</p>
+    <p><strong>Action:</strong> No recommendation</p>
+    <p><strong>Why:</strong> {reason}</p>
+    <p><strong>Next step:</strong> {next_step}</p>
   </body>
 </html>
 "#
@@ -157,16 +151,6 @@ fn build_real_ticker_operational_fallback(workspace_dir: &Path, request_text: &s
     } else {
         format!("Quick update on {}", display_name)
     };
-    let research_labels = collect_research_labels(workspace_dir);
-    let research_summary = if research_labels.is_empty() {
-        "I do not have preserved issuer-specific research notes worth presenting as evidence yet."
-            .to_string()
-    } else {
-        format!(
-            "I do have partial research notes saved from this pass: {}.",
-            research_labels.join(", ")
-        )
-    };
     let today = Utc::now().format("%Y-%m-%d").to_string();
 
     format!(
@@ -174,12 +158,10 @@ fn build_real_ticker_operational_fallback(workspace_dir: &Path, request_text: &s
   <body>
     <h1>{heading}</h1>
     <p><strong>As of:</strong> {today}</p>
-    <p>I could not finish a reliable buy-or-avoid review yet, so I am not sending a half-verified investment memo.</p>
-    <ul>
-      <li><strong>What I have so far:</strong> {research_summary}</li>
-      <li><strong>What is still missing:</strong> a current price and valuation cross-check, the latest issuer update read-through, and verified implications for margin, cash flow, or guidance.</li>
-      <li><strong>What this means now:</strong> treat this as incomplete work rather than a real Buy / Avoid / Add / Exit call.</li>
-    </ul>
+    <p><strong>Status:</strong> Unable to Verify</p>
+    <p><strong>Action:</strong> No recommendation</p>
+    <p><strong>Why:</strong> I could not finish a reliable investment update within the bounded runtime, so I am not sending a half-verified buy / wait / avoid call.</p>
+    <p><strong>Next step:</strong> If you want more than a bounded monitor reply, I can run a deeper report separately.</p>
   </body>
 </html>
 "#
@@ -454,6 +436,7 @@ fn extract_assumption_bullets(request_text: &str) -> Vec<String> {
         .collect()
 }
 
+#[allow(dead_code)]
 fn collect_research_labels(workspace_dir: &Path) -> Vec<String> {
     let research_dir = workspace_dir.join("work").join("research");
     let mut labels = Vec::new();

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -289,13 +289,10 @@ Do not pretend the job has been done without actually doing it."#
 - Prioritize delivering a useful reply within the remaining budget over rebuilding the entire original project from scratch.
 - Before starting new research, inspect any existing artifacts from the earlier pass, especially `codex_fast_completion_context.md`, `reply_email_draft.html`, `.codex_remote_output.log`, and `.run_task_trace_codex_primary/` if present. Reuse facts, sources, filenames, and partial drafts instead of starting over.
 - For long research or writing tasks, begin updating the final reply artifact immediately and keep it current as sections become ready.
-- For investment monitoring in this mode, treat the run as `draft first, research second`.
-- If the user asked for investment monitoring, `reply_email_draft.html` must exist within your next two tool actions. Do not start a fresh multi-site quote sweep, broad annual-report extraction, or repeated market-price loop before the draft exists.
-- If the user asked for investment monitoring and the earlier pass already gathered enough support for a calibrated call, stop researching and finalize the artifact now.
-- If the prompt says "only tell me if I should act" and the likely answer is `No Material Change`, write the short update immediately and stop.
-- After the draft exists, allow at most one additional targeted external check when a single missing fact blocks the verdict. Otherwise finalize with an explicit limitation note instead of continuing to search.
-- For incomplete real-ticker investment work, prefer a short honest fallback over a padded pseudo-memo. If you cannot support a real investment view within the remaining budget, do not invent action tables, triggers, or section shells just to make the reply look complete.
-- For monitor-style investment requests, prefer a concise operational update when context is missing instead of expanding into a full decision memo.
+- For investment monitoring in this mode, prefer a short bounded monitor reply over more research.
+- If the user asked for investment monitoring, `reply_email_draft.html` must exist within your next two tool actions.
+- Do not start a fresh multi-site quote sweep, annual-report extraction pass, or repeated market-price loop in recovery mode for investment monitoring.
+- If you cannot verify enough context quickly, finalize a short `Unable to Verify` reply instead of continuing to search.
 - Do not leave `Provisional update`, `still being finalized`, `TBD`, `to be confirmed`, or empty section shells in the final artifact.
 - Investment-monitor requests in this product are allowed. Do not refuse solely because the task concerns a stock, an ETF, or an assumption-based investment scenario. If evidence is limited, answer with calibrated limitation language instead of refusing.
 - If you are still gathering evidence, clearly mark the draft as provisional near the top, and remove or replace that note before you finish if the reply becomes complete.
@@ -628,50 +625,36 @@ See `.agents/skills/notion/SKILL.md` for detailed command reference.
 
 fn build_investment_capabilities_section() -> &'static str {
     r#"Investment research requests:
-- When the user asks about one U.S. stock or one U.S. ETF, asks whether now is a good time to buy, asks about buying before earnings, or wants a decision-useful investment view, read `.agents/skills/us-equity-daily-monitor/SKILL.md` and follow it.
-- Keep the final user-visible reply structured and scan-first. Do not collapse it into generic commentary or one long research wall.
-- Decide the monitor mode first: `No Material Change`, `Watch Closely`, or `Review Now`.
-- For email replies, render the memo structure from the skill in semantic HTML inside `reply_email_draft.html`.
-- For real-ticker deep-research requests, do a bounded first pass before you go deeper: latest company release or filing, one current price/reference check, and one independent cross-check. Then start or update the draft. Do not spend the whole run on page-by-page annual-report extraction unless that first pass leaves a material unresolved conflict.
-- Create or refresh `reply_email_draft.html` before starting a second layer of research. Keep the draft current as you verify more evidence.
-- Keep these visible sections and labels in the HTML body:
-  - `As of:`
-  - `Price:`
-  - `Investor question:`
-  - `Decision Card`
-  - `Monitor Status`
+- When the user asks about one U.S. stock or ETF, whether now is a good time to buy, or whether anything material changed, read `.agents/skills/us-equity-daily-monitor/SKILL.md` and follow it.
+- Treat this email path as a simple bounded monitor, not a deep-research pipeline.
+- Produce exactly one concise HTML reply inside `reply_email_draft.html`.
+- Use exactly one of these modes:
+  - `Actionable Update`
+  - `No Material Update`
+  - `Unable to Verify`
+- For `Actionable Update`, keep only:
+  - `Status`
   - `New Money Action`
   - `Existing Holder Action`
-  - `Thesis Impact`
-  - `Signal Quality`
+  - `Why now`
+  - `What changed`
+  - `What would change the view`
   - `Confidence`
-  - `One-line rationale:`
-  - For `Watch Closely` / `Review Now`: `Dual-Horizon Framing`, `Near-Term Timing View`, `Long-Term Ownership View`, `Verified Facts`, `Derived Metrics`, `Scenarios`, `Bull Case`, `Base Case`, `Bear Case`
-  - For `No Material Change`: `Why Now`, `What Would Change The View`, `Evidence Chips`
-  - Inside `What Would Change The View`, keep `Upgrade / Review Now`, `Downgrade / De-risk`, and `Invalidation`
-- Use the exact decision-card values below. Do not paraphrase them into sentence fragments.
-  - `Monitor Status`: `No Material Change` | `Watch Closely` | `Review Now`
-  - `New Money Action`: `Buy` | `Starter Only` | `Wait` | `Avoid for now`
-  - `Existing Holder Action`: `Add` | `Hold/Do not add` | `Hold` | `Trim` | `Exit`
-  - `Thesis Impact`: `No Material Change` | `Positive` | `Mixed` | `Negative`
-  - `Signal Quality`: `Weak` | `Moderate` | `Strong`
-  - `Confidence`: `Low` | `Medium` | `High`
-- Keep clickable source links near the factual claims they support. Compact chip-style links are fine, but regular inline links are also acceptable if they stay close to the claim.
-- Use a mix of source tiers: at least one primary filing or IR source, plus independent or reference cross-checks when relevant.
-- If the correct answer is `No Material Change`, prefer the short update contract instead of padding into a long memo.
-- If the user says "only tell me if I should act" and the correct mode is `No Material Change`, keep the output extremely short: no full memo, no scenario block, and stay under roughly 1200 visible characters.
-- For `No Material Change`, the final artifact should normally be closer to 250-900 visible characters than to 1200. Remove throat-clearing, provisional filler, and repeated caveats.
-- For `No Material Change`, `Evidence Chips` should contain 1 to 3 compact bullets or inline chips with concrete clickable links when those links are available. Do not leave `Evidence Chips` as a placeholder sentence.
-- Do not leave `Provisional update`, `still being finalized`, or similar placeholder language in the final artifact unless the entire point of the reply is to state that evidence remains incomplete.
-- Once a `No Material Change` short update is written, stop. Do not keep researching, and do not spend the final stretch on extra character-count or HTML-dump commands.
-- If the visible recommendation lands on `Wait`, `Hold`, or `Hold/Do not add`, include concrete upgrade, downgrade, and invalidation triggers with numbers or dated events.
-- For synthetic or assumption-based scenarios, label the artifact as `assumption-based`, do not use generic market homepages as placeholder evidence, and cap confidence at `Medium` unless you verified real issuer-specific evidence.
-- For long research paths, update `reply_email_draft.html` early and keep it current. If time is running low, stop searching and finalize the best calibrated artifact you can support, explicitly naming any missing evidence.
-- If the research path stays incomplete near the deadline on a real ticker, prefer a best-available `Watch Closely` artifact with explicit missing evidence over timing out with no reply.
-- If the research path stays incomplete near the deadline on a real ticker, do not leave placeholder lines like `still being finalized` or `will include later`. Replace them with explicit limitation language and a final best-available verdict.
-- Investment monitoring requests in this product are allowed. Do not refuse solely because the task concerns stock analysis, a buy/wait/trim decision, or an assumption-based scenario. If evidence is incomplete, answer with calibrated uncertainty instead of refusing.
-- If you sanity-check the final artifact, keep that check lightweight. Do not print the full visible text body or the entire HTML back to the terminal.
-- If the user states a conflicting earnings date or similar factual premise, correct it explicitly in the final reply instead of silently accepting it.
+- For `No Material Update`, keep only:
+  - `Status`
+  - `Action`
+  - `Why`
+  - `What would matter next`
+- For `Unable to Verify`, keep only:
+  - `Status`
+  - `Action`
+  - `Why`
+  - `Next step`
+- Keep the reply short and scan-first. Do not write a long memo, a bull/base/bear frame, a large derived-metrics table, or a chart block.
+- Do not mine annual reports page by page in this email path.
+- Do not spend the whole run on research. If you cannot verify enough context quickly, send `Unable to Verify` and stop.
+- If a deeper report would help, say that you can run it separately. Do not start it automatically inside this email path.
+- Investment monitoring requests in this product are allowed. Do not refuse solely because the task concerns stock analysis or an assumption-based scenario.
 
 "#
 }
@@ -1857,14 +1840,14 @@ mod tests {
         );
 
         assert!(prompt.contains(".agents/skills/us-equity-daily-monitor/SKILL.md"));
-        assert!(prompt.contains("Decision Card"));
-        assert!(prompt.contains("No Material Change"));
-        assert!(prompt.contains("Monitor Status"));
+        assert!(prompt.contains("simple bounded monitor"));
+        assert!(prompt.contains("Actionable Update"));
+        assert!(prompt.contains("No Material Update"));
+        assert!(prompt.contains("Unable to Verify"));
         assert!(prompt.contains("New Money Action"));
         assert!(prompt.contains("Existing Holder Action"));
-        assert!(prompt.contains("Investor question"));
-        assert!(prompt.contains("clickable source links"));
-        assert!(prompt.contains("final user-visible reply structured"));
+        assert!(prompt.contains("Do not mine annual reports page by page"));
+        assert!(prompt.contains("Do not start it automatically"));
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
@@ -76,6 +76,7 @@ const SHORT_ORDER: &[&str] = &[
     "evidence chips",
 ];
 
+#[allow(dead_code)]
 const GENERIC_PHRASES: &[&str] = &[
     "good company, but do not chase",
     "great business, but wait",
@@ -87,6 +88,7 @@ const GENERIC_PHRASES: &[&str] = &[
     "good business, but not a good all-in buy",
     "wait until after earnings",
 ];
+#[allow(dead_code)]
 const INCOMPLETE_FAIL_SOFT_MARKERS: &[&str] = &[
     "incomplete research artifact",
     "research did not complete within budget",
@@ -101,12 +103,14 @@ const INCOMPLETE_RESEARCH_MARKERS: &[&str] = &[
     "best-available timed artifact",
     "best-available timed reply",
 ];
+#[allow(dead_code)]
 const INTERNAL_THREAD_METADATA_MARKERS: &[&str] = &[
     "canonical thread request",
     "auto-generated merged view for reruns",
     "thread timeline",
     "merged attachments for this rerun",
 ];
+#[allow(dead_code)]
 const INTERNAL_RUNTIME_LANGUAGE_MARKERS: &[&str] = &[
     "verification incomplete in this timed monitor run",
     "verification incomplete in this timed run",
@@ -131,18 +135,14 @@ const INVESTMENT_INTENT_KEYWORDS: &[&str] = &[
     "a buy",
     "buy this week",
     "buy before",
-    "sell before",
-    "investing",
-    "investment view",
-    "investment case",
-    "investment memo",
     "starter position",
-    "starter only",
     "buy now",
     "add or trim",
+    "trim or exit",
+    "avoid for now",
 ];
 
-const INVESTMENT_RESEARCH_KEYWORDS: &[&str] = &["deep research", "analyze"];
+const INVESTMENT_RESEARCH_KEYWORDS: &[&str] = &["deep research"];
 const INVESTMENT_MONITOR_KEYWORDS: &[&str] = &[
     "material changed",
     "material change",
@@ -169,7 +169,9 @@ const ACTION_ONLY_MONITOR_KEYWORDS: &[&str] = &[
     "only tell me if i should act",
     "just tell me if i should act",
 ];
+#[allow(dead_code)]
 const SHORT_ARTIFACT_VISIBLE_CHAR_LIMIT: usize = 1200;
+const MAX_REPLY_ARTIFACT_BYTES: usize = 64 * 1024;
 const DOWHIZ_EMAIL_CONTENT_START: &str = "<!-- dowhiz-email-content:start -->";
 const DOWHIZ_EMAIL_CONTENT_END: &str = "<!-- dowhiz-email-content:end -->";
 const EMAIL_SHELL_BOILERPLATE: &[&str] = &[
@@ -277,82 +279,27 @@ pub(super) fn action_only_monitor_request_for_workspace(
 }
 
 fn investment_contract_violations(
-    workspace_dir: &Path,
+    _workspace_dir: &Path,
     reply_path: &Path,
 ) -> Result<Option<Vec<String>>, RunTaskError> {
-    let request_text = load_inbound_request_text(workspace_dir)?;
-    if !is_investment_request(&request_text) {
-        return Ok(None);
-    }
-    let synthetic_mode = is_synthetic_investment_request(&request_text);
-
     let reply_body = fs::read_to_string(reply_path)?;
-    let normalized_reply = normalize_search_text(&reply_body);
     let mut violations = Vec::new();
 
-    if contains_any_marker(&normalized_reply, INTERNAL_THREAD_METADATA_MARKERS) {
-        violations.push(
-            "reply leaks internal canonical-thread metadata instead of a user-facing question"
-                .to_string(),
-        );
+    if reply_body.len() > MAX_REPLY_ARTIFACT_BYTES {
+        violations.push("reply artifact exceeds bounded monitor size limit".to_string());
     }
 
-    if contains_any_marker(&normalized_reply, INTERNAL_RUNTIME_LANGUAGE_MARKERS) {
-        violations.push(
-            "reply contains internal timeout/recovery wording that is not user-sendable"
-                .to_string(),
-        );
+    if reply_body.contains('\0') {
+        violations.push("reply artifact contains null bytes".to_string());
     }
 
-    if reply_looks_like_templated_incomplete_investment_output(&normalized_reply) {
-        violations.push(
-            "incomplete investment fallbacks must not be sent as investment-looking decision memos"
-                .to_string(),
-        );
-    }
-
-    let clickable_links = clickable_links(&reply_body);
-    if detect_contract_type(&normalized_reply) == "short"
-        && normalized_reply.contains("no material change")
-        && normalized_reply.len() > SHORT_ARTIFACT_VISIBLE_CHAR_LIMIT
-    {
-        violations.push("No Material Change artifact exceeds short-output budget".to_string());
-    }
-
-    if synthetic_mode {
-        if !normalized_reply.contains("assumption-based") {
-            violations.push(
-                "synthetic scenario output must clearly label itself as assumption-based"
-                    .to_string(),
-            );
-        }
-        if normalized_reply.contains("confidence high")
-            && !clickable_links
-                .iter()
-                .any(|link| link_looks_specific(link) && !is_generic_placeholder_link(link))
-        {
-            violations.push(
-                "synthetic assumption-only output cannot use High confidence without specific source-backed issuer evidence"
-                    .to_string(),
-            );
-        }
-        if clickable_links
-            .iter()
-            .any(|link| is_generic_placeholder_link(link))
-        {
-            violations.push(
-                "synthetic scenario output uses generic placeholder links instead of clearly source-free assumption framing"
-                    .to_string(),
-            );
-        }
-    }
-
-    if GENERIC_PHRASES
-        .iter()
-        .any(|phrase| normalized_reply.contains(phrase))
-    {
-        violations
-            .push("generic hold/wait phrasing is not sendable as an investment reply".to_string());
+    let visible_text = if looks_like_html_reply(reply_path, &reply_body) {
+        rough_html_to_text(&reply_body)
+    } else {
+        reply_body.clone()
+    };
+    if visible_text.trim().is_empty() {
+        violations.push("reply artifact has no visible text".to_string());
     }
 
     if violations.is_empty() {
@@ -362,6 +309,14 @@ fn investment_contract_violations(
     }
 }
 
+fn looks_like_html_reply(reply_path: &Path, body: &str) -> bool {
+    matches!(
+        reply_path.extension().and_then(|value| value.to_str()),
+        Some("html") | Some("htm")
+    ) || body.contains('<')
+}
+
+#[allow(dead_code)]
 fn detect_contract_type(normalized_reply: &str) -> &'static str {
     if normalized_reply.contains("why now")
         && normalized_reply.contains("what would change the view")
@@ -440,6 +395,7 @@ fn neutral_actions_present(normalized_reply: &str) -> bool {
         || normalized_reply.contains("existing holder action hold/do not add")
 }
 
+#[allow(dead_code)]
 fn clickable_links(raw_reply: &str) -> Vec<String> {
     let fragment = visible_html_fragment(raw_reply);
     let document = kuchiki::parse_html().one(fragment);
@@ -768,6 +724,7 @@ fn style_hides_content(style: &str) -> bool {
         || normalized.contains("mso-hide:all")
 }
 
+#[allow(dead_code)]
 fn is_generic_placeholder_link(link: &str) -> bool {
     let lower = link.to_ascii_lowercase();
     let path = url_path(&lower);
@@ -803,6 +760,7 @@ fn is_generic_placeholder_link(link: &str) -> bool {
         .any(|domain| lower.contains(domain) && generic_paths.contains(&trimmed))
 }
 
+#[allow(dead_code)]
 fn link_looks_specific(link: &str) -> bool {
     let lower = link.to_ascii_lowercase();
     let path = url_path(&lower);
@@ -821,12 +779,14 @@ fn link_looks_specific(link: &str) -> bool {
         || trimmed.contains("article")
 }
 
+#[allow(dead_code)]
 fn contains_any_marker(normalized_reply: &str, markers: &[&str]) -> bool {
     markers
         .iter()
         .any(|marker| normalized_reply.contains(marker))
 }
 
+#[allow(dead_code)]
 fn reply_looks_like_templated_incomplete_investment_output(normalized_reply: &str) -> bool {
     let has_decision_card = normalized_reply.contains("decision card");
     let has_action_table = normalized_reply.contains("new money action")
@@ -837,6 +797,7 @@ fn reply_looks_like_templated_incomplete_investment_output(normalized_reply: &st
     (has_decision_card || has_action_table) && has_incomplete_marker
 }
 
+#[allow(dead_code)]
 fn url_path(link: &str) -> &str {
     let without_scheme = link.split_once("://").map(|(_, rest)| rest).unwrap_or(link);
     let Some(path_start) = without_scheme.find('/') else {
@@ -978,25 +939,20 @@ mod tests {
     }
 
     #[test]
-    fn generic_investment_commentary_fails_contract_validation() {
+    fn generic_investment_commentary_passes_mechanical_validation() {
         let workspace = write_workspace(
             "Give me deep research on NVDA and tell me whether now is a good time to buy.",
             "<p>NVIDIA is a good company, but I would wait for clarity and buy in tranches.</p>",
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
-        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "tail")
-            .expect_err("expected contract violation");
-        let rendered = err.to_string();
-        assert!(
-            rendered.contains("Output contract violation")
-                || rendered.contains("violates required contract")
-        );
-        assert!(!reply_artifact_ready_for_workspace(&workspace, &reply_path));
+        ensure_expected_reply_artifact(&workspace, &reply_path, "tail")
+            .expect("mechanical validation should not reject generic commentary");
+        assert!(reply_artifact_ready_for_workspace(&workspace, &reply_path));
     }
 
     #[test]
-    fn canonical_thread_metadata_in_reply_fails_sendability_gate() {
+    fn canonical_thread_metadata_is_not_blocked_by_mechanical_gate() {
         let workspace = write_workspace(
             "Check whether anything material changed for NVDA since your last note. Only tell me if I should act.",
             r#"
@@ -1008,11 +964,8 @@ mod tests {
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
-        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
-            .expect_err("canonical thread metadata should not be sendable");
-        assert!(err
-            .to_string()
-            .contains("reply leaks internal canonical-thread metadata"));
+        ensure_expected_reply_artifact(&workspace, &reply_path, "")
+            .expect("mechanical validation should not reject based on semantics");
     }
 
     #[test]
@@ -1072,8 +1025,9 @@ mod tests {
     }
 
     #[test]
-    fn no_material_change_monitor_prompt_fails_when_short_artifact_is_too_long() {
-        let repeated = "The latest public information does not change the call today. ".repeat(40);
+    fn oversized_reply_artifact_fails_mechanical_validation() {
+        let repeated =
+            "The latest public information does not change the call today. ".repeat(2000);
         let workspace = write_workspace(
             "Check whether anything material changed for NVDA since your last note. Only tell me if I should act.",
             &format!(
@@ -1119,86 +1073,31 @@ mod tests {
         let reply_path = workspace.join("reply_email_draft.html");
 
         let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
-            .expect_err("expected short-contract budget violation");
+            .expect_err("expected bounded monitor size violation");
         assert!(err
             .to_string()
-            .contains("No Material Change artifact exceeds short-output budget"));
+            .contains("reply artifact exceeds bounded monitor size limit"));
     }
 
     #[test]
-    fn synthetic_placeholder_links_and_high_confidence_fail_contract_validation() {
+    fn html_reply_with_no_visible_text_fails_mechanical_validation() {
         let workspace = write_workspace(
-            "Assume company X just raised FY revenue guidance by 15%, gross margin expanded 400 bps, free cash flow turned positive, and Reuters/Bloomberg reported stronger order demand. Write the investment monitor output.",
+            "Give me deep research on NVDA and tell me whether now is a good time to buy.",
             r#"
-            <section>
-              <p><strong>As of:</strong> 2026-05-01 · <strong>Price:</strong> Assumption-based scenario</p>
-              <p><strong>Investor question:</strong> Write the investment monitor output.</p>
-            </section>
-            <section>
-              <h2>Decision Card</h2>
-              <table>
-                <tr><td>Monitor Status</td><td>Review Now</td></tr>
-                <tr><td>New Money Action</td><td>Buy</td></tr>
-                <tr><td>Existing Holder Action</td><td>Add</td></tr>
-                <tr><td>Thesis Impact</td><td>Positive</td></tr>
-                <tr><td>Signal Quality</td><td>Strong</td></tr>
-                <tr><td>Confidence</td><td>High</td></tr>
-              </table>
-              <p><strong>One-line rationale:</strong> Assumption-based scenario with improving demand.</p>
-            </section>
-            <section>
-              <h2>Dual-Horizon Framing</h2>
-              <h3>Near-Term Timing View</h3>
-              <p>Momentum is positive.</p>
-              <h3>Long-Term Ownership View</h3>
-              <p>The scenario implies a stronger moat.</p>
-            </section>
-            <section>
-              <h2>Verified Facts</h2>
-              <ul>
-                <li>Assumption-based scenario only. <a href="https://www.reuters.com/markets/">Reuters</a></li>
-                <li>Peer valuation remains supportive. <a href="https://www.bloomberg.com/markets">Bloomberg</a></li>
-                <li>FCF turned positive. <a href="https://www.nasdaq.com/">Nasdaq</a></li>
-              </ul>
-            </section>
-            <section>
-              <h2>Derived Metrics</h2>
-              <p>Revenue uplift / EV-sales gap = 15 / 1.2</p>
-            </section>
-            <section>
-              <h2>Scenarios</h2>
-              <h3>Bull Case</h3>
-              <p>Execution holds.</p>
-              <h3>Base Case</h3>
-              <p>Demand remains healthy.</p>
-              <h3>Bear Case</h3>
-              <p>Demand cools quickly.</p>
-            </section>
-            <section>
-              <h2>Triggers — Verdict Movement</h2>
-              <ul>
-                <li><strong>Upgrade / Review Now:</strong> Revenue guide rises another 5%.</li>
-                <li><strong>Downgrade / De-risk:</strong> Gross margin gives back 200 bps.</li>
-                <li><strong>Invalidation:</strong> Orders soften by more than 10%.</li>
-              </ul>
-            </section>
-            <section>
-              <h2>Judgment</h2>
-              <p>This is assumption-based, but confidence is still high.</p>
-            </section>
+            <html><body><style>.hidden { display:none; }</style><div aria-hidden="true">hidden</div></body></html>
             "#,
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
         let err = ensure_expected_reply_artifact(&workspace, &reply_path, "tail")
-            .expect_err("synthetic placeholder links should fail");
-        let rendered = err.to_string();
-        assert!(rendered.contains("synthetic scenario output uses generic placeholder links"));
-        assert!(rendered.contains("cannot use High confidence"));
+            .expect_err("empty visible html should fail");
+        assert!(err
+            .to_string()
+            .contains("reply artifact has no visible text"));
     }
 
     #[test]
-    fn incomplete_research_investment_memo_fails_sendability_gate() {
+    fn incomplete_research_pseudo_memo_passes_mechanical_validation() {
         let workspace = write_workspace(
             "Give me a deep research about the Nokia stock, and tell me whether it is a good time to buy.",
             r#"
@@ -1272,15 +1171,12 @@ mod tests {
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
-        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
-            .expect_err("incomplete pseudo-memo should not be sendable");
-        assert!(err.to_string().contains(
-            "incomplete investment fallbacks must not be sent as investment-looking decision memos"
-        ));
+        ensure_expected_reply_artifact(&workspace, &reply_path, "")
+            .expect("runtime should not block based on semantic completeness");
     }
 
     #[test]
-    fn incomplete_short_monitor_artifact_fails_sendability_gate() {
+    fn incomplete_short_monitor_artifact_passes_mechanical_validation() {
         let workspace = write_workspace(
             "Check whether anything material changed for NVDA since your last note. Only tell me if I should act.",
             r#"
@@ -1322,14 +1218,7 @@ mod tests {
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
-        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
-            .expect_err("short incomplete monitor pseudo-memo should not be sendable");
-        let rendered = err.to_string();
-        assert!(rendered.contains(
-            "incomplete investment fallbacks must not be sent as investment-looking decision memos"
-        ));
-        assert!(rendered.contains(
-            "reply contains internal timeout/recovery wording that is not user-sendable"
-        ));
+        ensure_expected_reply_artifact(&workspace, &reply_path, "")
+            .expect("runtime should not block based on semantic completeness");
     }
 }

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -25,64 +25,17 @@ fn require_env(key: &'static str) {
     }
 }
 
-fn assert_investment_contract_labels(text: &str) {
-    for label in [
-        "As of:",
-        "Price:",
-        "Investor question:",
-        "Decision Card",
-        "Monitor Status",
-        "New Money Action",
-        "Existing Holder Action",
-        "Thesis Impact",
-        "Signal Quality",
-        "Confidence",
-        "One-line rationale:",
-        "Dual-Horizon Framing",
-        "Near-Term Timing View",
-        "Long-Term Ownership View",
-        "Verified Facts",
-        "Derived Metrics",
-        "Scenarios",
-        "Bull Case",
-        "Base Case",
-        "Bear Case",
-        "Triggers",
-        "Upgrade / Review Now",
-        "Downgrade / De-risk",
-        "Invalidation",
-        "Judgment",
-    ] {
-        assert!(text.contains(label), "missing label {label}");
-    }
+fn assert_non_empty_renderable_html(text: &str) {
+    assert!(!text.trim().is_empty(), "reply should not be empty");
+    let normalized = normalize_email_html("Test subject", text);
     assert!(
-        text.matches("href=\"http").count() + text.matches("href='http").count() >= 3,
-        "missing clickable source links"
+        !normalized.trim().is_empty(),
+        "normalized reply should still contain renderable HTML"
     );
-    for marker in [
-        "Decision Card",
-        "Dual-Horizon Framing",
-        "Verified Facts",
-        "Derived Metrics",
-        "Scenarios",
-        "Triggers",
-        "Judgment",
-    ]
-    .windows(2)
-    {
-        let earlier = text
-            .find(marker[0])
-            .unwrap_or_else(|| panic!("missing marker {}", marker[0]));
-        let later = text
-            .find(marker[1])
-            .unwrap_or_else(|| panic!("missing marker {}", marker[1]));
-        assert!(
-            earlier < later,
-            "expected {} to appear before {}",
-            marker[0],
-            marker[1]
-        );
-    }
+    assert!(
+        normalized.contains('<') && normalized.contains('>'),
+        "normalized reply should still look like HTML"
+    );
 }
 
 fn write_investment_request(workspace: &Path, subject: &str, prompt: &str) {
@@ -1093,10 +1046,11 @@ sleep 20
     let elapsed = started_at.elapsed();
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
     assert!(html.contains("Quick update on NVDA"));
-    assert!(html.contains("literal change-since-last-note check"));
-    assert!(html.contains("low-confidence buy / hold / trim call"));
+    assert!(html.contains("Status:"));
+    assert!(html.contains("Unable to Verify"));
+    assert!(html.contains("Action:"));
+    assert!(html.contains("No recommendation"));
     assert!(!html.contains("Decision Card"));
-    assert!(!html.contains("Insufficient Evidence"));
     assert!(!html.contains("Canonical thread request"));
     assert!(!html.contains("href=\"http"));
     assert!(!counter_path.exists());
@@ -1156,9 +1110,9 @@ sleep 20
         .expect("monitor timeout should produce fail-soft artifact");
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
     assert!(html.contains("Quick update on NVDA"));
-    assert!(html.contains("low-confidence buy / hold / trim call"));
+    assert!(html.contains("Unable to Verify"));
+    assert!(html.contains("No recommendation"));
     assert!(!html.contains("Decision Card"));
-    assert!(!html.contains("timed monitor run"));
     assert!(!html.contains("href=\"http"));
     let note = result.recovery_note.as_deref().unwrap_or("");
     assert!(note.contains("deterministic operational monitor fallback"));
@@ -1167,7 +1121,7 @@ sleep 20
 
 #[test]
 #[cfg(unix)]
-fn run_task_timeout_tries_fast_completion_before_failing_soft_for_real_ticker_research() {
+fn run_task_timeout_yields_single_pass_operational_fallback_for_real_ticker_research() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_fail_soft_before_retry").unwrap();
     let workspace = create_workspace(&temp.path).unwrap();
@@ -1244,25 +1198,24 @@ sleep 20
     ]);
 
     let result =
-        run_task(&build_params(&workspace)).expect("fail-soft artifact should recover timeout");
+        run_task(&build_params(&workspace)).expect("timeout should recover with one fallback");
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
     assert!(html.contains("Quick update on Nokia (NOK)"));
-    assert!(html.contains("I could not finish a reliable buy-or-avoid review yet"));
-    assert!(html.contains("What I have so far"));
-    assert!(html.contains("What is still missing"));
-    assert!(html.contains("incomplete work rather than a real Buy / Avoid / Add / Exit call"));
+    assert!(html.contains("Unable to Verify"));
+    assert!(html.contains("No recommendation"));
+    assert!(html.contains("deeper report separately"));
     assert!(!html.contains("Decision Card"));
     assert!(!html.contains("href=\"http"));
-    assert_eq!(fs::read_to_string(&counter_path).unwrap(), "2");
-    assert!(workspace.join("codex_fast_completion_context.md").exists());
+    assert_eq!(fs::read_to_string(&counter_path).unwrap(), "1");
+    assert!(!workspace.join("codex_fast_completion_context.md").exists());
     let note = result.recovery_note.as_deref().unwrap_or("");
     assert!(note.contains("deterministic operational investment fallback"));
-    assert!(!note.contains("Returned early once a valid reply artifact existed"));
+    assert!(!note.contains("Claude fallback"));
 }
 
 #[test]
 #[cfg(unix)]
-fn run_task_synthetic_investment_requests_use_assumption_fast_path() {
+fn run_task_synthetic_investment_requests_fall_back_once_without_assumption_mode() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_negative_synthetic_fail_soft").unwrap();
     let workspace = create_workspace(&temp.path).unwrap();
@@ -1294,7 +1247,7 @@ if [ -f "{counter_path}" ]; then
 fi
 count=$((count + 1))
 printf '%s' "$count" > "{counter_path}"
-echo "synthetic fast path should not invoke codex" >&2
+echo "synthetic request invoked codex once" >&2
 sleep 20
 "#,
             counter_path = counter_path.display()
@@ -1314,26 +1267,21 @@ sleep 20
         ("GH_AUTH_DISABLED", "1"),
     ]);
 
-    let result = run_task(&build_params(&workspace))
-        .expect("synthetic request should yield deterministic assumption artifact");
+    let result =
+        run_task(&build_params(&workspace)).expect("synthetic request should still return once");
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
-    assert!(html.contains("Assumption-based investment monitor output"));
-    assert!(html.contains("Avoid for now"));
-    assert!(html.contains("Exit"));
-    assert!(html.contains("Review Now"));
-    assert!(html.contains("assumption-based"));
-    assert!(html.contains("Medium"));
-    assert!(!html.contains("High"));
+    assert!(html.contains("Unable to Verify"));
+    assert!(html.contains("No recommendation"));
     assert!(!html.contains("href=\"http"));
-    assert!(!counter_path.exists());
+    assert_eq!(fs::read_to_string(&counter_path).unwrap(), "1");
     let note = result.recovery_note.as_deref().unwrap_or("");
-    assert!(note.contains("deterministic assumption-based investment artifact"));
+    assert!(note.contains("deterministic operational"));
     assert!(!note.contains("Claude fallback"));
 }
 
 #[test]
 #[cfg(unix)]
-fn run_task_watch_closely_synthetic_prompts_use_assumption_fast_path() {
+fn run_task_watch_closely_synthetic_prompts_fall_back_once_without_fast_path() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_watch_closely_synthetic_fast_path").unwrap();
     let workspace = create_workspace(&temp.path).unwrap();
@@ -1365,7 +1313,7 @@ if [ -f "{counter_path}" ]; then
 fi
 count=$((count + 1))
 printf '%s' "$count" > "{counter_path}"
-echo "watch-closely synthetic fast path should not invoke codex" >&2
+echo "watch-closely synthetic invoked codex once" >&2
 sleep 20
 "#,
             counter_path = counter_path.display()
@@ -1387,24 +1335,19 @@ sleep 20
 
     let started_at = Instant::now();
     let result = run_task(&build_params(&workspace))
-        .expect("synthetic watch-closely request should use fast path");
+        .expect("synthetic watch-closely request should still return once");
     let elapsed = started_at.elapsed();
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
-    assert!(html.contains("Assumption-based investment monitor output"));
-    assert!(html.contains("Watch Closely"));
-    assert!(html.contains("Starter Only"));
-    assert!(html.contains("Hold/Do not add"));
-    assert!(html.contains("assumption-based"));
-    assert!(html.contains("Medium"));
-    assert!(!html.contains("High"));
+    assert!(html.contains("Unable to Verify"));
+    assert!(html.contains("No recommendation"));
     assert!(!html.contains("href=\"http"));
-    assert!(!counter_path.exists());
+    assert_eq!(fs::read_to_string(&counter_path).unwrap(), "1");
     assert!(
-        elapsed.as_secs_f32() < 6.0,
-        "synthetic watch-closely fast path should return quickly, elapsed={elapsed:?}"
+        elapsed.as_secs_f32() < 25.0,
+        "synthetic fallback should stay within the bounded monitor timeout, elapsed={elapsed:?}"
     );
     let note = result.recovery_note.as_deref().unwrap_or("");
-    assert!(note.contains("deterministic assumption-based investment artifact"));
+    assert!(note.contains("deterministic operational"));
     assert!(!note.contains("Claude fallback"));
 }
 
@@ -1473,7 +1416,7 @@ exit 23
 
 #[test]
 #[cfg(unix)]
-fn run_task_nonzero_completed_turn_with_invalid_investment_reply_triggers_claude_fallback() {
+fn run_task_nonzero_completed_turn_with_generic_investment_reply_is_accepted() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_invalid_nonzero_fallback").unwrap();
     let workspace = create_workspace(&temp.path).unwrap();
@@ -1492,8 +1435,6 @@ fn run_task_nonzero_completed_turn_with_invalid_investment_reply_triggers_claude
         FakeCodexMode::InvestmentGenericTurnCompleteExitNonzero,
     )
     .unwrap();
-    write_fake_claude(&bin_dir, FakeClaudeMode::InvestmentStructured).unwrap();
-
     let old_path = env::var("PATH").unwrap_or_default();
     let new_path = format!("{}:{}", bin_dir.display(), old_path);
     let _env = EnvGuard::set(&[
@@ -1505,11 +1446,11 @@ fn run_task_nonzero_completed_turn_with_invalid_investment_reply_triggers_claude
     ]);
 
     let result =
-        run_task(&build_params(&workspace)).expect("invalid nonzero artifact should fall back");
+        run_task(&build_params(&workspace)).expect("generic nonzero artifact should still return");
     let html = fs::read_to_string(result.reply_html_path).unwrap();
-    assert!(html.contains("Decision Card"));
+    assert!(html.contains("wait until after earnings"));
     let note = result.recovery_note.unwrap_or_default();
-    assert!(note.contains("Claude fallback"));
+    assert!(note.contains("late exit as a warning"));
 }
 
 #[test]
@@ -2077,6 +2018,7 @@ fn run_task_accepts_structured_investment_reply_from_fake_codex() {
 
     let result = run_task(&build_params(&workspace)).unwrap();
     let html = fs::read_to_string(result.reply_html_path).unwrap();
+    assert_non_empty_renderable_html(&html);
     assert!(html.contains("Decision Card"));
     assert!(html.contains("Verified Facts"));
     assert!(html.contains("Triggers"));
@@ -2086,7 +2028,7 @@ fn run_task_accepts_structured_investment_reply_from_fake_codex() {
 
 #[test]
 #[cfg(unix)]
-fn run_task_final_artifact_preserves_investment_contract_after_email_normalization() {
+fn run_task_final_artifact_preserves_non_empty_html_after_email_normalization() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_investment_final_artifact").unwrap();
     let workspace = create_workspace(&temp.path).unwrap();
@@ -2116,15 +2058,15 @@ fn run_task_final_artifact_preserves_investment_contract_after_email_normalizati
     assert!(result.reply_html_path.ends_with("reply_email_draft.html"));
 
     let raw_reply = fs::read_to_string(&result.reply_html_path).unwrap();
-    assert_investment_contract_labels(&raw_reply);
+    assert_non_empty_renderable_html(&raw_reply);
 
     let final_html = normalize_email_html("NVDA investment memo", &raw_reply);
-    assert_investment_contract_labels(&final_html);
+    assert_non_empty_renderable_html(&final_html);
 }
 
 #[test]
 #[cfg(unix)]
-fn run_task_investment_contract_violation_triggers_claude_fallback() {
+fn run_task_generic_investment_reply_no_longer_triggers_claude_fallback() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_investment_fallback").unwrap();
     let workspace = create_workspace(&temp.path).unwrap();
@@ -2139,7 +2081,6 @@ fn run_task_investment_contract_violation_triggers_claude_fallback() {
     fs::create_dir_all(&home_dir).unwrap();
     fs::create_dir_all(&bin_dir).unwrap();
     write_fake_codex(&bin_dir, FakeCodexMode::InvestmentGeneric).unwrap();
-    write_fake_claude(&bin_dir, FakeClaudeMode::InvestmentStructured).unwrap();
 
     let old_path = env::var("PATH").unwrap_or_default();
     let new_path = format!("{}:{}", bin_dir.display(), old_path);
@@ -2153,15 +2094,16 @@ fn run_task_investment_contract_violation_triggers_claude_fallback() {
 
     let result = run_task(&build_params(&workspace)).unwrap();
     let html = fs::read_to_string(result.reply_html_path).unwrap();
+    assert_non_empty_renderable_html(&html);
+    assert!(html.contains("wait until after earnings"));
+    assert!(!html.contains("Decision Card"));
     let recovery = result.recovery_note.unwrap_or_default();
-    assert!(recovery.contains("Claude fallback"));
-    assert!(html.contains("Decision Card"));
-    assert!(html.contains("Bull Case"));
+    assert!(!recovery.contains("Claude fallback"));
 }
 
 #[test]
 #[cfg(unix)]
-fn run_task_investment_contract_violation_uses_fail_soft_artifact_when_fallback_is_still_generic() {
+fn run_task_generic_investment_reply_does_not_require_fail_soft_when_non_empty() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_investment_fail_closed").unwrap();
     let workspace = create_workspace(&temp.path).unwrap();
@@ -2176,7 +2118,6 @@ fn run_task_investment_contract_violation_uses_fail_soft_artifact_when_fallback_
     fs::create_dir_all(&home_dir).unwrap();
     fs::create_dir_all(&bin_dir).unwrap();
     write_fake_codex(&bin_dir, FakeCodexMode::InvestmentGeneric).unwrap();
-    write_fake_claude(&bin_dir, FakeClaudeMode::InvestmentGeneric).unwrap();
 
     let old_path = env::var("PATH").unwrap_or_default();
     let new_path = format!("{}:{}", bin_dir.display(), old_path);
@@ -2189,18 +2130,14 @@ fn run_task_investment_contract_violation_uses_fail_soft_artifact_when_fallback_
     ]);
 
     let result = run_task(&build_params(&workspace))
-        .expect("generic Codex + generic fallback should still return a fail-soft artifact");
+        .expect("generic non-empty investment reply should return directly");
     let html = fs::read_to_string(result.reply_html_path).unwrap();
+    assert_non_empty_renderable_html(&html);
     let recovery = result.recovery_note.unwrap_or_default();
-    assert!(html.contains("Quick update on NVDA"));
-    assert!(html.contains("I could not finish a reliable buy-or-avoid review yet"));
-    assert!(html.contains("What I have so far"));
-    assert!(html.contains("What is still missing"));
-    assert!(html.contains("incomplete work rather than a real Buy / Avoid / Add / Exit call"));
+    assert!(html.contains("wait until after earnings"));
     assert!(!html.contains("Decision Card"));
-    assert!(!html.contains("href=\"http"));
-    assert!(recovery.contains("deterministic operational investment fallback"));
-    assert!(recovery.contains("Codex and fallback recovery failed"));
+    assert!(!recovery.contains("deterministic operational investment fallback"));
+    assert!(!recovery.contains("Claude fallback"));
 }
 
 #[test]
@@ -2236,7 +2173,7 @@ fn run_task_real_codex_e2e_when_enabled() {
 
 #[test]
 #[cfg(unix)]
-fn run_task_real_codex_investment_contract_e2e_when_enabled() {
+fn run_task_real_codex_investment_e2e_when_enabled() {
     let _lock = ENV_MUTEX.lock().unwrap();
     if !env_enabled("RUN_CODEX_E2E") {
         eprintln!("RUN_CODEX_E2E not set; skipping investment Codex E2E test.");
@@ -2263,5 +2200,9 @@ fn run_task_real_codex_investment_contract_e2e_when_enabled() {
         panic!("Real investment Codex E2E test failed: {err}");
     });
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
-    assert_investment_contract_labels(&html);
+    assert_non_empty_renderable_html(&html);
+    assert!(
+        html.len() <= 64 * 1024,
+        "investment reply should stay within bounded artifact size"
+    );
 }

--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -780,6 +780,7 @@ fn notify_run_task_failure(
 ) -> Result<(), SchedulerError> {
     let failure_dir = task.workspace_dir.join(RUN_TASK_FAILURE_DIR);
     std::fs::create_dir_all(&failure_dir)?;
+    let failure_notice_marker = failure_notice_marker_path(task);
 
     let is_slack = matches!(task.channel, Channel::Slack);
     let user_notice = failure_class.user_notice();
@@ -800,7 +801,13 @@ fn notify_run_task_failure(
     std::fs::create_dir_all(&notice_attachments)?;
 
     if !task.reply_to.is_empty() {
-        if is_slack {
+        if failure_notice_marker.exists() {
+            warn!(
+                "suppressing duplicate run_task failure notice for workspace={} key={}",
+                task.workspace_dir.display(),
+                failure_notice_identity(task),
+            );
+        } else if is_slack {
             let slack_thread_ts = load_reply_context(&task.workspace_dir)
                 .in_reply_to
                 .or_else(|| slack_thread_ts_from_thread_key(task.thread_id.as_deref()));
@@ -822,6 +829,15 @@ fn notify_run_task_failure(
                 channel_metadata: task.normalized_channel_metadata(),
             };
             execute_slack_send(&send_task)?;
+            std::fs::write(
+                &failure_notice_marker,
+                format!(
+                    "task_id={}\nchannel={}\nidentity={}\n",
+                    task_id,
+                    task.channel,
+                    failure_notice_identity(task)
+                ),
+            )?;
         } else {
             let from = task
                 .reply_from
@@ -846,6 +862,15 @@ fn notify_run_task_failure(
             };
             send_emails_module::send_email(&params)
                 .map_err(|err| SchedulerError::TaskFailed(err.to_string()))?;
+            std::fs::write(
+                &failure_notice_marker,
+                format!(
+                    "task_id={}\nchannel={}\nidentity={}\n",
+                    task_id,
+                    task.channel,
+                    failure_notice_identity(task)
+                ),
+            )?;
         }
     } else {
         warn!("no reply_to recipients for task failure notice {}", task_id);
@@ -868,6 +893,38 @@ fn notify_run_task_failure(
     )?;
 
     Ok(())
+}
+
+fn failure_notice_marker_path(task: &RunTaskTask) -> PathBuf {
+    let failure_dir = task.workspace_dir.join(RUN_TASK_FAILURE_DIR);
+    let identity = failure_notice_identity(task);
+    let digest = format!("{:x}", md5::compute(identity.as_bytes()));
+    failure_dir.join(format!("user_notice_sent_{}.marker", digest))
+}
+
+fn failure_notice_identity(task: &RunTaskTask) -> String {
+    let reply_context = load_reply_context(&task.workspace_dir);
+    if let Some(thread_id) = task
+        .thread_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        return format!("channel:{}|thread:{}", task.channel, thread_id);
+    }
+    if let Some(in_reply_to) = reply_context
+        .in_reply_to
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        return format!("channel:{}|reply:{}", task.channel, in_reply_to);
+    }
+    format!(
+        "channel:{}|workspace:{}",
+        task.channel,
+        task.workspace_dir.display()
+    )
 }
 
 fn notify_run_task_retry(

--- a/DoWhiz_service/scheduler_module/tests/scheduler_retry_notifications_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_retry_notifications_e2e.rs
@@ -328,6 +328,132 @@ fn run_task_failure_retries_and_notifies() -> Result<(), Box<dyn std::error::Err
 }
 
 #[test]
+fn repeated_failures_for_same_thread_send_only_one_user_notice(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let Some(mongo_uri) =
+        require_mongodb_uri("repeated_failures_for_same_thread_send_only_one_user_notice")
+    else {
+        return Ok(());
+    };
+
+    let Some(mut server) = test_support::start_mockito_server(
+        "repeated_failures_for_same_thread_send_only_one_user_notice",
+    ) else {
+        return Ok(());
+    };
+    let admin_addr = "admin@example.com";
+    let user_addr = "user@example.com";
+
+    let user_mock = server
+        .mock("POST", "/email")
+        .match_header("x-postmark-server-token", "test-token")
+        .match_body(Matcher::Regex(user_addr.to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(success_body(user_addr))
+        .expect(1)
+        .create();
+
+    let admin_mock = server
+        .mock("POST", "/email")
+        .match_header("x-postmark-server-token", "test-token")
+        .match_body(Matcher::Regex(admin_addr.to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(success_body(admin_addr))
+        .expect(2)
+        .create();
+
+    let _guard_token = EnvGuard::set("POSTMARK_SERVER_TOKEN", "test-token");
+    let _guard_api = EnvGuard::set("POSTMARK_API_BASE_URL", server.url());
+    let _guard_admin = EnvGuard::set("ADMIN_EMAIL", admin_addr);
+
+    let temp = TempDir::new()?;
+    let workspace = temp.path().join("workspace");
+    let incoming_dir = workspace.join("incoming_email");
+    fs::create_dir_all(&incoming_dir)?;
+    fs::write(
+        incoming_dir.join("postmark_payload.json"),
+        r#"{"Subject":"Test subject","MessageID":"<msg-id>"}"#,
+    )?;
+
+    let make_task = || RunTaskTask {
+        workspace_dir: workspace.clone(),
+        input_email_dir: PathBuf::from("incoming_email"),
+        input_attachments_dir: PathBuf::from("incoming_attachments"),
+        memory_dir: PathBuf::from("memory"),
+        reference_dir: PathBuf::from("references"),
+        model_name: "gpt-test".to_string(),
+        runner: "codex".to_string(),
+        codex_disabled: false,
+        reply_to: vec![user_addr.to_string()],
+        reply_from: Some("service@example.com".to_string()),
+        archive_root: None,
+        thread_id: Some("email:test-thread-123".to_string()),
+        thread_epoch: None,
+        thread_state_path: None,
+        channel: Channel::Email,
+        slack_team_id: None,
+        employee_id: None,
+        requester_identifier_type: None,
+        requester_identifier: None,
+        account_id: None,
+        channel_metadata: Default::default(),
+    };
+
+    let db_path = temp.path().join("tasks.db");
+    let mut scheduler = Scheduler::load(&db_path, AlwaysFailExecutor)?;
+
+    let task_one =
+        scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(make_task()))?;
+    let _ = scheduler.tick();
+    force_one_shot_due(&mongo_uri, &db_path, task_one)?;
+    scheduler = Scheduler::load(&db_path, AlwaysFailExecutor)?;
+    let _ = scheduler.tick();
+    force_one_shot_due(&mongo_uri, &db_path, task_one)?;
+    scheduler = Scheduler::load(&db_path, AlwaysFailExecutor)?;
+    let _ = scheduler.tick();
+
+    let task_two =
+        scheduler.add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(make_task()))?;
+    let _ = scheduler.tick();
+    force_one_shot_due(&mongo_uri, &db_path, task_two)?;
+    scheduler = Scheduler::load(&db_path, AlwaysFailExecutor)?;
+    let _ = scheduler.tick();
+    force_one_shot_due(&mongo_uri, &db_path, task_two)?;
+    scheduler = Scheduler::load(&db_path, AlwaysFailExecutor)?;
+    let _ = scheduler.tick();
+
+    let failure_dir = workspace.join("failure_notifications");
+    let marker_count = fs::read_dir(&failure_dir)?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("marker"))
+        .count();
+    assert_eq!(
+        marker_count, 1,
+        "expected one user-notice suppression marker"
+    );
+
+    let report_dir = env::temp_dir().join("dowhiz_failure_reports");
+    let report_one = report_dir.join(format!("task_failure_{}.html", task_one));
+    let report_two = report_dir.join(format!("task_failure_{}.html", task_two));
+    assert!(
+        report_one.exists(),
+        "first admin failure report should exist"
+    );
+    assert!(
+        report_two.exists(),
+        "second admin failure report should exist"
+    );
+
+    user_mock.assert();
+    admin_mock.assert();
+
+    Ok(())
+}
+
+#[test]
 fn transient_codex_failures_send_retry_alerts_and_terminal_notice(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _lock = ENV_MUTEX.lock().unwrap();

--- a/DoWhiz_service/skills/us-equity-daily-monitor/SKILL.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/SKILL.md
@@ -1,55 +1,44 @@
 ---
 name: us-equity-daily-monitor
-description: Produce a calibrated U.S. equity decision memo or monitor update for one stock or ETF. Use whenever the user wants a decision-useful view on a single U.S. stock or ETF, including prompts like "should I buy NVDA", "is XOM still a hold", "what changed on PLUG", "thoughts on AAPL into earnings", "do I add or trim", or "is there any edge here". This skill separates monitor status from new-money and existing-holder actions, shortens no-edge situations into concise `No Material Change` updates, and forces concrete upgrade, downgrade, and invalidation triggers for neutral stances. Do not use for portfolio construction, crypto, FX, fixed income, multi-asset allocation, or broad macro notes.
+description: Produce a simple, bounded U.S. equity monitor reply for one stock or ETF. Use whenever the user wants a concise decision-useful update on a single U.S. stock or ETF, such as "should I buy NVDA", "what changed on PLUG", "do I add or trim", or "is there any edge here". Do not use for portfolio construction, crypto, FX, fixed income, multi-asset allocation, or broad macro notes.
 ---
 
 # U.S. Equity Daily Monitor
 
-Use this skill to produce calibrated decision support, not safe commentary. Decide the monitor mode first, then choose separate actions for new money and existing holders.
+This skill is a simple bounded monitor, not a deep-research pipeline.
 
-## Workflow
+## Output modes
 
-1. Restate the investor's actual question in one line.
-2. Choose the monitor mode from [`references/action-taxonomy.md`](references/action-taxonomy.md):
-   - `No Material Change`
-   - `Watch Closely`
-   - `Review Now`
-3. Pick the output contract from [`references/output-contract.md`](references/output-contract.md):
-   - `No Material Change` uses the short update contract.
-   - `Watch Closely` and `Review Now` use the full memo contract.
-4. Decide the fields in the Decision Card:
-   - `Monitor Status`
-   - `New Money Action`
-   - `Existing Holder Action`
-   - `Thesis Impact`
-   - `Signal Quality`
+Use exactly one of these modes:
+
+1. `Actionable Update`
+   - `Status`
+   - `New Money Action`: `Buy` | `Wait` | `Avoid`
+   - `Existing Holder Action`: `Hold` | `Add` | `Trim` | `Exit`
+   - `Why now`
+   - `What changed`
+   - `What would change the view`
    - `Confidence`
-5. Build the factual spine and derived metrics. Follow [`references/source-policy.md`](references/source-policy.md), [`references/data-adapters.md`](references/data-adapters.md), and [`references/formulas.md`](references/formulas.md). Use `scripts/compute_metrics.py` when the inputs fit the canonical schema.
-6. Run the anti-waffle pass from [`references/anti-waffle.md`](references/anti-waffle.md) before finalizing. If the visible recommendation lands on `Wait`, `Hold`, or `Hold/Do not add`, the artifact must include explicit `Upgrade / Review Now`, `Downgrade / De-risk`, and `Invalidation` triggers with concrete thresholds.
-7. Check [`references/monitor-vs-deep-research.md`](references/monitor-vs-deep-research.md) for when to stay short versus when to produce the full memo.
-8. Check [`references/special-cases.md`](references/special-cases.md) when the name is an ETF, loss-maker, recent IPO, or spin-off.
 
-## Core rules
+2. `No Material Update`
+   - `Status`
+   - `Action`: `No new action`
+   - `Why`
+   - `What would matter next`
 
-- `No Material Change` means the output gets shorter, not safer.
-- If the user says "only tell me if I should act" and the right answer is `No Material Change`, use the ultra-short contract.
-- `Review Now` means the evidence justifies a decision or re-underwrite now. It does not automatically mean `Buy` or `Sell`.
-- `Watch Closely` is for mixed but relevant change with concrete confirmation triggers, not filler prose.
-- Separate monitor status from the audience-specific actions.
-- Every material fact is sourced, every derived metric shows a formula, and every neutral stance has measurable movement criteria.
-- Do not pad low-edge cases into essays. If there is no new edge, say so briefly and specify what would change the call.
+3. `Unable to Verify`
+   - `Status`
+   - `Action`: `No recommendation`
+   - `Why`
+   - `Next step`
 
-## Bundled resources
+## Rules
 
-- [`references/output-contract.md`](references/output-contract.md) — exact full-memo and short-update contracts.
-- [`references/action-taxonomy.md`](references/action-taxonomy.md) — monitor-mode definitions and allowed action combinations.
-- [`references/anti-waffle.md`](references/anti-waffle.md) — generic-language traps and final-artifact self-checks.
-- [`references/monitor-vs-deep-research.md`](references/monitor-vs-deep-research.md) — when to stay brief versus when to go full memo.
-- [`references/source-policy.md`](references/source-policy.md) — source-tier rules and citation minimums.
-- [`references/formulas.md`](references/formulas.md) — standard metric formulas.
-- [`references/data-adapters.md`](references/data-adapters.md) — how to coerce upstream data into the metrics script.
-- [`references/special-cases.md`](references/special-cases.md) — changes for ETFs, loss-makers, IPOs, and spin-offs.
-- [`references/task-adapter-skillsbench.md`](references/task-adapter-skillsbench.md) — fixed I/O paths for the SkillsBench fixture only.
-- [`assets/memo-template.md`](assets/memo-template.md) — fillable full-contract skeleton.
-- [`assets/example-memo-nvda.md`](assets/example-memo-nvda.md) — calibrated example that shows `Watch Closely` without generic hold/wait waffle.
-- [`scripts/compute_metrics.py`](scripts/compute_metrics.py) — deterministic derived-metrics helper.
+- Keep the reply short and scan-first.
+- Do not write a long memo.
+- Do not produce bull/base/bear framing, large tables, or charts.
+- Do not mine annual reports page by page in the email path.
+- Use `Actionable Update` only when there is clear verified information.
+- Use `No Material Update` when no verified new catalyst is found.
+- Use `Unable to Verify` when tools, sources, or time budget are insufficient.
+- If a deeper report would help, say that you can run it separately, but do not start it automatically.


### PR DESCRIPTION
## Summary
- simplify the investment runtime into a bounded single-pass monitor path
- replace pseudo-investment fail-soft memos with short operational fallbacks
- add scheduler-side suppression for repeated terminal failure notices on the same thread/workspace

## Validation
- cargo fmt --all --check
- cargo test --locked -p run_task_module
- cargo clippy -p run_task_module --all-targets -- -D warnings
- cargo test -p scheduler_module --bin investment_eval -- --nocapture
- cargo test -p scheduler_module --test scheduler_retry_notifications_e2e -- --nocapture
- python3 DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py