### PR TITLE
Fix ACI terminal reconciliation race and recovery messaging

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/aci_container_store.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/aci_container_store.rs
@@ -190,6 +190,40 @@ pub fn deregister_aci_container_mongo(container_name: &str) {
     }
 }
 
+/// Deregister all ACI container records for a workspace path from MongoDB.
+/// Returns the number of deleted records.
+pub fn deregister_aci_container_mongo_by_workspace(workspace_path: &std::path::Path) -> usize {
+    let Some(coll) = collection() else {
+        return 0;
+    };
+
+    let filter = doc! {
+        "workspace_path": workspace_path.to_string_lossy().to_string(),
+    };
+
+    match coll.delete_many(filter, None) {
+        Ok(result) => {
+            let deleted = result.deleted_count as usize;
+            if deleted > 0 {
+                tracing::info!(
+                    "deregistered {} ACI container record(s) from MongoDB for workspace={}",
+                    deleted,
+                    workspace_path.display()
+                );
+            }
+            deleted
+        }
+        Err(err) => {
+            tracing::warn!(
+                "failed to deregister ACI container records by workspace: workspace={} error={}",
+                workspace_path.display(),
+                err
+            );
+            0
+        }
+    }
+}
+
 /// List all ACI container records from MongoDB.
 /// Returns all containers that were registered but not yet deregistered.
 /// Returns empty vec if MongoDB is not configured.

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -14,9 +14,7 @@ use std_semaphore::Semaphore;
 use chrono::{Duration as ChronoDuration, Utc};
 use serde::Deserialize;
 
-use super::aci_container_store::{
-    deregister_aci_container_mongo, register_aci_container_mongo, write_aci_recovery_context,
-};
+use super::aci_container_store::{register_aci_container_mongo, write_aci_recovery_context};
 use super::browserbase::{
     collect_browserbase_env_overrides, BrowserbaseSessionCleanupGuard,
     BROWSERBASE_ACTIVE_SESSION_PATH_ENV_KEY, BROWSERBASE_STATE_DIR_ENV_KEY,
@@ -2268,8 +2266,10 @@ fn run_codex_task_azure_aci(
                 container_name
             );
         }
+        // Keep the MongoDB registry record until the scheduler persists a terminal status.
+        // That gives stale reconciliation and startup recovery a chance to find the container
+        // if the worker dies after local cleanup but before terminal bookkeeping completes.
         deregister_aci_container(&container_name);
-        deregister_aci_container_mongo(&container_name);
     }
 
     if let Some(ref guard) = ephemeral_guard {

--- a/DoWhiz_service/run_task_module/src/run_task/mod.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/mod.rs
@@ -20,8 +20,8 @@ mod utils;
 mod workspace;
 
 pub use aci_container_store::{
-    find_aci_container_by_workspace, read_aci_recovery_context, AciContainerRecord,
-    AciRecoveryContext,
+    deregister_aci_container_mongo_by_workspace, find_aci_container_by_workspace,
+    read_aci_recovery_context, AciContainerRecord, AciRecoveryContext,
 };
 pub use codex::{
     cleanup_all_aci_containers, delete_aci_container_by_name,

--- a/DoWhiz_service/run_task_module/src/run_task/prompt.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/prompt.rs
@@ -1875,6 +1875,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
         let section = build_user_identities_section(&identities);
@@ -2211,6 +2212,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
 
@@ -2259,6 +2261,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
 
@@ -2316,6 +2319,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
 
@@ -2365,6 +2369,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
 
@@ -2509,6 +2514,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
 
@@ -2566,6 +2572,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
 
@@ -2627,6 +2634,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
 
@@ -2676,6 +2684,7 @@ mod tests {
             notion_database_id: None,
             discord_guild_id: None,
             slack_team_id: None,
+            github_org_name: None,
             organization_members: vec![],
         };
 

--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
+use run_task_module::deregister_aci_container_mongo_by_workspace;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -27,6 +28,17 @@ use super::types::{
     RUN_TASK_FAILURE_DIR, RUN_TASK_FAILURE_LIMIT, RUN_TASK_FAILURE_NOTICE,
     RUN_TASK_FAILURE_REPORT_DIR,
 };
+
+fn cleanup_run_task_aci_recovery_registration(task: &RunTaskTask) {
+    let deleted = deregister_aci_container_mongo_by_workspace(&task.workspace_dir);
+    if deleted > 0 {
+        info!(
+            "cleared {} stale ACI recovery registration(s) for workspace {} after terminal bookkeeping",
+            deleted,
+            task.workspace_dir.display()
+        );
+    }
+}
 
 pub struct Scheduler<E: TaskExecutor> {
     pub(super) tasks: Vec<ScheduledTask>,
@@ -310,6 +322,9 @@ impl<E: TaskExecutor> Scheduler<E> {
                     terminal_status,
                     terminal_note.as_deref(),
                 )?;
+                if let TaskKind::RunTask(task) = &task_kind {
+                    cleanup_run_task_aci_recovery_registration(task);
+                }
                 if terminal_status == "success" {
                     reset_reconciliation_failure_counter();
                 }
@@ -444,6 +459,9 @@ impl<E: TaskExecutor> Scheduler<E> {
                     "failed",
                     Some(&message),
                 )?;
+                if let TaskKind::RunTask(task) = &task_kind {
+                    cleanup_run_task_aci_recovery_registration(task);
+                }
                 // Sync failure status to user's account-level storage for Discord/Slack
                 if let TaskKind::RunTask(task) = &task_kind {
                     sync_task_status_to_user_storage(

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -479,7 +479,10 @@ impl MongoSchedulerStore {
                             status,
                             error_message,
                         )?;
-                        if matches!(status, "success" | "superseded") {
+                        if should_clear_auto_disabled_reason_after_stale_replacement(
+                            status,
+                            error_message,
+                        ) {
                             self.clear_auto_disabled_reason(task_id)?;
                         }
                         tracing::info!(
@@ -2221,6 +2224,35 @@ fn should_replace_stale_reconciliation_terminal_row(
     }
 }
 
+fn should_clear_auto_disabled_reason_after_stale_replacement(
+    desired_status: &str,
+    desired_error_message: Option<&str>,
+) -> bool {
+    matches!(desired_status, "success" | "superseded")
+        || (desired_status == "failed"
+            && desired_error_message
+                .map(|message| !is_stale_reconciliation_error(Some(message)))
+                .unwrap_or(false))
+}
+
+fn clear_auto_disabled_reason_by_task_id(
+    tasks: &Collection<Document>,
+    task_id: &str,
+) -> Result<(), SchedulerError> {
+    let filter = doc! { "task_id": task_id };
+    let update = doc! {
+        "$unset": {
+            "auto_disabled_reason": "",
+            "auto_disabled_at": "",
+        }
+    };
+    retry_mongo_write("tasks.clear_auto_disabled_reason_by_task_id", || {
+        tasks.update_many(filter.clone(), update.clone(), None)
+    })
+    .map_err(mongo_err)?;
+    Ok(())
+}
+
 fn apply_persisted_task_fields(
     document: &Document,
     task: &mut ScheduledTask,
@@ -2411,50 +2443,88 @@ pub fn mark_execution_finished_by_workspace(
         return Ok(false);
     }
 
-    // Find running execution for ANY of the matching tasks
-    let exec_filter = doc! {
+    let running_exec_filter = doc! {
         "owner_scope.kind": &owner_kind,
         "owner_scope.id": &owner_id,
         "task_id": { "$in": &matching_task_ids },
         "status": "running",
     };
-
+    let running_exec_options = FindOneOptions::builder()
+        .sort(doc! { "started_at": -1_i32 })
+        .build();
     let running_exec = retry_mongo_read("task_executions.find_running_for_recovery", || {
-        executions.find_one(exec_filter.clone(), None)
+        executions.find_one(running_exec_filter.clone(), running_exec_options.clone())
     })
     .map_err(mongo_err)?;
 
-    let Some(exec_doc) = running_exec else {
+    let target_row = if let Some(exec_doc) = running_exec {
+        Some(parse_execution_row(exec_doc)?)
+    } else {
+        let stale_failed_filter = doc! {
+            "owner_scope.kind": &owner_kind,
+            "owner_scope.id": &owner_id,
+            "task_id": { "$in": &matching_task_ids },
+            "status": "failed",
+        };
+        let stale_failed_options = FindOptions::builder()
+            .sort(doc! { "started_at": -1_i32 })
+            .limit(Some(8))
+            .build();
+        let cursor = retry_mongo_read("task_executions.find_stale_failed_for_recovery", || {
+            executions.find(stale_failed_filter.clone(), stale_failed_options.clone())
+        })
+        .map_err(mongo_err)?;
+
+        let mut replaceable = None;
+        for doc_result in cursor {
+            let row = parse_execution_row(doc_result.map_err(mongo_err)?)?;
+            if should_replace_stale_reconciliation_terminal_row(&row, status, error_message) {
+                replaceable = Some(row);
+                break;
+            }
+        }
+        replaceable
+    };
+
+    let Some(target_row) = target_row else {
         tracing::debug!(
-            "no running execution found for tasks {:?} - may already be marked",
+            "no running or replaceable stale execution found for tasks {:?} - may already be marked",
             matching_task_ids
         );
         return Ok(false);
     };
 
-    let doc_id = exec_doc.get("_id").cloned().unwrap_or(Bson::Null);
-    let task_id = exec_doc.get_str("task_id").unwrap_or("unknown");
     let now = Utc::now();
 
-    // Mark as finished with the given status
     let update = doc! {
         "$set": {
             "status": status,
             "finished_at": BsonDateTime::from_chrono(now),
-            "error_message": error_message,
+            "error_message": error_message.map(Bson::from).unwrap_or(Bson::Null),
         }
     };
 
     retry_mongo_write("task_executions.mark_finished_by_recovery", || {
-        executions.update_one(doc! { "_id": doc_id.clone() }, update.clone(), None)
+        executions.update_one(
+            doc! { "_id": target_row.doc_id.clone() },
+            update.clone(),
+            None,
+        )
     })
     .map_err(mongo_err)?;
 
+    if target_row.status != "running"
+        && should_clear_auto_disabled_reason_after_stale_replacement(status, error_message)
+    {
+        clear_auto_disabled_reason_by_task_id(&tasks, &target_row.task_id)?;
+    }
+
     tracing::info!(
-        "ACI recovery marked execution as {}: task_id={} workspace={}",
+        "ACI recovery marked execution as {}: task_id={} workspace={} previous_status={}",
         status,
-        task_id,
-        workspace_path.display()
+        target_row.task_id,
+        workspace_path.display(),
+        target_row.status
     );
 
     Ok(true)
@@ -2497,10 +2567,8 @@ mod tests {
     use super::{
         apply_persisted_task_fields, build_task_status_summary,
         missing_aci_registry_reconciliation_reason, resolve_owner_scope,
-        should_replace_stale_reconciliation_terminal_row,
-        workspace_peer_supersede_reason,
-        workspace_suggests_recent_inflight_aci_result_handling,
-        ExecutionRow,
+        should_replace_stale_reconciliation_terminal_row, workspace_peer_supersede_reason,
+        workspace_suggests_recent_inflight_aci_result_handling, ExecutionRow,
     };
     use crate::channel::Channel;
     use crate::{RunTaskTask, Schedule, ScheduledTask, TaskKind};

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -471,7 +471,8 @@ impl MongoSchedulerStore {
             )?;
             return match existing {
                 Some(row) if row.status != "running" => {
-                    if should_replace_stale_reconciliation_terminal_row(&row, status) {
+                    if should_replace_stale_reconciliation_terminal_row(&row, status, error_message)
+                    {
                         self.overwrite_terminal_execution_row(
                             &row.doc_id,
                             finished_at,
@@ -1957,10 +1958,15 @@ fn workspace_suggests_recent_inflight_aci_result_handling(
         return false;
     }
 
-    let activity_at_ms = metadata
-        .stage_updated_at_unix_ms
-        .or(metadata.started_at_unix_ms)
-        .unwrap_or_default();
+    let activity_at_ms = [
+        metadata.stage_updated_at_unix_ms,
+        metadata.started_at_unix_ms,
+        current_run_output_artifact_activity_ms(workspace_dir, started_at),
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .unwrap_or_default();
     if activity_at_ms == 0 {
         return false;
     }
@@ -1968,6 +1974,32 @@ fn workspace_suggests_recent_inflight_aci_result_handling(
     let grace = resolve_aci_trace_activity_grace_period();
     let activity_age_ms = now.timestamp_millis().saturating_sub(activity_at_ms);
     activity_age_ms <= grace.num_milliseconds()
+}
+
+fn current_run_output_artifact_activity_ms(
+    workspace_dir: &Path,
+    started_at: chrono::DateTime<Utc>,
+) -> Option<i64> {
+    [
+        workspace_dir.join("reply_email_draft.html"),
+        workspace_dir.join("reply_message.txt"),
+        workspace_dir.join(".notion_api_replied"),
+        workspace_dir.join("reply_email_attachments"),
+    ]
+    .into_iter()
+    .filter_map(|path| current_run_path_activity_ms(&path, started_at))
+    .max()
+}
+
+fn current_run_path_activity_ms(path: &Path, started_at: chrono::DateTime<Utc>) -> Option<i64> {
+    let modified_at_ms = path_modified_at_unix_ms(path)?;
+    let earliest_current_run_ms = started_at
+        .timestamp_millis()
+        .saturating_sub(CURRENT_TRACE_START_MATCH_TOLERANCE_MS);
+    if modified_at_ms < earliest_current_run_ms {
+        return None;
+    }
+    Some(modified_at_ms)
 }
 
 fn workspace_suggests_unfinished_fallback_after_aci_run(
@@ -2145,22 +2177,20 @@ fn trace_started_at_matches_execution(
 }
 
 fn path_mtime_matches_execution(path: &Path, started_at: chrono::DateTime<Utc>) -> bool {
-    let Ok(metadata) = fs::metadata(path) else {
-        return false;
-    };
-    let Ok(modified_at) = metadata.modified() else {
-        return false;
-    };
-    let Ok(duration) = modified_at.duration_since(UNIX_EPOCH) else {
-        return false;
-    };
-    let Ok(modified_at_ms) = i64::try_from(duration.as_millis()) else {
+    let Some(modified_at_ms) = path_modified_at_unix_ms(path) else {
         return false;
     };
     modified_at_ms
         .saturating_sub(started_at.timestamp_millis())
         .abs()
         <= CURRENT_TRACE_START_MATCH_TOLERANCE_MS
+}
+
+fn path_modified_at_unix_ms(path: &Path) -> Option<i64> {
+    let metadata = fs::metadata(path).ok()?;
+    let modified_at = metadata.modified().ok()?;
+    let duration = modified_at.duration_since(UNIX_EPOCH).ok()?;
+    i64::try_from(duration.as_millis()).ok()
 }
 
 fn is_stale_reconciliation_error(reason: Option<&str>) -> bool {
@@ -2176,10 +2206,19 @@ fn is_stale_reconciliation_error(reason: Option<&str>) -> bool {
 fn should_replace_stale_reconciliation_terminal_row(
     row: &ExecutionRow,
     desired_status: &str,
+    desired_error_message: Option<&str>,
 ) -> bool {
-    row.status == "failed"
-        && matches!(desired_status, "success" | "superseded")
-        && is_stale_reconciliation_error(row.error_message.as_deref())
+    if row.status != "failed" || !is_stale_reconciliation_error(row.error_message.as_deref()) {
+        return false;
+    }
+
+    match desired_status {
+        "success" | "superseded" => true,
+        "failed" => desired_error_message
+            .map(|message| !is_stale_reconciliation_error(Some(message)))
+            .unwrap_or(false),
+        _ => false,
+    }
 }
 
 fn apply_persisted_task_fields(
@@ -2458,7 +2497,10 @@ mod tests {
     use super::{
         apply_persisted_task_fields, build_task_status_summary,
         missing_aci_registry_reconciliation_reason, resolve_owner_scope,
-        workspace_peer_supersede_reason, ExecutionRow,
+        should_replace_stale_reconciliation_terminal_row,
+        workspace_peer_supersede_reason,
+        workspace_suggests_recent_inflight_aci_result_handling,
+        ExecutionRow,
     };
     use crate::channel::Channel;
     use crate::{RunTaskTask, Schedule, ScheduledTask, TaskKind};
@@ -2752,6 +2794,74 @@ mod tests {
             "reconciled stale running execution; ACI container not found"
         );
         let _ = fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn inflight_aci_result_handling_accepts_recent_reply_artifact_activity() {
+        let workspace = temp_workspace("aci_recent_reply");
+        let started_at = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        let now = started_at + ChronoDuration::minutes(40);
+        let trace_dir = workspace.join(".run_task_trace");
+        fs::create_dir_all(&trace_dir).unwrap();
+        fs::write(
+            trace_dir.join("metadata.json"),
+            format!(
+                r#"{{
+  "backend": "codex_azure_aci",
+  "current_stage": "creating_ephemeral_share",
+  "started_at_unix_ms": {},
+  "stage_updated_at_unix_ms": {},
+  "finished_at_unix_ms": null,
+  "success": null
+}}"#,
+                started_at.timestamp_millis(),
+                started_at.timestamp_millis()
+            ),
+        )
+        .unwrap();
+        fs::write(workspace.join(".aci_recovery_context.json"), "{}").unwrap();
+        fs::write(
+            workspace.join("reply_email_draft.html"),
+            "<html><body>fresh reply</body></html>",
+        )
+        .unwrap();
+
+        assert!(
+            workspace_suggests_recent_inflight_aci_result_handling(
+                workspace.as_path(),
+                started_at,
+                now
+            ),
+            "a fresh reply artifact from the current run should keep result handling open"
+        );
+        let _ = fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn stale_reconciliation_failure_can_be_replaced_by_real_failure_reason() {
+        let row = ExecutionRow {
+            doc_id: Bson::Null,
+            task_id: "task".to_string(),
+            execution_id: 1,
+            started_at: Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap(),
+            finished_at: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 10, 0).unwrap()),
+            status: "failed".to_string(),
+            error_message: Some(
+                "reconciled stale running execution after an ACI-backed runner executed but no live registry record remained"
+                    .to_string(),
+            ),
+        };
+
+        assert!(should_replace_stale_reconciliation_terminal_row(
+            &row,
+            "failed",
+            Some("task execution failed: Primary runner failed:"),
+        ));
+        assert!(!should_replace_stale_reconciliation_terminal_row(
+            &row,
+            "failed",
+            Some("reconciled stale running execution; ACI container not found"),
+        ));
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -1502,6 +1502,105 @@ fn record_execution_finish_replaces_stale_reconciliation_failure_with_real_failu
             .expect("error after"),
         "task execution failed: Primary runner failed:"
     );
+
+    let tasks_after = load_task_documents("late-real-failure-user", task_id);
+    assert_eq!(tasks_after.len(), 1);
+    assert!(
+        !tasks_after[0].contains_key("auto_disabled_reason"),
+        "late real failure should clear stale auto-disabled state"
+    );
+}
+
+#[test]
+fn mark_execution_finished_by_workspace_replaces_stale_reconciliation_failure_with_success() {
+    use super::mark_execution_finished_by_workspace;
+    use super::store::SchedulerStore;
+
+    if !mongo_execution_tests_enabled() {
+        eprintln!("Skipping execution reconciliation test; MongoDB config not set.");
+        return;
+    }
+
+    let _lock = env_lock();
+    let _aci_rg = EnvGuard::set("RUN_TASK_AZURE_ACI_RESOURCE_GROUP", "test-rg");
+
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = user_scoped_tasks_db(&temp, "recovery-success-user");
+    let workspace = temp.path().join("workspace");
+    let mail_root = temp.path().join("mail");
+    fs::create_dir_all(&workspace).expect("workspace");
+    fs::create_dir_all(&mail_root).expect("mail");
+
+    let task_id = {
+        let mut scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("load");
+        scheduler
+            .add_one_shot_in(
+                Duration::from_secs(0),
+                TaskKind::RunTask(base_run_task(&workspace, &mail_root)),
+            )
+            .expect("add task")
+    };
+
+    let started_at = parse_utc("2026-04-03T00:00:00Z");
+    let stale_finished_at = parse_utc("2026-04-03T00:19:00Z");
+    let trace_dir = workspace.join(".run_task_trace");
+    fs::create_dir_all(&trace_dir).expect("trace dir");
+    fs::write(
+        trace_dir.join("metadata.json"),
+        format!(
+            r#"{{
+  "backend": "codex_azure_aci",
+  "current_stage": "completed",
+  "started_at_unix_ms": {},
+  "finished_at_unix_ms": {},
+  "success": true
+}}"#,
+            started_at.timestamp_millis(),
+            stale_finished_at.timestamp_millis()
+        ),
+    )
+    .expect("trace metadata");
+    fs::write(workspace.join(".aci_recovery_context.json"), "{}").expect("aci evidence");
+
+    let store = SchedulerStore::new(tasks_db).expect("open store");
+    store
+        .record_execution_start(task_id, started_at)
+        .expect("record start");
+
+    let summary = store
+        .reconcile_stale_running_executions_for_task(
+            &task_id.to_string(),
+            parse_utc("2026-04-03T00:20:00Z"),
+            chrono::Duration::hours(24),
+        )
+        .expect("reconcile");
+    assert_eq!(summary.failed_count, 1);
+
+    assert!(
+        mark_execution_finished_by_workspace(&workspace, "success", None)
+            .expect("workspace recovery should overwrite stale failure"),
+        "workspace recovery should report that it updated a row"
+    );
+
+    let executions_after = load_execution_documents("recovery-success-user", task_id);
+    assert_eq!(executions_after.len(), 1);
+    assert_eq!(
+        executions_after[0].get_str("status").expect("status after"),
+        "success"
+    );
+    assert_eq!(
+        executions_after[0]
+            .get("error_message")
+            .expect("error field after"),
+        &Bson::Null
+    );
+
+    let tasks_after = load_task_documents("recovery-success-user", task_id);
+    assert_eq!(tasks_after.len(), 1);
+    assert!(
+        !tasks_after[0].contains_key("auto_disabled_reason"),
+        "workspace recovery success should clear stale auto-disabled state"
+    );
 }
 
 #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -1416,6 +1416,95 @@ fn record_execution_finish_replaces_stale_reconciliation_failure_with_success() 
 }
 
 #[test]
+fn record_execution_finish_replaces_stale_reconciliation_failure_with_real_failure() {
+    use super::store::SchedulerStore;
+
+    if !mongo_execution_tests_enabled() {
+        eprintln!("Skipping execution reconciliation test; MongoDB config not set.");
+        return;
+    }
+
+    let _lock = env_lock();
+    let _aci_rg = EnvGuard::set("RUN_TASK_AZURE_ACI_RESOURCE_GROUP", "test-rg");
+
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = user_scoped_tasks_db(&temp, "late-real-failure-user");
+    let workspace = temp.path().join("workspace");
+    let mail_root = temp.path().join("mail");
+    fs::create_dir_all(&workspace).expect("workspace");
+    fs::create_dir_all(&mail_root).expect("mail");
+
+    let task_id = {
+        let mut scheduler = Scheduler::load(&tasks_db, NoopExecutor::default()).expect("load");
+        scheduler
+            .add_one_shot_in(
+                Duration::from_secs(0),
+                TaskKind::RunTask(base_run_task(&workspace, &mail_root)),
+            )
+            .expect("add task")
+    };
+
+    let started_at = parse_utc("2026-04-01T00:00:00Z");
+    let stale_finished_at = parse_utc("2026-04-01T00:19:00Z");
+    let real_finished_at = parse_utc("2026-04-01T00:21:00Z");
+    let trace_dir = workspace.join(".run_task_trace");
+    fs::create_dir_all(&trace_dir).expect("trace dir");
+    fs::write(
+        trace_dir.join("metadata.json"),
+        format!(
+            r#"{{
+  "backend": "codex_azure_aci",
+  "current_stage": "failed",
+  "started_at_unix_ms": {},
+  "finished_at_unix_ms": {},
+  "success": false
+}}"#,
+            started_at.timestamp_millis(),
+            stale_finished_at.timestamp_millis()
+        ),
+    )
+    .expect("trace metadata");
+    fs::write(workspace.join(".aci_recovery_context.json"), "{}").expect("aci evidence");
+
+    let store = SchedulerStore::new(tasks_db).expect("open store");
+    let handle = store
+        .record_execution_start(task_id, started_at)
+        .expect("record start");
+
+    let summary = store
+        .reconcile_stale_running_executions_for_task(
+            &task_id.to_string(),
+            parse_utc("2026-04-01T00:20:00Z"),
+            chrono::Duration::hours(24),
+        )
+        .expect("reconcile");
+    assert_eq!(summary.failed_count, 1);
+
+    store
+        .record_execution_finish(
+            task_id,
+            handle,
+            real_finished_at,
+            "failed",
+            Some("task execution failed: Primary runner failed:"),
+        )
+        .expect("late real failure should overwrite stale failure");
+
+    let executions_after = load_execution_documents("late-real-failure-user", task_id);
+    assert_eq!(executions_after.len(), 1);
+    assert_eq!(
+        executions_after[0].get_str("status").expect("status after"),
+        "failed"
+    );
+    assert_eq!(
+        executions_after[0]
+            .get_str("error_message")
+            .expect("error after"),
+        "task execution failed: Primary runner failed:"
+    );
+}
+
+#[test]
 fn scheduler_load_ignores_zero_byte_placeholder_path() {
     let temp = TempDir::new().expect("tempdir");
     let tasks_db = temp.path().join("tasks.db");

--- a/website/public/auth/index.html
+++ b/website/public/auth/index.html
@@ -878,6 +878,15 @@
         line-height: 1.45;
         word-break: break-word;
       }
+      .task-timeline-note {
+        margin-top: 0.7rem;
+        padding-top: 0.7rem;
+        border-top: 1px solid rgba(59, 130, 246, 0.16);
+        color: #dbeafe;
+        font-size: 0.88rem;
+        line-height: 1.45;
+        word-break: break-word;
+      }
 
       #refresh-tasks-btn {
         padding: 0.5rem 1rem;
@@ -8067,6 +8076,17 @@
         }
       }
 
+      function taskMessagePresentation(task) {
+        const status = taskStatusKey(task);
+        const isInformational = status === 'success' || status === 'superseded';
+        return {
+          label: isInformational ? 'Note' : 'Error',
+          value: parseErrorMessage(task?.error_message),
+          tone: isInformational ? 'muted' : 'danger',
+          className: isInformational ? 'task-timeline-note' : 'task-timeline-error'
+        };
+      }
+
       function taskUpdatedAt(task) {
         return task.status_changed_at || task.last_run || task.execution_started_at || task.created_at;
       }
@@ -8129,10 +8149,11 @@
         }
 
         if (task.error_message) {
+          const message = taskMessagePresentation(task);
           metaItems.push({
-            label: 'Error',
-            value: parseErrorMessage(task.error_message),
-            tone: 'danger'
+            label: message.label,
+            value: message.value,
+            tone: message.tone
           });
         }
 
@@ -8240,8 +8261,9 @@
           <div class="task-timeline">
             ${executions.map((execution) => {
               const status = taskStatusPresentation({ status: execution.status });
-              const errorHtml = execution.error_message
-                ? `<div class="task-timeline-error">${escapeHtml(parseErrorMessage(execution.error_message))}</div>`
+              const message = execution.error_message ? taskMessagePresentation(execution) : null;
+              const errorHtml = message
+                ? `<div class="${message.className}"><span class="task-timeline-meta-label">${escapeHtml(message.label)}</span><div>${escapeHtml(message.value)}</div></div>`
                 : '';
               return `
                 <div class="task-timeline-item">


### PR DESCRIPTION
## Summary
- keep ACI recovery registrations in Mongo until scheduler terminal bookkeeping completes, then clean them up by workspace
- let authoritative late terminal results overwrite stale reconciliation failures and clear stale auto-disabled metadata
- preserve the more accurate terminal failure reason when stale reconciliation wrote a generic failure first
- render recovery notes as informational notes instead of red errors when a task has already completed successfully

## Prod Validation
- validated the reported production failure via `ssh dp` log inspection
- confirmed the problematic ACI registry row was deleted while the container was still `Running`
- confirmed the worker then shut down and restarted before terminal bookkeeping completed
- confirmed scheduler repeatedly observed `ACI registry is gone while local result handling is still active` and finally auto-disabled the task via stale reconciliation
- confirmed the failing workspace had no reply draft or sent marker, so this specific failure was a real terminal/result-handling loss rather than a hidden successful reply

## Test Evidence
- `cargo fmt --all`
- `cargo check --locked -p run_task_module --lib`
- `cargo test --locked -p scheduler_module --lib --no-run`
- `cargo test --locked -p scheduler_module stale_reconciliation_failure_can_be_replaced_by_real_failure_reason -- --nocapture`
- `cargo test --locked -p scheduler_module inflight_aci_result_handling_accepts_recent_reply_artifact_activity -- --nocapture`
- `cargo test --locked -p scheduler_module record_execution_finish_replaces_stale_reconciliation_failure_with_real_failure -- --nocapture`
- `cargo test --locked -p scheduler_module mark_execution_finished_by_workspace_replaces_stale_reconciliation_failure_with_success -- --nocapture`
- `cargo test --locked -p run_task_module --lib --no-run` still fails because pre-existing `prompt.rs` test fixtures initialize `UserIdentities` without `github_org_name`; that issue is outside this PR's touched files
