### PR TITLE
Harden investment content-filter recovery

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/core.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/core.rs
@@ -25,6 +25,8 @@ const MAX_INVESTMENT_MONITOR_PRIMARY_TIMEOUT_SECS: u64 = 30;
 const MAX_INVESTMENT_MONITOR_FAST_COMPLETION_TIMEOUT_SECS: u64 = 20;
 const MAX_INVESTMENT_RESEARCH_PRIMARY_TIMEOUT_SECS: u64 = 90;
 const MAX_INVESTMENT_RESEARCH_FAST_COMPLETION_TIMEOUT_SECS: u64 = 30;
+const MAX_INVESTMENT_CONTENT_FILTER_MONITOR_RETRY_TIMEOUT_SECS: u64 = 20;
+const MAX_INVESTMENT_CONTENT_FILTER_RESEARCH_RETRY_TIMEOUT_SECS: u64 = 45;
 const SIMPLE_INVESTMENT_MONITOR_TIMEOUT_SECS: u64 = 20;
 const SIMPLE_INVESTMENT_RESEARCH_TIMEOUT_SECS: u64 = 45;
 
@@ -98,6 +100,30 @@ pub fn run_task(params: &RunTaskParams) -> Result<RunTaskOutput, RunTaskError> {
         Ok(output) => Ok(output),
         Err(primary_err) => {
             let mut fallback_primary_err = primary_err;
+            if runner.eq_ignore_ascii_case("codex")
+                && investment_request
+                && !params.reply_to.is_empty()
+                && is_investment_content_filter_failure(&fallback_primary_err)
+            {
+                match run_investment_content_filter_retry(
+                    params,
+                    &workspace_dir,
+                    &runner,
+                    &fallback_primary_err,
+                ) {
+                    Ok(output) => return Ok(output),
+                    Err(retry_err) => {
+                        if let Some(output) = maybe_finalize_investment_artifact_before_fallback(
+                            params,
+                            &workspace_dir,
+                            &retry_err,
+                        )? {
+                            return Ok(output);
+                        }
+                        return Err(retry_err);
+                    }
+                }
+            }
             if let Some((_, fast_completion_timeout)) = codex_budget_split {
                 match maybe_run_codex_fast_completion_retry(
                     params,
@@ -185,6 +211,30 @@ fn run_simple_investment_monitor_task(
     match primary_result {
         Ok(output) => Ok(output),
         Err(primary_err) => {
+            if runner.eq_ignore_ascii_case("codex")
+                && is_investment_content_filter_failure(&primary_err)
+            {
+                match run_investment_content_filter_retry(
+                    params,
+                    workspace_dir,
+                    runner,
+                    &primary_err,
+                ) {
+                    Ok(output) => return Ok(output),
+                    Err(retry_err) => {
+                        if let Some(output) = finalize_simple_investment_fallback(
+                            params,
+                            workspace_dir,
+                            &retry_err,
+                            &reply_html_path,
+                            &reply_attachments_dir,
+                        )? {
+                            return Ok(output);
+                        }
+                        return Err(retry_err);
+                    }
+                }
+            }
             if let Some(output) = finalize_simple_investment_fallback(
                 params,
                 workspace_dir,
@@ -240,6 +290,16 @@ fn simple_investment_timeout(workspace_dir: &Path) -> Result<Duration, RunTaskEr
     Ok(codex_command_timeout().min(Duration::from_secs(cap_secs)))
 }
 
+fn investment_content_filter_retry_timeout(workspace_dir: &Path) -> Result<Duration, RunTaskError> {
+    let cap_secs = if investment_monitor_request_for_workspace(workspace_dir)? {
+        MAX_INVESTMENT_CONTENT_FILTER_MONITOR_RETRY_TIMEOUT_SECS
+    } else {
+        MAX_INVESTMENT_CONTENT_FILTER_RESEARCH_RETRY_TIMEOUT_SECS
+    };
+
+    Ok(codex_command_timeout().min(Duration::from_secs(cap_secs)))
+}
+
 fn should_prefer_investment_fail_soft(
     params: &RunTaskParams,
     workspace_dir: &Path,
@@ -283,6 +343,90 @@ fn maybe_finalize_action_only_monitor_artifact(
         token_usage: None,
         recovery_note: Some(recovery_note),
     }))
+}
+
+fn is_investment_content_filter_failure(err: &RunTaskError) -> bool {
+    let output = match err {
+        RunTaskError::CodexFailed { output, .. }
+        | RunTaskError::ClaudeFailed { output, .. }
+        | RunTaskError::CommandTimeout { output, .. }
+        | RunTaskError::OutputMissing { output, .. }
+        | RunTaskError::OutputContractViolation { output, .. } => output,
+        RunTaskError::FallbackFailed { primary, fallback } => {
+            return output_looks_like_content_filter_failure(primary)
+                || output_looks_like_content_filter_failure(fallback);
+        }
+        _ => return false,
+    };
+
+    output_looks_like_content_filter_failure(output)
+}
+
+fn output_looks_like_content_filter_failure(output: &str) -> bool {
+    let normalized = output.to_ascii_lowercase();
+    normalized.contains("content_filter")
+        || normalized.contains("reason: content_filter")
+        || normalized.contains("stream disconnected before completion")
+        || normalized.contains("incomplete response returned")
+        || normalized.contains("i'm sorry, but i cannot assist with that request")
+        || normalized.contains("i cannot assist with that request")
+}
+
+fn run_investment_content_filter_retry(
+    params: &RunTaskParams,
+    workspace_dir: &Path,
+    runner: &str,
+    primary_err: &RunTaskError,
+) -> Result<RunTaskOutput, RunTaskError> {
+    let retry_timeout = investment_content_filter_retry_timeout(workspace_dir)?;
+    write_investment_content_filter_retry_context(workspace_dir, primary_err, retry_timeout)?;
+    let request = build_request(workspace_dir, params, params.model_name.as_str());
+    let (reply_html_path, reply_attachments_dir) = prepare_workspace(&request)?;
+    let mut output = run_codex_task_with_fast_completion(
+        build_request(workspace_dir, params, params.model_name.as_str()),
+        runner,
+        reply_html_path,
+        reply_attachments_dir,
+        Some(retry_timeout),
+    )?;
+    let retry_note = format!(
+        "Recovered via one content-filter-safe Codex retry after primary failure ({})",
+        primary_error_summary(primary_err)
+    );
+    output.recovery_note = Some(match output.recovery_note.take() {
+        Some(existing) => format!("{}\n{}", existing, retry_note),
+        None => retry_note,
+    });
+    Ok(output)
+}
+
+fn write_investment_content_filter_retry_context(
+    workspace_dir: &Path,
+    primary_err: &RunTaskError,
+    retry_timeout: Duration,
+) -> Result<(), RunTaskError> {
+    let context = format!(
+        "# Codex fast-completion context\n\n\
+This workspace is running exactly one bounded retry because the earlier pass was blocked by provider content filtering.\n\n\
+Remaining retry budget: approximately {budget_secs} seconds.\n\n\
+Primary failure class: {primary_summary}\n\n\
+Required behavior now:\n\
+- Normalize the user's request into a neutral public-company monitoring task before doing any other work.\n\
+- Do not repeat roleplay framing such as `Wall Street trader`, `deep research`, `investment advice`, or open-ended buy/sell solicitation language in your own task framing.\n\
+- Focus on verified public developments about the company or ticker and map them into the product's bounded monitor labels.\n\
+- Produce exactly one concise HTML reply in `reply_email_draft.html`.\n\
+- Use only `Actionable Update`, `No Material Update`, or `Unable to Verify`.\n\
+- Do not restart broad page-by-page filing extraction, long quote sweeps, or a new multi-site research loop.\n\
+- If the request still cannot be answered safely within this retry budget, finalize `Unable to Verify` instead of refusing or timing out.\n\
+- Do not mention internal policy machinery unless the user explicitly asks why the system could not answer.\n",
+        budget_secs = retry_timeout.as_secs(),
+        primary_summary = primary_error_summary(primary_err),
+    );
+    fs::write(
+        workspace_dir.join("codex_fast_completion_context.md"),
+        context,
+    )?;
+    Ok(())
 }
 
 fn maybe_finalize_investment_artifact_before_fallback(

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -385,7 +385,7 @@ Rules:
   Prefer creating a work/ directory for clones, patches, and build artifacts.
 - If attachments include version suffixes like _v1, _v2, the highest version should be the latest version.
 - Avoid interactive commands; use non-interactive flags for git/gh (for example, `gh pr create --title ... --body ...`).
-- Content filter handling: If you encounter repeated "content_filter" errors or "I cannot assist with that request" responses when trying to complete a task, you MUST still create a reply informing the user. Write a polite reply explaining that the task could not be completed due to content policy restrictions, and suggest they rephrase or simplify their request. Never leave the user without any response.
+- Content filter handling: Never leave the user without any response. For investment-monitoring requests, first normalize the task into a neutral public-company monitoring request and try to finish within the bounded monitor format instead of surfacing provider-policy language immediately. If that still fails, send a short `Unable to Verify` reply. For non-investment tasks, if you encounter repeated "content_filter" errors or "I cannot assist with that request" responses, write a polite reply explaining that the task could not be completed and suggest a simpler rephrase.
 {filesystem_security_section}{registration_section}"#,
         input_email = input_email_dir.display(),
         input_attachments = input_attachments_dir.display(),
@@ -626,8 +626,10 @@ See `.agents/skills/notion/SKILL.md` for detailed command reference.
 
 fn build_investment_capabilities_section() -> &'static str {
     r#"Investment research requests:
-- When the user asks about one U.S. stock or ETF, whether now is a good time to buy, or whether anything material changed, read `.agents/skills/us-equity-daily-monitor/SKILL.md` and follow it.
+- When the user asks about one U.S. stock or ETF, whether now is a good time to buy, or whether anything material changed, use `.agents/skills/us-equity-daily-monitor/SKILL.md` only as background. The bounded monitor rules below override any longer memo or deep-research workflow in that skill for this email path.
 - Treat this email path as a simple bounded monitor, not a deep-research pipeline.
+- Normalize roleplay or advice-heavy wording into a neutral public-company monitoring task before you begin. Do not mirror phrases like `Wall Street trader`, `stock pitch`, or open-ended personal financial-advisor language in your own framing.
+- Focus on verified public developments and map them into the product labels below. This is a product monitor, not a personalized wealth-management service.
 - Produce exactly one concise HTML reply inside `reply_email_draft.html`.
 - Use exactly one of these modes:
   - `Actionable Update`
@@ -654,6 +656,7 @@ fn build_investment_capabilities_section() -> &'static str {
 - Keep the reply short and scan-first. Do not write a long memo, a bull/base/bear frame, a large derived-metrics table, or a chart block.
 - Do not mine annual reports page by page in this email path.
 - Do not spend the whole run on research. If you cannot verify enough context quickly, send `Unable to Verify` and stop.
+- If the initial wording appears to trigger provider safety systems, retry your own reasoning once with a narrower public-monitor framing rather than repeating the same advice-heavy wording.
 - If a deeper report would help, say that you can run it separately. Do not start it automatically inside this email path.
 - Investment monitoring requests in this product are allowed. Do not refuse solely because the task concerns stock analysis or an assumption-based scenario.
 

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -1531,6 +1531,88 @@ fn run_task_times_out_with_codex() {
 
 #[test]
 #[cfg(unix)]
+fn run_task_investment_content_filter_retry_recovers_without_claude_fallback() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_investment_content_filter_retry").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+    write_investment_request(
+        &workspace,
+        "Novo Nordisk - NYSE NVO",
+        "Please deep research Novo Nordisk stock (NYSE: NVO) and give me investment advice.",
+    );
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_codex(
+        &bin_dir,
+        FakeCodexMode::InvestmentContentFilterThenRetrySuccess,
+    )
+    .unwrap();
+    write_fake_claude(&bin_dir, FakeClaudeMode::Fail).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let params = build_params(&workspace);
+    let result = run_task(&params).unwrap();
+    let reply = fs::read_to_string(&result.reply_html_path).unwrap();
+    assert!(reply.contains("Quick update on NVO"));
+    assert!(reply.contains("Unable to Verify"));
+    let note = result.recovery_note.unwrap_or_default();
+    assert!(note.contains("content-filter-safe Codex retry"));
+    assert!(!note.contains("Claude fallback"));
+}
+
+#[test]
+#[cfg(unix)]
+fn run_task_investment_content_filter_failure_returns_bounded_fallback_without_claude() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_investment_content_filter_fallback").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+    write_investment_request(
+        &workspace,
+        "Novo Nordisk - NYSE NVO",
+        "Please deep research Novo Nordisk stock (NYSE: NVO) and give me investment advice.",
+    );
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_codex(&bin_dir, FakeCodexMode::InvestmentContentFilterAlwaysFail).unwrap();
+    write_fake_claude(&bin_dir, FakeClaudeMode::Fail).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let params = build_params(&workspace);
+    let result = run_task(&params).unwrap();
+    let reply = fs::read_to_string(&result.reply_html_path).unwrap();
+    assert!(reply.contains("Status:</strong> Unable to Verify"));
+    assert!(reply.contains("Action:</strong> No recommendation"));
+    let note = result.recovery_note.unwrap_or_default();
+    assert!(note.contains("deterministic operational investment fallback"));
+    assert!(!note.contains("Claude fallback"));
+}
+
+#[test]
+#[cfg(unix)]
 fn run_task_preserves_primary_draft_when_fallback_fails_after_timeout() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_timeout_preserve_primary_draft").unwrap();

--- a/DoWhiz_service/run_task_module/tests/support/mod.rs
+++ b/DoWhiz_service/run_task_module/tests/support/mod.rs
@@ -123,6 +123,8 @@ pub enum FakeCodexMode {
     Success,
     InvestmentStructured,
     InvestmentGeneric,
+    InvestmentContentFilterAlwaysFail,
+    InvestmentContentFilterThenRetrySuccess,
     NoOutput,
     EmptyReply,
     Fail,
@@ -239,6 +241,31 @@ cat > reply_email_draft.html <<'HTML'
 HTML
 mkdir -p reply_email_attachments
 echo "attachment" > reply_email_attachments/attachment.txt
+"#
+        }
+        FakeCodexMode::InvestmentContentFilterAlwaysFail => {
+            r#"#!/bin/sh
+set -e
+echo "I'm sorry, but I cannot assist with that request." >&2
+echo "stream disconnected before completion: Incomplete response returned, reason: content_filter" >&2
+exit 1
+"#
+        }
+        FakeCodexMode::InvestmentContentFilterThenRetrySuccess => {
+            r#"#!/bin/sh
+set -e
+if [ -f codex_fast_completion_context.md ] && grep -q "provider content filtering" codex_fast_completion_context.md; then
+  cat > reply_email_draft.html <<'HTML'
+<html><body><h1>Quick update on NVO</h1><p><strong>Status:</strong> Unable to Verify</p><p><strong>Action:</strong> No recommendation</p><p><strong>Why:</strong> Fresh public context remained too thin for a reliable act-now update.</p><p><strong>Next step:</strong> Run a deeper report separately if needed.</p></body></html>
+HTML
+  mkdir -p reply_email_attachments
+  echo "attachment" > reply_email_attachments/attachment.txt
+  exit 0
+fi
+echo "I'm sorry, but I cannot assist with that request." >&2
+echo "turn.failed" >&2
+echo "stream disconnected before completion: Incomplete response returned, reason: content_filter" >&2
+exit 1
 "#
         }
         FakeCodexMode::NoOutput => {

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -7,6 +7,7 @@ use run_task_module::{
     find_aci_container_by_workspace, query_aci_container_status, AciContainerStatus,
 };
 use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::path::Path;
 use std::sync::atomic::{AtomicI64, Ordering};
 use uuid::Uuid;
@@ -652,12 +653,11 @@ impl MongoSchedulerStore {
                         let execution_age = now - row.started_at;
 
                         if execution_age > aci_grace_period {
-                            // Past grace period - task died in "danger zone" between
-                            // record_execution_start() and ACI container creation
-                            if let Err(e) = self.disable_task_by_id(
-                                task_id,
-                                "auto-disabled: execution started but ACI container was never created",
-                            ) {
+                            let (disable_reason, error_reason) =
+                                missing_aci_registry_reconciliation_reason(
+                                    workspace_dir.as_deref(),
+                                );
+                            if let Err(e) = self.disable_task_by_id(task_id, disable_reason) {
                                 tracing::error!(
                                     "failed to disable task {} after ACI not found: {}",
                                     task_id,
@@ -665,11 +665,7 @@ impl MongoSchedulerStore {
                                 );
                                 None
                             } else {
-                                Some((
-                                    "failed",
-                                    "reconciled stale running execution; ACI container not found"
-                                        .to_string(),
-                                ))
+                                Some(("failed", error_reason))
                             }
                         } else {
                             // Within grace period - might still be uploading ephemeral share
@@ -1514,6 +1510,77 @@ fn resolve_aci_registration_grace_period() -> ChronoDuration {
         .unwrap_or_else(|| ChronoDuration::seconds(DEFAULT_ACI_REGISTRATION_GRACE_SECS))
 }
 
+fn missing_aci_registry_reconciliation_reason(
+    workspace_dir: Option<&str>,
+) -> (&'static str, String) {
+    let Some(workspace_dir) = workspace_dir.map(Path::new) else {
+        return (
+            "auto-disabled: execution started but ACI container was never created",
+            "reconciled stale running execution; ACI container not found".to_string(),
+        );
+    };
+
+    if workspace_suggests_unfinished_fallback_after_aci_run(workspace_dir) {
+        return (
+            "auto-disabled: primary runner failed and fallback never reached a terminal state",
+            "reconciled stale running execution after primary ACI run failed and fallback never reached a terminal state".to_string(),
+        );
+    }
+
+    if workspace_has_aci_execution_evidence(workspace_dir) {
+        return (
+            "auto-disabled: execution lost terminal reconciliation after an ACI-backed runner failure",
+            "reconciled stale running execution after an ACI-backed runner executed but no live registry record remained".to_string(),
+        );
+    }
+
+    (
+        "auto-disabled: execution started but ACI container was never created",
+        "reconciled stale running execution; ACI container not found".to_string(),
+    )
+}
+
+fn workspace_has_aci_execution_evidence(workspace_dir: &Path) -> bool {
+    [
+        workspace_dir.join(".run_task_trace_codex_primary/aci/container_show.json"),
+        workspace_dir.join(".run_task_trace_codex_primary/aci/remote_exit_code.txt"),
+        workspace_dir.join(".run_task_trace_codex_primary/aci/remote_output.log"),
+        workspace_dir.join(".codex_remote_output.log"),
+        workspace_dir.join(".aci_recovery_context.json"),
+    ]
+    .iter()
+    .any(|path| path.exists())
+}
+
+fn workspace_suggests_unfinished_fallback_after_aci_run(workspace_dir: &Path) -> bool {
+    if !workspace_has_aci_execution_evidence(workspace_dir) {
+        return false;
+    }
+
+    let fallback_metadata = workspace_dir.join(".run_task_trace/metadata.json");
+    let Ok(contents) = fs::read_to_string(fallback_metadata) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+    let backend = value
+        .get("backend")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    let current_stage = value
+        .get("current_stage")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    let finished = value.get("finished_at_unix_ms").and_then(|v| v.as_i64());
+    let success = value.get("success").and_then(|v| v.as_bool());
+
+    backend == "claude_local"
+        && current_stage == "executing_claude_local"
+        && finished.is_none()
+        && success.is_none()
+}
+
 fn apply_persisted_task_fields(
     document: &Document,
     task: &mut ScheduledTask,
@@ -1779,13 +1846,16 @@ fn mongo_config_err(err: crate::mongo_store::MongoStoreError) -> SchedulerError 
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use chrono::{Duration as ChronoDuration, TimeZone, Utc};
     use mongodb::bson::{doc, Bson, DateTime as BsonDateTime};
 
     use super::{
-        apply_persisted_task_fields, build_task_status_summary, resolve_owner_scope, ExecutionRow,
+        apply_persisted_task_fields, build_task_status_summary,
+        missing_aci_registry_reconciliation_reason, resolve_owner_scope, ExecutionRow,
     };
     use crate::channel::Channel;
     use crate::{RunTaskTask, Schedule, ScheduledTask, TaskKind};
@@ -1825,6 +1895,17 @@ mod tests {
             created_at: run_at - ChronoDuration::minutes(30),
             last_run: None,
         }
+    }
+
+    fn temp_workspace(label: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        path.push(format!("{}_{}_{}", label, std::process::id(), now));
+        fs::create_dir_all(&path).unwrap();
+        path
     }
 
     #[test]
@@ -1972,5 +2053,53 @@ mod tests {
         assert!(summary.can_resubmit);
         assert!(!summary.will_retry);
         assert!(summary.retry_at.is_none());
+    }
+
+    #[test]
+    fn missing_aci_reason_stays_never_created_when_no_trace_exists() {
+        let workspace = temp_workspace("aci_not_created");
+        let (disable_reason, error_reason) =
+            missing_aci_registry_reconciliation_reason(Some(workspace.to_str().unwrap()));
+        assert_eq!(
+            disable_reason,
+            "auto-disabled: execution started but ACI container was never created"
+        );
+        assert_eq!(
+            error_reason,
+            "reconciled stale running execution; ACI container not found"
+        );
+        let _ = fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn missing_aci_reason_prefers_primary_failure_when_trace_shows_fallback_stuck() {
+        let workspace = temp_workspace("aci_trace_exists");
+        let primary_aci_dir = workspace.join(".run_task_trace_codex_primary/aci");
+        fs::create_dir_all(&primary_aci_dir).unwrap();
+        fs::write(primary_aci_dir.join("container_show.json"), "{}").unwrap();
+        let fallback_trace_dir = workspace.join(".run_task_trace");
+        fs::create_dir_all(&fallback_trace_dir).unwrap();
+        fs::write(
+            fallback_trace_dir.join("metadata.json"),
+            r#"{
+  "backend": "claude_local",
+  "current_stage": "executing_claude_local",
+  "finished_at_unix_ms": null,
+  "success": null
+}"#,
+        )
+        .unwrap();
+
+        let (disable_reason, error_reason) =
+            missing_aci_registry_reconciliation_reason(Some(workspace.to_str().unwrap()));
+        assert_eq!(
+            disable_reason,
+            "auto-disabled: primary runner failed and fallback never reached a terminal state"
+        );
+        assert_eq!(
+            error_reason,
+            "reconciled stale running execution after primary ACI run failed and fallback never reached a terminal state"
+        );
+        let _ = fs::remove_dir_all(workspace);
     }
 }


### PR DESCRIPTION
## Summary
- add a single bounded Codex retry for investment requests that fail with provider content-filter/refusal signals
- finalize bounded investment fallback instead of cascading into Claude fallback after repeated content-filter failures
- make stale-running reconciliation distinguish real ACI-backed primary failures from true "container never created" cases

## Validation
- cargo fmt --all --check
- cargo test --locked -p run_task_module
- cargo test --locked -p run_task_module --test run_task_tests -- --nocapture
- cargo test --locked -p scheduler_module --lib missing_aci_reason_ -- --nocapture
- cargo clippy -p run_task_module --all-targets -- -D warnings

## Notes
- `cargo clippy -p scheduler_module --lib --tests -- -D warnings` still fails on substantial pre-existing warnings/errors outside this change set.
