### PR TITLE
Fix stale task reconciliation and ACI timeout recovery

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -519,22 +519,50 @@ fn late_codex_failure_description(exit_status: Option<i32>, failure_output: &str
     let lowered = failure_output.to_ascii_lowercase();
     if lowered.contains("response.failed event received") {
         "Codex stream disconnect during finalization".to_string()
+    } else if lowered.contains("command timed out (az container create") {
+        "ACI container provisioning timed out after writing output".to_string()
+    } else if lowered.contains("command timed out (az container show") {
+        "ACI container polling timed out after writing output".to_string()
     } else if lowered.contains("command timed out") || lowered.contains("timed out (codex") {
-        "Codex timed out after writing output".to_string()
+        "the run timed out after writing output".to_string()
     } else if lowered.contains("cannot assist with that request") {
         "a late Codex refusal".to_string()
     } else if lowered.contains("task_complete reported status=") {
         "Codex reported a late task_complete failure".to_string()
     } else if let Some(code) = exit_status.filter(|code| *code != 0) {
-        format!("Codex exited with status {code} after writing output")
+        format!("the runner exited with status {code} after writing output")
     } else {
-        "a late Codex failure".to_string()
+        "a late runner failure".to_string()
     }
 }
 
 fn maybe_recover_reply_artifact_from_recent_session(
     workspace_dir: &Path,
     expected_reply_path: &Path,
+) -> Option<PathBuf> {
+    maybe_recover_reply_artifact_from_recent_session_with_min_mtime(
+        workspace_dir,
+        expected_reply_path,
+        None,
+    )
+}
+
+fn maybe_recover_reply_artifact_from_recent_session_since(
+    workspace_dir: &Path,
+    expected_reply_path: &Path,
+    min_mtime: SystemTime,
+) -> Option<PathBuf> {
+    maybe_recover_reply_artifact_from_recent_session_with_min_mtime(
+        workspace_dir,
+        expected_reply_path,
+        Some(min_mtime),
+    )
+}
+
+fn maybe_recover_reply_artifact_from_recent_session_with_min_mtime(
+    workspace_dir: &Path,
+    expected_reply_path: &Path,
+    min_mtime: Option<SystemTime>,
 ) -> Option<PathBuf> {
     let home = env::var("HOME").ok()?;
     let sessions_root = PathBuf::from(home).join(".codex").join("sessions");
@@ -567,6 +595,15 @@ fn maybe_recover_reply_artifact_from_recent_session(
 
     let workspace_marker = workspace_dir.to_string_lossy();
     for session_path in session_files.into_iter().take(40) {
+        if let Some(min_mtime) = min_mtime {
+            let modified = session_path
+                .metadata()
+                .ok()
+                .and_then(|meta| meta.modified().ok());
+            if modified.is_none_or(|modified| modified < min_mtime) {
+                continue;
+            }
+        }
         let Ok(contents) = fs::read_to_string(&session_path) else {
             continue;
         };
@@ -756,6 +793,65 @@ fn maybe_recover_from_ready_reply_artifact(
     ))
 }
 
+const TIMEOUT_REPLY_ARTIFACT_FRESHNESS_SLACK: Duration = Duration::from_secs(2);
+
+fn timeout_reply_artifact_freshness_floor(run_started_at: SystemTime) -> SystemTime {
+    run_started_at
+        .checked_sub(TIMEOUT_REPLY_ARTIFACT_FRESHNESS_SLACK)
+        .unwrap_or(UNIX_EPOCH)
+}
+
+fn reply_artifact_modified_after(path: &Path, earliest_mtime: SystemTime) -> bool {
+    fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .is_ok_and(|modified| modified >= earliest_mtime)
+}
+
+fn timeout_reply_recovery_supported_command(command: &str) -> bool {
+    matches!(command, "codex" | "docker run" | "az container create")
+}
+
+fn maybe_recover_from_recent_ready_reply_artifact(
+    run_started_at: SystemTime,
+    reply_expected: bool,
+    workspace_dir: &Path,
+    expected_reply_path: &Path,
+    exit_status: Option<i32>,
+    failure_output: &str,
+) -> Option<String> {
+    if !reply_expected {
+        return None;
+    }
+
+    let failure_description = late_codex_failure_description(exit_status, failure_output);
+    let freshness_floor = timeout_reply_artifact_freshness_floor(run_started_at);
+    if reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path)
+        && reply_artifact_modified_after(expected_reply_path, freshness_floor)
+    {
+        return Some(format!(
+            "Recovered ready reply artifact written during this run after {}",
+            failure_description
+        ));
+    }
+
+    let session_path = maybe_recover_reply_artifact_from_recent_session_since(
+        workspace_dir,
+        expected_reply_path,
+        freshness_floor,
+    )?;
+    if !reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path)
+        || !reply_artifact_modified_after(expected_reply_path, freshness_floor)
+    {
+        return None;
+    }
+
+    Some(format!(
+        "Recovered reply artifact from a current Codex session log ({}) after {}",
+        session_path.display(),
+        failure_description
+    ))
+}
+
 fn codex_turn_completed(output: &str) -> bool {
     output
         .lines()
@@ -786,21 +882,21 @@ fn maybe_accept_nonfatal_post_completion_reply_artifact(
 }
 
 fn maybe_accept_timeout_with_ready_reply_artifact(
-    investment_request: bool,
+    run_started_at: SystemTime,
     reply_expected: bool,
     workspace_dir: &Path,
     expected_reply_path: &Path,
     err: &RunTaskError,
 ) -> Option<String> {
-    if !investment_request {
+    let RunTaskError::CommandTimeout { command, .. } = err else {
         return None;
-    }
-    if !matches!(err, RunTaskError::CommandTimeout { command, .. } if *command == "codex" || *command == "docker run")
-    {
+    };
+    if !timeout_reply_recovery_supported_command(command) {
         return None;
     }
 
-    maybe_recover_from_ready_reply_artifact(
+    maybe_recover_from_recent_ready_reply_artifact(
+        run_started_at,
         reply_expected,
         workspace_dir,
         expected_reply_path,
@@ -1326,6 +1422,7 @@ fn run_codex_task_with_options(
             )
         };
 
+        let command_started_at = SystemTime::now();
         match run_command_with_timeout_and_cancel_with_ready_check(
             cmd,
             timeout,
@@ -1342,7 +1439,7 @@ fn run_codex_task_with_options(
             }
             Err(err) => {
                 if let Some(recovery_note) = maybe_accept_timeout_with_ready_reply_artifact(
-                    investment_request,
+                    command_started_at,
                     !request.reply_to.is_empty(),
                     request.workspace_dir,
                     &expected_reply_path,
@@ -1474,6 +1571,7 @@ fn run_codex_task_with_options(
             )
         };
 
+        let command_started_at = SystemTime::now();
         match run_command_with_timeout_and_cancel_with_ready_check(
             cmd,
             timeout,
@@ -1490,7 +1588,7 @@ fn run_codex_task_with_options(
             }
             Err(err) => {
                 if let Some(recovery_note) = maybe_accept_timeout_with_ready_reply_artifact(
-                    investment_request,
+                    command_started_at,
                     !request.reply_to.is_empty(),
                     request.workspace_dir,
                     &expected_reply_path,
@@ -2102,6 +2200,7 @@ fn run_codex_task_azure_aci(
         container_name, config.resource_group, config.image
     );
     let _ = trace.set_stage("starting_aci_container");
+    let execution_started_at = SystemTime::now();
     let execution = run_azure_aci_execution(
         &config,
         &container_name,
@@ -2169,13 +2268,66 @@ fn run_codex_task_azure_aci(
     if remote_exit_code_path.exists() {
         let _ = trace.copy_file(&remote_exit_code_path, "aci/remote_exit_code.txt");
     }
+    let expected_reply_path =
+        resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
     let execution = match execution {
         Ok(execution) => execution,
         Err(err) => {
             let _ = trace.record_text("logs/combined.log", &output_content);
+            let token_usage = extract_token_usage(&output_content);
+            if let Some(recovery_note) = maybe_accept_timeout_with_ready_reply_artifact(
+                execution_started_at,
+                !request.reply_to.is_empty(),
+                request.workspace_dir,
+                &expected_reply_path,
+                &err,
+            ) {
+                let output_tail = if output_content.trim().is_empty() {
+                    tail_string(&err.to_string(), 4000)
+                } else {
+                    tail_string(&output_content, 4000)
+                };
+                let (
+                    scheduled_tasks,
+                    scheduled_tasks_error,
+                    scheduler_actions,
+                    scheduler_actions_error,
+                ) = parse_scheduling_from_outputs(
+                    &output_content,
+                    "",
+                    &output_content,
+                    request.workspace_dir,
+                );
+                let completed_timing = timing.finish();
+                let _ = trace.record_timing(&completed_timing);
+                record_codex_success(
+                    &mut trace,
+                    exit_status,
+                    &output_tail,
+                    Some(&recovery_note),
+                    token_usage.as_ref(),
+                );
+                TIMING_COLLECTOR.record(completed_timing);
+                return Ok(RunTaskOutput {
+                    reply_html_path: expected_reply_path.clone(),
+                    reply_attachments_dir: reply_attachments_dir.clone(),
+                    codex_output: output_tail,
+                    scheduled_tasks,
+                    scheduled_tasks_error,
+                    scheduler_actions,
+                    scheduler_actions_error,
+                    token_usage,
+                    recovery_note: Some(recovery_note),
+                });
+            }
             let completed_timing = timing.finish();
             let _ = trace.record_timing(&completed_timing);
-            let _ = trace.finish(exit_status, false, Some(&err.to_string()), None);
+            let _ = trace.finish(
+                exit_status,
+                false,
+                Some(&err.to_string()),
+                token_usage.as_ref(),
+            );
             TIMING_COLLECTOR.record(completed_timing);
             return Err(err);
         }
@@ -2208,9 +2360,6 @@ fn run_codex_task_azure_aci(
         );
     let token_usage = extract_token_usage(&combined_output);
     let output_tail = tail_string(&combined_output, 4000);
-    let expected_reply_path =
-        resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
-
     if !azure_aci_execution_succeeded(&execution, exit_status) {
         let err = RunTaskError::CodexFailed {
             status: exit_status,
@@ -3444,6 +3593,59 @@ fn aci_show_indicates_container_started(show_json: &str) -> bool {
         || instance_state.eq_ignore_ascii_case("Stopped")
 }
 
+fn confirm_aci_container_started_after_create_timeout(
+    config: &AzureAciConfig,
+    container_name: &str,
+    attempts: usize,
+    sleep_between_attempts: Duration,
+) -> Option<String> {
+    let attempts = attempts.max(1);
+    for attempt in 1..=attempts {
+        if let Ok(show_json) = fetch_aci_show_json(config, container_name) {
+            if aci_show_indicates_container_started(&show_json) {
+                let note = if let Some((provisioning_state, instance_state)) =
+                    parse_aci_show_states(&show_json)
+                {
+                    format!(
+                        "show-json observed provisioning_state={} instance_state={} on attempt {}",
+                        provisioning_state.as_deref().unwrap_or("-"),
+                        instance_state.as_deref().unwrap_or("-"),
+                        attempt
+                    )
+                } else {
+                    format!(
+                        "show-json observed a started container on attempt {}",
+                        attempt
+                    )
+                };
+                return Some(note);
+            }
+        }
+
+        match query_aci_container_status(container_name, &config.resource_group) {
+            AciContainerStatus::Running => {
+                return Some(format!(
+                    "status query reported Running on attempt {}",
+                    attempt
+                ));
+            }
+            AciContainerStatus::Terminal(state) => {
+                return Some(format!(
+                    "status query reported terminal state {} on attempt {}",
+                    state, attempt
+                ));
+            }
+            AciContainerStatus::NotFound | AciContainerStatus::Error(_) => {}
+        }
+
+        if attempt < attempts && !sleep_between_attempts.is_zero() {
+            thread::sleep(sleep_between_attempts);
+        }
+    }
+
+    None
+}
+
 fn create_aci_container(
     config: &AzureAciConfig,
     container_name: &str,
@@ -3468,27 +3670,22 @@ fn create_aci_container(
     ) {
         Ok(output) => output,
         Err(timeout @ RunTaskError::CommandTimeout { .. }) => {
-            match fetch_aci_show_json(config, container_name) {
-                Ok(show_json) if aci_show_indicates_container_started(&show_json) => {
-                    if let Some((provisioning_state, instance_state)) =
-                        parse_aci_show_states(&show_json)
-                    {
-                        eprintln!(
-                            "[run_task] azure_aci create timeout but container is present container={} provisioning_state={} instance_state={}; continuing with state polling",
-                            container_name,
-                            provisioning_state.as_deref().unwrap_or("-"),
-                            instance_state.as_deref().unwrap_or("-")
-                        );
-                    } else {
-                        eprintln!(
-                            "[run_task] azure_aci create timeout but container is present container={}; continuing with state polling",
-                            container_name
-                        );
-                    }
+            match confirm_aci_container_started_after_create_timeout(
+                config,
+                container_name,
+                6,
+                Duration::from_secs(5),
+            ) {
+                Some(observation) => {
+                    eprintln!(
+                        "[run_task] azure_aci create timeout but container became visible container={} observation={}; continuing with state polling",
+                        container_name, observation
+                    );
                     return Ok(());
                 }
-                Ok(_) => return Err(timeout),
-                Err(_) => return Err(timeout),
+                None => {
+                    return Err(timeout);
+                }
             }
         }
         Err(RunTaskError::Io(err)) if err.kind() == io::ErrorKind::NotFound => {
@@ -6357,6 +6554,115 @@ printf '%s\n' "$@" > "$capture_file"
     }
 
     #[test]
+    #[cfg(unix)]
+    fn test_confirm_aci_container_started_after_create_timeout_uses_status_query_fallback() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+        let az_path = bin_dir.join("az");
+        fs::write(
+            &az_path,
+            r#"#!/bin/sh
+set -e
+if echo "$*" | grep -q -- "--query instanceView.state"; then
+    printf 'Running\n'
+    exit 0
+fi
+printf 'not-json\n'
+"#,
+        )
+        .expect("write fake az");
+        let mut perms = fs::metadata(&az_path).expect("az metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&az_path, perms).expect("chmod fake az");
+
+        let original_path = env::var("PATH").unwrap_or_default();
+        let path_value = format!("{}:{}", bin_dir.display(), original_path);
+        let _guards = [EnvVarGuard::set("PATH", &path_value)];
+
+        let config = AzureAciConfig {
+            resource_group: "stg-rg".to_string(),
+            image: "stg.azurecr.io/dowhiz-service:test".to_string(),
+            location: None,
+            registry_server: None,
+            registry_username: None,
+            registry_password: None,
+            cpu: "1.0".to_string(),
+            memory_gb: "2.0".to_string(),
+            storage_account: "storageacct".to_string(),
+            storage_key: "storagekey".to_string(),
+            file_share: "run-task-share".to_string(),
+            host_share_root: PathBuf::from("/host/share"),
+            container_share_root: PathBuf::from("/mnt/dowhiz-share"),
+        };
+
+        let observation = confirm_aci_container_started_after_create_timeout(
+            &config,
+            "dwz-codex-timeout-test",
+            1,
+            Duration::ZERO,
+        )
+        .expect("expected timeout recovery observation");
+
+        assert!(observation.contains("status query reported Running"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_confirm_aci_container_started_after_create_timeout_returns_none_when_absent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+        let az_path = bin_dir.join("az");
+        fs::write(
+            &az_path,
+            r#"#!/bin/sh
+echo 'ERROR: (ResourceNotFound) The Resource was not found' >&2
+exit 3
+"#,
+        )
+        .expect("write fake az");
+        let mut perms = fs::metadata(&az_path).expect("az metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&az_path, perms).expect("chmod fake az");
+
+        let original_path = env::var("PATH").unwrap_or_default();
+        let path_value = format!("{}:{}", bin_dir.display(), original_path);
+        let _guards = [EnvVarGuard::set("PATH", &path_value)];
+
+        let config = AzureAciConfig {
+            resource_group: "stg-rg".to_string(),
+            image: "stg.azurecr.io/dowhiz-service:test".to_string(),
+            location: None,
+            registry_server: None,
+            registry_username: None,
+            registry_password: None,
+            cpu: "1.0".to_string(),
+            memory_gb: "2.0".to_string(),
+            storage_account: "storageacct".to_string(),
+            storage_key: "storagekey".to_string(),
+            file_share: "run-task-share".to_string(),
+            host_share_root: PathBuf::from("/host/share"),
+            container_share_root: PathBuf::from("/mnt/dowhiz-share"),
+        };
+
+        let observation = confirm_aci_container_started_after_create_timeout(
+            &config,
+            "dwz-codex-timeout-missing",
+            1,
+            Duration::ZERO,
+        );
+
+        assert!(observation.is_none());
+    }
+
+    #[test]
     fn test_reply_artifact_ready_rejects_empty_email_reply() {
         let temp = tempfile::tempdir().expect("tempdir");
         let reply = temp.path().join("reply_email_draft.html");
@@ -6546,6 +6852,61 @@ printf '%s\n' "$@" > "$capture_file"
         .expect("expected recovery note");
 
         assert!(note.contains("Recovered ready reply artifact"));
+    }
+
+    #[test]
+    fn test_maybe_accept_timeout_with_ready_reply_artifact_recovers_recent_non_investment_reply() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reply = temp.path().join("reply_email_draft.html");
+        let run_started_at = SystemTime::now();
+        fs::write(&reply, "<html><body>ready</body></html>").expect("write reply");
+
+        let err = RunTaskError::CommandTimeout {
+            command: "az container create",
+            timeout_secs: 300,
+            output: "create timed out".to_string(),
+        };
+
+        let note = maybe_accept_timeout_with_ready_reply_artifact(
+            run_started_at,
+            true,
+            temp.path(),
+            &reply,
+            &err,
+        )
+        .expect("expected timeout recovery");
+
+        assert!(note.contains("Recovered ready reply artifact written during this run"));
+        assert!(note.contains("ACI container provisioning timed out"));
+    }
+
+    #[test]
+    fn test_maybe_accept_timeout_with_ready_reply_artifact_rejects_stale_reply() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reply = temp.path().join("reply_email_draft.html");
+        fs::write(&reply, "<html><body>stale</body></html>").expect("write reply");
+        let run_started_at = SystemTime::now()
+            .checked_add(Duration::from_secs(5))
+            .expect("future system time");
+
+        let err = RunTaskError::CommandTimeout {
+            command: "codex",
+            timeout_secs: 30,
+            output: "timed out".to_string(),
+        };
+
+        let note = maybe_accept_timeout_with_ready_reply_artifact(
+            run_started_at,
+            true,
+            temp.path(),
+            &reply,
+            &err,
+        );
+
+        assert!(
+            note.is_none(),
+            "stale reply artifact should not be accepted"
+        );
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -16,7 +16,8 @@ use super::reply::load_reply_context;
 use super::schedule::{next_run_after, validate_cron_expression};
 use super::snapshot::{snapshot_reply_draft, write_scheduler_snapshot};
 use super::store::{
-    reset_reconciliation_failure_counter, ExecutionReconciliationSummary, SchedulerStore,
+    reset_reconciliation_failure_counter, ExecutionReconciliationSummary, ExecutionRecordHandle,
+    SchedulerStore,
 };
 use super::types::{
     RunTaskTask, Schedule, ScheduledTask, SchedulerError, SendReplyTask, TaskKind,
@@ -328,6 +329,7 @@ impl<E: TaskExecutor> Scheduler<E> {
                         sync_task_status_to_user_storage(
                             task_id,
                             task,
+                            execution_handle,
                             executed_at,
                             terminal_status,
                             terminal_note.as_deref(),
@@ -396,7 +398,14 @@ impl<E: TaskExecutor> Scheduler<E> {
                         );
                     }
                     // Sync success status to user's account-level storage for Discord/Slack
-                    sync_task_status_to_user_storage(task_id, task, executed_at, "success", None);
+                    sync_task_status_to_user_storage(
+                        task_id,
+                        task,
+                        execution_handle,
+                        executed_at,
+                        "success",
+                        None,
+                    );
                 }
                 if let Some(session) = archive_session.take() {
                     match session.finalize(
@@ -437,6 +446,7 @@ impl<E: TaskExecutor> Scheduler<E> {
                     sync_task_status_to_user_storage(
                         task_id,
                         task,
+                        execution_handle,
                         executed_at,
                         "failed",
                         Some(&message),
@@ -606,7 +616,8 @@ impl<E: TaskExecutor> Scheduler<E> {
 fn sync_task_status_to_user_storage(
     task_id: Uuid,
     task: &RunTaskTask,
-    executed_at: DateTime<Utc>,
+    execution: ExecutionRecordHandle,
+    finished_at: DateTime<Utc>,
     status: &str,
     error_message: Option<&str>,
 ) {
@@ -682,33 +693,22 @@ fn sync_task_status_to_user_storage(
     // Open the user's scheduler store and update the task
     match SchedulerStore::new(user_tasks_db_path.clone()) {
         Ok(store) => {
-            // Record execution start and finish to update status
-            match store.record_execution_start(task_id, executed_at) {
-                Ok(execution) => {
-                    if let Err(err) = store.record_execution_finish(
-                        task_id,
-                        execution,
-                        executed_at,
-                        status,
-                        error_message,
-                    ) {
-                        warn!(
-                            "failed to record execution finish for task {} in user storage: {}",
-                            task_id, err
-                        );
-                    } else {
-                        info!(
-                            "synced task {} status '{}' to user storage account={}",
-                            task_id, status, account_id
-                        );
-                    }
-                }
-                Err(err) => {
-                    warn!(
-                        "failed to record execution start for task {} in user storage: {}",
-                        task_id, err
-                    );
-                }
+            if let Err(err) = store.upsert_terminal_execution(
+                task_id,
+                execution,
+                finished_at,
+                status,
+                error_message,
+            ) {
+                warn!(
+                    "failed to mirror execution {} for task {} in user storage: {}",
+                    execution.execution_id, task_id, err
+                );
+            } else {
+                info!(
+                    "mirrored task {} execution {} status '{}' to user storage account={}",
+                    task_id, execution.execution_id, status, account_id
+                );
             }
         }
         Err(err) => {

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
@@ -107,6 +107,18 @@ impl SchedulerStore {
             .record_execution_finish(task_id, execution, finished_at, status, error_message)
     }
 
+    pub(crate) fn upsert_terminal_execution(
+        &self,
+        task_id: Uuid,
+        execution: ExecutionRecordHandle,
+        finished_at: DateTime<Utc>,
+        status: &str,
+        error_message: Option<&str>,
+    ) -> Result<(), SchedulerError> {
+        self.mongo
+            .upsert_terminal_execution(task_id, execution, finished_at, status, error_message)
+    }
+
     pub(crate) fn reconcile_stale_running_executions(
         &self,
         now: DateTime<Utc>,

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -43,6 +43,15 @@ struct ExecutionRow {
     error_message: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum UnfinishedFallbackReconciliationAction {
+    KeepRunning,
+    Fail {
+        disable_reason: &'static str,
+        error_reason: String,
+    },
+}
+
 fn next_execution_id(started_at: chrono::DateTime<Utc>) -> i64 {
     let base = started_at.timestamp_micros();
     let mut current = EXECUTION_SEQ.load(Ordering::Relaxed);
@@ -459,6 +468,40 @@ impl MongoSchedulerStore {
         Ok(())
     }
 
+    pub(crate) fn upsert_terminal_execution(
+        &self,
+        task_id: Uuid,
+        execution: ExecutionRecordHandle,
+        finished_at: chrono::DateTime<Utc>,
+        status: &str,
+        error_message: Option<&str>,
+    ) -> Result<(), SchedulerError> {
+        let filter = doc! {
+            "owner_scope.kind": &self.owner_kind,
+            "owner_scope.id": &self.owner_id,
+            "task_id": task_id.to_string(),
+            "execution_id": execution.execution_id,
+        };
+        let update = doc! {
+            "$set": {
+                "owner_scope": self.owner_scope_doc(),
+                "execution_id": execution.execution_id,
+                "task_id": task_id.to_string(),
+                "started_at": BsonDateTime::from_chrono(execution.started_at),
+                "finished_at": BsonDateTime::from_chrono(finished_at),
+                "status": status,
+                "error_message": error_message.map(Bson::from).unwrap_or(Bson::Null),
+            }
+        };
+        let options = UpdateOptions::builder().upsert(Some(true)).build();
+        retry_mongo_write("task_executions.upsert_terminal_execution", || {
+            self.executions
+                .update_one(filter.clone(), update.clone(), options.clone())
+        })
+        .map_err(mongo_err)?;
+        Ok(())
+    }
+
     /// Get workspace_dir from a task's task_json field.
     /// Returns None if task not found or workspace_dir cannot be parsed.
     fn get_task_workspace_dir(&self, task_id: &str) -> Option<String> {
@@ -533,9 +576,16 @@ impl MongoSchedulerStore {
         let stale_before = now - stale_after;
         let stale_timeout_secs = stale_after.num_seconds();
         let aci_resource_group = std::env::var("RUN_TASK_AZURE_ACI_RESOURCE_GROUP").ok();
+        let workspace_dir = self.get_task_workspace_dir(task_id);
+        let workspace_path = workspace_dir.as_deref().map(Path::new);
 
         let mut summary = ExecutionReconciliationSummary::default();
         for row in rows.iter().filter(|row| row.status == "running") {
+            let unfinished_fallback_action = unfinished_fallback_reconciliation_action(
+                workspace_path,
+                row.started_at,
+                stale_before,
+            );
             let action = if latest_terminal_finished_at
                 .map(|finished_at| row.started_at <= finished_at)
                 .unwrap_or(false)
@@ -561,8 +611,6 @@ impl MongoSchedulerStore {
                     ),
                 ))
             } else if let Some(ref rg) = aci_resource_group {
-                // Look up ACI container by workspace_dir from tasks
-                let workspace_dir = self.get_task_workspace_dir(task_id);
                 let container_record = workspace_dir
                     .as_ref()
                     .and_then(|ws| find_aci_container_by_workspace(ws));
@@ -572,23 +620,27 @@ impl MongoSchedulerStore {
                         // Container found in registry, check its actual Azure status
                         match query_aci_container_status(&record.container_name, rg) {
                             AciContainerStatus::NotFound => {
-                                // Container was registered but no longer exists in Azure
-                                // This means it completed but execution wasn't marked done (crash/restart)
-                                if let Err(e) = self.disable_task_by_id(
-                                    task_id,
-                                    "auto-disabled: ACI container was registered but no longer exists in Azure",
-                                ) {
-                                    tracing::error!(
-                                        "failed to disable task {} after ACI gone from Azure: {}",
+                                match unfinished_fallback_action.as_ref() {
+                                    Some(UnfinishedFallbackReconciliationAction::KeepRunning) => {
+                                        tracing::info!(
+                                            "leaving task {} running because primary ACI is gone but local fallback is still active",
+                                            task_id
+                                        );
+                                        None
+                                    }
+                                    Some(UnfinishedFallbackReconciliationAction::Fail {
+                                        disable_reason,
+                                        error_reason,
+                                    }) => self.auto_disable_failed_action(
                                         task_id,
-                                        e
-                                    );
-                                    None
-                                } else {
-                                    Some((
-                                        "failed",
+                                        disable_reason,
+                                        error_reason.clone(),
+                                    ),
+                                    None => self.auto_disable_failed_action(
+                                        task_id,
+                                        "auto-disabled: ACI container was registered but no longer exists in Azure",
                                         "reconciled stale running execution; ACI container was registered but no longer exists in Azure".to_string(),
-                                    ))
+                                    ),
                                 }
                             }
                             AciContainerStatus::Terminal(state) => {
@@ -600,27 +652,36 @@ impl MongoSchedulerStore {
                                         task_id
                                     );
                                     None
-                                } else if let Err(e) = self.disable_task_by_id(
-                                    task_id,
-                                    &format!(
-                                        "auto-disabled: ACI container terminated with state: {}",
-                                        state
-                                    ),
-                                ) {
-                                    tracing::error!(
-                                        "failed to disable task {} after ACI terminal state: {}",
-                                        task_id,
-                                        e
-                                    );
-                                    None
                                 } else {
-                                    Some((
-                                        "failed",
-                                        format!(
-                                            "reconciled stale running execution; ACI container terminated with state: {}",
-                                            state
+                                    match unfinished_fallback_action.as_ref() {
+                                        Some(UnfinishedFallbackReconciliationAction::KeepRunning) => {
+                                            tracing::info!(
+                                                "leaving task {} running because primary ACI terminated with state={} but local fallback is still active",
+                                                task_id,
+                                                state
+                                            );
+                                            None
+                                        }
+                                        Some(UnfinishedFallbackReconciliationAction::Fail {
+                                            disable_reason,
+                                            error_reason,
+                                        }) => self.auto_disable_failed_action(
+                                            task_id,
+                                            disable_reason,
+                                            error_reason.clone(),
                                         ),
-                                    ))
+                                        None => self.auto_disable_failed_action(
+                                            task_id,
+                                            &format!(
+                                                "auto-disabled: ACI container terminated with state: {}",
+                                                state
+                                            ),
+                                            format!(
+                                                "reconciled stale running execution; ACI container terminated with state: {}",
+                                                state
+                                            ),
+                                        ),
+                                    }
                                 }
                             }
                             AciContainerStatus::Running => {
@@ -631,7 +692,17 @@ impl MongoSchedulerStore {
                                 None
                             }
                             AciContainerStatus::Error(err) => {
-                                if row.started_at <= stale_before {
+                                if matches!(
+                                    unfinished_fallback_action,
+                                    Some(UnfinishedFallbackReconciliationAction::KeepRunning)
+                                ) {
+                                    tracing::info!(
+                                        "ignoring ACI status query error for task {} because local fallback is still active: {}",
+                                        task_id,
+                                        err
+                                    );
+                                    None
+                                } else if row.started_at <= stale_before {
                                     Some((
                                         "failed",
                                         format!(
@@ -652,30 +723,43 @@ impl MongoSchedulerStore {
                         let aci_grace_period = resolve_aci_registration_grace_period();
                         let execution_age = now - row.started_at;
 
-                        if execution_age > aci_grace_period {
-                            let (disable_reason, error_reason) =
-                                missing_aci_registry_reconciliation_reason(
-                                    workspace_dir.as_deref(),
-                                );
-                            if let Err(e) = self.disable_task_by_id(task_id, disable_reason) {
-                                tracing::error!(
-                                    "failed to disable task {} after ACI not found: {}",
-                                    task_id,
-                                    e
+                        match unfinished_fallback_action.as_ref() {
+                            Some(UnfinishedFallbackReconciliationAction::KeepRunning) => {
+                                tracing::info!(
+                                    "leaving task {} running because ACI registry is gone but local fallback is still active",
+                                    task_id
                                 );
                                 None
-                            } else {
-                                Some(("failed", error_reason))
                             }
-                        } else {
-                            // Within grace period - might still be uploading ephemeral share
-                            tracing::debug!(
-                                "ACI container not found for task {} but within grace period ({} < {}), skipping",
+                            Some(UnfinishedFallbackReconciliationAction::Fail {
+                                disable_reason,
+                                error_reason,
+                            }) => self.auto_disable_failed_action(
                                 task_id,
-                                execution_age,
-                                aci_grace_period
-                            );
-                            None
+                                disable_reason,
+                                error_reason.clone(),
+                            ),
+                            None if execution_age > aci_grace_period => {
+                                let (disable_reason, error_reason) =
+                                    missing_aci_registry_reconciliation_reason(
+                                        workspace_dir.as_deref(),
+                                    );
+                                self.auto_disable_failed_action(
+                                    task_id,
+                                    disable_reason,
+                                    error_reason,
+                                )
+                            }
+                            None => {
+                                // Within grace period - might still be uploading ephemeral share
+                                tracing::debug!(
+                                    "ACI container not found for task {} but within grace period ({} < {}), skipping",
+                                    task_id,
+                                    execution_age,
+                                    aci_grace_period
+                                );
+                                None
+                            }
                         }
                     }
                 }
@@ -703,6 +787,24 @@ impl MongoSchedulerStore {
             }
         }
         Ok(summary)
+    }
+
+    fn auto_disable_failed_action(
+        &self,
+        task_id: &str,
+        disable_reason: &str,
+        error_reason: String,
+    ) -> Option<(&'static str, String)> {
+        if let Err(err) = self.disable_task_by_id(task_id, disable_reason) {
+            tracing::error!(
+                "failed to disable task {} during stale reconciliation: {}",
+                task_id,
+                err
+            );
+            None
+        } else {
+            Some(("failed", error_reason))
+        }
     }
 
     pub(crate) fn record_task_debug_archive(
@@ -1537,6 +1639,34 @@ fn missing_aci_registry_reconciliation_reason(
     (
         "auto-disabled: execution started but ACI container was never created",
         "reconciled stale running execution; ACI container not found".to_string(),
+    )
+}
+
+fn unfinished_fallback_reconciliation_action(
+    workspace_dir: Option<&Path>,
+    started_at: chrono::DateTime<Utc>,
+    stale_before: chrono::DateTime<Utc>,
+) -> Option<UnfinishedFallbackReconciliationAction> {
+    let workspace_dir = workspace_dir?;
+    if !workspace_suggests_unfinished_fallback_after_aci_run(workspace_dir) {
+        return None;
+    }
+
+    if started_at <= stale_before {
+        let (disable_reason, error_reason) = unfinished_fallback_reconciliation_reason();
+        Some(UnfinishedFallbackReconciliationAction::Fail {
+            disable_reason,
+            error_reason,
+        })
+    } else {
+        Some(UnfinishedFallbackReconciliationAction::KeepRunning)
+    }
+}
+
+fn unfinished_fallback_reconciliation_reason() -> (&'static str, String) {
+    (
+        "auto-disabled: primary runner failed and fallback never reached a terminal state",
+        "reconciled stale running execution after primary ACI run failed and fallback never reached a terminal state".to_string(),
     )
 }
 

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -3,6 +3,7 @@ use mongodb::bson::{doc, Document};
 use mongodb::options::FindOptions;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -142,6 +143,33 @@ fn load_execution_documents(user_id: &str, task_id: Uuid) -> Vec<Document> {
         .expect("find executions")
         .map(|row| row.expect("execution document"))
         .collect()
+}
+
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
 }
 
 #[test]
@@ -785,6 +813,150 @@ fn reconcile_stale_running_execution_fails_orphaned_latest_row_after_timeout() {
 }
 
 #[test]
+fn reconcile_stale_running_execution_keeps_active_fallback_open() {
+    use super::store::SchedulerStore;
+
+    if !mongo_execution_tests_enabled() {
+        eprintln!("Skipping execution reconciliation test; MongoDB config not set.");
+        return;
+    }
+
+    let _lock = env_lock();
+    let _aci_rg = EnvGuard::set("RUN_TASK_AZURE_ACI_RESOURCE_GROUP", "test-rg");
+
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = user_scoped_tasks_db(&temp, "stale-active-fallback-user");
+    let workspace = temp.path().join("workspace");
+    let mail_root = temp.path().join("mail");
+    fs::create_dir_all(&workspace).expect("workspace");
+    fs::create_dir_all(&mail_root).expect("mail");
+
+    let task_id = {
+        let mut scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("load");
+        scheduler
+            .add_one_shot_in(
+                Duration::from_secs(0),
+                TaskKind::RunTask(base_run_task(&workspace, &mail_root)),
+            )
+            .expect("add task")
+    };
+
+    let primary_aci_dir = workspace.join(".run_task_trace_codex_primary/aci");
+    fs::create_dir_all(&primary_aci_dir).expect("primary trace dir");
+    fs::write(primary_aci_dir.join("container_show.json"), "{}").expect("container show");
+
+    let fallback_trace_dir = workspace.join(".run_task_trace");
+    fs::create_dir_all(&fallback_trace_dir).expect("fallback trace dir");
+    fs::write(
+        fallback_trace_dir.join("metadata.json"),
+        r#"{
+  "backend": "claude_local",
+  "current_stage": "executing_claude_local",
+  "finished_at_unix_ms": null,
+  "success": null
+}"#,
+    )
+    .expect("fallback metadata");
+
+    let store = SchedulerStore::new(tasks_db).expect("open store");
+    store
+        .record_execution_start(task_id, parse_utc("2026-04-01T00:00:00Z"))
+        .expect("record start");
+
+    let summary = store
+        .reconcile_stale_running_executions_for_task(
+            &task_id.to_string(),
+            parse_utc("2026-04-01T00:20:00Z"),
+            chrono::Duration::hours(24),
+        )
+        .expect("reconcile");
+
+    assert_eq!(summary.superseded_count, 0);
+    assert_eq!(summary.failed_count, 0);
+    assert!(store
+        .has_running_execution(&task_id.to_string())
+        .expect("running check"));
+
+    let executions = load_execution_documents("stale-active-fallback-user", task_id);
+    assert_eq!(executions.len(), 1);
+    assert_eq!(executions[0].get_str("status").expect("status"), "running");
+}
+
+#[test]
+fn reconcile_stale_running_execution_fails_abandoned_fallback_after_watchdog() {
+    use super::store::SchedulerStore;
+
+    if !mongo_execution_tests_enabled() {
+        eprintln!("Skipping execution reconciliation test; MongoDB config not set.");
+        return;
+    }
+
+    let _lock = env_lock();
+    let _aci_rg = EnvGuard::set("RUN_TASK_AZURE_ACI_RESOURCE_GROUP", "test-rg");
+
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = user_scoped_tasks_db(&temp, "stale-abandoned-fallback-user");
+    let workspace = temp.path().join("workspace");
+    let mail_root = temp.path().join("mail");
+    fs::create_dir_all(&workspace).expect("workspace");
+    fs::create_dir_all(&mail_root).expect("mail");
+
+    let task_id = {
+        let mut scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("load");
+        scheduler
+            .add_one_shot_in(
+                Duration::from_secs(0),
+                TaskKind::RunTask(base_run_task(&workspace, &mail_root)),
+            )
+            .expect("add task")
+    };
+
+    let primary_aci_dir = workspace.join(".run_task_trace_codex_primary/aci");
+    fs::create_dir_all(&primary_aci_dir).expect("primary trace dir");
+    fs::write(primary_aci_dir.join("container_show.json"), "{}").expect("container show");
+
+    let fallback_trace_dir = workspace.join(".run_task_trace");
+    fs::create_dir_all(&fallback_trace_dir).expect("fallback trace dir");
+    fs::write(
+        fallback_trace_dir.join("metadata.json"),
+        r#"{
+  "backend": "claude_local",
+  "current_stage": "executing_claude_local",
+  "finished_at_unix_ms": null,
+  "success": null
+}"#,
+    )
+    .expect("fallback metadata");
+
+    let store = SchedulerStore::new(tasks_db).expect("open store");
+    store
+        .record_execution_start(task_id, parse_utc("2026-04-01T00:00:00Z"))
+        .expect("record start");
+
+    let summary = store
+        .reconcile_stale_running_executions_for_task(
+            &task_id.to_string(),
+            parse_utc("2026-04-02T02:00:00Z"),
+            chrono::Duration::hours(24),
+        )
+        .expect("reconcile");
+
+    assert_eq!(summary.superseded_count, 0);
+    assert_eq!(summary.failed_count, 1);
+    assert!(!store
+        .has_running_execution(&task_id.to_string())
+        .expect("running check"));
+
+    let executions = load_execution_documents("stale-abandoned-fallback-user", task_id);
+    assert_eq!(executions.len(), 1);
+    assert_eq!(executions[0].get_str("status").expect("status"), "failed");
+    assert_eq!(
+        executions[0].get_str("error_message").expect("error"),
+        "reconciled stale running execution after primary ACI run failed and fallback never reached a terminal state"
+    );
+}
+
+#[test]
 fn reconcile_stale_running_execution_supersedes_overlap_after_later_completion() {
     use super::store::SchedulerStore;
 
@@ -1247,6 +1419,81 @@ fn full_slack_flow_task_sync_and_status_update() {
             Some(error_message.to_string())
         );
     }
+}
+
+#[test]
+fn mirrored_terminal_execution_preserves_source_execution_identity() {
+    use super::store::SchedulerStore;
+
+    if !mongo_execution_tests_enabled() {
+        eprintln!("Skipping mirror execution test; MongoDB config not set.");
+        return;
+    }
+
+    let temp = TempDir::new().expect("tempdir");
+    let workspace_db = user_scoped_tasks_db(&temp, "mirror-live-user");
+    let account_db = user_scoped_tasks_db(&temp, "mirror-account-user");
+    let workspace_dir = temp.path().join("workspace");
+    let mail_root = temp.path().join("mail");
+    fs::create_dir_all(&workspace_dir).expect("workspace");
+    fs::create_dir_all(&mail_root).expect("mail");
+
+    let run_task = base_run_task(&workspace_dir, &mail_root);
+    let task_id = {
+        let mut scheduler =
+            Scheduler::load(&workspace_db, NoopExecutor::default()).expect("load workspace");
+        scheduler
+            .add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task.clone()))
+            .expect("add workspace task")
+    };
+
+    {
+        let mut scheduler =
+            Scheduler::load(&account_db, NoopExecutor::default()).expect("load account");
+        scheduler
+            .add_one_shot_in_with_id(task_id, Duration::from_secs(0), TaskKind::RunTask(run_task))
+            .expect("add account task");
+    }
+
+    let started_at = parse_utc("2026-04-01T00:00:00Z");
+    let finished_at = parse_utc("2026-04-01T00:10:00Z");
+    let workspace_store = SchedulerStore::new(workspace_db).expect("open workspace");
+    let execution = workspace_store
+        .record_execution_start(task_id, started_at)
+        .expect("record source start");
+    workspace_store
+        .record_execution_finish(task_id, execution, finished_at, "success", None)
+        .expect("record source finish");
+
+    let account_store = SchedulerStore::new(account_db).expect("open account");
+    account_store
+        .upsert_terminal_execution(task_id, execution, finished_at, "success", None)
+        .expect("mirror execution");
+    account_store
+        .upsert_terminal_execution(task_id, execution, finished_at, "success", None)
+        .expect("mirror execution idempotent");
+
+    let executions = load_execution_documents("mirror-account-user", task_id);
+    assert_eq!(executions.len(), 1);
+    assert_eq!(
+        executions[0].get_i64("execution_id").expect("execution id"),
+        execution.execution_id
+    );
+    assert_eq!(
+        executions[0]
+            .get_datetime("started_at")
+            .expect("started_at")
+            .to_chrono(),
+        started_at
+    );
+    assert_eq!(
+        executions[0]
+            .get_datetime("finished_at")
+            .expect("finished_at")
+            .to_chrono(),
+        finished_at
+    );
+    assert_eq!(executions[0].get_str("status").expect("status"), "success");
 }
 
 #[test]

--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -8507,6 +8507,48 @@ mod tests {
         assert_eq!(preferred_task_match_index(&matches), Some(0));
     }
 
+    #[test]
+    fn merged_task_execution_history_dedupes_identical_mirror_rows() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 1, 12, 0, 0).unwrap();
+        let task = ScheduledTask {
+            id: Uuid::new_v4(),
+            kind: TaskKind::RunTask(sample_run_task_task()),
+            schedule: Schedule::OneShot { run_at: now },
+            enabled: false,
+            created_at: now - ChronoDuration::minutes(5),
+            last_run: Some(now),
+        };
+        let task_id = task.id.to_string();
+        let execution = TaskExecutionSummary {
+            execution_id: 1778001442579447,
+            status: "failed".to_string(),
+            started_at: now.to_rfc3339(),
+            finished_at: Some((now + ChronoDuration::minutes(10)).to_rfc3339()),
+            error_message: Some("primary runner failed".to_string()),
+            duration_seconds: Some(600),
+        };
+        let matches = vec![
+            TaskStorageMatch {
+                path: PathBuf::from("/tmp/users/live-user/state/tasks.db"),
+                task: task.clone(),
+                summary: sample_task_status_summary(&task_id, "failed", now),
+                executions: vec![execution.clone()],
+            },
+            TaskStorageMatch {
+                path: PathBuf::from("/tmp/users/account-mirror/state/tasks.db"),
+                task,
+                summary: sample_task_status_summary(&task_id, "failed", now),
+                executions: vec![execution.clone()],
+            },
+        ];
+
+        let merged = merge_task_execution_summaries(&matches);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].execution_id, execution.execution_id);
+        assert_eq!(merged[0].started_at, execution.started_at);
+        assert_eq!(merged[0].finished_at, execution.finished_at);
+    }
+
     // ==================== WeCom OAuth Tests ====================
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve source execution identities in account-storage mirrors and avoid stale reconciliation falsely terminalizing runs while fallback is still active
- recover current-run reply artifacts after codex/ACI timeouts instead of forcing unnecessary fallback failures
- harden ACI create-timeout recovery by confirming started containers via status-query fallback before giving up

## Test evidence
- `cargo test -q --manifest-path DoWhiz_service/Cargo.toml -p scheduler_module --lib merged_task_execution_history_dedupes_identical_mirror_rows -- --nocapture`
- `cargo test -q --manifest-path DoWhiz_service/Cargo.toml -p scheduler_module --lib mirrored_terminal_execution_preserves_source_execution_identity -- --nocapture` (skips when Mongo config is absent)
- `cargo test -q --manifest-path DoWhiz_service/Cargo.toml -p scheduler_module --lib reconcile_stale_running_execution_keeps_active_fallback_open -- --nocapture`
- `cargo test -q --manifest-path DoWhiz_service/Cargo.toml -p scheduler_module --lib reconcile_stale_running_execution_fails_abandoned_fallback_after_watchdog -- --nocapture` (skips when Mongo config is absent)
- `cargo test -q --manifest-path DoWhiz_service/Cargo.toml -p run_task_module --lib maybe_accept_timeout_with_ready_reply_artifact -- --nocapture`
- `cargo test -q --manifest-path DoWhiz_service/Cargo.toml -p run_task_module --lib confirm_aci_container_started_after_create_timeout -- --nocapture`
- `cargo test -q --manifest-path DoWhiz_service/Cargo.toml -p run_task_module --lib test_create_aci_container_ -- --nocapture`
- `cargo test -q --manifest-path DoWhiz_service/Cargo.toml -p run_task_module --lib --no-run`

## Residual risk
- This does not yet address Claude fallback silent failures (`exit_status=0` with empty logs and no reply artifact).