### PR TITLE
Add selective peer context to equity monitor

### DIFF
--- a/.agents/skills/us-equity-daily-monitor/SKILL.md
+++ b/.agents/skills/us-equity-daily-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: us-equity-daily-monitor
-description: Produce a one-page U.S. equity signal monitor for a single stock or ETF. Front-load exactly one monitor badge (`Review Now`, `Watch Closely`, `No Material Change`, or `Insufficient Evidence`), explain why the signal matters now, what changed or did not change in the thesis, the main risk to the signal, and what would change the view next. Use whenever the user asks whether a stock is a buy or sell, wants a single-name investment memo, asks what changed since a prior note, wants an earnings setup, or says "should I act" about one ticker. Keep it as public-market analysis rather than personalized portfolio advice. Do not use for portfolio optimization, multi-asset allocation, crypto, FX, fixed-income, or macro strategy notes.
+description: Produce a one-page U.S. equity signal monitor for a single stock or ETF. Front-load exactly one monitor badge (`Review Now`, `Watch Closely`, `No Material Change`, or `Insufficient Evidence`), explain why the signal matters now, what changed or did not change in the thesis, the main risk to the signal, and what would change the view next. Use whenever the user asks whether a stock is a buy or sell, wants a single-name investment memo, asks for deep research or a high-level investment view on one company, wants a thesis review versus peers or sector expectations, asks what changed since a prior note, wants an earnings setup, or says "should I act" about one ticker. Keep it as public-market analysis rather than personalized portfolio advice. Do not use for portfolio optimization, multi-asset allocation, crypto, FX, fixed-income, or macro strategy notes.
 ---
 
 # U.S. Equity Daily Monitor
@@ -15,7 +15,8 @@ A structured framework for one-page single-name U.S. equity signal monitors. The
 4. **Tie uncertainty to a specific evidence gap.** Allowed: "Confidence is Medium because the margin guide still depends on an unproven product ramp." Not allowed: "Markets are uncertain, so be careful."
 5. **Keep the monitor badge primary.** If the current product contract also expects `New Money Action` or `Existing Holder Action`, include them as a secondary translation layer. Do not let those rows replace the badge or drift into personalized portfolio advice.
 6. **Quantify what would move the view.** Use explicit thresholds (`%`, `$`, `bps`, `x`, quarter counts) in the change-view section.
-7. **Keep compliance concise.** Use exactly one short sentence such as: `This is a public-market signal assessment, not personalized financial advice.`
+7. **Use peer context only when it sharpens the call.** A `2-5` name peer set is a lens for better judgment, not a mandatory sector report.
+8. **Keep compliance concise.** Use exactly one short sentence such as: `This is a public-market signal assessment, not personalized financial advice.`
 
 ## Badge rubric
 
@@ -47,11 +48,15 @@ Avoid leading with `Buy`, `Hold`, or `Sell` as the main answer unless the surrou
 2. **Determine the monitor type before writing.**
    - Use the **full monitor** when the user asks for deep research, a full memo, or a fresh single-name view.
    - Use the **concise monitor** when the user asks "what changed," "since your last note," or "only tell me if I should act."
-3. **Choose the badge first.** Decide whether the evidence supports `Review Now`, `Watch Closely`, `No Material Change`, or `Insufficient Evidence` before drafting prose.
-4. **Compute derived metrics deterministically** when the full monitor needs them. Use `scripts/compute_metrics.py` if the inputs match [references/data-adapters.md](references/data-adapters.md); otherwise compute directly from [references/formulas.md](references/formulas.md).
-5. **Draft from the template.** Copy [assets/memo-template.md](assets/memo-template.md) and fill every required field. Section structure is defined in [references/sections.md](references/sections.md).
-6. **Cite cleanly.** Every material fact ends in a source chip. Aim for at least three distinct sources in a full monitor and at least two in a concise monitor. Rules live in [references/evidence.md](references/evidence.md).
-7. **Name the main risk and what would change the view.** Caution is allowed only when the specific risk, threshold, or missing evidence is named.
+3. **Decide whether `Competitive / Peer Context` earns its keep.**
+   - Include it when the user asks for deep research, a high-level investment view, a thesis review, sector-relative valuation context, or when competitor/substitute dynamics materially shape the current signal.
+   - Usually skip it for narrow factual, latest-news, market-cap, CEO-comment, or single-event prompts unless the catalyst is directly peer-driven or clearly sector-wide.
+   - If the user already asked for a direct comparison (for example `NVDA vs AMD`), keep the named comparison primary and do not add extra peers unless they materially change the thesis.
+4. **Choose the badge first.** Decide whether the evidence supports `Review Now`, `Watch Closely`, `No Material Change`, or `Insufficient Evidence` before drafting prose.
+5. **Compute derived metrics deterministically** when the full monitor needs them. Use `scripts/compute_metrics.py` if the inputs match [references/data-adapters.md](references/data-adapters.md); otherwise compute directly from [references/formulas.md](references/formulas.md).
+6. **Draft from the template.** Copy [assets/memo-template.md](assets/memo-template.md) and fill every required field. Section structure is defined in [references/sections.md](references/sections.md).
+7. **Cite cleanly.** Every material fact ends in a source chip. Aim for at least three distinct sources in a full monitor and at least two in a concise monitor. Rules live in [references/evidence.md](references/evidence.md).
+8. **Name the main risk and what would change the view.** Caution is allowed only when the specific risk, threshold, or missing evidence is named.
 
 ## Output contract
 
@@ -85,6 +90,7 @@ Use this for deep-research or first-look requests. Include:
 - `Decision Card`
 - `Why Now`
 - `Dual-Horizon Framing`
+- `Competitive / Peer Context` (optional)
 - `Verified Facts`
 - `Derived Metrics`
 - `Scenarios`
@@ -97,10 +103,37 @@ Use this for delta checks and "should I act" requests. Include:
 
 - `Decision Card`
 - `Why Now`
+- `Competitive / Peer Context` (optional)
 - `What Would Change The View`
 - `Evidence Chips`
 
 In concise mode, shorten the artifact, not the analysis. The reader still needs a concrete badge, signal direction, thesis impact, main risk, and the missing or moving evidence.
+
+## Competitive / Peer Context
+
+Include this section only when it materially sharpens the investment judgment. It is optional, not default.
+
+When you include it:
+
+- Pick `2-5` relevant peers, substitutes, adjacent platforms, or structural threats.
+- Explain briefly why that peer set matters for this thesis. If the peer set is weak or imperfect, say so instead of forcing fake comparables.
+- Compare only the dimensions that actually matter to the call now: pricing power, margin durability, software moat, customer concentration, capital intensity, autonomy credibility, regulatory pressure, or sector-relative valuation.
+- Keep the section concise. Usually four short bullets are enough:
+  - `Relevant peers/substitutes`
+  - `Where the target looks stronger`
+  - `Where peers create pressure`
+  - `Investment implication`
+- If a table is clearer, keep it small and thesis-relevant rather than exhaustive.
+- Current or factual peer claims must be sourced. Do not rely only on the target company's materials to make claims about competitors.
+- Do not invent peer sets, market-share numbers, or current metrics when the comparison is fuzzy.
+- Do not let this become a full sector report unless the user explicitly asks for one.
+
+Illustrative peer-selection patterns:
+
+- `NVDA`: AMD, Broadcom, hyperscaler custom ASIC efforts, cloud providers' internal silicon programs.
+- `TSLA`: BYD, legacy OEM EV programs, and autonomy competitors when autonomy is part of the thesis.
+- `AAPL`: Samsung, Google, Microsoft, or Meta when ecosystem durability, services, AI platform risk, or regulation is the relevant lens.
+- `SHOP`: Amazon, Adobe Commerce, BigCommerce, Wix/Squarespace, or merchant-stack/payment substitutes when platform economics are the question.
 
 ## Anti-waffle rules
 
@@ -110,6 +143,7 @@ In concise mode, shorten the artifact, not the analysis. The reader still needs 
 - Do not hide behind valuation language unless you explain which expectation is already priced in and why that limits the signal.
 - Do not give portfolio sizing, tax, cost-basis, or risk-tolerance advice.
 - Do not turn the answer into a disclaimer block.
+- Do not write empty competition filler such as "faces competition from many players" without naming the specific pressure and why it matters now.
 
 ## Compact examples
 
@@ -174,6 +208,7 @@ Before finalizing, check this in one pass while you draft:
 - Did I state what would change the view?
 - Did I avoid generic `wait/hold` language?
 - Did I avoid personalized buy/sell instructions?
+- If I used `Competitive / Peer Context`, did it stay concise, use real peers/substitutes, and change the judgment rather than pad the answer?
 
 ## What this framework rejects
 
@@ -182,6 +217,7 @@ Before finalizing, check this in one pass while you draft:
 - Uncertainty language that is not attached to a concrete missing fact, threshold, or catalyst.
 - Big disclaimer blocks or repeated "not financial advice" language.
 - Unsupported "monitor closely" prose that never names the variable being monitored.
+- Peer sections that read like a generic industry roundup rather than a thesis-calibration tool.
 
 ## Special cases
 

--- a/.agents/skills/us-equity-daily-monitor/assets/example-memo-nvda.md
+++ b/.agents/skills/us-equity-daily-monitor/assets/example-memo-nvda.md
@@ -39,6 +39,13 @@ The next print is the dominant catalyst because it can confirm whether the raise
 ### Long-Term Ownership View (multi-year)
 The multi-year AI infrastructure thesis still looks intact because hyperscaler spending, inference demand, and ecosystem lock-in remain supportive. Long-term ownership depends less on one quarter and more on whether NVIDIA can sustain pricing power and platform breadth as customers optimize their capex.
 
+## Competitive / Peer Context
+
+- **Relevant peers/substitutes:** AMD and Broadcom matter because they offer alternative merchant accelerator paths, while hyperscaler custom ASIC efforts matter because they can cap NVIDIA's share of wallet even if AI spending stays strong.
+- **Where NVIDIA looks stronger:** CUDA and the surrounding software stack still support better monetization and switching costs than most merchant alternatives.
+- **Where peers create pressure:** Custom silicon and credible merchant alternatives can narrow pricing power at the largest cloud accounts and make today's margin assumptions harder to sustain indefinitely.
+- **Investment implication:** The bull case still leads, but peer pressure is why gross-margin guardrails and customer-concentration risk matter more than a pure demand-growth narrative.
+
 ## Verified Facts
 
 - NVIDIA reported FY2026 revenue of $215.9B in its latest annual disclosures. ([NVIDIA IR](https://investor.nvidia.com/))

--- a/.agents/skills/us-equity-daily-monitor/assets/memo-template.md
+++ b/.agents/skills/us-equity-daily-monitor/assets/memo-template.md
@@ -34,6 +34,17 @@
 ### Long-Term Ownership View (multi-year)
 {2-4 sentences. Structural drivers, competitive position, or capital structure. Keep this separate from the near-term signal.}
 
+## Competitive / Peer Context (optional)
+
+{Only include this section when the user wants a high-level / deep research / investment-view answer, asks for a thesis review, asks for sector-relative valuation context, or when peer/substitute dynamics materially shape the current signal. Otherwise omit it.}
+
+- **Relevant peers/substitutes:** {2-5 names}, because {why this comparison set actually matters. If direct peers are imperfect, say that briefly.}
+- **Where the target looks stronger:** {1-2 concise points on the thesis-relevant dimensions only.}
+- **Where peers create pressure:** {1-2 concise points on the main competitive or substitute risk.}
+- **Investment implication:** {How this peer read-through changes or calibrates the badge, thesis impact, or confidence.}
+
+> Keep this section short. Use a small table only when it clarifies more than bullets would.
+
 ## Verified Facts
 
 - {Reported figure with units} ([{Source name}]({URL}))
@@ -85,4 +96,6 @@
 - [ ] `What Would Change The View` contains explicit thresholds or concrete events.
 - [ ] I avoided generic `wait/hold/be careful/it depends` filler.
 - [ ] I kept any action rows secondary rather than as the headline answer.
+- [ ] If I included `Competitive / Peer Context`, it stayed concise, used real peers/substitutes, and only covered the thesis-relevant dimensions.
+- [ ] If I made current peer claims, I sourced them.
 - [ ] The compliance sentence appears once and stays concise.

--- a/.agents/skills/us-equity-daily-monitor/references/evidence.md
+++ b/.agents/skills/us-equity-daily-monitor/references/evidence.md
@@ -39,6 +39,7 @@ When you have multiple corroborating sources for one claim, chain them: `... ([R
 - Reported financials, guidance, capex/spend figures.
 - Margin trajectory, customer concentration, regulatory exposure.
 - Industry data points (hyperscaler capex, export-control rules, demand trends).
+- Current peer or competitor claims, sector-relative valuation comparisons, market-share shifts, substitute threats, or pricing moves.
 - Any numeric claim that is **not** derived in the **Derived Metrics** table.
 
 ## What does not need a chip
@@ -46,6 +47,15 @@ When you have multiple corroborating sources for one claim, chain them: `... ([R
 - Values inside the **Derived Metrics** table — the formula column is the citation.
 - The **Judgment** section — explicitly labelled inference.
 - Scenario price targets, provided the scenario row shows the math (e.g. forward EPS × multiple).
+
+## Peer-context discipline
+
+The optional `Competitive / Peer Context` section can stay compact without becoming loose.
+
+- If you say a peer is gaining share, cutting prices, guiding differently, or trading at a specific multiple, source that claim.
+- Do not use the target company's materials as the only support for claims about a competitor or substitute. Pair them with the competitor's own disclosures or independent reporting.
+- Structural comparisons such as "custom ASICs can cap share of wallet" can stay inference-driven, but label them as judgment rather than fact when the claim is not directly measured.
+- If the peer set is weak or the comparison is apples-to-oranges, say that explicitly instead of forcing a fake precision claim.
 
 ## URL hygiene
 

--- a/.agents/skills/us-equity-daily-monitor/references/sections.md
+++ b/.agents/skills/us-equity-daily-monitor/references/sections.md
@@ -7,12 +7,13 @@ The monitor is a single document with the sections below, in order. The structur
 | 1 | `## Decision Card` | Front-loads the badge plus the supporting signal fields. This is the headline judgment. |
 | 2 | `## Why Now` | Explains why the signal matters now, or why there is no material signal now. |
 | 3 | `## Dual-Horizon Framing` | Full monitors only. Separates near-term timing from long-term ownership. |
-| 4 | `## Verified Facts` | Full monitors only. Bullet list of sourced factual claims. |
-| 5 | `## Derived Metrics` | Full monitors only. Computed values with formulas and inputs. |
-| 6 | `## Scenarios` | Full monitors only. Bull/base/bear framing with explicit conditions. |
-| 7 | `## What Would Change The View` | The explicit thresholds or events that move the signal. |
-| 8 | `## Judgment` | Full monitors only. One short paragraph of labelled inference. |
-| 9 | `## Evidence Chips` | Concise monitors only. Short sourced fact list in place of the full evidence stack. |
+| 4 | `## Competitive / Peer Context` | Optional. Adds a concise comparison lens when peers or substitutes materially sharpen the thesis. |
+| 5 | `## Verified Facts` | Full monitors only. Bullet list of sourced factual claims. |
+| 6 | `## Derived Metrics` | Full monitors only. Computed values with formulas and inputs. |
+| 7 | `## Scenarios` | Full monitors only. Bull/base/bear framing with explicit conditions. |
+| 8 | `## What Would Change The View` | The explicit thresholds or events that move the signal. |
+| 9 | `## Judgment` | Full monitors only. One short paragraph of labelled inference. |
+| 10 | `## Evidence Chips` | Concise monitors only. Short sourced fact list in place of the full evidence stack. |
 
 ## Required Decision Card fields
 
@@ -53,6 +54,12 @@ Those action rows are secondary translations. They do not replace the monitor ba
 ### Near-Term Timing View (next 1-2 quarters)
 ### Long-Term Ownership View (multi-year)
 
+## Competitive / Peer Context      (optional)
+- **Relevant peers/substitutes:** ...
+- **Where the target looks stronger:** ...
+- **Where peers create pressure:** ...
+- **Investment implication:** ...
+
 ## Verified Facts                   (full monitor only)
 - ... ([Source name](URL))
 
@@ -75,10 +82,13 @@ Those action rows are secondary translations. They do not replace the monitor ba
 - ... ([Source name](URL))
 ```
 
+If the monitor is concise and peer context is actually needed, place `## Competitive / Peer Context` between `## Why Now` and `## What Would Change The View`.
+
 ## Header conventions
 
 - Use ATX headers (`#`, `##`, `###`).
 - Keep `Why Now`, `What Would Change The View`, and `Evidence Chips` as exact strings in concise monitors.
+- Keep `Competitive / Peer Context` as the exact string when that optional section is used.
 - Keep `Bull Case`, `Base Case`, and `Bear Case` as exact strings in full monitors.
 - Prefer short bold labels inside paragraphs over long prose preambles.
 
@@ -87,3 +97,4 @@ Those action rows are secondary translations. They do not replace the monitor ba
 - Full monitors should stay roughly one page. If the answer is drifting into a long essay, cut repetition before cutting the signal fields.
 - Concise monitors should still feel decision-useful. Short means compressed, not vague.
 - Bullets and tables beat generic paragraphs for evidence, scenarios, and thresholds.
+- `Competitive / Peer Context` should usually stay to four short bullets or a very small table. Omit it entirely when it does not change the judgment.

--- a/.agents/skills/us-equity-daily-monitor/references/special-cases.md
+++ b/.agents/skills/us-equity-daily-monitor/references/special-cases.md
@@ -45,6 +45,15 @@ Pro-forma history matters more than reported history. In the monitor:
 - The **Peer median** row should use the fundamental peers of the new standalone entity, not the parent's old peer set.
 - The **Bear Case** invalidation should include a TSA-renewal or dis-synergy-overrun condition where applicable.
 
+## Weak or imperfect peer sets
+
+Some names do not have a clean direct-comp set. Berkshire Hathaway is the obvious example, but the same problem shows up in exchanges, rating agencies, and dominant platforms.
+
+- Say directly that the peer set is imperfect when that is true.
+- Use the nearest decision-useful comparison set rather than pretending there is a perfect one: diversified insurers, asset managers, conglomerates, broad-market alternatives, or other substitutes that reflect how investors actually compare the name.
+- Keep the peer section shorter than usual. Focus on the one or two dimensions that matter most, such as underwriting quality, capital allocation, fee-like earnings quality, look-through valuation, or balance-sheet optionality.
+- If the substitutes are too heterogeneous to support a clean relative-valuation call, say so and lean back on company-specific thesis evidence.
+
 ## When in doubt
 
 If the name does not cleanly fit any of these buckets (e.g. a profitable mid-cap with a recent transformative acquisition, or a foreign issuer dual-listed in the U.S.), keep the default structure but add a one-bullet "structural caveat" inside the **Judgment** section explaining which standard assumption is broken. Do not silently bend the template — readers rely on the section contracts being stable.

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -1851,6 +1851,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
         let section = build_user_identities_section(&identities);
@@ -2185,6 +2187,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
 
@@ -2231,6 +2235,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
 
@@ -2286,6 +2292,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
 
@@ -2333,6 +2341,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
 
@@ -2475,6 +2485,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
 
@@ -2530,6 +2542,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
 
@@ -2589,6 +2603,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
 
@@ -2636,6 +2652,8 @@ mod tests {
             organization_id: None,
             organization_name: None,
             notion_database_id: None,
+            discord_guild_id: None,
+            slack_team_id: None,
             organization_members: vec![],
         };
 

--- a/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
@@ -142,7 +142,18 @@ const INVESTMENT_INTENT_KEYWORDS: &[&str] = &[
     "avoid for now",
 ];
 
-const INVESTMENT_RESEARCH_KEYWORDS: &[&str] = &["deep research"];
+const INVESTMENT_RESEARCH_KEYWORDS: &[&str] = &[
+    "deep research",
+    "investment analysis",
+    "high-level investment analysis",
+    "high level investment analysis",
+    "investment view",
+    "as an investment",
+    "thesis review",
+    "compare the thesis",
+    "should i care about this stock",
+    "overvalued relative to its sector",
+];
 const INVESTMENT_MONITOR_KEYWORDS: &[&str] = &[
     "material changed",
     "material change",
@@ -535,7 +546,8 @@ fn is_investment_request(raw: &str) -> bool {
 
     (has_instrument_context
         && (has_investment_intent || has_investment_research || has_monitor_intent))
-        || (has_probable_ticker && (has_investment_intent || has_monitor_intent))
+        || (has_probable_ticker
+            && (has_investment_intent || has_investment_research || has_monitor_intent))
         || has_synthetic_monitor_contract
 }
 
@@ -819,16 +831,30 @@ mod tests {
             "Give me deep research on NVDA and tell me whether now is a good time to buy."
         ));
         assert!(is_investment_request(
+            "Give me a high-level investment analysis of NVDA."
+        ));
+        assert!(is_investment_request(
             "Is NVDA a buy this week for a 3-month position?"
         ));
         assert!(is_investment_request(
             "Please analyze Tesla stock and tell me if it is worth buying now."
         ));
+        assert!(is_investment_request("Give me an investment view on AMD."));
+        assert!(is_investment_request("Compare the thesis for AMD."));
         assert!(!is_investment_request(
             "Please buy an NVDA GPU and compare keyboard options."
         ));
         assert!(!is_investment_request(
             "Analyze PR comments on our API design and summarize the tradeoffs."
+        ));
+        assert!(!is_investment_request(
+            "What was Apple's revenue last quarter?"
+        ));
+        assert!(!is_investment_request(
+            "Why did Microsoft stock move today?"
+        ));
+        assert!(!is_investment_request(
+            "Summarize the latest news about AMD."
         ));
         assert!(is_investment_request(
             "Assume company Z reported revenue slightly above expectations, but lowered next-quarter margin guidance because of temporary supply-chain costs. Demand commentary improved, but free cash flow remained negative. Write the investment monitor output."

--- a/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
@@ -540,14 +540,13 @@ fn is_investment_request(raw: &str) -> bool {
         .iter()
         .any(|keyword| normalized.contains(keyword));
     let has_probable_ticker = contains_probable_ticker(raw);
+    let has_supported_intent =
+        has_investment_intent || has_investment_research || has_monitor_intent;
     let has_explicit_monitor_contract = normalized.contains("investment monitor");
     let has_synthetic_monitor_contract =
         is_synthetic_investment_request(raw) && has_explicit_monitor_contract;
 
-    (has_instrument_context
-        && (has_investment_intent || has_investment_research || has_monitor_intent))
-        || (has_probable_ticker
-            && (has_investment_intent || has_investment_research || has_monitor_intent))
+    ((has_instrument_context || has_probable_ticker) && has_supported_intent)
         || has_synthetic_monitor_contract
 }
 

--- a/DoWhiz_service/skills/us-equity-daily-monitor/SKILL.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: us-equity-daily-monitor
-description: Produce a one-page U.S. equity signal monitor for a single stock or ETF. Front-load exactly one monitor badge (`Review Now`, `Watch Closely`, `No Material Change`, or `Insufficient Evidence`), explain why the signal matters now, what changed or did not change in the thesis, the main risk to the signal, and what would change the view next. Use whenever the user asks whether a stock is a buy or sell, wants a single-name investment memo, asks what changed since a prior note, wants an earnings setup, or says "should I act" about one ticker. Keep it as public-market analysis rather than personalized portfolio advice. Do not use for portfolio optimization, multi-asset allocation, crypto, FX, fixed-income, or macro strategy notes.
+description: Produce a one-page U.S. equity signal monitor for a single stock or ETF. Front-load exactly one monitor badge (`Review Now`, `Watch Closely`, `No Material Change`, or `Insufficient Evidence`), explain why the signal matters now, what changed or did not change in the thesis, the main risk to the signal, and what would change the view next. Use whenever the user asks whether a stock is a buy or sell, wants a single-name investment memo, asks for deep research or a high-level investment view on one company, wants a thesis review versus peers or sector expectations, asks what changed since a prior note, wants an earnings setup, or says "should I act" about one ticker. Keep it as public-market analysis rather than personalized portfolio advice. Do not use for portfolio optimization, multi-asset allocation, crypto, FX, fixed-income, or macro strategy notes.
 ---
 
 # U.S. Equity Daily Monitor
@@ -15,7 +15,8 @@ A structured framework for one-page single-name U.S. equity signal monitors. The
 4. **Tie uncertainty to a specific evidence gap.** Allowed: "Confidence is Medium because the margin guide still depends on an unproven product ramp." Not allowed: "Markets are uncertain, so be careful."
 5. **Keep the monitor badge primary.** If the current product contract also expects `New Money Action` or `Existing Holder Action`, include them as a secondary translation layer. Do not let those rows replace the badge or drift into personalized portfolio advice.
 6. **Quantify what would move the view.** Use explicit thresholds (`%`, `$`, `bps`, `x`, quarter counts) in the change-view section.
-7. **Keep compliance concise.** Use exactly one short sentence such as: `This is a public-market signal assessment, not personalized financial advice.`
+7. **Use peer context only when it sharpens the call.** A `2-5` name peer set is a lens for better judgment, not a mandatory sector report.
+8. **Keep compliance concise.** Use exactly one short sentence such as: `This is a public-market signal assessment, not personalized financial advice.`
 
 ## Badge rubric
 
@@ -47,11 +48,15 @@ Avoid leading with `Buy`, `Hold`, or `Sell` as the main answer unless the surrou
 2. **Determine the monitor type before writing.**
    - Use the **full monitor** when the user asks for deep research, a full memo, or a fresh single-name view.
    - Use the **concise monitor** when the user asks "what changed," "since your last note," or "only tell me if I should act."
-3. **Choose the badge first.** Decide whether the evidence supports `Review Now`, `Watch Closely`, `No Material Change`, or `Insufficient Evidence` before drafting prose.
-4. **Compute derived metrics deterministically** when the full monitor needs them. Use `scripts/compute_metrics.py` if the inputs match [references/data-adapters.md](references/data-adapters.md); otherwise compute directly from [references/formulas.md](references/formulas.md).
-5. **Draft from the template.** Copy [assets/memo-template.md](assets/memo-template.md) and fill every required field. Section structure is defined in [references/sections.md](references/sections.md).
-6. **Cite cleanly.** Every material fact ends in a source chip. Aim for at least three distinct sources in a full monitor and at least two in a concise monitor. Rules live in [references/evidence.md](references/evidence.md).
-7. **Name the main risk and what would change the view.** Caution is allowed only when the specific risk, threshold, or missing evidence is named.
+3. **Decide whether `Competitive / Peer Context` earns its keep.**
+   - Include it when the user asks for deep research, a high-level investment view, a thesis review, sector-relative valuation context, or when competitor/substitute dynamics materially shape the current signal.
+   - Usually skip it for narrow factual, latest-news, market-cap, CEO-comment, or single-event prompts unless the catalyst is directly peer-driven or clearly sector-wide.
+   - If the user already asked for a direct comparison (for example `NVDA vs AMD`), keep the named comparison primary and do not add extra peers unless they materially change the thesis.
+4. **Choose the badge first.** Decide whether the evidence supports `Review Now`, `Watch Closely`, `No Material Change`, or `Insufficient Evidence` before drafting prose.
+5. **Compute derived metrics deterministically** when the full monitor needs them. Use `scripts/compute_metrics.py` if the inputs match [references/data-adapters.md](references/data-adapters.md); otherwise compute directly from [references/formulas.md](references/formulas.md).
+6. **Draft from the template.** Copy [assets/memo-template.md](assets/memo-template.md) and fill every required field. Section structure is defined in [references/sections.md](references/sections.md).
+7. **Cite cleanly.** Every material fact ends in a source chip. Aim for at least three distinct sources in a full monitor and at least two in a concise monitor. Rules live in [references/evidence.md](references/evidence.md).
+8. **Name the main risk and what would change the view.** Caution is allowed only when the specific risk, threshold, or missing evidence is named.
 
 ## Output contract
 
@@ -85,6 +90,7 @@ Use this for deep-research or first-look requests. Include:
 - `Decision Card`
 - `Why Now`
 - `Dual-Horizon Framing`
+- `Competitive / Peer Context` (optional)
 - `Verified Facts`
 - `Derived Metrics`
 - `Scenarios`
@@ -97,10 +103,37 @@ Use this for delta checks and "should I act" requests. Include:
 
 - `Decision Card`
 - `Why Now`
+- `Competitive / Peer Context` (optional)
 - `What Would Change The View`
 - `Evidence Chips`
 
 In concise mode, shorten the artifact, not the analysis. The reader still needs a concrete badge, signal direction, thesis impact, main risk, and the missing or moving evidence.
+
+## Competitive / Peer Context
+
+Include this section only when it materially sharpens the investment judgment. It is optional, not default.
+
+When you include it:
+
+- Pick `2-5` relevant peers, substitutes, adjacent platforms, or structural threats.
+- Explain briefly why that peer set matters for this thesis. If the peer set is weak or imperfect, say so instead of forcing fake comparables.
+- Compare only the dimensions that actually matter to the call now: pricing power, margin durability, software moat, customer concentration, capital intensity, autonomy credibility, regulatory pressure, or sector-relative valuation.
+- Keep the section concise. Usually four short bullets are enough:
+  - `Relevant peers/substitutes`
+  - `Where the target looks stronger`
+  - `Where peers create pressure`
+  - `Investment implication`
+- If a table is clearer, keep it small and thesis-relevant rather than exhaustive.
+- Current or factual peer claims must be sourced. Do not rely only on the target company's materials to make claims about competitors.
+- Do not invent peer sets, market-share numbers, or current metrics when the comparison is fuzzy.
+- Do not let this become a full sector report unless the user explicitly asks for one.
+
+Illustrative peer-selection patterns:
+
+- `NVDA`: AMD, Broadcom, hyperscaler custom ASIC efforts, cloud providers' internal silicon programs.
+- `TSLA`: BYD, legacy OEM EV programs, and autonomy competitors when autonomy is part of the thesis.
+- `AAPL`: Samsung, Google, Microsoft, or Meta when ecosystem durability, services, AI platform risk, or regulation is the relevant lens.
+- `SHOP`: Amazon, Adobe Commerce, BigCommerce, Wix/Squarespace, or merchant-stack/payment substitutes when platform economics are the question.
 
 ## Anti-waffle rules
 
@@ -110,6 +143,7 @@ In concise mode, shorten the artifact, not the analysis. The reader still needs 
 - Do not hide behind valuation language unless you explain which expectation is already priced in and why that limits the signal.
 - Do not give portfolio sizing, tax, cost-basis, or risk-tolerance advice.
 - Do not turn the answer into a disclaimer block.
+- Do not write empty competition filler such as "faces competition from many players" without naming the specific pressure and why it matters now.
 
 ## Compact examples
 
@@ -174,6 +208,7 @@ Before finalizing, check this in one pass while you draft:
 - Did I state what would change the view?
 - Did I avoid generic `wait/hold` language?
 - Did I avoid personalized buy/sell instructions?
+- If I used `Competitive / Peer Context`, did it stay concise, use real peers/substitutes, and change the judgment rather than pad the answer?
 
 ## What this framework rejects
 
@@ -182,6 +217,7 @@ Before finalizing, check this in one pass while you draft:
 - Uncertainty language that is not attached to a concrete missing fact, threshold, or catalyst.
 - Big disclaimer blocks or repeated "not financial advice" language.
 - Unsupported "monitor closely" prose that never names the variable being monitored.
+- Peer sections that read like a generic industry roundup rather than a thesis-calibration tool.
 
 ## Special cases
 

--- a/DoWhiz_service/skills/us-equity-daily-monitor/assets/example-memo-nvda.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/assets/example-memo-nvda.md
@@ -39,6 +39,13 @@ The next print is the dominant catalyst because it can confirm whether the raise
 ### Long-Term Ownership View (multi-year)
 The multi-year AI infrastructure thesis still looks intact because hyperscaler spending, inference demand, and ecosystem lock-in remain supportive. Long-term ownership depends less on one quarter and more on whether NVIDIA can sustain pricing power and platform breadth as customers optimize their capex.
 
+## Competitive / Peer Context
+
+- **Relevant peers/substitutes:** AMD and Broadcom matter because they offer alternative merchant accelerator paths, while hyperscaler custom ASIC efforts matter because they can cap NVIDIA's share of wallet even if AI spending stays strong.
+- **Where NVIDIA looks stronger:** CUDA and the surrounding software stack still support better monetization and switching costs than most merchant alternatives.
+- **Where peers create pressure:** Custom silicon and credible merchant alternatives can narrow pricing power at the largest cloud accounts and make today's margin assumptions harder to sustain indefinitely.
+- **Investment implication:** The bull case still leads, but peer pressure is why gross-margin guardrails and customer-concentration risk matter more than a pure demand-growth narrative.
+
 ## Verified Facts
 
 - NVIDIA reported FY2026 revenue of $215.9B in its latest annual disclosures. ([NVIDIA IR](https://investor.nvidia.com/))

--- a/DoWhiz_service/skills/us-equity-daily-monitor/assets/memo-template.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/assets/memo-template.md
@@ -34,6 +34,17 @@
 ### Long-Term Ownership View (multi-year)
 {2-4 sentences. Structural drivers, competitive position, or capital structure. Keep this separate from the near-term signal.}
 
+## Competitive / Peer Context (optional)
+
+{Only include this section when the user wants a high-level / deep research / investment-view answer, asks for a thesis review, asks for sector-relative valuation context, or when peer/substitute dynamics materially shape the current signal. Otherwise omit it.}
+
+- **Relevant peers/substitutes:** {2-5 names}, because {why this comparison set actually matters. If direct peers are imperfect, say that briefly.}
+- **Where the target looks stronger:** {1-2 concise points on the thesis-relevant dimensions only.}
+- **Where peers create pressure:** {1-2 concise points on the main competitive or substitute risk.}
+- **Investment implication:** {How this peer read-through changes or calibrates the badge, thesis impact, or confidence.}
+
+> Keep this section short. Use a small table only when it clarifies more than bullets would.
+
 ## Verified Facts
 
 - {Reported figure with units} ([{Source name}]({URL}))
@@ -85,4 +96,6 @@
 - [ ] `What Would Change The View` contains explicit thresholds or concrete events.
 - [ ] I avoided generic `wait/hold/be careful/it depends` filler.
 - [ ] I kept any action rows secondary rather than as the headline answer.
+- [ ] If I included `Competitive / Peer Context`, it stayed concise, used real peers/substitutes, and only covered the thesis-relevant dimensions.
+- [ ] If I made current peer claims, I sourced them.
 - [ ] The compliance sentence appears once and stays concise.

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/evals.json
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/evals.json
@@ -38,6 +38,7 @@
       "require_change_view": true,
       "min_clickable_links": 2,
       "require_compliance_sentence": true,
+      "expect_peer_context": false,
       "must_contain_any": [
         "does not yet prove a durable thesis change",
         "no verified guidance revision"
@@ -60,6 +61,7 @@
       "require_change_view": true,
       "min_clickable_links": 2,
       "require_compliance_sentence": true,
+      "expect_peer_context": false,
       "must_contain_any": [
         "no new filing, guidance reset, or disclosed demand break",
         "specific `No Material Change` call"
@@ -106,6 +108,7 @@
       "require_change_view": true,
       "min_clickable_links": 2,
       "require_compliance_sentence": true,
+      "expect_peer_context": false,
       "must_contain_any": [
         "no verified issuer disclosure",
         "missing evidence is the issue"
@@ -142,6 +145,156 @@
       "artifact_file": "fixtures/polished_waffle_rejected.html",
       "contract": "short",
       "expected_failure": true
+    },
+    {
+      "id": 8,
+      "name": "high-level-nvda-peer-context",
+      "kind": "fixture",
+      "artifact_file": "fixtures/high_level_nvda_peer_context.html",
+      "contract": "full",
+      "expected_status": "Review Now",
+      "expected_signal_direction": "Positive",
+      "expected_thesis_impact": "Positive",
+      "expected_signal_quality": "Strong",
+      "expected_urgency": "High",
+      "expected_confidence": "Medium",
+      "require_why_now": true,
+      "require_main_risk": true,
+      "require_change_view": true,
+      "require_citations": true,
+      "min_clickable_links": 3,
+      "require_scan_first": true,
+      "require_compliance_sentence": true,
+      "expect_peer_context": true,
+      "peer_section_must_contain_all": [
+        "relevant peers/substitutes",
+        "where the target looks stronger",
+        "where peers create pressure",
+        "investment implication",
+        "amd"
+      ],
+      "peer_section_must_contain_any": [
+        "broadcom",
+        "custom asic",
+        "hyperscaler"
+      ],
+      "peer_section_max_words": 120
+    },
+    {
+      "id": 9,
+      "name": "weak-peer-set-brkb-stays-honest",
+      "kind": "fixture",
+      "artifact_file": "fixtures/weak_peer_set_brkb.html",
+      "contract": "full",
+      "expected_status": "No Material Change",
+      "expected_signal_direction": "Neutral",
+      "expected_thesis_impact": "Neutral",
+      "expected_signal_quality": "Mixed",
+      "expected_urgency": "Low",
+      "expected_confidence": "Medium",
+      "require_why_now": true,
+      "require_main_risk": true,
+      "require_change_view": true,
+      "require_citations": true,
+      "min_clickable_links": 3,
+      "require_scan_first": true,
+      "require_compliance_sentence": true,
+      "expect_peer_context": true,
+      "peer_section_must_contain_any": [
+        "peer set is imperfect",
+        "direct peers are imperfect",
+        "diversified insurers",
+        "asset managers",
+        "broad-market alternative"
+      ],
+      "peer_section_max_words": 120
+    },
+    {
+      "id": 10,
+      "name": "tesla-peer-context-stays-specific",
+      "kind": "fixture",
+      "artifact_file": "fixtures/tesla_peer_context.html",
+      "contract": "full",
+      "expected_status": "Watch Closely",
+      "expected_signal_direction": "Neutral",
+      "expected_thesis_impact": "Neutral",
+      "expected_signal_quality": "Mixed",
+      "expected_urgency": "High",
+      "expected_confidence": "Medium",
+      "require_why_now": true,
+      "require_main_risk": true,
+      "require_change_view": true,
+      "require_citations": true,
+      "min_clickable_links": 3,
+      "require_scan_first": true,
+      "require_compliance_sentence": true,
+      "expect_peer_context": true,
+      "peer_section_must_contain_any": [
+        "byd",
+        "legacy oem",
+        "autonomy"
+      ],
+      "peer_section_max_words": 120
+    },
+    {
+      "id": 11,
+      "name": "shopify-peer-context-stays-platform-specific",
+      "kind": "fixture",
+      "artifact_file": "fixtures/shopify_peer_context.html",
+      "contract": "full",
+      "expected_status": "Watch Closely",
+      "expected_signal_direction": "Positive",
+      "expected_thesis_impact": "Positive",
+      "expected_signal_quality": "Mixed",
+      "expected_urgency": "Medium",
+      "expected_confidence": "Medium",
+      "require_why_now": true,
+      "require_main_risk": true,
+      "require_change_view": true,
+      "require_citations": true,
+      "min_clickable_links": 3,
+      "require_scan_first": true,
+      "require_compliance_sentence": true,
+      "expect_peer_context": true,
+      "peer_section_must_contain_any": [
+        "amazon",
+        "adobe commerce",
+        "bigcommerce",
+        "wix",
+        "squarespace"
+      ],
+      "peer_section_max_words": 120
+    },
+    {
+      "id": 12,
+      "name": "nvda-amd-direct-compare-stays-focused",
+      "kind": "fixture",
+      "artifact_file": "fixtures/nvda_amd_direct_compare.html",
+      "contract": "full",
+      "expected_status": "Watch Closely",
+      "expected_signal_direction": "Neutral",
+      "expected_thesis_impact": "Neutral",
+      "expected_signal_quality": "Strong",
+      "expected_urgency": "Medium",
+      "expected_confidence": "Medium",
+      "require_why_now": true,
+      "require_main_risk": true,
+      "require_change_view": true,
+      "require_citations": true,
+      "min_clickable_links": 3,
+      "require_scan_first": true,
+      "require_compliance_sentence": true,
+      "expect_peer_context": true,
+      "peer_section_must_contain_all": [
+        "amd",
+        "extra peers are not needed"
+      ],
+      "peer_section_must_not_contain_any": [
+        "broadcom",
+        "custom asic",
+        "hyperscaler"
+      ],
+      "peer_section_max_words": 120
     }
   ]
 }

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/high_level_nvda_peer_context.html
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/high_level_nvda_peer_context.html
@@ -1,0 +1,88 @@
+<section>
+  <p><strong>As of:</strong> 2026-05-01 · <strong>Price:</strong> $202.06</p>
+  <p><strong>Investor question:</strong> Give me a high-level investment analysis of NVDA.</p>
+</section>
+
+<section>
+  <h2>Decision Card</h2>
+  <table>
+    <tr><th>Field</th><th>Value</th></tr>
+    <tr><td>Monitor Status</td><td>Review Now</td></tr>
+    <tr><td>Signal Direction</td><td>Positive</td></tr>
+    <tr><td>Thesis Impact</td><td>Positive</td></tr>
+    <tr><td>Signal Quality</td><td>Strong</td></tr>
+    <tr><td>Urgency</td><td>High</td></tr>
+    <tr><td>Confidence</td><td>Medium</td></tr>
+    <tr><td>New Money Action</td><td>Starter Only</td></tr>
+    <tr><td>Existing Holder Action</td><td>Hold/Do not add</td></tr>
+  </table>
+  <p><strong>One-line rationale:</strong> The demand backdrop is still strong enough to justify a fresh underwriting pass, but the right call depends on how durable NVIDIA's edge looks relative to real substitutes, not on a single-company story alone.</p>
+  <p><strong>Main Risk To The Signal:</strong> Valuation and customer concentration can compress upside quickly if peer or in-house alternatives narrow NVIDIA's pricing power faster than expected.</p>
+  <p><strong>Not Personalized Advice:</strong> This is a public-market signal assessment, not personalized financial advice.</p>
+</section>
+
+<section>
+  <h2>Why Now</h2>
+  <p>NVIDIA still sits at the center of AI infrastructure spending, so a high-level investment view has to decide whether the current operating strength is durable enough to justify the expectations already embedded in the stock. This remains a `Review Now` setup because the next leg of the thesis depends on whether revenue scale, margins, and platform control can outrun rising substitute pressure.</p>
+</section>
+
+<section>
+  <h2>Dual-Horizon Framing</h2>
+  <h3>Near-Term Timing View</h3>
+  <p>The next one to two quarters matter because hyperscaler demand and gross-margin durability are the cleanest tests of whether the current run-rate is still moving higher rather than merely meeting a crowded narrative.</p>
+  <h3>Long-Term Ownership View</h3>
+  <p>The long-run question is less "is AI demand real?" and more whether NVIDIA can keep software and ecosystem advantages large enough to defend share of wallet as large customers build more alternatives.</p>
+</section>
+
+<section>
+  <h2>Competitive / Peer Context</h2>
+  <ul>
+    <li><strong>Relevant peers/substitutes:</strong> AMD, Broadcom, and hyperscaler custom ASIC efforts matter because they are the main alternative ways to satisfy accelerator demand.</li>
+    <li><strong>Where the target looks stronger:</strong> CUDA, tooling depth, and today's margin profile still make NVIDIA the cleanest full-stack option.</li>
+    <li><strong>Where peers create pressure:</strong> Merchant alternatives and custom silicon can cap pricing power at the biggest cloud accounts even if AI spending stays strong.</li>
+    <li><strong>Investment implication:</strong> The thesis stays positive, but peer pressure is why margin durability and customer concentration matter as much as raw demand growth.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Verified Facts</h2>
+  <ul>
+    <li>NVIDIA reported FY2026 revenue of $215.9B in its latest annual disclosures. <a href="https://investor.nvidia.com/">NVIDIA IR</a></li>
+    <li>The most recent earnings release showed Q4 FY2026 revenue of $68.1B and GAAP diluted EPS of $1.76. <a href="https://www.sec.gov/">SEC EDGAR</a></li>
+    <li>Independent reporting continued to frame hyperscaler AI spending and custom silicon efforts as the key competitive backdrop into 2026. <a href="https://www.reuters.com/technology/">Reuters</a></li>
+  </ul>
+</section>
+
+<section>
+  <h2>Derived Metrics</h2>
+  <table>
+    <tr><th>Metric</th><th>Value</th><th>Formula / Inputs</th></tr>
+    <tr><td>P/E (TTM)</td><td>41.2x</td><td>$202.06 / TTM diluted EPS $4.90</td></tr>
+    <tr><td>Revenue YoY (Q4)</td><td>21.0%</td><td>$68.1B / $56.3B - 1</td></tr>
+    <tr><td>Gross-margin guardrail</td><td>74%</td><td>Current signal strengthens if GAAP gross margin holds above 74%</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Scenarios</h2>
+  <h3>Bull Case</h3>
+  <p>Revenue rises above $70B and gross margin stays above 74%, proving that substitute pressure is not yet eroding economics.</p>
+  <h3>Base Case</h3>
+  <p>Demand stays strong, but margins settle in the low-to-mid 70s as customers diversify some spend.</p>
+  <h3>Bear Case</h3>
+  <p>Large accounts shift more workloads to custom silicon or alternatives, and gross margin slips below 71%.</p>
+</section>
+
+<section>
+  <h2>What Would Change The View</h2>
+  <ul>
+    <li><strong>Upgrade / Review Now:</strong> Revenue above $70B with gross margin above 74%, or a guide lift that raises the annual run-rate by more than 5%.</li>
+    <li><strong>Downgrade / De-risk:</strong> Gross margin falls below 71% or management flags a customer-mix shift that pressures pricing by more than 150 bps.</li>
+    <li><strong>Invalidation:</strong> A customer capex reset or substitute ramp threatens more than 10% of expected accelerator revenue.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Judgment</h2>
+  <p><em>Inference, Medium confidence.</em> NVIDIA still deserves a positive `Review Now` framing, but the peer lens is what keeps the thesis honest: the upside case depends on defending software and margin advantages, not just riding AI demand in the abstract.</p>
+</section>

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/nvda_amd_direct_compare.html
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/nvda_amd_direct_compare.html
@@ -1,0 +1,88 @@
+<section>
+  <p><strong>As of:</strong> 2026-05-01 · <strong>Price:</strong> NVDA $202.06 · AMD $171.40</p>
+  <p><strong>Investor question:</strong> Compare NVDA and AMD.</p>
+</section>
+
+<section>
+  <h2>Decision Card</h2>
+  <table>
+    <tr><th>Field</th><th>Value</th></tr>
+    <tr><td>Monitor Status</td><td>Watch Closely</td></tr>
+    <tr><td>Signal Direction</td><td>Neutral</td></tr>
+    <tr><td>Thesis Impact</td><td>Neutral</td></tr>
+    <tr><td>Signal Quality</td><td>Strong</td></tr>
+    <tr><td>Urgency</td><td>Medium</td></tr>
+    <tr><td>Confidence</td><td>Medium</td></tr>
+    <tr><td>New Money Action</td><td>Wait</td></tr>
+    <tr><td>Existing Holder Action</td><td>Hold/Do not add</td></tr>
+  </table>
+  <p><strong>One-line rationale:</strong> This is a real comparison question, not a market roundup: NVIDIA still has the stronger full-stack position, but AMD remains the most relevant relative-value and catch-up check on whether that gap can narrow.</p>
+  <p><strong>Main Risk To The Signal:</strong> A direct compare can hide the fact that valuation, ecosystem maturity, and execution risk are different, so the risk is forcing a false one-number winner when the gap depends on time horizon and workload mix.</p>
+  <p><strong>Not Personalized Advice:</strong> This is a public-market signal assessment, not personalized financial advice.</p>
+</section>
+
+<section>
+  <h2>Why Now</h2>
+  <p>The point of this prompt is to compare the two names directly, so the signal depends on whether NVIDIA's software and platform lead is still large enough to justify its premium versus AMD's catch-up path. That makes this `Watch Closely`: the comparison is decision-useful, but the market already knows both sides of the high-level story.</p>
+</section>
+
+<section>
+  <h2>Dual-Horizon Framing</h2>
+  <h3>Near-Term Timing View</h3>
+  <p>Near-term differentiation still comes down to who proves demand conversion, margin durability, and customer deployment momentum more clearly over the next one to two quarters.</p>
+  <h3>Long-Term Ownership View</h3>
+  <p>Long-run separation depends on whether AMD can narrow the ecosystem and deployment gap enough to weaken NVIDIA's premium economics.</p>
+</section>
+
+<section>
+  <h2>Competitive / Peer Context</h2>
+  <ul>
+    <li><strong>Relevant peers/substitutes:</strong> AMD is the primary comparison, and extra peers are not needed for this question.</li>
+    <li><strong>Where the target looks stronger:</strong> NVIDIA still leads on ecosystem depth, deployment breadth, and monetization today.</li>
+    <li><strong>Where peers create pressure:</strong> AMD is the clearest relative challenger on performance-per-dollar and any narrowing of the software gap matters directly.</li>
+    <li><strong>Investment implication:</strong> Keep the comparison focused on NVDA versus AMD rather than padding it with third-party names that do not improve the call.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Verified Facts</h2>
+  <ul>
+    <li>NVIDIA's investor materials continue to emphasize data-center scale, software, and platform breadth. <a href="https://investor.nvidia.com/">NVIDIA IR</a></li>
+    <li>AMD's investor materials continue to emphasize accelerator roadmap progress and data-center share gains. <a href="https://ir.amd.com/">AMD IR</a></li>
+    <li>Independent coverage continues to frame AMD as the most direct merchant-silicon comparison to NVIDIA in AI infrastructure. <a href="https://www.reuters.com/technology/">Reuters</a></li>
+  </ul>
+</section>
+
+<section>
+  <h2>Derived Metrics</h2>
+  <table>
+    <tr><th>Metric</th><th>Value</th><th>Formula / Inputs</th></tr>
+    <tr><td>Relative premium</td><td>Meaningful</td><td>NVIDIA trades at a premium because current revenue scale and software moat are stronger</td></tr>
+    <tr><td>Execution gap</td><td>Open but narrowing</td><td>AMD must convert roadmap progress into real deployment and margin proof</td></tr>
+    <tr><td>Comparison horizon</td><td>Multi-quarter</td><td>The gap matters more over several quarters than over one headline print</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Scenarios</h2>
+  <h3>Bull Case</h3>
+  <p>NVIDIA keeps proving premium economics while AMD's catch-up remains incremental rather than disruptive.</p>
+  <h3>Base Case</h3>
+  <p>NVIDIA remains ahead, but AMD narrows enough of the gap to keep valuation pressure alive.</p>
+  <h3>Bear Case</h3>
+  <p>AMD closes the deployment and margin gap faster than expected, compressing NVIDIA's premium.</p>
+</section>
+
+<section>
+  <h2>What Would Change The View</h2>
+  <ul>
+    <li><strong>Upgrade / Review Now:</strong> NVIDIA extends the gap with another clear revenue and margin beat while AMD fails to convert roadmap claims into material deployment evidence.</li>
+    <li><strong>Downgrade / De-risk:</strong> AMD proves stronger share gains or pricing leverage while NVIDIA's margin premium compresses by more than 200 bps.</li>
+    <li><strong>Invalidation:</strong> The market stops treating AMD as a credible narrowing force or, conversely, stops treating NVIDIA's ecosystem advantage as durable.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Judgment</h2>
+  <p><em>Inference, Medium confidence.</em> The direct compare should stay direct. NVIDIA still looks stronger today, but AMD is the right pressure test, and adding extra peers would add noise rather than insight.</p>
+</section>

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/shopify_peer_context.html
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/shopify_peer_context.html
@@ -1,0 +1,88 @@
+<section>
+  <p><strong>As of:</strong> 2026-05-01 · <strong>Price:</strong> $84.15</p>
+  <p><strong>Investor question:</strong> Analyze Shopify as an investment.</p>
+</section>
+
+<section>
+  <h2>Decision Card</h2>
+  <table>
+    <tr><th>Field</th><th>Value</th></tr>
+    <tr><td>Monitor Status</td><td>Watch Closely</td></tr>
+    <tr><td>Signal Direction</td><td>Positive</td></tr>
+    <tr><td>Thesis Impact</td><td>Positive</td></tr>
+    <tr><td>Signal Quality</td><td>Mixed</td></tr>
+    <tr><td>Urgency</td><td>Medium</td></tr>
+    <tr><td>Confidence</td><td>Medium</td></tr>
+    <tr><td>New Money Action</td><td>Starter Only</td></tr>
+    <tr><td>Existing Holder Action</td><td>Hold/Do not add</td></tr>
+  </table>
+  <p><strong>One-line rationale:</strong> Shopify still has a credible merchant-platform thesis, but the investment call depends on whether it can keep monetizing merchant growth without drifting into lower-quality GMV or expensive ecosystem sprawl.</p>
+  <p><strong>Main Risk To The Signal:</strong> Merchant growth can look healthy while take-rate or margin quality disappoints if the platform has to work harder against larger commerce or merchant-stack substitutes.</p>
+  <p><strong>Not Personalized Advice:</strong> This is a public-market signal assessment, not personalized financial advice.</p>
+</section>
+
+<section>
+  <h2>Why Now</h2>
+  <p>The important question is not whether e-commerce still exists, but whether Shopify can keep deepening wallet share across payments, software, and merchant tools without sacrificing profitability or platform focus. That keeps the stock in `Watch Closely`: the thesis is constructive, but platform competition still matters enough to cap confidence.</p>
+</section>
+
+<section>
+  <h2>Dual-Horizon Framing</h2>
+  <h3>Near-Term Timing View</h3>
+  <p>Near-term setup depends on merchant additions, attach rates, and whether operating leverage continues even as the platform invests in more merchant services.</p>
+  <h3>Long-Term Ownership View</h3>
+  <p>The long-run case is about Shopify becoming the default independent commerce stack, not just a website builder, which means ecosystem depth and payment monetization matter more than pure storefront count.</p>
+</section>
+
+<section>
+  <h2>Competitive / Peer Context</h2>
+  <ul>
+    <li><strong>Relevant peers/substitutes:</strong> Amazon matters as the default external marketplace, Adobe Commerce and BigCommerce matter in merchant-stack selection, and Wix or Squarespace matter at the lighter-weight storefront edge.</li>
+    <li><strong>Where the target looks stronger:</strong> Shopify still has a cleaner ecosystem and merchant operating system story than most smaller storefront or commerce-suite peers.</li>
+    <li><strong>Where peers create pressure:</strong> Amazon can still absorb merchant demand directly, while Adobe Commerce, BigCommerce, Wix, and Squarespace create alternative paths for merchants with different complexity and cost needs.</li>
+    <li><strong>Investment implication:</strong> The thesis stays positive, but peer context is why GMV quality, take-rate durability, and margin structure matter more than headline merchant count alone.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Verified Facts</h2>
+  <ul>
+    <li>Shopify's investor materials continue to frame merchant solutions, payments attachment, and operating leverage as the key value drivers. <a href="https://investors.shopify.com/">Shopify IR</a></li>
+    <li>The company's SEC filings remain the primary source for revenue mix, margin, and risk disclosures. <a href="https://www.sec.gov/">SEC EDGAR</a></li>
+    <li>Independent coverage continues to compare Shopify against marketplace and merchant-stack alternatives rather than against consumer e-commerce demand alone. <a href="https://www.reuters.com/technology/">Reuters</a></li>
+  </ul>
+</section>
+
+<section>
+  <h2>Derived Metrics</h2>
+  <table>
+    <tr><th>Metric</th><th>Value</th><th>Formula / Inputs</th></tr>
+    <tr><td>Merchant-solutions mix</td><td>High and rising</td><td>Signal improves if payments and merchant-services growth expands faster than subscription drag</td></tr>
+    <tr><td>Operating-leverage watchline</td><td>Positive</td><td>Current thesis holds if revenue growth continues to outpace opex growth</td></tr>
+    <tr><td>GMV quality check</td><td>Critical</td><td>Platform growth matters more if attach-rate and monetization quality hold alongside GMV growth</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Scenarios</h2>
+  <h3>Bull Case</h3>
+  <p>Merchant growth, payments attachment, and operating leverage all hold together, proving the platform is deepening rather than merely adding low-quality volume.</p>
+  <h3>Base Case</h3>
+  <p>Merchant growth continues, but margin and take-rate progress stay mixed because platform competition remains real.</p>
+  <h3>Bear Case</h3>
+  <p>Shopify keeps growing merchants, but monetization quality and operating leverage soften as substitutes win at the edges.</p>
+</section>
+
+<section>
+  <h2>What Would Change The View</h2>
+  <ul>
+    <li><strong>Upgrade / Review Now:</strong> Merchant-solutions revenue growth beats expectations by at least 5% and operating margin expands by more than 200 bps.</li>
+    <li><strong>Downgrade / De-risk:</strong> GMV grows but attach rate slips by more than 100 bps or operating margin falls by more than 150 bps.</li>
+    <li><strong>Invalidation:</strong> Two quarters of sub-10% merchant-solutions growth or a persistent take-rate reset breaks the operating-system thesis.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Judgment</h2>
+  <p><em>Inference, Medium confidence.</em> Shopify still deserves a constructive read, but the peer lens keeps the thesis objective: the value is in platform economics and ecosystem depth, not in generic e-commerce volume.</p>
+</section>

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/tesla_peer_context.html
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/tesla_peer_context.html
@@ -1,0 +1,88 @@
+<section>
+  <p><strong>As of:</strong> 2026-05-01 · <strong>Price:</strong> $182.30</p>
+  <p><strong>Investor question:</strong> Do a deep research style analysis of Tesla stock.</p>
+</section>
+
+<section>
+  <h2>Decision Card</h2>
+  <table>
+    <tr><th>Field</th><th>Value</th></tr>
+    <tr><td>Monitor Status</td><td>Watch Closely</td></tr>
+    <tr><td>Signal Direction</td><td>Neutral</td></tr>
+    <tr><td>Thesis Impact</td><td>Neutral</td></tr>
+    <tr><td>Signal Quality</td><td>Mixed</td></tr>
+    <tr><td>Urgency</td><td>High</td></tr>
+    <tr><td>Confidence</td><td>Medium</td></tr>
+    <tr><td>New Money Action</td><td>Wait</td></tr>
+    <tr><td>Existing Holder Action</td><td>Hold/Do not add</td></tr>
+  </table>
+  <p><strong>One-line rationale:</strong> Tesla still has real strategic options, but EV pricing pressure and autonomy execution are doing enough damage to margin visibility that the stock needs closer underwriting rather than a generic growth-company pass.</p>
+  <p><strong>Main Risk To The Signal:</strong> Margin compression can persist longer than the market expects if volume growth depends on repeated price cuts before autonomy or energy profits become large enough to offset them.</p>
+  <p><strong>Not Personalized Advice:</strong> This is a public-market signal assessment, not personalized financial advice.</p>
+</section>
+
+<section>
+  <h2>Why Now</h2>
+  <p>The key question is no longer only whether Tesla can grow deliveries, but whether it can defend economics while it waits for autonomy and energy to matter more. That keeps the name in `Watch Closely`: the thesis is still alive, but peer-driven pricing and execution risk are central right now.</p>
+</section>
+
+<section>
+  <h2>Dual-Horizon Framing</h2>
+  <h3>Near-Term Timing View</h3>
+  <p>The next few quarters matter because vehicle-margin trajectory and China pricing are still the cleanest tests of whether volume growth is being bought at too high a cost.</p>
+  <h3>Long-Term Ownership View</h3>
+  <p>The multi-year case still depends on whether software, autonomy, and energy become material enough to make Tesla look less like a price-taking automaker and more like a platform company.</p>
+</section>
+
+<section>
+  <h2>Competitive / Peer Context</h2>
+  <ul>
+    <li><strong>Relevant peers/substitutes:</strong> BYD matters on global EV price pressure, legacy OEM programs matter on volume competition, and autonomy competitors matter because software upside is still part of the bull case.</li>
+    <li><strong>Where the target looks stronger:</strong> Tesla still has stronger vertical integration and a more credible software optionality story than most legacy OEMs.</li>
+    <li><strong>Where peers create pressure:</strong> BYD and other EV rivals can force more pricing pressure, and autonomy credibility stays capped until Tesla proves a commercial step-change.</li>
+    <li><strong>Investment implication:</strong> Peer pressure keeps the stock in `Watch Closely` because growth alone is not enough if pricing and autonomy execution do not translate into durable margins.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Verified Facts</h2>
+  <ul>
+    <li>Tesla's latest shareholder materials still frame vehicle margins, autonomy progress, and energy growth as the main investor variables. <a href="https://ir.tesla.com/">Tesla IR</a></li>
+    <li>The company's SEC filings remain the primary source for reported revenue, margins, and risk-factor language. <a href="https://www.sec.gov/">SEC EDGAR</a></li>
+    <li>Independent coverage continues to treat EV pricing and Chinese competition as the main near-term pressure points. <a href="https://www.reuters.com/business/autos-transportation/">Reuters</a></li>
+  </ul>
+</section>
+
+<section>
+  <h2>Derived Metrics</h2>
+  <table>
+    <tr><th>Metric</th><th>Value</th><th>Formula / Inputs</th></tr>
+    <tr><td>Automotive gross-margin watchline</td><td>15%</td><td>Current signal improves if automotive gross margin ex-credits holds above 15%</td></tr>
+    <tr><td>Delivery-growth hurdle</td><td>20%</td><td>Volume growth needs to outpace price-cut pressure to strengthen the thesis</td></tr>
+    <tr><td>Energy contribution</td><td>Rising but not thesis-carrying</td><td>Energy must become large enough to offset auto-margin compression before it changes the core view</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Scenarios</h2>
+  <h3>Bull Case</h3>
+  <p>Vehicle margins stabilize while autonomy or energy contribution becomes material enough to improve the earnings mix.</p>
+  <h3>Base Case</h3>
+  <p>Deliveries grow, but peer-driven pricing pressure keeps the margin story mixed.</p>
+  <h3>Bear Case</h3>
+  <p>Pricing pressure deepens, autonomy remains unproven, and the market pays less for long-duration optionality.</p>
+</section>
+
+<section>
+  <h2>What Would Change The View</h2>
+  <ul>
+    <li><strong>Upgrade / Review Now:</strong> Automotive gross margin ex-credits climbs above 15% while energy and software contribution materially lifts earnings quality.</li>
+    <li><strong>Downgrade / De-risk:</strong> Price cuts drive another 200 bps or more of margin erosion, or management pushes out a key autonomy milestone again.</li>
+    <li><strong>Invalidation:</strong> Tesla loses the ability to argue that software or energy can offset a structurally lower-margin EV business.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Judgment</h2>
+  <p><em>Inference, Medium confidence.</em> Tesla still warrants a real monitor, but the competitive lens is the whole point: EV pricing, BYD pressure, and autonomy credibility are what stop this from being a clean positive signal today.</p>
+</section>

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/weak_peer_set_brkb.html
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/fixtures/weak_peer_set_brkb.html
@@ -1,0 +1,88 @@
+<section>
+  <p><strong>As of:</strong> 2026-05-01 · <strong>Price:</strong> $521.40</p>
+  <p><strong>Investor question:</strong> Analyze BRK.B as an investment.</p>
+</section>
+
+<section>
+  <h2>Decision Card</h2>
+  <table>
+    <tr><th>Field</th><th>Value</th></tr>
+    <tr><td>Monitor Status</td><td>No Material Change</td></tr>
+    <tr><td>Signal Direction</td><td>Neutral</td></tr>
+    <tr><td>Thesis Impact</td><td>Neutral</td></tr>
+    <tr><td>Signal Quality</td><td>Mixed</td></tr>
+    <tr><td>Urgency</td><td>Low</td></tr>
+    <tr><td>Confidence</td><td>Medium</td></tr>
+    <tr><td>New Money Action</td><td>Wait</td></tr>
+    <tr><td>Existing Holder Action</td><td>Hold/Do not add</td></tr>
+  </table>
+  <p><strong>One-line rationale:</strong> Berkshire still looks durable, but there is no fresh thesis break today and relative-value shortcuts are less clean than they look because the business mix is unusually broad.</p>
+  <p><strong>Main Risk To The Signal:</strong> A weak peer set can create false precision on valuation, so the biggest risk is over-reading comparisons that do not actually map to Berkshire's mix of insurance, operating businesses, and capital allocation.</p>
+  <p><strong>Not Personalized Advice:</strong> This is a public-market signal assessment, not personalized financial advice.</p>
+</section>
+
+<section>
+  <h2>Why Now</h2>
+  <p>The main current question is calibration, not a new operating shock. Berkshire still needs to be judged on underwriting discipline, capital allocation, and look-through earnings quality, but there is no verified new evidence here that forces a fresh positive or negative thesis call today.</p>
+</section>
+
+<section>
+  <h2>Dual-Horizon Framing</h2>
+  <h3>Near-Term Timing View</h3>
+  <p>Near-term upside or downside depends more on capital deployment, insurance underwriting, and large equity-market moves than on one headline catalyst.</p>
+  <h3>Long-Term Ownership View</h3>
+  <p>The long-term ownership case still centers on balance-sheet flexibility and reinvestment discipline rather than on a single business line.</p>
+</section>
+
+<section>
+  <h2>Competitive / Peer Context</h2>
+  <ul>
+    <li><strong>Relevant peers/substitutes:</strong> Direct peers are imperfect for Berkshire, so diversified insurers, asset managers, and a broad-market alternative are the closest useful lenses.</li>
+    <li><strong>Where the target looks stronger:</strong> Berkshire still stands out on capital allocation flexibility and balance-sheet strength.</li>
+    <li><strong>Where peers create pressure:</strong> The peer set is imperfect, which limits how cleanly investors can use relative-valuation shortcuts across very different business mixes.</li>
+    <li><strong>Investment implication:</strong> Peer context is a calibration tool here, not a decisive scoreboard, so the badge should still lean on company-specific underwriting and capital-allocation evidence.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Verified Facts</h2>
+  <ul>
+    <li>Berkshire's annual letter and filings still frame insurance float and disciplined capital allocation as core parts of the model. <a href="https://www.berkshirehathaway.com/">Berkshire Hathaway</a></li>
+    <li>The latest SEC filings remain the primary source for book value, investment holdings, and segment detail. <a href="https://www.sec.gov/">SEC EDGAR</a></li>
+    <li>Independent coverage still treats Berkshire as a hybrid of insurer, conglomerate, and capital allocator rather than a clean single-sector comp. <a href="https://www.reuters.com/markets/us/">Reuters</a></li>
+  </ul>
+</section>
+
+<section>
+  <h2>Derived Metrics</h2>
+  <table>
+    <tr><th>Metric</th><th>Value</th><th>Formula / Inputs</th></tr>
+    <tr><td>Price / book proxy</td><td>1.7x</td><td>$521.40 / estimated per-share book value proxy of about $307</td></tr>
+    <tr><td>Cash optionality</td><td>High</td><td>Large cash and Treasury position / near-term capital needs</td></tr>
+    <tr><td>Look-through valuation</td><td>Not reliably derivable</td><td>Conglomerate mix and public-equity holdings make a single comp multiple noisy</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Scenarios</h2>
+  <h3>Bull Case</h3>
+  <p>Capital deployment improves intrinsic-value compounding without weakening balance-sheet flexibility.</p>
+  <h3>Base Case</h3>
+  <p>The business mix keeps compounding steadily, but no new catalyst forces a valuation rerating.</p>
+  <h3>Bear Case</h3>
+  <p>Insurance underwriting weakens and capital allocation opportunities stay thin, leaving the stock more exposed to a soft relative-value case.</p>
+</section>
+
+<section>
+  <h2>What Would Change The View</h2>
+  <ul>
+    <li><strong>Upgrade / Review Now:</strong> Book value growth or look-through earnings power accelerates enough to lift intrinsic-value estimates by more than 5%.</li>
+    <li><strong>Downgrade / De-risk:</strong> Insurance underwriting deteriorates materially or capital deployment reduces liquidity discipline by more than $25B.</li>
+    <li><strong>Invalidation:</strong> A sustained capital-allocation misstep or underwriting breakdown changes the balance-sheet-first thesis.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Judgment</h2>
+  <p><em>Inference, Medium confidence.</em> `No Material Change` is still the right answer, and the weak peer set is part of why confidence is not higher: Berkshire can be compared, but not with the fake neatness of a normal sector comp table.</p>
+</section>

--- a/DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py
@@ -84,6 +84,7 @@ FULL_ORDER = [
     "decision card",
     "why now",
     "dual-horizon framing",
+    "competitive / peer context",
     "verified facts",
     "derived metrics",
     "scenarios",
@@ -92,6 +93,25 @@ FULL_ORDER = [
 ]
 
 SHORT_ORDER = [
+    "decision card",
+    "why now",
+    "competitive / peer context",
+    "what would change the view",
+    "evidence chips",
+]
+
+FULL_REQUIRED_ORDER = [
+    "decision card",
+    "why now",
+    "dual-horizon framing",
+    "verified facts",
+    "derived metrics",
+    "scenarios",
+    "what would change the view",
+    "judgment",
+]
+
+SHORT_REQUIRED_ORDER = [
     "decision card",
     "why now",
     "what would change the view",
@@ -339,9 +359,12 @@ def audit_artifact(case: dict[str, Any], artifact_html: str) -> dict[str, Any]:
     text = normalize_text(artifact_html)
     html_lower = artifact_html.lower()
     labels = FULL_REQUIRED_LABELS if contract == "full" else SHORT_REQUIRED_LABELS
-    order = FULL_ORDER if contract == "full" else SHORT_ORDER
+    order = FULL_REQUIRED_ORDER if contract == "full" else SHORT_REQUIRED_ORDER
+    section_order = FULL_ORDER if contract == "full" else SHORT_ORDER
     evidence_heading = "verified facts" if contract == "full" else "evidence chips"
     change_view_passed, change_view_detail = change_view_ok(html_lower, contract)
+    peer_section = extract_section(html_lower, "competitive / peer context", section_order) or ""
+    peer_section_text = normalize_text(peer_section)
 
     return {
         "contract": contract,
@@ -352,7 +375,7 @@ def audit_artifact(case: dict[str, Any], artifact_html: str) -> dict[str, Any]:
         "decision_card_near_top": text.find("decision card") != -1 and text.find("decision card") < 500,
         "decision_card_order_ok": decision_card_core_precedes_actions(text),
         "clickable_link_count": count_clickable_links(html_lower),
-        "evidence_section_has_link": section_contains_link(html_lower, evidence_heading, order),
+        "evidence_section_has_link": section_contains_link(html_lower, evidence_heading, section_order),
         "derived_metrics_ok": derived_metrics_has_formula(html_lower) if contract == "full" else True,
         "why_now_specific": why_now_specific(html_lower, contract),
         "main_risk_present": main_risk_present(text),
@@ -360,6 +383,9 @@ def audit_artifact(case: dict[str, Any], artifact_html: str) -> dict[str, Any]:
         "change_view_detail": change_view_detail,
         "compliance_sentence_once": compliance_sentence_once(text),
         "banned_phrases": banned_phrases_found(text, case.get("banned_phrases")),
+        "peer_context_present": bool(peer_section_text),
+        "peer_section_text": peer_section_text,
+        "peer_section_word_count": len(peer_section_text.split()),
     }
 
 
@@ -516,6 +542,90 @@ def grade_case(case: dict[str, Any], run_result: dict[str, Any]) -> dict[str, An
                 "required_specific_phrase_present",
                 passed,
                 "ok" if passed else f"missing any of {case['must_contain_any']}",
+            )
+        )
+
+    if case.get("must_contain_all"):
+        lower_html = run_result["artifact_html"].lower()
+        missing = [needle for needle in case["must_contain_all"] if needle.lower() not in lower_html]
+        checks.append(
+            make_check(
+                "required_specific_phrases_present",
+                not missing,
+                "ok" if not missing else f"missing {missing}",
+            )
+        )
+
+    if case.get("must_not_contain_any"):
+        lower_html = run_result["artifact_html"].lower()
+        found = [needle for needle in case["must_not_contain_any"] if needle.lower() in lower_html]
+        checks.append(
+            make_check(
+                "forbidden_specific_phrases_absent",
+                not found,
+                "ok" if not found else f"found {found}",
+            )
+        )
+
+    if "expect_peer_context" in case:
+        checks.append(
+            make_check(
+                "peer_context_presence_matches",
+                audit["peer_context_present"] == case["expect_peer_context"],
+                (
+                    f"peer_context_present={audit['peer_context_present']}"
+                    if audit["peer_context_present"] == case["expect_peer_context"]
+                    else f"expected peer_context_present={case['expect_peer_context']}, got {audit['peer_context_present']}"
+                ),
+            )
+        )
+
+    if case.get("peer_section_must_contain_any"):
+        found = any(
+            needle.lower() in audit["peer_section_text"] for needle in case["peer_section_must_contain_any"]
+        )
+        checks.append(
+            make_check(
+                "peer_section_contains_required_marker",
+                found,
+                "ok" if found else f"missing any of {case['peer_section_must_contain_any']}",
+            )
+        )
+
+    if case.get("peer_section_must_contain_all"):
+        missing = [
+            needle
+            for needle in case["peer_section_must_contain_all"]
+            if needle.lower() not in audit["peer_section_text"]
+        ]
+        checks.append(
+            make_check(
+                "peer_section_contains_all_required_markers",
+                not missing,
+                "ok" if not missing else f"missing {missing}",
+            )
+        )
+
+    if case.get("peer_section_must_not_contain_any"):
+        found = [
+            needle
+            for needle in case["peer_section_must_not_contain_any"]
+            if needle.lower() in audit["peer_section_text"]
+        ]
+        checks.append(
+            make_check(
+                "peer_section_forbidden_markers_absent",
+                not found,
+                "ok" if not found else f"found {found}",
+            )
+        )
+
+    if case.get("peer_section_max_words") is not None:
+        checks.append(
+            make_check(
+                "peer_section_stays_concise",
+                audit["peer_section_word_count"] <= case["peer_section_max_words"],
+                f"peer_section_word_count={audit['peer_section_word_count']}",
             )
         )
 

--- a/DoWhiz_service/skills/us-equity-daily-monitor/references/evidence.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/references/evidence.md
@@ -39,6 +39,7 @@ When you have multiple corroborating sources for one claim, chain them: `... ([R
 - Reported financials, guidance, capex/spend figures.
 - Margin trajectory, customer concentration, regulatory exposure.
 - Industry data points (hyperscaler capex, export-control rules, demand trends).
+- Current peer or competitor claims, sector-relative valuation comparisons, market-share shifts, substitute threats, or pricing moves.
 - Any numeric claim that is **not** derived in the **Derived Metrics** table.
 
 ## What does not need a chip
@@ -46,6 +47,15 @@ When you have multiple corroborating sources for one claim, chain them: `... ([R
 - Values inside the **Derived Metrics** table — the formula column is the citation.
 - The **Judgment** section — explicitly labelled inference.
 - Scenario price targets, provided the scenario row shows the math (e.g. forward EPS × multiple).
+
+## Peer-context discipline
+
+The optional `Competitive / Peer Context` section can stay compact without becoming loose.
+
+- If you say a peer is gaining share, cutting prices, guiding differently, or trading at a specific multiple, source that claim.
+- Do not use the target company's materials as the only support for claims about a competitor or substitute. Pair them with the competitor's own disclosures or independent reporting.
+- Structural comparisons such as "custom ASICs can cap share of wallet" can stay inference-driven, but label them as judgment rather than fact when the claim is not directly measured.
+- If the peer set is weak or the comparison is apples-to-oranges, say that explicitly instead of forcing a fake precision claim.
 
 ## URL hygiene
 

--- a/DoWhiz_service/skills/us-equity-daily-monitor/references/sections.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/references/sections.md
@@ -7,12 +7,13 @@ The monitor is a single document with the sections below, in order. The structur
 | 1 | `## Decision Card` | Front-loads the badge plus the supporting signal fields. This is the headline judgment. |
 | 2 | `## Why Now` | Explains why the signal matters now, or why there is no material signal now. |
 | 3 | `## Dual-Horizon Framing` | Full monitors only. Separates near-term timing from long-term ownership. |
-| 4 | `## Verified Facts` | Full monitors only. Bullet list of sourced factual claims. |
-| 5 | `## Derived Metrics` | Full monitors only. Computed values with formulas and inputs. |
-| 6 | `## Scenarios` | Full monitors only. Bull/base/bear framing with explicit conditions. |
-| 7 | `## What Would Change The View` | The explicit thresholds or events that move the signal. |
-| 8 | `## Judgment` | Full monitors only. One short paragraph of labelled inference. |
-| 9 | `## Evidence Chips` | Concise monitors only. Short sourced fact list in place of the full evidence stack. |
+| 4 | `## Competitive / Peer Context` | Optional. Adds a concise comparison lens when peers or substitutes materially sharpen the thesis. |
+| 5 | `## Verified Facts` | Full monitors only. Bullet list of sourced factual claims. |
+| 6 | `## Derived Metrics` | Full monitors only. Computed values with formulas and inputs. |
+| 7 | `## Scenarios` | Full monitors only. Bull/base/bear framing with explicit conditions. |
+| 8 | `## What Would Change The View` | The explicit thresholds or events that move the signal. |
+| 9 | `## Judgment` | Full monitors only. One short paragraph of labelled inference. |
+| 10 | `## Evidence Chips` | Concise monitors only. Short sourced fact list in place of the full evidence stack. |
 
 ## Required Decision Card fields
 
@@ -53,6 +54,12 @@ Those action rows are secondary translations. They do not replace the monitor ba
 ### Near-Term Timing View (next 1-2 quarters)
 ### Long-Term Ownership View (multi-year)
 
+## Competitive / Peer Context      (optional)
+- **Relevant peers/substitutes:** ...
+- **Where the target looks stronger:** ...
+- **Where peers create pressure:** ...
+- **Investment implication:** ...
+
 ## Verified Facts                   (full monitor only)
 - ... ([Source name](URL))
 
@@ -75,10 +82,13 @@ Those action rows are secondary translations. They do not replace the monitor ba
 - ... ([Source name](URL))
 ```
 
+If the monitor is concise and peer context is actually needed, place `## Competitive / Peer Context` between `## Why Now` and `## What Would Change The View`.
+
 ## Header conventions
 
 - Use ATX headers (`#`, `##`, `###`).
 - Keep `Why Now`, `What Would Change The View`, and `Evidence Chips` as exact strings in concise monitors.
+- Keep `Competitive / Peer Context` as the exact string when that optional section is used.
 - Keep `Bull Case`, `Base Case`, and `Bear Case` as exact strings in full monitors.
 - Prefer short bold labels inside paragraphs over long prose preambles.
 
@@ -87,3 +97,4 @@ Those action rows are secondary translations. They do not replace the monitor ba
 - Full monitors should stay roughly one page. If the answer is drifting into a long essay, cut repetition before cutting the signal fields.
 - Concise monitors should still feel decision-useful. Short means compressed, not vague.
 - Bullets and tables beat generic paragraphs for evidence, scenarios, and thresholds.
+- `Competitive / Peer Context` should usually stay to four short bullets or a very small table. Omit it entirely when it does not change the judgment.

--- a/DoWhiz_service/skills/us-equity-daily-monitor/references/special-cases.md
+++ b/DoWhiz_service/skills/us-equity-daily-monitor/references/special-cases.md
@@ -45,6 +45,15 @@ Pro-forma history matters more than reported history. In the monitor:
 - The **Peer median** row should use the fundamental peers of the new standalone entity, not the parent's old peer set.
 - The **Bear Case** invalidation should include a TSA-renewal or dis-synergy-overrun condition where applicable.
 
+## Weak or imperfect peer sets
+
+Some names do not have a clean direct-comp set. Berkshire Hathaway is the obvious example, but the same problem shows up in exchanges, rating agencies, and dominant platforms.
+
+- Say directly that the peer set is imperfect when that is true.
+- Use the nearest decision-useful comparison set rather than pretending there is a perfect one: diversified insurers, asset managers, conglomerates, broad-market alternatives, or other substitutes that reflect how investors actually compare the name.
+- Keep the peer section shorter than usual. Focus on the one or two dimensions that matter most, such as underwriting quality, capital allocation, fee-like earnings quality, look-through valuation, or balance-sheet optionality.
+- If the substitutes are too heterogeneous to support a clean relative-valuation call, say so and lean back on company-specific thesis evidence.
+
 ## When in doubt
 
 If the name does not cleanly fit any of these buckets (e.g. a profitable mid-cap with a recent transformative acquisition, or a foreign issuer dual-listed in the U.S.), keep the default structure but add a one-bullet "structural caveat" inside the **Judgment** section explaining which standard assumption is broken. Do not silently bend the template — readers rely on the section contracts being stable.


### PR DESCRIPTION
## Summary
- add selective `Competitive / Peer Context` guidance to the U.S. equity daily monitor for high-level, thesis, and investment-view prompts while keeping narrow factual and latest-news prompts peer-free by default
- extend the skill eval harness and fixtures to validate both include-peer and skip-peer scenarios, including NVDA, Tesla, Shopify, BRK.B, and direct NVDA vs AMD comparison cases
- expand `run_task` investment-request detection coverage for high-level investment-analysis phrasing and fix test fixture compile blockers in `prompt.rs`

## Validation
- `python3 DoWhiz_service/skills/us-equity-daily-monitor/evals/run_final_artifact_regression.py --iteration iteration-peer-context-fixtures-v3`
- `cargo fmt --all`
- `cargo test -p run_task_module investment_request_detection_handles_single_ticker_prompts`
- `cargo test -p run_task_module structured_investment_reply_passes_contract_validation`