### PR TITLE
Reconcile before scheduler load

### DIFF
--- a/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
@@ -14,11 +14,11 @@ mod utils;
 
 pub use core::Scheduler;
 pub use executor::{ModuleExecutor, TaskExecutor};
+pub(crate) use store::SchedulerStore;
 pub use store::{
     check_and_send_alert_if_needed, mark_execution_finished_by_workspace,
     reset_reconciliation_failure_counter, RoutineSummary, TaskExecutionSummary, TaskStatusSummary,
 };
-pub(crate) use store::SchedulerStore;
 pub use types::{
     RunTaskTask, Schedule, ScheduledTask, SchedulerError, SendReplyTask, TaskExecution, TaskKind,
 };

--- a/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
@@ -18,6 +18,7 @@ pub use store::{
     check_and_send_alert_if_needed, mark_execution_finished_by_workspace,
     reset_reconciliation_failure_counter, RoutineSummary, TaskExecutionSummary, TaskStatusSummary,
 };
+pub(crate) use store::SchedulerStore;
 pub use types::{
     RunTaskTask, Schedule, ScheduledTask, SchedulerError, SendReplyTask, TaskExecution, TaskKind,
 };

--- a/DoWhiz_service/scheduler_module/src/service/scheduler.rs
+++ b/DoWhiz_service/scheduler_module/src/service/scheduler.rs
@@ -12,9 +12,9 @@ use uuid::Uuid;
 
 use crate::index_store::{IndexStore, TaskRef};
 use crate::scheduler::check_and_send_alert_if_needed;
+use crate::scheduler::SchedulerStore;
 use crate::thread_state::default_thread_state_path;
 use crate::user_store::UserStore;
-use crate::scheduler::SchedulerStore;
 use crate::{ModuleExecutor, Schedule, ScheduledTask, Scheduler, SchedulerError, TaskKind};
 
 use super::config::ServiceConfig;

--- a/DoWhiz_service/scheduler_module/src/service/scheduler.rs
+++ b/DoWhiz_service/scheduler_module/src/service/scheduler.rs
@@ -14,6 +14,7 @@ use crate::index_store::{IndexStore, TaskRef};
 use crate::scheduler::check_and_send_alert_if_needed;
 use crate::thread_state::default_thread_state_path;
 use crate::user_store::UserStore;
+use crate::scheduler::SchedulerStore;
 use crate::{ModuleExecutor, Schedule, ScheduledTask, Scheduler, SchedulerError, TaskKind};
 
 use super::config::ServiceConfig;
@@ -899,31 +900,46 @@ fn execute_due_task(
         user_paths.tasks_db_path
     };
 
-    let mut scheduler = Scheduler::load(&tasks_db_path, ModuleExecutor::default())?;
-
+    // Run reconciliation BEFORE loading the Scheduler.
+    // This ensures any tasks disabled during reconciliation are already disabled
+    // when we load into the in-memory Vec, preventing race conditions where
+    // execute_task_by_id sees stale enabled state.
     let stale_after = resolve_stale_execution_timeout();
-    match scheduler.reconcile_stale_running_executions_for_task(
-        &task_ref.task_id,
-        Utc::now(),
-        stale_after,
-    ) {
-        Ok(summary) if summary.total_reconciled() > 0 => {
-            info!(
-                "scheduler reconciled stale execution rows task_id={} user_id={} superseded={} failed={}",
-                task_ref.task_id,
-                task_ref.user_id,
-                summary.superseded_count,
-                summary.failed_count
-            );
+    match SchedulerStore::with_shared_client(tasks_db_path.clone()) {
+        Ok(store) => {
+            match store.reconcile_stale_running_executions_for_task(
+                &task_ref.task_id,
+                Utc::now(),
+                stale_after,
+            ) {
+                Ok(summary) if summary.total_reconciled() > 0 => {
+                    info!(
+                        "scheduler reconciled stale execution rows task_id={} user_id={} superseded={} failed={}",
+                        task_ref.task_id,
+                        task_ref.user_id,
+                        summary.superseded_count,
+                        summary.failed_count
+                    );
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    warn!(
+                        "scheduler failed to reconcile stale execution rows task_id={} user_id={}: {}",
+                        task_ref.task_id, task_ref.user_id, err
+                    );
+                }
+            }
         }
-        Ok(_) => {}
         Err(err) => {
             warn!(
-                "scheduler failed to reconcile stale execution rows task_id={} user_id={}: {}",
+                "scheduler failed to create store for reconciliation task_id={} user_id={}: {}",
                 task_ref.task_id, task_ref.user_id, err
             );
         }
     }
+
+    // Now load the Scheduler - any tasks disabled during reconciliation will be loaded as disabled
+    let mut scheduler = Scheduler::load(&tasks_db_path, ModuleExecutor::default())?;
 
     // Check for existing running execution in MongoDB.
     // This prevents duplicate executions when the worker restarts and loses in-memory claims.


### PR DESCRIPTION
Race condition between scheduler and reconciliation logic

Reconciliation:                    Scheduler:
1. finish_execution_row() //FRONTEND fetch          
   (marks id=4 as failed)            
                                   2. Checks: any running? NO
                                   3. Checks: task enabled? YES
                                   4. record_execution_start() 
                                      (starts id=5)
5. disable_task_by_id()
   (too late - id=5 already started) //Actual tasks db that scheduler polls


Timeline:
00:27:50.XXX - Scheduler loop queries task_index, loads task (still enabled)
00:27:50.486 - Reconciliation: finish_execution_row (marks id=4 failed)
00:27:50.543 - Reconciliation: disable_task_by_id (sets enabled=false)
00:27:50.671 - Scheduler: record_execution_start (creates id=5)
              ↑ Scheduler was already processing the task in-memory,
                doesn't re-check if task is still enabled

Scheduler::load → loads tasks from MongoDB into self.tasks Vec (task.enabled = true)
reconcile_stale_running_executions_for_task → calls store method → updates MongoDB (enabled = false)
execute_task_by_id → checks self.tasks[index].enabled → still true (in-memory stale)

execute_due_task() called for a due task
    ↓
Line 902: Scheduler::load() → loads from MongoDB into Vec (task enabled = true)
    ↓
Line 905: reconcile_stale_running_executions() → updates MongoDB (enabled = false)
    ↓
Line 930: has_running_execution() → false (execution just marked failed)
    ↓
Line 1003: execute_task_by_id() → checks in-memory vec (enabled = true, stale)
    ↓
Execution #5 starts





Solution: Invert load and reconcile_stale_running_executions()

// Run reconciliation BEFORE loading the Scheduler.
   // This ensures any tasks disabled during reconciliation are already disabled
   // when we load into the in-memory Vec, preventing race conditions where
   // execute_task_by_id sees stale enabled state.
   let stale_after = resolve_stale_execution_timeout();
   match SchedulerStore::with_shared_client(tasks_db_path.clone()) {
       Ok(store) => {
	// Since reconciliation now comes before scheduler load, must use SchedulerStore rather than calling Scheduler.reconcile_stale_running_executions()
           match store.reconcile_stale_running_executions_for_task(
               &task_ref.task_id,
               Utc::now(),
               stale_after,
           ) {
               Ok(summary) if summary.total_reconciled() > 0 => {
                   info!(
                       "scheduler reconciled stale execution rows task_id={} user_id={} superseded={} failed={}",
                       task_ref.task_id,
                       task_ref.user_id,
                       summary.superseded_count,
                       summary.failed_count
                   );
               }
               Ok(_) => {}
               Err(err) => {
                   warn!(
                       "scheduler failed to reconcile stale execution rows task_id={} user_id={}: {}",
                       task_ref.task_id, task_ref.user_id, err
                   );
               }
           }
       }
       Err(err) => {
           warn!(
               "scheduler failed to create store for reconciliation task_id={} user_id={}: {}",
               task_ref.task_id, task_ref.user_id, err
           );
       }
   }


   // Now load the Scheduler - any tasks disabled during reconciliation will be loaded in memory as disabled
   let mut scheduler = Scheduler::load(&tasks_db_path, ModuleExecutor::default())?;



Store (SchedulerStore / MongoSchedulerStore):
Pure data access layer - MongoDB client wrapper
No in-memory state
Methods: load_tasks(), update_task(), disable_task_by_id(), record_execution_start()
Each call goes directly to MongoDB

Scheduler:
Has tasks: Vec<ScheduledTask> - in-memory cache loaded once from store
Has store: SchedulerStore - for persisting changes
Has executor: E - for running tasks
Methods: tick(), execute_task_by_id(), is_due() checks

Scheduler
├── tasks: Vec<ScheduledTask>   ← in-memory cache (loaded once)
├── store: SchedulerStore       ← MongoDB access
└── executor                    ← runs tasks


