### PR TITLE
Merge dev to main

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -388,56 +388,14 @@ jobs:
           echo "KROGER_CLIENT_SECRET=${{ secrets.KROGER_CLIENT_SECRET }}" >> /home/${{ secrets.PROD_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service/.env
           EOF
 
-      - name: Restart DoWhiz services before ACI build
+      - name: Disable legacy service before ACI build
         run: |
           ssh -F ~/.ssh/config azureproduction << 'EOF'
           set -e
-          if [ -s /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh ]; then
-            source /home/${{ secrets.PROD_AZURE_VM_USER }}/.nvm/nvm.sh
-          fi
-          APP_DIR=/home/${{ secrets.PROD_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
-          ENV_FILE="$APP_DIR/.env"
-          set -a
-          source "$ENV_FILE"
-          set +a
 
           if systemctl list-unit-files 'dowhiz-oliver.service' --no-legend 2>/dev/null | grep -q '^dowhiz-oliver\.service'; then
             sudo systemctl disable --now dowhiz-oliver.service || true
           fi
-
-          if pm2 describe dw_worker >/dev/null 2>&1; then
-            pm2 restart dw_worker --update-env
-          else
-            pm2 start "$APP_DIR/target/release/rust_service" --name dw_worker --cwd "$APP_DIR" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
-          fi
-
-          if pm2 describe dw_gateway >/dev/null 2>&1; then
-            pm2 restart dw_gateway --update-env
-          else
-            pm2 start "$APP_DIR/target/release/inbound_gateway" --name dw_gateway --cwd "$APP_DIR"
-          fi
-
-          wait_for_health() {
-            local label="$1"
-            local url="$2"
-            local http_code=""
-            local attempt
-            for attempt in $(seq 1 12); do
-              http_code="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "$url" || true)"
-              if [[ "$http_code" == "200" ]]; then
-                printf '%s' "$http_code"
-                return 0
-              fi
-              echo "Waiting for $label health endpoint (${attempt}/12), last HTTP ${http_code:-000}..."
-              sleep 5
-            done
-            echo "Early $label health check failed after retries (HTTP ${http_code:-000})" >&2
-            return 1
-          }
-
-          worker_health="$(wait_for_health worker "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health")"
-          gateway_health="$(wait_for_health gateway "http://127.0.0.1:${GATEWAY_PORT:-9100}/health")"
-          echo "Early health check passed: worker=$worker_health gateway=$gateway_health"
           EOF
 
       - name: Resolve ACI build configuration
@@ -713,37 +671,16 @@ jobs:
             fi
           done
 
-          worker_running=0
-          for service in dw_worker dowhiz_rust_service dowhiz-rust-service; do
-            if pm2 describe "$service" >/dev/null 2>&1; then
-              if pm2 restart "$service" --update-env; then
-                worker_running=1
-                break
-              fi
-              echo "PM2 restart failed for $service, deleting stale entry and trying next option." >&2
-              pm2 delete "$service" >/dev/null 2>&1 || true
+          for stale_service in dowhiz_rust_service dowhiz-rust-service dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway; do
+            if pm2 describe "$stale_service" >/dev/null 2>&1; then
+              pm2 delete "$stale_service" >/dev/null 2>&1 || true
             fi
           done
-          if [ "$worker_running" -eq 0 ]; then
-            echo "No worker process found in PM2, starting dw_worker."
-            pm2 start "$APP_DIR/target/release/rust_service" --name dw_worker --cwd "$APP_DIR" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
-          fi
 
-          gateway_running=0
-          for service in dw_gateway dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway; do
-            if pm2 describe "$service" >/dev/null 2>&1; then
-              if pm2 restart "$service" --update-env; then
-                gateway_running=1
-                break
-              fi
-              echo "PM2 restart failed for $service, deleting stale entry and trying next option." >&2
-              pm2 delete "$service" >/dev/null 2>&1 || true
-            fi
-          done
-          if [ "$gateway_running" -eq 0 ]; then
-            echo "No gateway process found in PM2, starting dw_gateway."
-            pm2 start "$APP_DIR/target/release/inbound_gateway" --name dw_gateway --cwd "$APP_DIR"
-          fi
+          export PM2_APP_DIR="$APP_DIR"
+          export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
+          export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
+          pm2 startOrRestart "$APP_DIR/ecosystem.config.cjs" --only dw_worker,dw_gateway --update-env
 
           pm2 save
           pm2 list

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -423,56 +423,14 @@ jobs:
           echo "KROGER_CLIENT_SECRET=${{ secrets.KROGER_CLIENT_SECRET }}" >> /home/${{ secrets.STAGING_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service/.env
           EOF
 
-      - name: Restart DoWhiz services before ACI build
+      - name: Disable legacy service before ACI build
         run: |
           ssh -F ~/.ssh/config azureproduction << 'EOF'
           set -e
-          if [ -s /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh ]; then
-            source /home/${{ secrets.STAGING_AZURE_VM_USER }}/.nvm/nvm.sh
-          fi
-          APP_DIR=/home/${{ secrets.STAGING_AZURE_VM_USER }}/server/DoWhiz/DoWhiz_service
-          ENV_FILE="$APP_DIR/.env"
-          set -a
-          source "$ENV_FILE"
-          set +a
 
           if systemctl list-unit-files 'dowhiz-oliver.service' --no-legend 2>/dev/null | grep -q '^dowhiz-oliver\.service'; then
             sudo systemctl disable --now dowhiz-oliver.service || true
           fi
-
-          if pm2 describe dw_worker >/dev/null 2>&1; then
-            pm2 restart dw_worker --update-env
-          else
-            pm2 start "$APP_DIR/target/release/rust_service" --name dw_worker --cwd "$APP_DIR" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
-          fi
-
-          if pm2 describe dw_gateway >/dev/null 2>&1; then
-            pm2 restart dw_gateway --update-env
-          else
-            pm2 start "$APP_DIR/target/release/inbound_gateway" --name dw_gateway --cwd "$APP_DIR"
-          fi
-
-          wait_for_health() {
-            local label="$1"
-            local url="$2"
-            local http_code=""
-            local attempt
-            for attempt in $(seq 1 12); do
-              http_code="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 8 --max-time 15 "$url" || true)"
-              if [[ "$http_code" == "200" ]]; then
-                printf '%s' "$http_code"
-                return 0
-              fi
-              echo "Waiting for $label health endpoint (${attempt}/12), last HTTP ${http_code:-000}..."
-              sleep 5
-            done
-            echo "Early $label health check failed after retries (HTTP ${http_code:-000})" >&2
-            return 1
-          }
-
-          worker_health="$(wait_for_health worker "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health")"
-          gateway_health="$(wait_for_health gateway "http://127.0.0.1:${GATEWAY_PORT:-9100}/health")"
-          echo "Early health check passed: worker=$worker_health gateway=$gateway_health"
           EOF
 
       - name: Resolve ACI build configuration
@@ -754,37 +712,16 @@ jobs:
             fi
           done
 
-          worker_running=0
-          for service in dw_worker dowhiz_rust_service dowhiz-rust-service; do
-            if pm2 describe "$service" >/dev/null 2>&1; then
-              if pm2 restart "$service" --update-env; then
-                worker_running=1
-                break
-              fi
-              echo "PM2 restart failed for $service, deleting stale entry and trying next option." >&2
-              pm2 delete "$service" >/dev/null 2>&1 || true
+          for stale_service in dowhiz_rust_service dowhiz-rust-service dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway; do
+            if pm2 describe "$stale_service" >/dev/null 2>&1; then
+              pm2 delete "$stale_service" >/dev/null 2>&1 || true
             fi
           done
-          if [ "$worker_running" -eq 0 ]; then
-            echo "No worker process found in PM2, starting dw_worker."
-            pm2 start "$APP_DIR/target/release/rust_service" --name dw_worker --cwd "$APP_DIR" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
-          fi
 
-          gateway_running=0
-          for service in dw_gateway dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway; do
-            if pm2 describe "$service" >/dev/null 2>&1; then
-              if pm2 restart "$service" --update-env; then
-                gateway_running=1
-                break
-              fi
-              echo "PM2 restart failed for $service, deleting stale entry and trying next option." >&2
-              pm2 delete "$service" >/dev/null 2>&1 || true
-            fi
-          done
-          if [ "$gateway_running" -eq 0 ]; then
-            echo "No gateway process found in PM2, starting dw_gateway."
-            pm2 start "$APP_DIR/target/release/inbound_gateway" --name dw_gateway --cwd "$APP_DIR"
-          fi
+          export PM2_APP_DIR="$APP_DIR"
+          export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
+          export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
+          pm2 startOrRestart "$APP_DIR/ecosystem.config.cjs" --only dw_worker,dw_gateway --update-env
 
           pm2 save
           pm2 list

--- a/DoWhiz_service/OPERATIONS.md
+++ b/DoWhiz_service/OPERATIONS.md
@@ -86,13 +86,10 @@ if [ -s /home/azureuser/.nvm/nvm.sh ]; then
   source /home/azureuser/.nvm/nvm.sh
 fi
 
-# worker
-pm2 restart dw_worker --update-env || \
-  pm2 start ./target/release/rust_service --name dw_worker --cwd "$PWD" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
-
-# gateway
-pm2 restart dw_gateway --update-env || \
-  pm2 start ./target/release/inbound_gateway --name dw_gateway --cwd "$PWD"
+export PM2_APP_DIR="$PWD"
+export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
+export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
+pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 
 pm2 save
 pm2 list
@@ -230,8 +227,8 @@ Operational rollback (same code, restart services):
 
 ```bash
 cd /home/azureuser/server/DoWhiz/DoWhiz_service
-pm2 restart dw_gateway --update-env
-pm2 restart dw_worker --update-env
+export PM2_APP_DIR="$PWD"
+pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 ```
 
 Code rollback:

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -101,8 +101,10 @@ set -a
 source .env
 set +a
 sudo systemctl disable --now dowhiz-oliver.service || true
-pm2 restart dw_gateway --update-env || pm2 start ./target/release/inbound_gateway --name dw_gateway --cwd "$PWD"
-pm2 restart dw_worker --update-env || pm2 start ./target/release/rust_service --name dw_worker --cwd "$PWD" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
+export PM2_APP_DIR="$PWD"
+export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
+export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
+pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 pm2 save
 pm2 list
 ```
@@ -115,8 +117,10 @@ set -a
 source .env
 set +a
 sudo systemctl disable --now dowhiz-oliver.service || true
-pm2 restart dw_gateway --update-env || pm2 start ./target/release/inbound_gateway --name dw_gateway --cwd "$PWD"
-pm2 restart dw_worker --update-env || pm2 start ./target/release/rust_service --name dw_worker --cwd "$PWD" -- --host 0.0.0.0 --port "${RUST_SERVICE_PORT:-9001}"
+export PM2_APP_DIR="$PWD"
+export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
+export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
+pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 pm2 save
 pm2 list
 ```

--- a/DoWhiz_service/docs/task_debug_archives.md
+++ b/DoWhiz_service/docs/task_debug_archives.md
@@ -230,7 +230,6 @@ want = [
     "runtime/env_redacted.json",
     "runtime/tool_versions.json",
     "runtime/git.json",
-    "workspace_before/thread_state.json",
     "workspace_after/thread_state.json",
     "workspace_after/reply_email_draft.html",
     "workspace_after/.run_task_trace/metadata.json",
@@ -253,7 +252,8 @@ PY
 What these files are for:
 - `manifest.json`: top-level archive metadata
 - `manifests/workspace_before.json`, `workspace_after.json`, `workspace_diff.json`: file-level
-  inventory and delta
+  inventory and delta. `workspace_before` is metadata-only by design, so the archive may omit
+  `workspace_before/*` file bodies.
 - `runtime/*`: sanitized env view, tool versions, and git snapshot
 - `.run_task_trace/logs/*`: stdout, stderr, and combined run logs
 - `.run_task_trace/aci/*`: the captured Azure container metadata and logs, even after the live
@@ -280,8 +280,8 @@ POSTMARK_TEST_SERVICE_ADDRESS=dowhiz@deep-tutor.com \
 POSTMARK_TEST_FROM=deep-tutor@deep-tutor.com \
 cargo test -p scheduler_module --test service_real_email -- --nocapture
 
-pm2 restart dw_gateway --update-env
-pm2 restart dw_worker --update-env
+export PM2_APP_DIR="$PWD"
+pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 pm2 save
 ```
 

--- a/DoWhiz_service/ecosystem.config.cjs
+++ b/DoWhiz_service/ecosystem.config.cjs
@@ -1,0 +1,26 @@
+const appDir = process.env.PM2_APP_DIR || process.cwd();
+const workerPort = process.env.RUST_SERVICE_PORT || "9001";
+const killTimeout = Number(process.env.PM2_KILL_TIMEOUT_MS || 300000);
+const listenTimeout = Number(process.env.PM2_LISTEN_TIMEOUT_MS || 15000);
+
+module.exports = {
+  apps: [
+    {
+      name: "dw_worker",
+      cwd: appDir,
+      script: "./target/release/rust_service",
+      args: ["--host", "0.0.0.0", "--port", workerPort],
+      interpreter: "none",
+      kill_timeout: killTimeout,
+      listen_timeout: listenTimeout,
+    },
+    {
+      name: "dw_gateway",
+      cwd: appDir,
+      script: "./target/release/inbound_gateway",
+      interpreter: "none",
+      kill_timeout: killTimeout,
+      listen_timeout: listenTimeout,
+    },
+  ],
+};

--- a/DoWhiz_service/scheduler_module/src/bin/rust_service.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/rust_service.rs
@@ -48,6 +48,24 @@ fn help_text() -> String {
     .join("\n")
 }
 
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let mut sigterm = signal(SignalKind::terminate()).expect("register SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), BoxError> {
     tracing_subscriber::fmt().with_target(false).init();
@@ -70,9 +88,8 @@ async fn main() -> Result<(), BoxError> {
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     tokio::spawn(async move {
-        if tokio::signal::ctrl_c().await.is_ok() {
-            let _ = shutdown_tx.send(());
-        }
+        wait_for_shutdown_signal().await;
+        let _ = shutdown_tx.send(());
     });
 
     info!(

--- a/DoWhiz_service/scheduler_module/src/scheduler/debug_archive.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/debug_archive.rs
@@ -13,7 +13,7 @@ use chrono::{DateTime, Utc};
 use reqwest::{blocking::Client, Url};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use tempfile::TempDir;
+use tempfile::{Builder as TempDirBuilder, TempDir};
 use uuid::Uuid;
 use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipWriter};
@@ -28,6 +28,7 @@ const ARCHIVE_VERSION: i32 = 1;
 const DEFAULT_ARCHIVE_CONTAINER: &str = "task-debug-archives";
 const DEFAULT_ARCHIVE_PATH_PREFIX: &str = "task_debug_archives";
 const LOCAL_FALLBACK_DIRNAME: &str = ".task_debug_archives_failed";
+const LOCAL_STAGING_DIRNAME: &str = ".task_debug_archives_staging";
 const MAX_GIT_CAPTURE_BYTES: usize = 1_000_000;
 const MAX_TOOL_OUTPUT_BYTES: usize = 32_000;
 const HEAVY_SKIP_DIRS: &[&str] = &[
@@ -87,7 +88,7 @@ pub(crate) struct PendingTaskDebugArchive {
     deploy_target: String,
     started_at: DateTime<Utc>,
     before_capture_duration_ms: i64,
-    temp_dir: TempDir,
+    staging_dir: TempDir,
     before_snapshot: SnapshotCollection,
     storage_plan: ArchiveStoragePlan,
 }
@@ -237,15 +238,14 @@ impl PendingTaskDebugArchive {
             return Ok(None);
         };
 
-        let temp_dir = TempDir::new()?;
-        let before_root = temp_dir.path().join("workspace_before");
-        fs::create_dir_all(&before_root)?;
+        let staging_dir =
+            create_archive_staging_dir(&run_task.workspace_dir, run_task.archive_root.as_deref())?;
 
         let capture_started = Instant::now();
         let before_snapshot = collect_snapshot(
             &run_task.workspace_dir,
             "workspace_before",
-            SnapshotMode::CopyTo(before_root),
+            SnapshotMode::MetadataOnly,
         )?;
         let before_capture_duration_ms = capture_started.elapsed().as_millis() as i64;
 
@@ -262,7 +262,7 @@ impl PendingTaskDebugArchive {
                 .to_ascii_lowercase(),
             started_at,
             before_capture_duration_ms,
-            temp_dir,
+            staging_dir,
             before_snapshot,
             storage_plan: resolve_archive_storage_plan(),
         }))
@@ -336,7 +336,7 @@ impl PendingTaskDebugArchive {
             error_summary: error_summary.map(|value| truncate_string(value, 4000)),
         };
 
-        let zip_path = self.temp_dir.path().join("task_debug_bundle.zip");
+        let zip_path = self.staging_dir.path().join("task_debug_bundle.zip");
         build_archive_zip(
             &zip_path,
             &manifest,
@@ -409,9 +409,23 @@ impl PendingTaskDebugArchive {
     }
 }
 
+fn create_archive_staging_dir(
+    workspace_dir: &Path,
+    archive_root: Option<&Path>,
+) -> Result<TempDir, SchedulerError> {
+    let staging_parent = archive_root
+        .and_then(|path| path.parent())
+        .unwrap_or(workspace_dir)
+        .join(LOCAL_STAGING_DIRNAME);
+    fs::create_dir_all(&staging_parent)?;
+    Ok(TempDirBuilder::new()
+        .prefix("bundle-")
+        .tempdir_in(staging_parent)?)
+}
+
 #[derive(Debug, Clone)]
 enum SnapshotMode {
-    CopyTo(PathBuf),
+    MetadataOnly,
     InPlace,
 }
 
@@ -520,18 +534,13 @@ fn collect_snapshot_dir(
             }
             SnapshotDecision::Include => {
                 let (sha256, size_bytes, copied_path) = match mode {
-                    SnapshotMode::CopyTo(target_root) => {
-                        let copied_path = target_root.join(&relative_path);
-                        if let Some(parent) = copied_path.parent() {
-                            fs::create_dir_all(parent)?;
-                        }
-                        let (sha256, size_bytes) =
-                            copy_file_and_hash(&absolute_path, &copied_path)?;
-                        (sha256, size_bytes, copied_path)
+                    SnapshotMode::MetadataOnly => {
+                        let (sha256, size_bytes) = hash_file(&absolute_path)?;
+                        (sha256, size_bytes, None)
                     }
                     SnapshotMode::InPlace => {
                         let (sha256, size_bytes) = hash_file(&absolute_path)?;
-                        (sha256, size_bytes, absolute_path.clone())
+                        (sha256, size_bytes, Some(absolute_path.clone()))
                     }
                 };
                 snapshot.summary.file_count += 1;
@@ -545,10 +554,12 @@ fn collect_snapshot_dir(
                     sha256: Some(sha256),
                     reason: None,
                 });
-                snapshot.included_files.push(SnapshotFileSource {
-                    relative_path: relative_display,
-                    source_path: copied_path,
-                });
+                if let Some(source_path) = copied_path {
+                    snapshot.included_files.push(SnapshotFileSource {
+                        relative_path: relative_display,
+                        source_path,
+                    });
+                }
             }
         }
     }
@@ -1248,24 +1259,6 @@ fn capture_command(mut command: Command) -> String {
     }
 }
 
-fn copy_file_and_hash(source: &Path, destination: &Path) -> Result<(String, u64), SchedulerError> {
-    let mut input = File::open(source)?;
-    let mut output = File::create(destination)?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0u8; 8192];
-    let mut total_bytes = 0u64;
-    loop {
-        let read = input.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        output.write_all(&buffer[..read])?;
-        hasher.update(&buffer[..read]);
-        total_bytes += read as u64;
-    }
-    Ok((format!("{:x}", hasher.finalize()), total_bytes))
-}
-
 fn hash_file(path: &Path) -> Result<(String, u64), SchedulerError> {
     let mut file = File::open(path)?;
     let mut hasher = Sha256::new();
@@ -1409,6 +1402,18 @@ mod tests {
     }
 
     #[test]
+    fn create_archive_staging_dir_stays_near_workspace_instead_of_system_tmp() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let staging = create_archive_staging_dir(temp.path(), None).expect("staging dir");
+        assert!(
+            staging
+                .path()
+                .starts_with(temp.path().join(LOCAL_STAGING_DIRNAME)),
+            "staging dir should live under the workspace-managed staging root"
+        );
+    }
+
+    #[test]
     fn pending_archive_finalize_local_only_writes_zip_with_expected_entries() {
         let _guard = env_lock().lock().expect("env lock");
         let _env_guards = vec![
@@ -1482,6 +1487,10 @@ mod tests {
         assert!(zip.by_name("manifest.json").is_ok());
         assert!(zip.by_name("task/task_before.json").is_ok());
         assert!(zip.by_name("manifests/workspace_before.json").is_ok());
+        assert!(
+            zip.by_name("workspace_before/incoming_email/body.txt").is_err(),
+            "pre-run snapshot should stay metadata-only to avoid duplicating the workspace before execution"
+        );
         assert!(
             zip.by_name("workspace_after/reply_email_draft.html")
                 .is_ok(),

--- a/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/mod.rs
@@ -117,7 +117,7 @@ pub fn persist_scheduled_task(
     task: &ScheduledTask,
 ) -> Result<(), SchedulerError> {
     let store = store::SchedulerStore::new(tasks_db_path.to_path_buf())?;
-    store.update_task(task)
+    store.replace_task(task)
 }
 
 /// Insert a new scheduled task into scheduler storage.

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
@@ -75,6 +75,10 @@ impl SchedulerStore {
         self.mongo.update_task(task)
     }
 
+    pub(crate) fn replace_task(&self, task: &ScheduledTask) -> Result<(), SchedulerError> {
+        self.mongo.replace_task(task)
+    }
+
     /// Check if there's already a running execution for this task.
     ///
     /// This prevents duplicate executions when the worker process restarts

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -29,6 +29,7 @@ use super::{
 
 static EXECUTION_SEQ: AtomicI64 = AtomicI64::new(0);
 const LONG_RUNNING_WARNING_SECS: i64 = 3600;
+const DEFAULT_ACI_REGISTRATION_GRACE_SECS: i64 = 15 * 60;
 
 #[derive(Debug, Clone)]
 struct ExecutionRow {
@@ -178,6 +179,7 @@ impl MongoSchedulerStore {
                 }
             }
             let mut task = deserialize_task_document(&document)?;
+            apply_persisted_task_fields(&document, &mut task)?;
             if maybe_repair_legacy_weekday_cron_task(&mut task, now)? {
                 self.update_task(&task)?;
             }
@@ -200,6 +202,7 @@ impl MongoSchedulerStore {
         };
 
         let mut task = deserialize_task_document(&document)?;
+        apply_persisted_task_fields(&document, &mut task)?;
         if maybe_repair_legacy_weekday_cron_task(&mut task, Utc::now())? {
             self.update_task(&task)?;
         }
@@ -245,21 +248,49 @@ impl MongoSchedulerStore {
     }
 
     pub(crate) fn update_task(&self, task: &ScheduledTask) -> Result<(), SchedulerError> {
+        self.update_task_internal(task, false)
+    }
+
+    pub(crate) fn replace_task(&self, task: &ScheduledTask) -> Result<(), SchedulerError> {
+        self.update_task_internal(task, true)
+    }
+
+    fn update_task_internal(
+        &self,
+        task: &ScheduledTask,
+        allow_reenable_and_clear_auto_disable: bool,
+    ) -> Result<(), SchedulerError> {
         let task_json = serde_json::to_string(task)
             .map_err(|err| SchedulerError::Storage(format!("serialize task failed: {err}")))?;
-        let filter = doc! { "task_id": task.id.to_string() };
-        let update = doc! {
+        let mut filter = doc! { "task_id": task.id.to_string() };
+        if task.enabled && !allow_reenable_and_clear_auto_disable {
+            filter.insert(
+                "$or",
+                Bson::Array(vec![
+                    Bson::Document(doc! { "enabled": { "$ne": false } }),
+                    Bson::Document(doc! { "auto_disabled_reason": { "$exists": false } }),
+                    Bson::Document(doc! { "auto_disabled_reason": Bson::Null }),
+                    Bson::Document(doc! { "auto_disabled_reason": "" }),
+                ]),
+            );
+        }
+        let mut update = doc! {
             "$set": {
                 "enabled": task.enabled,
                 "last_run": task.last_run.map(BsonDateTime::from_chrono).map(Bson::DateTime).unwrap_or(Bson::Null),
                 "schedule": schedule_doc(&task.schedule),
                 "task_json": task_json,
             },
-            "$unset": {
-                "auto_disabled_reason": "",
-                "auto_disabled_at": "",
-            },
         };
+        if allow_reenable_and_clear_auto_disable {
+            update.insert(
+                "$unset",
+                Bson::Document(doc! {
+                    "auto_disabled_reason": "",
+                    "auto_disabled_at": "",
+                }),
+            );
+        }
         let result = retry_mongo_write("tasks.update_task", || {
             self.tasks.update_many(filter.clone(), update.clone(), None)
         })
@@ -277,11 +308,12 @@ impl MongoSchedulerStore {
             );
         } else {
             tracing::debug!(
-                "update_task succeeded: task_id={} matched={} modified={} enabled={}",
+                "update_task succeeded: task_id={} matched={} modified={} enabled={} force_replace={}",
                 task.id,
                 result.matched_count,
                 result.modified_count,
-                task.enabled
+                task.enabled,
+                allow_reenable_and_clear_auto_disable
             );
         }
         Ok(())
@@ -400,12 +432,28 @@ impl MongoSchedulerStore {
         })
         .map_err(mongo_err)?;
         if result.matched_count == 0 {
-            return Err(SchedulerError::Storage(format!(
-                "missing running execution row for task {} execution_id={} started_at={}",
-                task_id,
+            let existing = self.find_execution_row(
+                &task_id.to_string(),
                 execution.execution_id,
-                execution.started_at.to_rfc3339()
-            )));
+                execution.started_at,
+            )?;
+            return match existing {
+                Some(row) if row.status != "running" => {
+                    tracing::warn!(
+                        "record_execution_finish observed terminal row already written for task {} execution_id={} status={}",
+                        task_id,
+                        execution.execution_id,
+                        row.status
+                    );
+                    Ok(())
+                }
+                _ => Err(SchedulerError::Storage(format!(
+                    "missing running execution row for task {} execution_id={} started_at={}",
+                    task_id,
+                    execution.execution_id,
+                    execution.started_at.to_rfc3339()
+                ))),
+            };
         }
         Ok(())
     }
@@ -574,14 +622,21 @@ impl MongoSchedulerStore {
                                     ))
                                 }
                             }
-                            _ => {
-                                // Container still running or error querying - fall through to stale check
+                            AciContainerStatus::Running => {
+                                tracing::debug!(
+                                    "ACI container for task {} still running; leaving execution row as running",
+                                    task_id
+                                );
+                                None
+                            }
+                            AciContainerStatus::Error(err) => {
                                 if row.started_at <= stale_before {
                                     Some((
                                         "failed",
                                         format!(
-                                            "reconciled stale running execution after worker restart; execution exceeded {}s without a terminal status",
-                                            stale_timeout_secs
+                                            "reconciled stale running execution after worker restart; ACI status query kept failing for {}s: {}",
+                                            stale_timeout_secs,
+                                            err
                                         ),
                                     ))
                                 } else {
@@ -593,7 +648,7 @@ impl MongoSchedulerStore {
                     None => {
                         // No container registered for this workspace
                         // Either: never created (danger zone) or already deregistered (completed)
-                        let aci_grace_period = ChronoDuration::minutes(60);
+                        let aci_grace_period = resolve_aci_registration_grace_period();
                         let execution_age = now - row.started_at;
 
                         if execution_age > aci_grace_period {
@@ -819,11 +874,56 @@ impl MongoSchedulerStore {
         })
         .map_err(mongo_err)?;
         if result.matched_count == 0 {
+            let document = retry_mongo_read("task_executions.finish_execution_row.lookup", || {
+                self.executions.find_one(
+                    doc! {
+                        "_id": doc_id.clone(),
+                        "owner_scope.kind": &self.owner_kind,
+                        "owner_scope.id": &self.owner_id,
+                    },
+                    None,
+                )
+            })
+            .map_err(mongo_err)?;
+            if let Some(document) = document {
+                let row = parse_execution_row(document)?;
+                if row.status != "running" {
+                    tracing::warn!(
+                        "finish_execution_row observed terminal row already written for task {} execution_id={} status={}",
+                        row.task_id,
+                        row.execution_id,
+                        row.status
+                    );
+                    return Ok(());
+                }
+            }
             return Err(SchedulerError::Storage(
                 "missing running execution row while reconciling stale execution".to_string(),
             ));
         }
         Ok(())
+    }
+
+    fn find_execution_row(
+        &self,
+        task_id: &str,
+        execution_id: i64,
+        started_at: chrono::DateTime<Utc>,
+    ) -> Result<Option<ExecutionRow>, SchedulerError> {
+        let document = retry_mongo_read("task_executions.find_execution_row", || {
+            self.executions.find_one(
+                doc! {
+                    "owner_scope.kind": &self.owner_kind,
+                    "owner_scope.id": &self.owner_id,
+                    "task_id": task_id,
+                    "execution_id": execution_id,
+                    "started_at": BsonDateTime::from_chrono(started_at),
+                },
+                None,
+            )
+        })
+        .map_err(mongo_err)?;
+        document.map(parse_execution_row).transpose()
     }
 
     pub(crate) fn get_retry_count(&self, task_id: &str) -> Result<u32, SchedulerError> {
@@ -1405,6 +1505,70 @@ fn humanize_auto_disabled_reason(raw: &str) -> String {
         .to_string()
 }
 
+fn resolve_aci_registration_grace_period() -> ChronoDuration {
+    std::env::var("RUN_TASK_ACI_REGISTRATION_GRACE_SECS")
+        .ok()
+        .and_then(|value| value.trim().parse::<i64>().ok())
+        .filter(|value| *value > 0)
+        .map(ChronoDuration::seconds)
+        .unwrap_or_else(|| ChronoDuration::seconds(DEFAULT_ACI_REGISTRATION_GRACE_SECS))
+}
+
+fn apply_persisted_task_fields(
+    document: &Document,
+    task: &mut ScheduledTask,
+) -> Result<(), SchedulerError> {
+    if let Ok(enabled) = document.get_bool("enabled") {
+        task.enabled = enabled;
+    }
+    if let Ok(last_run) = document.get_datetime("last_run") {
+        task.last_run = Some(last_run.to_chrono());
+    }
+    if matches!(document.get("last_run"), Some(Bson::Null)) {
+        task.last_run = None;
+    }
+    if let Ok(schedule) = document.get_document("schedule") {
+        task.schedule = parse_schedule_doc(schedule)?;
+    }
+    Ok(())
+}
+
+fn parse_schedule_doc(document: &Document) -> Result<Schedule, SchedulerError> {
+    let schedule_type = document
+        .get_str("type")
+        .map_err(|err| SchedulerError::Storage(format!("missing schedule.type: {err}")))?;
+    match schedule_type {
+        "cron" => {
+            let expression = document
+                .get_str("cron_expression")
+                .map_err(|err| {
+                    SchedulerError::Storage(format!("missing schedule.cron_expression: {err}"))
+                })?
+                .to_string();
+            let next_run = document
+                .get_datetime("next_run")
+                .map_err(|err| {
+                    SchedulerError::Storage(format!("missing schedule.next_run: {err}"))
+                })?
+                .to_chrono();
+            Ok(Schedule::Cron {
+                expression,
+                next_run,
+            })
+        }
+        "one_shot" => {
+            let run_at = document
+                .get_datetime("run_at")
+                .map_err(|err| SchedulerError::Storage(format!("missing schedule.run_at: {err}")))?
+                .to_chrono();
+            Ok(Schedule::OneShot { run_at })
+        }
+        other => Err(SchedulerError::Storage(format!(
+            "unsupported schedule.type: {other}"
+        ))),
+    }
+}
+
 fn bson_i64(value: Option<&Bson>, field: &str) -> Result<i64, SchedulerError> {
     match value {
         Some(Bson::Int64(value)) => Ok(*value),
@@ -1618,9 +1782,11 @@ mod tests {
     use std::path::PathBuf;
 
     use chrono::{Duration as ChronoDuration, TimeZone, Utc};
-    use mongodb::bson::Bson;
+    use mongodb::bson::{doc, Bson, DateTime as BsonDateTime};
 
-    use super::{build_task_status_summary, resolve_owner_scope, ExecutionRow};
+    use super::{
+        apply_persisted_task_fields, build_task_status_summary, resolve_owner_scope, ExecutionRow,
+    };
     use crate::channel::Channel;
     use crate::{RunTaskTask, Schedule, ScheduledTask, TaskKind};
 
@@ -1694,6 +1860,33 @@ mod tests {
         assert_eq!(summary.status, "scheduled");
         assert!(summary.can_cancel);
         assert!(!summary.can_resubmit);
+    }
+
+    #[test]
+    fn apply_persisted_task_fields_overrides_stale_task_json_state() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 12, 0, 0).unwrap();
+        let mut task = sample_one_shot_task(now + ChronoDuration::minutes(15));
+        let document = doc! {
+            "enabled": false,
+            "last_run": BsonDateTime::from_chrono(now),
+            "schedule": doc! {
+                "type": "one_shot",
+                "cron_expression": Bson::Null,
+                "next_run": Bson::Null,
+                "run_at": BsonDateTime::from_chrono(now + ChronoDuration::minutes(45)),
+            },
+        };
+
+        apply_persisted_task_fields(&document, &mut task).expect("apply persisted fields");
+
+        assert!(!task.enabled);
+        assert_eq!(task.last_run, Some(now));
+        match task.schedule {
+            Schedule::OneShot { run_at } => {
+                assert_eq!(run_at, now + ChronoDuration::minutes(45));
+            }
+            other => panic!("expected one-shot schedule, got {other:?}"),
+        }
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -843,6 +843,53 @@ fn reconcile_stale_running_execution_supersedes_overlap_after_later_completion()
 }
 
 #[test]
+fn record_execution_finish_is_idempotent_after_reconciliation_closes_row() {
+    use super::store::SchedulerStore;
+
+    if !mongo_execution_tests_enabled() {
+        eprintln!("Skipping execution reconciliation test; MongoDB config not set.");
+        return;
+    }
+
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = user_scoped_tasks_db(&temp, "late-finish-user");
+    let task_id = {
+        let mut scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("load");
+        scheduler
+            .add_one_shot_in(Duration::from_secs(0), TaskKind::Noop)
+            .expect("add task")
+    };
+
+    let store = SchedulerStore::new(tasks_db).expect("open store");
+    let handle = store
+        .record_execution_start(task_id, parse_utc("2026-04-01T00:00:00Z"))
+        .expect("record start");
+
+    let summary = store
+        .reconcile_stale_running_executions_for_task(
+            &task_id.to_string(),
+            parse_utc("2026-04-02T02:00:00Z"),
+            chrono::Duration::hours(24),
+        )
+        .expect("reconcile");
+    assert_eq!(summary.failed_count, 1);
+
+    store
+        .record_execution_finish(
+            task_id,
+            handle,
+            parse_utc("2026-04-02T02:05:00Z"),
+            "failed",
+            Some("late finish after reconciliation"),
+        )
+        .expect("late finish should be tolerated");
+
+    let executions = load_execution_documents("late-finish-user", task_id);
+    assert_eq!(executions.len(), 1);
+    assert_eq!(executions[0].get_str("status").expect("status"), "failed");
+}
+
+#[test]
 fn scheduler_load_ignores_zero_byte_placeholder_path() {
     let temp = TempDir::new().expect("tempdir");
     let tasks_db = temp.path().join("tasks.db");

--- a/DoWhiz_service/scripts/disk_watchdog.sh
+++ b/DoWhiz_service/scripts/disk_watchdog.sh
@@ -57,15 +57,24 @@ if [ -f "$CADDY_LOG" ]; then
     fi
 fi
 
-# 6. Orphaned debug archive temp directories (older than 1 day)
-# These are created by TempDir::new() in debug_archive.rs and left behind on upload failure
-# Delete in batches to avoid stalling on large counts
-TMP_DIRS=$(ls -d /tmp/.tmp* 2>/dev/null | wc -l)
-if [ "$TMP_DIRS" -gt 0 ]; then
-    echo "$LOG_PREFIX Cleaning orphaned temp directories ($TMP_DIRS found)..."
-    for _ in 1 2 3 4 5; do
-        ls -d /tmp/.tmp* 2>/dev/null | head -100 | xargs rm -rf 2>/dev/null || true
-    done
+# 6. Debug archive staging directories (older than 1 day)
+if [ -d "$HOME/server" ]; then
+    echo "$LOG_PREFIX Cleaning stale debug archive staging directories..."
+    find "$HOME/server" -type d -name ".task_debug_archives_staging" -prune \
+        -exec find {} -mindepth 1 -maxdepth 1 -type d -mtime +1 -exec rm -rf {} + \; \
+        2>/dev/null || true
+fi
+
+# 7. AzCopy job plans/logs older than 2 days
+if [ -d "$HOME/.azcopy" ]; then
+    echo "$LOG_PREFIX Cleaning stale AzCopy artifacts..."
+    find "$HOME/.azcopy" -mindepth 1 -mtime +2 -delete 2>/dev/null || true
+fi
+
+# 8. Old deploy snapshots older than 7 days
+if [ -d "$HOME/server/DoWhiz" ]; then
+    echo "$LOG_PREFIX Cleaning old deploy snapshots..."
+    find "$HOME/server/DoWhiz" -maxdepth 1 -type d -name '.deploy_*' -mtime +7 -exec rm -rf {} + 2>/dev/null || true
 fi
 
 # Final status

--- a/website/src/DashboardPage.jsx
+++ b/website/src/DashboardPage.jsx
@@ -413,8 +413,19 @@ const formatTaskOpsTiming = (value) => {
 const summarizeTaskOpsError = (message) => {
   const raw = String(message || '').trim();
   if (!raw) return '';
-  const firstLine = raw.split('\n').map((line) => line.trim()).find(Boolean) || raw;
-  return firstLine.length > 160 ? `${firstLine.slice(0, 157)}...` : firstLine;
+  const lines = raw.split('\n').map((line) => line.trim()).filter(Boolean);
+  const genericPrefixes = [
+    'task execution failed:',
+    'task_execution failed:',
+    'task failed:',
+    'primary runner failed:',
+    'runner failed:',
+  ];
+  const informative =
+    lines.find((line) => !genericPrefixes.includes(line.toLowerCase())) ||
+    lines[0] ||
+    raw;
+  return informative.length > 200 ? `${informative.slice(0, 197)}...` : informative;
 };
 
 function TaskOpsStatusBadge({ status, isRunningLong }) {


### PR DESCRIPTION
## Summary
- release the worker recovery, debug archive, deploy restart, janitor safety, and dashboard error-surfacing fixes from `dev` to `main`
- keep production deployment on the repository's standard `main` PR-close workflow instead of a one-off host-side change

## Validation carried into this release
- `npm run lint`
- `bash -n DoWhiz_service/scripts/disk_watchdog.sh`
- `node -e 'const cfg=require("./DoWhiz_service/ecosystem.config.cjs"); console.log(cfg.apps.map(a=>`${a.name}:${a.kill_timeout}:${a.listen_timeout}`).join("\\n"))'`\n- `cargo test -p scheduler_module pending_archive_ -- --nocapture`\n- `cargo test -p scheduler_module apply_persisted_task_fields_overrides_stale_task_json_state -- --nocapture`\n- `cargo test -p scheduler_module record_execution_finish_is_idempotent_after_reconciliation_closes_row -- --nocapture`\n- `cargo test -p scheduler_module closure_loop_guard_skips_when_fresh_thread_guidance_is_present -- --nocapture`\n- `cargo test -p scheduler_module --no-run`\n\n## Notes\n- production deploy should be triggered automatically by merging this PR into `main`\n- read-only prod verification will follow after the deploy run completes