### PR TITLE
Fix resubmit queue publication and mirror task status

### DIFF
--- a/DoWhiz_service/scheduler_module/src/account_store.rs
+++ b/DoWhiz_service/scheduler_module/src/account_store.rs
@@ -2309,6 +2309,33 @@ pub fn get_global_account_store() -> Option<Arc<AccountStore>> {
         .clone()
 }
 
+/// Best-effort check for whether an owner id is a real unified account id.
+///
+/// Channel-scoped user ids are also UUIDs, so the only reliable distinction we
+/// have at runtime is whether the UUID resolves to an account in AccountStore.
+/// Fail open on lookup errors so task scheduling does not break when account
+/// storage is unavailable.
+pub fn is_global_account_id(owner_id: &str) -> bool {
+    let Ok(account_id) = Uuid::parse_str(owner_id) else {
+        return false;
+    };
+    let Some(store) = get_global_account_store() else {
+        return false;
+    };
+
+    match store.get_account(account_id) {
+        Ok(Some(_)) => true,
+        Ok(None) => false,
+        Err(err) => {
+            warn!(
+                "failed to classify owner id {} against AccountStore: {}",
+                owner_id, err
+            );
+            false
+        }
+    }
+}
+
 /// Map a channel type to the identifier_type used in account_identifiers table
 pub fn channel_to_identifier_type(channel: &crate::channel::Channel) -> &'static str {
     use crate::channel::Channel;

--- a/DoWhiz_service/scheduler_module/src/index_store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/index_store/mod.rs
@@ -9,9 +9,8 @@ use mongodb::IndexModel;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use tracing::warn;
-use uuid::Uuid;
 
-use crate::account_store::get_global_account_store;
+use crate::account_store::is_global_account_id;
 use crate::mongo_store::{create_client_from_env, database_from_env, ensure_index_compatible};
 use crate::{Schedule, ScheduledTask};
 
@@ -54,6 +53,14 @@ impl IndexStore {
         tasks: &[ScheduledTask],
     ) -> Result<(), IndexStoreError> {
         self.mongo.sync_user_tasks(user_id, tasks)
+    }
+
+    pub fn upsert_user_task(
+        &self,
+        user_id: &str,
+        task: &ScheduledTask,
+    ) -> Result<(), IndexStoreError> {
+        self.mongo.upsert_user_task(user_id, task)
     }
 
     pub fn due_user_ids(
@@ -101,31 +108,8 @@ impl MongoIndexStore {
         user_id: &str,
         tasks: &[ScheduledTask],
     ) -> Result<(), IndexStoreError> {
-        // Gate: block if user_id is a Supabase account_id (not a channel_user_id).
-        // Account IDs come from auth and should never be used for task scheduling.
-        // Channel user IDs are created via get_or_create_user and are valid.
-        if let Ok(uuid) = Uuid::parse_str(user_id) {
-            if let Some(store) = get_global_account_store() {
-                match store.get_account(uuid) {
-                    Ok(Some(_account)) => {
-                        warn!(
-                            "sync_user_tasks blocked: user_id {} is a Supabase account_id, not a channel_user_id",
-                            user_id
-                        );
-                        return Ok(());
-                    }
-                    Ok(None) => {
-                        // Not an account_id, allow through (it's a channel_user_id)
-                    }
-                    Err(e) => {
-                        // If we can't check, allow through to avoid blocking legitimate users
-                        warn!(
-                            "sync_user_tasks: account_store check failed for {}: {}, allowing through",
-                            user_id, e
-                        );
-                    }
-                }
-            }
+        if !should_schedule_for_user_id(user_id, "sync_user_tasks") {
+            return Ok(());
         }
 
         let task_rows = enabled_task_next_runs(tasks);
@@ -164,6 +148,42 @@ impl MongoIndexStore {
                 },
                 options.clone(),
             )?;
+        }
+
+        Ok(())
+    }
+
+    fn upsert_user_task(&self, user_id: &str, task: &ScheduledTask) -> Result<(), IndexStoreError> {
+        if !should_schedule_for_user_id(user_id, "upsert_user_task") {
+            return Ok(());
+        }
+
+        let next_run = match (&task.enabled, &task.schedule) {
+            (true, Schedule::Cron { next_run, .. }) => Some(*next_run),
+            (true, Schedule::OneShot { run_at }) => Some(*run_at),
+            (false, _) => None,
+        };
+
+        let task_id = task.id.to_string();
+        if let Some(next_run) = next_run {
+            let options = UpdateOptions::builder().upsert(Some(true)).build();
+            self.task_index.update_one(
+                doc! { "task_id": &task_id, "user_id": user_id },
+                doc! {
+                    "$set": {
+                        "next_run": BsonDateTime::from_chrono(next_run),
+                        "enabled": true,
+                    },
+                    "$setOnInsert": {
+                        "task_id": &task_id,
+                        "user_id": user_id,
+                    },
+                },
+                options,
+            )?;
+        } else {
+            self.task_index
+                .delete_many(doc! { "task_id": &task_id, "user_id": user_id }, None)?;
         }
 
         Ok(())
@@ -264,6 +284,17 @@ fn enabled_task_next_runs(tasks: &[ScheduledTask]) -> Vec<(String, DateTime<Utc>
         deduped.insert(task.id.to_string(), next_run);
     }
     deduped.into_iter().collect()
+}
+
+fn should_schedule_for_user_id(user_id: &str, context: &str) -> bool {
+    if is_global_account_id(user_id) {
+        warn!(
+            "{} blocked: user_id {} is a Supabase account_id, not a channel_user_id",
+            context, user_id
+        );
+        return false;
+    }
+    true
 }
 
 fn is_order_by_index_excluded(err: &mongodb::error::Error) -> bool {

--- a/DoWhiz_service/scheduler_module/src/index_store/tests/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/index_store/tests/mod.rs
@@ -4,11 +4,26 @@ use chrono::{Duration, Utc};
 use tempfile::TempDir;
 use uuid::Uuid;
 
-#[test]
-fn sync_user_tasks_and_query_due_users() {
+fn maybe_index_store() -> Option<IndexStore> {
+    if std::env::var("MONGODB_URI")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .is_none()
+    {
+        eprintln!("skipping index_store test: MONGODB_URI is not set");
+        return None;
+    }
+
     let temp = TempDir::new().unwrap();
     let db_path = temp.path().join("task_index.db");
-    let store = IndexStore::new(db_path).unwrap();
+    Some(IndexStore::new(db_path).unwrap())
+}
+
+#[test]
+fn sync_user_tasks_and_query_due_users() {
+    let Some(store) = maybe_index_store() else {
+        return;
+    };
 
     let now = Utc::now();
     let past = now - Duration::minutes(5);
@@ -45,9 +60,9 @@ fn sync_user_tasks_and_query_due_users() {
 
 #[test]
 fn sync_user_tasks_dedupes_repeated_task_ids() {
-    let temp = TempDir::new().unwrap();
-    let db_path = temp.path().join("task_index.db");
-    let store = IndexStore::new(db_path).unwrap();
+    let Some(store) = maybe_index_store() else {
+        return;
+    };
 
     let now = Utc::now();
     let task_id = Uuid::new_v4();
@@ -97,4 +112,34 @@ fn sync_user_tasks_dedupes_repeated_task_ids() {
         .filter(|task_ref| task_ref.user_id == user_id)
         .collect();
     assert_eq!(matching.len(), 1);
+}
+
+#[test]
+fn upsert_user_task_publishes_single_due_task() {
+    let Some(store) = maybe_index_store() else {
+        return;
+    };
+
+    let now = Utc::now();
+    let due_task = ScheduledTask {
+        id: Uuid::new_v4(),
+        kind: TaskKind::Noop,
+        schedule: Schedule::OneShot {
+            run_at: now - Duration::minutes(1),
+        },
+        enabled: true,
+        created_at: now,
+        last_run: None,
+    };
+    let user_id = format!("user_a_{}", Uuid::new_v4());
+
+    store.upsert_user_task(&user_id, &due_task).unwrap();
+
+    let refs = store.due_task_refs(now, 10_000).unwrap();
+    let matching: Vec<_> = refs
+        .into_iter()
+        .filter(|task_ref| task_ref.user_id == user_id)
+        .collect();
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].task_id, due_task.id.to_string());
 }

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::UNIX_EPOCH;
 use uuid::Uuid;
 
+use crate::account_store::is_global_account_id;
 use crate::mongo_store::{
     create_client_from_env, database_from_env, ensure_index_compatible, get_shared_client,
     retry_mongo_read, retry_mongo_write,
@@ -1348,6 +1349,7 @@ impl MongoSchedulerStore {
                 retry_count,
                 auto_disabled_reason,
                 auto_disabled_at,
+                self.owner_accepts_worker_pickup(),
                 now,
             ));
         }
@@ -1411,6 +1413,7 @@ impl MongoSchedulerStore {
             retry_count,
             auto_disabled_reason,
             auto_disabled_at,
+            self.owner_accepts_worker_pickup(),
             now,
         )))
     }
@@ -1536,6 +1539,10 @@ impl MongoSchedulerStore {
             "id": &self.owner_id,
         }
     }
+
+    fn owner_accepts_worker_pickup(&self) -> bool {
+        self.owner_kind == "user"
+    }
 }
 
 fn parse_execution_row(document: Document) -> Result<ExecutionRow, SchedulerError> {
@@ -1593,6 +1600,7 @@ fn build_task_status_summary(
     retry_count: u32,
     auto_disabled_reason: Option<String>,
     auto_disabled_at: Option<String>,
+    owner_accepts_worker_pickup: bool,
     now: chrono::DateTime<Utc>,
 ) -> TaskStatusSummary {
     let latest_execution = executions.first();
@@ -1601,6 +1609,7 @@ fn build_task_status_summary(
         latest_execution,
         retry_count,
         auto_disabled_reason.as_deref(),
+        owner_accepts_worker_pickup,
         now,
     );
 
@@ -1649,6 +1658,7 @@ fn derive_user_task_status(
     latest_execution: Option<&ExecutionRow>,
     retry_count: u32,
     auto_disabled_reason: Option<&str>,
+    owner_accepts_worker_pickup: bool,
     now: chrono::DateTime<Utc>,
 ) -> DerivedTaskStatus {
     let is_one_shot = matches!(&task.schedule, Schedule::OneShot { .. });
@@ -1659,7 +1669,7 @@ fn derive_user_task_status(
     let mut will_retry = false;
     let mut is_running_long = false;
     let (status, status_changed_at) = if let Some(row) = latest_execution {
-        let mut status = "scheduled";
+        let status;
         let status_changed_at = Some(row.finished_at.unwrap_or(row.started_at).to_rfc3339());
         match row.status.as_str() {
             "running" => {
@@ -1703,17 +1713,29 @@ fn derive_user_task_status(
                                 Some(format!("{retry_prefix} for {}", run_at.to_rfc3339()));
                         }
                         Schedule::OneShot { run_at } => {
-                            status = "queued";
                             retry_at = Some(run_at.to_rfc3339());
                             will_retry = true;
-                            status_reason = Some(if retry_count > 0 {
-                                format!(
-                                        "Automatic retry {retry_count} is due and waiting for a worker to pick it up."
+                            if owner_accepts_worker_pickup {
+                                status = "queued";
+                                status_reason = Some(if retry_count > 0 {
+                                    format!(
+                                        "Automatic retry {retry_count} is due and waiting for a worker to claim it."
                                     )
+                                } else {
+                                    "Automatic retry is due and waiting for a worker to claim it."
+                                        .to_string()
+                                });
                             } else {
-                                "Automatic retry is due and waiting for a worker to pick it up."
-                                    .to_string()
-                            });
+                                status = "retry_scheduled";
+                                status_reason = Some(if retry_count > 0 {
+                                    format!(
+                                        "Automatic retry {retry_count} is pending on the live channel task."
+                                    )
+                                } else {
+                                    "Automatic retry is pending on the live channel task."
+                                        .to_string()
+                                });
+                            }
                         }
                         Schedule::Cron { .. } => {
                             status = "failed";
@@ -1755,9 +1777,17 @@ fn derive_user_task_status(
             Schedule::OneShot { run_at } => {
                 if task.enabled {
                     if *run_at <= now {
-                        status = "queued";
-                        status_reason =
-                            Some("Waiting for a worker to pick up this task.".to_string());
+                        if owner_accepts_worker_pickup {
+                            status = "queued";
+                            status_reason =
+                                Some("Waiting for a worker to claim this task.".to_string());
+                        } else {
+                            status = "scheduled";
+                            status_reason = Some(
+                                "Mirrored task record. Worker pickup happens from the live channel task."
+                                    .to_string(),
+                            );
+                        }
                         status_changed_at = Some(run_at.to_rfc3339());
                     } else {
                         status = "scheduled";
@@ -2356,6 +2386,13 @@ fn routine_schedule_fields(schedule: &Schedule) -> (String, Option<String>, Opti
 }
 
 fn resolve_owner_scope(path: &Path) -> (String, String) {
+    resolve_owner_scope_with(path, is_global_account_id)
+}
+
+fn resolve_owner_scope_with<F>(path: &Path, is_account_owner_id: F) -> (String, String)
+where
+    F: Fn(&str) -> bool,
+{
     let mut components: Vec<String> = Vec::new();
     for component in path.components() {
         if let Some(value) = component.as_os_str().to_str() {
@@ -2366,7 +2403,10 @@ fn resolve_owner_scope(path: &Path) -> (String, String) {
     for (idx, value) in components.iter().enumerate() {
         if value == "users" {
             if let Some(owner_id) = components.get(idx + 1) {
-                return ("user".to_string(), owner_id.to_string());
+                return (
+                    owner_kind_for_id(owner_id, &is_account_owner_id).to_string(),
+                    owner_id.to_string(),
+                );
             }
         }
     }
@@ -2376,7 +2416,10 @@ fn resolve_owner_scope(path: &Path) -> (String, String) {
             if state_dir.file_name().and_then(|v| v.to_str()) == Some("state") {
                 if let Some(owner_dir) = state_dir.parent() {
                     if let Some(owner_id) = owner_dir.file_name().and_then(|v| v.to_str()) {
-                        return ("user".to_string(), owner_id.to_string());
+                        return (
+                            owner_kind_for_id(owner_id, &is_account_owner_id).to_string(),
+                            owner_id.to_string(),
+                        );
                     }
                 }
             }
@@ -2385,6 +2428,17 @@ fn resolve_owner_scope(path: &Path) -> (String, String) {
 
     let hashed = format!("{:x}", md5::compute(path.to_string_lossy().as_bytes()));
     ("path_scope".to_string(), hashed)
+}
+
+fn owner_kind_for_id<F>(owner_id: &str, is_account_owner_id: F) -> &'static str
+where
+    F: Fn(&str) -> bool,
+{
+    if is_account_owner_id(owner_id) {
+        "account"
+    } else {
+        "user"
+    }
 }
 
 /// Mark orphaned execution as finished by workspace path.
@@ -2566,7 +2620,7 @@ mod tests {
 
     use super::{
         apply_persisted_task_fields, build_task_status_summary,
-        missing_aci_registry_reconciliation_reason, resolve_owner_scope,
+        missing_aci_registry_reconciliation_reason, resolve_owner_scope_with,
         should_replace_stale_reconciliation_terminal_row, workspace_peer_supersede_reason,
         workspace_suggests_recent_inflight_aci_result_handling, ExecutionRow,
     };
@@ -2624,9 +2678,18 @@ mod tests {
     #[test]
     fn resolve_owner_scope_extracts_user_id() {
         let path = PathBuf::from("/tmp/runtime/users/user-123/state/tasks.db");
-        let scope = resolve_owner_scope(&path);
+        let scope = resolve_owner_scope_with(&path, |_| false);
         assert_eq!(scope.0, "user");
         assert_eq!(scope.1, "user-123");
+    }
+
+    #[test]
+    fn resolve_owner_scope_classifies_known_account_ids() {
+        let account_id = "2f5cdd1a-0d10-4bdf-bd48-3b993a09b0f9";
+        let path = PathBuf::from(format!("/tmp/runtime/users/{account_id}/state/tasks.db"));
+        let scope = resolve_owner_scope_with(&path, |candidate| candidate == account_id);
+        assert_eq!(scope.0, "account");
+        assert_eq!(scope.1, account_id);
     }
 
     #[test]
@@ -2647,6 +2710,7 @@ mod tests {
             0,
             None,
             None,
+            true,
             now,
         );
 
@@ -2711,6 +2775,7 @@ mod tests {
             0,
             None,
             None,
+            true,
             now,
         );
 
@@ -2752,6 +2817,7 @@ mod tests {
                 "auto-disabled: execution started but ACI container was never created".to_string(),
             ),
             Some((now - ChronoDuration::minutes(8)).to_rfc3339()),
+            true,
             now,
         );
 
@@ -2766,6 +2832,104 @@ mod tests {
         assert!(summary.can_resubmit);
         assert!(!summary.will_retry);
         assert!(summary.retry_at.is_none());
+    }
+
+    #[test]
+    fn task_status_summary_marks_due_one_shot_as_queued_for_live_user() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 12, 0, 0).unwrap();
+        let task = sample_one_shot_task(now - ChronoDuration::minutes(5));
+
+        let summary = build_task_status_summary(
+            &task.id.to_string(),
+            "run_task",
+            "slack",
+            Some("Review launch checklist".to_string()),
+            &task,
+            "one_shot".to_string(),
+            None,
+            Some((now - ChronoDuration::minutes(5)).to_rfc3339()),
+            &[],
+            0,
+            None,
+            None,
+            true,
+            now,
+        );
+
+        assert_eq!(summary.status, "queued");
+        assert_eq!(
+            summary.status_reason.as_deref(),
+            Some("Waiting for a worker to claim this task.")
+        );
+    }
+
+    #[test]
+    fn task_status_summary_marks_due_account_mirror_as_scheduled() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 12, 0, 0).unwrap();
+        let task = sample_one_shot_task(now - ChronoDuration::minutes(5));
+
+        let summary = build_task_status_summary(
+            &task.id.to_string(),
+            "run_task",
+            "slack",
+            Some("Review launch checklist".to_string()),
+            &task,
+            "one_shot".to_string(),
+            None,
+            Some((now - ChronoDuration::minutes(5)).to_rfc3339()),
+            &[],
+            0,
+            None,
+            None,
+            false,
+            now,
+        );
+
+        assert_eq!(summary.status, "scheduled");
+        assert_eq!(
+            summary.status_reason.as_deref(),
+            Some("Mirrored task record. Worker pickup happens from the live channel task.")
+        );
+    }
+
+    #[test]
+    fn task_status_summary_keeps_due_retry_off_account_mirror_queue() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 12, 0, 0).unwrap();
+        let started_at = now - ChronoDuration::minutes(10);
+        let task = sample_one_shot_task(now - ChronoDuration::minutes(1));
+        let execution = ExecutionRow {
+            doc_id: Bson::Null,
+            task_id: task.id.to_string(),
+            execution_id: 7,
+            started_at,
+            finished_at: Some(now - ChronoDuration::minutes(9)),
+            status: "failed".to_string(),
+            error_message: Some("worker died".to_string()),
+        };
+
+        let summary = build_task_status_summary(
+            &task.id.to_string(),
+            "run_task",
+            "slack",
+            Some("Review launch checklist".to_string()),
+            &task,
+            "one_shot".to_string(),
+            None,
+            Some((now - ChronoDuration::minutes(1)).to_rfc3339()),
+            &[execution],
+            1,
+            None,
+            None,
+            false,
+            now,
+        );
+
+        assert_eq!(summary.status, "retry_scheduled");
+        assert_eq!(
+            summary.status_reason.as_deref(),
+            Some("Automatic retry 1 is pending on the live channel task.")
+        );
+        assert!(summary.will_retry);
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/service/auth.rs
+++ b/DoWhiz_service/scheduler_module/src/service/auth.rs
@@ -9,7 +9,7 @@ use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path as FsPath, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 use tokio::task;
@@ -7443,9 +7443,12 @@ fn mutate_unified_account_task_blocking(
                     "Only failed or expired workflow tasks can be resubmitted safely.",
                 ));
             }
-            let write_target_idx = primary_account_task_path
-                .and_then(|path| preferred_task_write_match_index(&matches, path))
-                .unwrap_or(selected_idx);
+            let write_target_idx = resolve_resubmit_write_match_index(
+                &matches,
+                primary_account_task_path,
+                selected_idx,
+            )
+            .map_err(|message| json_error_response(StatusCode::CONFLICT, &message))?;
             let write_target = matches[write_target_idx].clone();
             let resubmitted_task = build_resubmitted_task(&selected.task, Utc::now())
                 .map_err(|message| json_error_response(StatusCode::CONFLICT, &message))?;
@@ -7474,6 +7477,18 @@ fn mutate_unified_account_task_blocking(
                     })?;
                 }
             }
+            sync_resubmitted_task_index(&write_target.path, &resubmitted_task).map_err(|err| {
+                error!(
+                    "failed to publish resubmitted task {} from {} into task_index: {}",
+                    resubmitted_task.id,
+                    write_target.path.display(),
+                    err
+                );
+                json_error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to publish resubmitted task",
+                )
+            })?;
             Ok(Some(TaskMutationOutcome {
                 task_id: task_id.to_string(),
                 resubmitted_task_id: Some(resubmitted_task.id.to_string()),
@@ -7566,6 +7581,46 @@ fn preferred_task_write_match_index(
         }
     }
     best_idx
+}
+
+fn resolve_resubmit_write_match_index(
+    matches: &[TaskStorageMatch],
+    primary_account_task_path: Option<&FsPath>,
+    selected_idx: usize,
+) -> Result<usize, String> {
+    if let Some(account_path) = primary_account_task_path {
+        return preferred_task_write_match_index(matches, account_path).ok_or_else(|| {
+            "This task only exists in account-level history. Send a fresh message instead of resubmitting it."
+                .to_string()
+        });
+    }
+
+    Ok(selected_idx)
+}
+
+fn task_path_owner_id(task_path: &FsPath) -> Option<&str> {
+    let state_dir = task_path.parent()?;
+    if state_dir.file_name().and_then(|value| value.to_str()) != Some("state") {
+        return None;
+    }
+    state_dir.parent()?.file_name()?.to_str()
+}
+
+fn sync_resubmitted_task_index(
+    task_path: &FsPath,
+    task: &ScheduledTask,
+) -> Result<(), crate::index_store::IndexStoreError> {
+    let Some(user_id) = task_path_owner_id(task_path) else {
+        warn!(
+            "skipping task_index publish for resubmitted task {} because owner id could not be parsed from {}",
+            task.id,
+            task_path.display()
+        );
+        return Ok(());
+    };
+
+    let index_store = IndexStore::new(task_path.to_path_buf())?;
+    index_store.upsert_user_task(user_id, task)
 }
 
 fn request_running_task_cancellation(task: &crate::RunTaskTask) -> Result<(), String> {
@@ -8777,6 +8832,71 @@ mod tests {
             preferred_task_write_match_index(&matches, account_path.as_path()),
             Some(1)
         );
+    }
+
+    #[test]
+    fn resolve_resubmit_write_match_index_rejects_account_only_history() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 1, 12, 0, 0).unwrap();
+        let task = ScheduledTask {
+            id: Uuid::new_v4(),
+            kind: TaskKind::RunTask(sample_run_task_task()),
+            schedule: Schedule::OneShot { run_at: now },
+            enabled: false,
+            created_at: now - ChronoDuration::minutes(5),
+            last_run: Some(now - ChronoDuration::minutes(1)),
+        };
+        let account_path = PathBuf::from("/tmp/users/account-123/state/tasks.db");
+        let matches = vec![TaskStorageMatch {
+            path: account_path.clone(),
+            task,
+            summary: sample_task_status_summary("task-1", "failed", now),
+            executions: Vec::new(),
+        }];
+
+        let err = resolve_resubmit_write_match_index(&matches, Some(account_path.as_path()), 0)
+            .expect_err("account-only resubmit should fail");
+        assert!(err.contains("account-level history"));
+    }
+
+    #[test]
+    fn resolve_resubmit_write_match_index_prefers_live_copy() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 1, 12, 0, 0).unwrap();
+        let task = ScheduledTask {
+            id: Uuid::new_v4(),
+            kind: TaskKind::RunTask(sample_run_task_task()),
+            schedule: Schedule::OneShot { run_at: now },
+            enabled: false,
+            created_at: now - ChronoDuration::minutes(5),
+            last_run: Some(now - ChronoDuration::minutes(1)),
+        };
+        let account_path = PathBuf::from("/tmp/users/account-123/state/tasks.db");
+        let live_path = PathBuf::from("/tmp/users/slack-user-1/state/tasks.db");
+        let matches = vec![
+            TaskStorageMatch {
+                path: account_path.clone(),
+                task: task.clone(),
+                summary: sample_task_status_summary(&task.id.to_string(), "failed", now),
+                executions: Vec::new(),
+            },
+            TaskStorageMatch {
+                path: live_path,
+                task,
+                summary: sample_task_status_summary("live-copy", "failed", now),
+                executions: Vec::new(),
+            },
+        ];
+
+        assert_eq!(
+            resolve_resubmit_write_match_index(&matches, Some(account_path.as_path()), 0)
+                .expect("live write target"),
+            1
+        );
+    }
+
+    #[test]
+    fn task_path_owner_id_extracts_parent_directory_name() {
+        let path = PathBuf::from("/tmp/users/live-user-123/state/tasks.db");
+        assert_eq!(task_path_owner_id(path.as_path()), Some("live-user-123"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- publish manual resubmits into `task_index` immediately so due one-shot tasks can actually be claimed by the scheduler
- refuse resubmits that only exist in account-level history instead of creating dead queued tasks
- distinguish live user tasks from account mirrors in owner scope and queued-status derivation so mirrors no longer pretend to be waiting on a worker

## Root Cause
Manual resubmit was inserting a fresh task into `tasks.db` but not syncing the new task into `task_index`, while the dashboard inferred `queued` from `tasks` alone. That created fake queued tasks that workers never saw. Account mirror records also shared the same owner-scope label as live user tasks, which made queued/retry status misleading.

## Validation
- `cargo fmt --all`
- `cargo test --locked -p scheduler_module --lib --no-run`
- `cargo test --locked -p scheduler_module --lib resolve_resubmit_write_match_index -- --nocapture`
- `cargo test --locked -p scheduler_module --lib 'task_status_summary_marks_due_' -- --nocapture`
- `cargo test --locked -p scheduler_module --lib 'resolve_owner_scope_' -- --nocapture`
- `cargo test --locked -p scheduler_module --lib task_status_summary_keeps_due_retry_off_account_mirror_queue -- --nocapture`

## Notes
- `cargo clippy --locked -p scheduler_module --tests -- -D warnings` still fails on pre-existing package-wide warnings/clippy debt outside this diff.