### PR TITLE
Stabilize PM2 restart in deploy workflows

### DIFF
--- a/.github/workflows/CICD-production.yml
+++ b/.github/workflows/CICD-production.yml
@@ -671,7 +671,26 @@ jobs:
             fi
           done
 
-          for stale_service in dowhiz_rust_service dowhiz-rust-service dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway; do
+          dump_pm2_diagnostics() {
+            echo "--- pm2 list ---"
+            pm2 list || true
+            echo "--- pm2 describe dw_worker ---"
+            pm2 describe dw_worker || true
+            echo "--- pm2 describe dw_gateway ---"
+            pm2 describe dw_gateway || true
+            echo "--- worker error log ---"
+            tail -n 120 "/home/${{ secrets.PROD_AZURE_VM_USER }}/.pm2/logs/dw_worker-error.log" || true
+            echo "--- worker out log ---"
+            tail -n 120 "/home/${{ secrets.PROD_AZURE_VM_USER }}/.pm2/logs/dw_worker-out.log" || true
+            echo "--- gateway error log ---"
+            tail -n 120 "/home/${{ secrets.PROD_AZURE_VM_USER }}/.pm2/logs/dw_gateway-error.log" || true
+            echo "--- gateway out log ---"
+            tail -n 120 "/home/${{ secrets.PROD_AZURE_VM_USER }}/.pm2/logs/dw_gateway-out.log" || true
+            echo "--- listening ports 9001/9100 ---"
+            ss -ltnp '( sport = :9001 or sport = :9100 )' || true
+          }
+
+          for stale_service in dowhiz_rust_service dowhiz-rust-service dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway dw_worker dw_gateway; do
             if pm2 describe "$stale_service" >/dev/null 2>&1; then
               pm2 delete "$stale_service" >/dev/null 2>&1 || true
             fi
@@ -680,7 +699,10 @@ jobs:
           export PM2_APP_DIR="$APP_DIR"
           export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
           export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
-          pm2 startOrRestart "$APP_DIR/ecosystem.config.cjs" --only dw_worker,dw_gateway --update-env
+          pm2 start "$APP_DIR/ecosystem.config.cjs" --only dw_worker,dw_gateway --update-env || {
+            dump_pm2_diagnostics
+            exit 1
+          }
 
           pm2 save
           pm2 list
@@ -700,8 +722,8 @@ jobs:
 
           worker_pid="$(find_pm2_pid dw_worker dowhiz_rust_service dowhiz-rust-service || true)"
           gateway_pid="$(find_pm2_pid dw_gateway dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway || true)"
-          [[ -n "$worker_pid" ]] || { echo "No running worker PID found after restart" >&2; exit 1; }
-          [[ -n "$gateway_pid" ]] || { echo "No running gateway PID found after restart" >&2; exit 1; }
+          [[ -n "$worker_pid" ]] || { echo "No running worker PID found after restart" >&2; dump_pm2_diagnostics; exit 1; }
+          [[ -n "$gateway_pid" ]] || { echo "No running gateway PID found after restart" >&2; dump_pm2_diagnostics; exit 1; }
 
           wait_for_health() {
             local label="$1"
@@ -720,7 +742,13 @@ jobs:
             return 1
           }
 
-          worker_health="$(wait_for_health worker "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health")"
-          gateway_health="$(wait_for_health gateway "http://127.0.0.1:${GATEWAY_PORT:-9100}/health")"
+          worker_health="$(wait_for_health worker "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health")" || {
+            dump_pm2_diagnostics
+            exit 1
+          }
+          gateway_health="$(wait_for_health gateway "http://127.0.0.1:${GATEWAY_PORT:-9100}/health")" || {
+            dump_pm2_diagnostics
+            exit 1
+          }
           echo "Post-restart health check passed: worker=$worker_health gateway=$gateway_health"
           EOF

--- a/.github/workflows/CICD-staging.yml
+++ b/.github/workflows/CICD-staging.yml
@@ -712,7 +712,26 @@ jobs:
             fi
           done
 
-          for stale_service in dowhiz_rust_service dowhiz-rust-service dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway; do
+          dump_pm2_diagnostics() {
+            echo "--- pm2 list ---"
+            pm2 list || true
+            echo "--- pm2 describe dw_worker ---"
+            pm2 describe dw_worker || true
+            echo "--- pm2 describe dw_gateway ---"
+            pm2 describe dw_gateway || true
+            echo "--- worker error log ---"
+            tail -n 120 "/home/${{ secrets.STAGING_AZURE_VM_USER }}/.pm2/logs/dw_worker-error.log" || true
+            echo "--- worker out log ---"
+            tail -n 120 "/home/${{ secrets.STAGING_AZURE_VM_USER }}/.pm2/logs/dw_worker-out.log" || true
+            echo "--- gateway error log ---"
+            tail -n 120 "/home/${{ secrets.STAGING_AZURE_VM_USER }}/.pm2/logs/dw_gateway-error.log" || true
+            echo "--- gateway out log ---"
+            tail -n 120 "/home/${{ secrets.STAGING_AZURE_VM_USER }}/.pm2/logs/dw_gateway-out.log" || true
+            echo "--- listening ports 9001/9100 ---"
+            ss -ltnp '( sport = :9001 or sport = :9100 )' || true
+          }
+
+          for stale_service in dowhiz_rust_service dowhiz-rust-service dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway dw_worker dw_gateway; do
             if pm2 describe "$stale_service" >/dev/null 2>&1; then
               pm2 delete "$stale_service" >/dev/null 2>&1 || true
             fi
@@ -721,7 +740,10 @@ jobs:
           export PM2_APP_DIR="$APP_DIR"
           export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
           export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
-          pm2 startOrRestart "$APP_DIR/ecosystem.config.cjs" --only dw_worker,dw_gateway --update-env
+          pm2 start "$APP_DIR/ecosystem.config.cjs" --only dw_worker,dw_gateway --update-env || {
+            dump_pm2_diagnostics
+            exit 1
+          }
 
           pm2 save
           pm2 list
@@ -741,8 +763,8 @@ jobs:
 
           worker_pid="$(find_pm2_pid dw_worker dowhiz_rust_service dowhiz-rust-service || true)"
           gateway_pid="$(find_pm2_pid dw_gateway dowhiz_inbound_gateway dowhiz_gateway dowhiz-inbound-gateway || true)"
-          [[ -n "$worker_pid" ]] || { echo "No running worker PID found after restart" >&2; exit 1; }
-          [[ -n "$gateway_pid" ]] || { echo "No running gateway PID found after restart" >&2; exit 1; }
+          [[ -n "$worker_pid" ]] || { echo "No running worker PID found after restart" >&2; dump_pm2_diagnostics; exit 1; }
+          [[ -n "$gateway_pid" ]] || { echo "No running gateway PID found after restart" >&2; dump_pm2_diagnostics; exit 1; }
 
           wait_for_health() {
             local label="$1"
@@ -761,7 +783,13 @@ jobs:
             return 1
           }
 
-          worker_health="$(wait_for_health worker "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health")"
-          gateway_health="$(wait_for_health gateway "http://127.0.0.1:${GATEWAY_PORT:-9100}/health")"
+          worker_health="$(wait_for_health worker "http://127.0.0.1:${RUST_SERVICE_PORT:-9001}/health")" || {
+            dump_pm2_diagnostics
+            exit 1
+          }
+          gateway_health="$(wait_for_health gateway "http://127.0.0.1:${GATEWAY_PORT:-9100}/health")" || {
+            dump_pm2_diagnostics
+            exit 1
+          }
           echo "Post-restart health check passed: worker=$worker_health gateway=$gateway_health"
           EOF

--- a/DoWhiz_service/OPERATIONS.md
+++ b/DoWhiz_service/OPERATIONS.md
@@ -89,7 +89,8 @@ fi
 export PM2_APP_DIR="$PWD"
 export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
 export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
-pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
+pm2 delete dw_worker dw_gateway >/dev/null 2>&1 || true
+pm2 start ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 
 pm2 save
 pm2 list
@@ -228,7 +229,8 @@ Operational rollback (same code, restart services):
 ```bash
 cd /home/azureuser/server/DoWhiz/DoWhiz_service
 export PM2_APP_DIR="$PWD"
-pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
+pm2 delete dw_worker dw_gateway >/dev/null 2>&1 || true
+pm2 start ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 ```
 
 Code rollback:

--- a/DoWhiz_service/docs/staging_production_deploy.md
+++ b/DoWhiz_service/docs/staging_production_deploy.md
@@ -104,7 +104,8 @@ sudo systemctl disable --now dowhiz-oliver.service || true
 export PM2_APP_DIR="$PWD"
 export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
 export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
-pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
+pm2 delete dw_worker dw_gateway >/dev/null 2>&1 || true
+pm2 start ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 pm2 save
 pm2 list
 ```
@@ -120,7 +121,8 @@ sudo systemctl disable --now dowhiz-oliver.service || true
 export PM2_APP_DIR="$PWD"
 export PM2_KILL_TIMEOUT_MS="${PM2_KILL_TIMEOUT_MS:-300000}"
 export PM2_LISTEN_TIMEOUT_MS="${PM2_LISTEN_TIMEOUT_MS:-15000}"
-pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
+pm2 delete dw_worker dw_gateway >/dev/null 2>&1 || true
+pm2 start ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 pm2 save
 pm2 list
 ```
@@ -152,7 +154,7 @@ Deployment workflows should:
 - inject artifact binaries (`rust_service`, `inbound_fanout`, `inbound_gateway`, `google-docs`)
 - run `az acr build`
 - do not run `cargo build` during image build
-13. Use `pm2 restart --update-env` so runtime env changes (for example `EMPLOYEE_ID`) are applied to existing processes, and finish with local health checks that allow a short retry window while worker/gateway bind their ports.
+13. Remove stale canonical PM2 entries (`dw_worker`, `dw_gateway`) and start them fresh from `ecosystem.config.cjs`, then finish with local health checks that allow a short retry window while worker/gateway bind their ports.
 14. Staging may skip ACI rebuild for gateway-only source changes to reduce unnecessary image churn.
 
 ### CI/CD Maintenance Notes

--- a/DoWhiz_service/docs/task_debug_archives.md
+++ b/DoWhiz_service/docs/task_debug_archives.md
@@ -281,7 +281,8 @@ POSTMARK_TEST_FROM=deep-tutor@deep-tutor.com \
 cargo test -p scheduler_module --test service_real_email -- --nocapture
 
 export PM2_APP_DIR="$PWD"
-pm2 startOrRestart ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
+pm2 delete dw_worker dw_gateway >/dev/null 2>&1 || true
+pm2 start ./ecosystem.config.cjs --only dw_worker,dw_gateway --update-env
 pm2 save
 ```
 


### PR DESCRIPTION
## Summary
- fix staging/production deploy workflows to delete stale canonical PM2 entries before starting `dw_worker` and `dw_gateway`
- add on-failure PM2/log/port diagnostics to the deploy restart step
- align deploy/operations docs with the new fresh-start PM2 procedure

## Root cause
The failed staging deploy in run 25573122697 was not caused by business logic or config target mix-up. The deploy restart step reused an existing stale `dw_worker` PM2 entry via `pm2 startOrRestart`, leading PM2 to attempt a restart by old process id (`Process 4 not found`) while leaving the app in a `waiting` state. The worker never rebound port 9001, so health checks failed.

## Validation
- YAML parse via Ruby for both workflows
- GitHub-rendered workflow YAML parse via `gh workflow view --yaml`
- `bash -n` on the extracted `Restart DoWhiz services` shell blocks for both workflows

## Scope
Only workflow and ops-doc changes:
- `.github/workflows/CICD-staging.yml`
- `.github/workflows/CICD-production.yml`
- `DoWhiz_service/docs/staging_production_deploy.md`
- `DoWhiz_service/OPERATIONS.md`
- `DoWhiz_service/docs/task_debug_archives.md`
