### PR TITLE
Fix run_task fast-completion timeout handling

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/claude.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/claude.rs
@@ -176,6 +176,8 @@ pub(super) fn run_claude_task(
     combined_output.push_str(&stderr);
     let _ = trace.record_outputs(&stdout, &stderr, &combined_output);
     let output_tail = tail_string(&combined_output, 2000);
+    let expected_reply_path =
+        resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
 
     if !output.status.success() {
         let err = RunTaskError::ClaudeFailed {
@@ -192,6 +194,26 @@ pub(super) fn run_claude_task(
             status: output.status.code(),
             output: annotate_claude_failure_output(&output_tail),
         };
+        if let Some(recovery_note) = maybe_recover_from_ready_reply_artifact(
+            !request.reply_to.is_empty(),
+            request.workspace_dir,
+            &expected_reply_path,
+            &err,
+        ) {
+            let _ = trace.record_text("logs/recovery_note.txt", &recovery_note);
+            let _ = trace.finish(output.status.code(), true, None, None);
+            return Ok(RunTaskOutput {
+                reply_html_path: expected_reply_path,
+                reply_attachments_dir,
+                codex_output: recovery_note.clone(),
+                scheduled_tasks: Vec::new(),
+                scheduled_tasks_error: None,
+                scheduler_actions: Vec::new(),
+                scheduler_actions_error: None,
+                token_usage: None,
+                recovery_note: Some(recovery_note),
+            });
+        }
         let _ = trace.finish(output.status.code(), false, Some(&err.to_string()), None);
         return Err(err);
     }
@@ -202,8 +224,6 @@ pub(super) fn run_claude_task(
 
     // Only check for reply file if a reply was expected
     // Use cross-channel routing to determine actual expected path
-    let expected_reply_path =
-        resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
     if !request.reply_to.is_empty() {
         let _ = trace.set_stage("validating_reply_artifact");
         let err = match ensure_expected_reply_artifact(
@@ -420,6 +440,12 @@ fn maybe_recover_from_ready_reply_artifact(
             "Recovered ready reply artifact after Claude timed out after {}s",
             timeout_secs
         ),
+        RunTaskError::ClaudeFailed {
+            status: Some(0), ..
+        } => {
+            "Recovered ready reply artifact after Claude exited successfully without assistant text"
+                .to_string()
+        }
         RunTaskError::ClaudeFailed {
             status: Some(code), ..
         } => format!(

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -121,6 +121,8 @@ const REMOTE_EXIT_CODE_FILENAME: &str = ".codex_remote_exit_code";
 const HAG_MCP_CONFIG_START_MARKER: &str = "# BEGIN DOWHIZ HUMAN APPROVAL GATE MCP";
 const HAG_MCP_CONFIG_END_MARKER: &str = "# END DOWHIZ HUMAN APPROVAL GATE MCP";
 const EPHEMERAL_SHARE_PREFIX: &str = "task-";
+const MAX_AZURE_ACI_CREATE_TIMEOUT_SECS: u64 = 300;
+const MIN_AZURE_ACI_FAST_COMPLETION_TIMEOUT_SECS: u64 = 60;
 const DEFAULT_AZCOPY_TIMEOUT_SECS: u64 = 900;
 const DOWNLOADED_WORKSPACE_SKIP_ROOT_ENTRIES: &[&str] = &[
     ".agents",
@@ -2145,6 +2147,19 @@ fn run_codex_task_azure_aci(
         }),
         &env_overrides,
     )?;
+    if options.prefer_fast_completion && should_skip_azure_aci_fast_completion_retry(timeout) {
+        let err = RunTaskError::CommandTimeout {
+            command: "az container create",
+            timeout_secs: timeout.as_secs(),
+            output: format!(
+                "skipped Azure ACI fast-completion retry because remaining budget {}s is below the minimum viable Azure ACI retry window of {}s",
+                timeout.as_secs(),
+                MIN_AZURE_ACI_FAST_COMPLETION_TIMEOUT_SECS,
+            ),
+        };
+        let _ = trace.finish(None, false, Some(&err.to_string()), None);
+        return Err(err);
+    }
     let _ = trace.set_stage("preparing_azure_aci");
     let _ = trace.record_text("aci/prompt_path.txt", &prompt_path.to_string_lossy());
     let env_override_keys: Vec<&str> = env_overrides.iter().map(|(key, _)| key.as_str()).collect();
@@ -3362,6 +3377,7 @@ exit \"$status\"\n",
         &create_command,
         env_overrides,
         file_share,
+        effective_aci_create_timeout(timeout),
     ) {
         Ok(()) => {}
         Err(err) if is_aci_quota_error(&err) => {
@@ -3389,6 +3405,7 @@ exit \"$status\"\n",
                 &create_command,
                 env_overrides,
                 file_share,
+                effective_aci_create_timeout(timeout),
             )?;
         }
         Err(err) => return Err(err),
@@ -3670,12 +3687,21 @@ fn confirm_aci_container_started_after_create_timeout(
     None
 }
 
+fn effective_aci_create_timeout(timeout: Duration) -> Duration {
+    timeout.min(Duration::from_secs(MAX_AZURE_ACI_CREATE_TIMEOUT_SECS))
+}
+
+fn should_skip_azure_aci_fast_completion_retry(timeout: Duration) -> bool {
+    timeout < Duration::from_secs(MIN_AZURE_ACI_FAST_COMPLETION_TIMEOUT_SECS)
+}
+
 fn create_aci_container(
     config: &AzureAciConfig,
     container_name: &str,
     create_command: &str,
     env_overrides: &[(String, String)],
     file_share: &str,
+    create_timeout: Duration,
 ) -> Result<(), RunTaskError> {
     let mut create_cmd =
         build_aci_create_command(config, container_name, create_command, file_share);
@@ -3689,7 +3715,7 @@ fn create_aci_container(
 
     let create_output = match run_command_with_timeout(
         create_cmd,
-        Duration::from_secs(300),
+        create_timeout,
         "az container create",
     ) {
         Ok(output) => output,
@@ -6230,6 +6256,28 @@ addresses = ["dowhiz@deep-tutor.com"]
     }
 
     #[test]
+    fn test_effective_aci_create_timeout_caps_to_remaining_budget() {
+        assert_eq!(
+            effective_aci_create_timeout(Duration::from_secs(30)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            effective_aci_create_timeout(Duration::from_secs(900)),
+            Duration::from_secs(MAX_AZURE_ACI_CREATE_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn test_should_skip_azure_aci_fast_completion_retry_for_nonviable_budget() {
+        assert!(should_skip_azure_aci_fast_completion_retry(
+            Duration::from_secs(30)
+        ));
+        assert!(!should_skip_azure_aci_fast_completion_retry(
+            Duration::from_secs(MIN_AZURE_ACI_FAST_COMPLETION_TIMEOUT_SECS)
+        ));
+    }
+
+    #[test]
     fn test_codex_command_timeout_defaults_to_overall_budget_when_unset() {
         let _lock = env_lock();
         let _guards = [
@@ -6410,6 +6458,7 @@ printf '%s\n' "$@" > "$capture_file"
             "/bin/bash -lc 'echo ok'",
             &env_overrides,
             &config.file_share,
+            Duration::from_secs(300),
         )
         .expect("create container");
 
@@ -6485,6 +6534,7 @@ printf '%s\n' "$@" > "$capture_file"
             "/bin/bash -lc 'echo ok'",
             &env_overrides,
             &config.file_share,
+            Duration::from_secs(300),
         )
         .expect("create container");
 

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -816,6 +816,44 @@ fn run_task_recovers_ready_reply_after_claude_fallback_timeout() {
 
 #[test]
 #[cfg(unix)]
+fn run_task_recovers_ready_reply_after_claude_exit_zero_without_assistant_text() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_claude_empty_output_recovery").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_codex(&bin_dir, FakeCodexMode::Fail).unwrap();
+    write_fake_claude(&bin_dir, FakeClaudeMode::ReplyWithoutAssistantText).unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let params = build_params(&workspace);
+    let result =
+        run_task(&params).expect("run_task should recover reply after empty Claude output");
+    let html = fs::read_to_string(&result.reply_html_path).unwrap();
+    assert!(html.contains("Claude artifact recovery reply"));
+    let recovery_note = result.recovery_note.as_deref().unwrap_or("");
+    assert!(recovery_note.contains(
+        "Recovered ready reply artifact after Claude exited successfully without assistant text"
+    ));
+    assert!(recovery_note.contains(
+        "Recovered via Claude fallback after primary Codex failure (Codex failed) using Claude model claude-sonnet-4-5"
+    ));
+}
+
+#[test]
+#[cfg(unix)]
 fn run_task_recovers_ready_reply_after_late_codex_failure() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_reply_then_fail").unwrap();

--- a/DoWhiz_service/run_task_module/tests/support/mod.rs
+++ b/DoWhiz_service/run_task_module/tests/support/mod.rs
@@ -535,6 +535,7 @@ pub enum FakeClaudeMode {
     EnsureModel,
     Fail,
     ReplyThenSleep,
+    ReplyWithoutAssistantText,
     Sleep,
 }
 
@@ -615,6 +616,14 @@ echo "<html><body>Claude timeout recovery reply</body></html>" > reply_email_dra
 mkdir -p reply_email_attachments
 echo "attachment" > reply_email_attachments/attachment.txt
 sleep "${SLEEP_SECS:-2}"
+"#
+        }
+        FakeClaudeMode::ReplyWithoutAssistantText => {
+            r#"#!/bin/sh
+set -e
+echo "<html><body>Claude artifact recovery reply</body></html>" > reply_email_draft.html
+mkdir -p reply_email_attachments
+echo "attachment" > reply_email_attachments/attachment.txt
 "#
         }
         FakeClaudeMode::Sleep => {


### PR DESCRIPTION
## Summary
- fix Azure ACI fast-completion retries so they do not launch with a non-viable remaining budget
- cap `az container create` by the actual remaining run-task timeout instead of always allowing a 300s create window
- recover valid reply artifacts when Claude fallback exits 0 without assistant text
- add regression coverage for the new timeout and Claude artifact-recovery paths

## Root cause
The prod `nvo` failure was not primarily a stale-reconcile issue.

The user-visible failure email came from this runtime chain:
1. the second Codex fast-completion pass only had ~30s of remaining budget
2. the Azure ACI path still allowed `az container create` to consume up to 300s
3. the trace then failed with `container create consumed run_task timeout budget before polling`
4. Claude fallback exited with `status=0` but no assistant text
5. the investment operational-failure artifact became the final emailed reply

## Validation
- `cargo fmt --manifest-path DoWhiz_service/Cargo.toml --all`
- `cargo test --locked --manifest-path DoWhiz_service/Cargo.toml -p run_task_module`
