### PR TITLE
Fix run task false success states

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/claude.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/claude.rs
@@ -162,6 +162,7 @@ pub(super) fn run_claude_task(
                     scheduler_actions_error: None,
                     token_usage: None,
                     recovery_note: Some(recovery_note),
+                    terminal_error_message: None,
                 });
             }
             let _ = trace.finish(None, false, Some(&err.to_string()), None);
@@ -212,6 +213,7 @@ pub(super) fn run_claude_task(
                 scheduler_actions_error: None,
                 token_usage: None,
                 recovery_note: Some(recovery_note),
+                terminal_error_message: None,
             });
         }
         let _ = trace.finish(output.status.code(), false, Some(&err.to_string()), None);
@@ -244,6 +246,7 @@ pub(super) fn run_claude_task(
                     scheduler_actions_error,
                     token_usage: None, // TODO: Extract from Claude API response
                     recovery_note: None,
+                    terminal_error_message: None,
                 });
             }
             Err(err) => err,
@@ -263,6 +266,7 @@ pub(super) fn run_claude_task(
         scheduler_actions_error,
         token_usage: None, // TODO: Extract from Claude API response
         recovery_note: None,
+        terminal_error_message: None,
     })
 }
 

--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -791,13 +791,16 @@ fn maybe_recover_from_ready_reply_artifact(
     expected_reply_path: &Path,
     exit_status: Option<i32>,
     failure_output: &str,
+    baseline: Option<&ReplyArtifactSnapshot>,
 ) -> Option<String> {
     if !reply_expected {
         return None;
     }
 
     let failure_description = late_codex_failure_description(exit_status, failure_output);
-    if reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path) {
+    if reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path)
+        && reply_artifact_changed_since(expected_reply_path, baseline)
+    {
         return Some(format!(
             "Recovered ready reply artifact after {}",
             failure_description
@@ -805,7 +808,9 @@ fn maybe_recover_from_ready_reply_artifact(
     }
     let session_path =
         maybe_recover_reply_artifact_from_recent_session(workspace_dir, expected_reply_path)?;
-    if !reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path) {
+    if !reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path)
+        || !reply_artifact_changed_since(expected_reply_path, baseline)
+    {
         return None;
     }
 
@@ -830,6 +835,27 @@ fn reply_artifact_modified_after(path: &Path, earliest_mtime: SystemTime) -> boo
         .is_ok_and(|modified| modified >= earliest_mtime)
 }
 
+#[derive(Debug, Clone)]
+struct ReplyArtifactSnapshot {
+    bytes: Option<Vec<u8>>,
+}
+
+fn snapshot_reply_artifact(path: &Path) -> ReplyArtifactSnapshot {
+    ReplyArtifactSnapshot {
+        bytes: fs::read(path).ok(),
+    }
+}
+
+fn reply_artifact_changed_since(path: &Path, baseline: Option<&ReplyArtifactSnapshot>) -> bool {
+    let Some(baseline) = baseline else {
+        return true;
+    };
+    let Ok(current) = fs::read(path) else {
+        return false;
+    };
+    baseline.bytes.as_deref() != Some(current.as_slice())
+}
+
 fn timeout_reply_recovery_supported_command(command: &str) -> bool {
     matches!(command, "codex" | "docker run" | "az container create")
 }
@@ -841,6 +867,7 @@ fn maybe_recover_from_recent_ready_reply_artifact(
     expected_reply_path: &Path,
     exit_status: Option<i32>,
     failure_output: &str,
+    baseline: Option<&ReplyArtifactSnapshot>,
 ) -> Option<String> {
     if !reply_expected {
         return None;
@@ -850,6 +877,7 @@ fn maybe_recover_from_recent_ready_reply_artifact(
     let freshness_floor = timeout_reply_artifact_freshness_floor(run_started_at);
     if reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path)
         && reply_artifact_modified_after(expected_reply_path, freshness_floor)
+        && reply_artifact_changed_since(expected_reply_path, baseline)
     {
         return Some(format!(
             "Recovered ready reply artifact written during this run after {}",
@@ -864,6 +892,7 @@ fn maybe_recover_from_recent_ready_reply_artifact(
     )?;
     if !reply_artifact_ready_for_workspace(workspace_dir, expected_reply_path)
         || !reply_artifact_modified_after(expected_reply_path, freshness_floor)
+        || !reply_artifact_changed_since(expected_reply_path, baseline)
     {
         return None;
     }
@@ -910,6 +939,7 @@ fn maybe_accept_timeout_with_ready_reply_artifact(
     workspace_dir: &Path,
     expected_reply_path: &Path,
     err: &RunTaskError,
+    baseline: Option<&ReplyArtifactSnapshot>,
 ) -> Option<String> {
     let RunTaskError::CommandTimeout { command, .. } = err else {
         return None;
@@ -925,6 +955,7 @@ fn maybe_accept_timeout_with_ready_reply_artifact(
         expected_reply_path,
         None,
         &err.to_string(),
+        baseline,
     )
 }
 
@@ -961,6 +992,7 @@ fn validate_warm_pool_codex_result(
             expected_reply_path,
             Some(exit_status),
             &err.to_string(),
+            None,
         ) {
             return Ok(Some(recovery_note));
         }
@@ -986,6 +1018,7 @@ fn validate_warm_pool_codex_result(
             expected_reply_path,
             status,
             &err.to_string(),
+            None,
         ) {
             return Ok(Some(recovery_note));
         }
@@ -1066,6 +1099,7 @@ fn run_codex_task_with_options(
     }
     let expected_reply_path =
         resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
+    let reply_artifact_baseline = snapshot_reply_artifact(&expected_reply_path);
     let investment_request = investment_request_for_workspace(request.workspace_dir)?;
     let _browserbase_cleanup = BrowserbaseSessionCleanupGuard::new(request.workspace_dir);
     let cancel_monitor = request
@@ -1468,6 +1502,7 @@ fn run_codex_task_with_options(
                     request.workspace_dir,
                     &expected_reply_path,
                     &err,
+                    Some(&reply_artifact_baseline),
                 ) {
                     let output_tail = tail_string(&err.to_string(), 2000);
                     record_codex_success(
@@ -1487,6 +1522,7 @@ fn run_codex_task_with_options(
                         scheduler_actions_error: None,
                         token_usage: None,
                         recovery_note: Some(recovery_note),
+                        terminal_error_message: None,
                     });
                 }
                 let _ = trace.finish(None, false, Some(&err.to_string()), None);
@@ -1617,6 +1653,7 @@ fn run_codex_task_with_options(
                     request.workspace_dir,
                     &expected_reply_path,
                     &err,
+                    Some(&reply_artifact_baseline),
                 ) {
                     let output_tail = tail_string(&err.to_string(), 2000);
                     record_codex_success(
@@ -1636,6 +1673,7 @@ fn run_codex_task_with_options(
                         scheduler_actions_error: None,
                         token_usage: None,
                         recovery_note: Some(recovery_note),
+                        terminal_error_message: None,
                     });
                 }
                 let _ = trace.finish(None, false, Some(&err.to_string()), None);
@@ -1678,6 +1716,7 @@ fn run_codex_task_with_options(
             scheduler_actions_error,
             token_usage,
             recovery_note: Some(note),
+            terminal_error_message: None,
         });
     }
     if !output.status.success() {
@@ -1705,6 +1744,7 @@ fn run_codex_task_with_options(
                 scheduler_actions_error,
                 token_usage,
                 recovery_note: Some(note),
+                terminal_error_message: None,
             });
         }
         let err = if use_docker {
@@ -1724,6 +1764,7 @@ fn run_codex_task_with_options(
             &expected_reply_path,
             output.status.code(),
             &err.to_string(),
+            Some(&reply_artifact_baseline),
         ) {
             record_codex_success(
                 &mut trace,
@@ -1742,6 +1783,7 @@ fn run_codex_task_with_options(
                 scheduler_actions_error,
                 token_usage,
                 recovery_note: Some(recovery_note),
+                terminal_error_message: None,
             });
         }
         let _ = trace.finish(
@@ -1781,6 +1823,7 @@ fn run_codex_task_with_options(
             &expected_reply_path,
             status,
             &err.to_string(),
+            Some(&reply_artifact_baseline),
         ) {
             record_codex_success(
                 &mut trace,
@@ -1799,6 +1842,7 @@ fn run_codex_task_with_options(
                 scheduler_actions_error,
                 token_usage,
                 recovery_note: Some(recovery_note),
+                terminal_error_message: None,
             });
         }
         let _ = trace.finish(status, false, Some(&err.to_string()), token_usage.as_ref());
@@ -1832,6 +1876,7 @@ fn run_codex_task_with_options(
                     scheduler_actions_error,
                     token_usage,
                     recovery_note: None,
+                    terminal_error_message: None,
                 });
             }
             Err(err) => err,
@@ -1862,6 +1907,7 @@ fn run_codex_task_with_options(
         scheduler_actions_error,
         token_usage,
         recovery_note: None,
+        terminal_error_message: None,
     })
 }
 
@@ -1929,6 +1975,9 @@ fn run_codex_task_azure_aci(
     let config = load_azure_aci_config()?;
     let mut timing = TaskTimingBuilder::new("pending");
     timing.start_stage();
+    let expected_reply_path =
+        resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
+    let reply_artifact_baseline = snapshot_reply_artifact(&expected_reply_path);
 
     let host_workspace_dir = canonicalize_dir(request.workspace_dir)?;
     let host_share_root = canonicalize_dir(&config.host_share_root)?;
@@ -2307,8 +2356,6 @@ fn run_codex_task_azure_aci(
     if remote_exit_code_path.exists() {
         let _ = trace.copy_file(&remote_exit_code_path, "aci/remote_exit_code.txt");
     }
-    let expected_reply_path =
-        resolve_expected_reply_path(request.workspace_dir, reply_html_path.clone());
     let execution = match execution {
         Ok(execution) => execution,
         Err(err) => {
@@ -2320,6 +2367,7 @@ fn run_codex_task_azure_aci(
                 request.workspace_dir,
                 &expected_reply_path,
                 &err,
+                Some(&reply_artifact_baseline),
             ) {
                 let output_tail = if output_content.trim().is_empty() {
                     tail_string(&err.to_string(), 4000)
@@ -2357,6 +2405,7 @@ fn run_codex_task_azure_aci(
                     scheduler_actions_error,
                     token_usage,
                     recovery_note: Some(recovery_note),
+                    terminal_error_message: None,
                 });
             }
             let completed_timing = timing.finish();
@@ -2419,6 +2468,7 @@ fn run_codex_task_azure_aci(
             &expected_reply_path,
             exit_status,
             &err.to_string(),
+            Some(&reply_artifact_baseline),
         ) {
             let completed_timing = timing.finish();
             let _ = trace.record_timing(&completed_timing);
@@ -2440,6 +2490,7 @@ fn run_codex_task_azure_aci(
                 scheduler_actions_error,
                 token_usage,
                 recovery_note: Some(recovery_note),
+                terminal_error_message: None,
             });
         }
         let completed_timing = timing.finish();
@@ -2483,6 +2534,7 @@ fn run_codex_task_azure_aci(
                     scheduler_actions_error,
                     token_usage,
                     recovery_note: None,
+                    terminal_error_message: None,
                 });
             }
             Err(err) => err,
@@ -2520,6 +2572,7 @@ fn run_codex_task_azure_aci(
         scheduler_actions_error,
         token_usage,
         recovery_note: None,
+        terminal_error_message: None,
     })
 }
 
@@ -5208,6 +5261,7 @@ pub fn run_codex_warm_pool(
         scheduler_actions_error,
         token_usage,
         recovery_note,
+        terminal_error_message: None,
     })
 }
 
@@ -6922,6 +6976,7 @@ exit 3
             &reply,
             Some(23),
             "response.failed event received",
+            None,
         )
         .expect("expected recovery note");
 
@@ -6932,6 +6987,7 @@ exit 3
     fn test_maybe_accept_timeout_with_ready_reply_artifact_recovers_recent_non_investment_reply() {
         let temp = tempfile::tempdir().expect("tempdir");
         let reply = temp.path().join("reply_email_draft.html");
+        let baseline = snapshot_reply_artifact(&reply);
         let run_started_at = SystemTime::now();
         fs::write(&reply, "<html><body>ready</body></html>").expect("write reply");
 
@@ -6947,6 +7003,7 @@ exit 3
             temp.path(),
             &reply,
             &err,
+            Some(&baseline),
         )
         .expect("expected timeout recovery");
 
@@ -6975,11 +7032,43 @@ exit 3
             temp.path(),
             &reply,
             &err,
+            None,
         );
 
         assert!(
             note.is_none(),
             "stale reply artifact should not be accepted"
+        );
+    }
+
+    #[test]
+    fn test_maybe_accept_timeout_with_ready_reply_artifact_rejects_refreshed_unchanged_reply() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reply = temp.path().join("reply_email_draft.html");
+        let stale_body = "<html><body>old but mechanically valid</body></html>";
+        fs::write(&reply, stale_body).expect("write stale reply");
+        let baseline = snapshot_reply_artifact(&reply);
+        let run_started_at = SystemTime::now();
+        fs::write(&reply, stale_body).expect("refresh stale reply mtime without changing content");
+
+        let err = RunTaskError::CommandTimeout {
+            command: "az container create",
+            timeout_secs: 300,
+            output: "container create timed out".to_string(),
+        };
+
+        let note = maybe_accept_timeout_with_ready_reply_artifact(
+            run_started_at,
+            true,
+            temp.path(),
+            &reply,
+            &err,
+            Some(&baseline),
+        );
+
+        assert!(
+            note.is_none(),
+            "timeout recovery must not accept an unchanged pre-existing artifact even if its mtime was refreshed"
         );
     }
 

--- a/DoWhiz_service/run_task_module/src/run_task/core.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/core.rs
@@ -19,9 +19,7 @@ use super::utils::split_reply_completion_budget;
 use super::workspace::{prepare_workspace, remap_workspace_dir, write_placeholder_reply};
 
 const MAX_INVESTMENT_MONITOR_PRIMARY_TIMEOUT_SECS: u64 = 30;
-const MAX_INVESTMENT_MONITOR_FAST_COMPLETION_TIMEOUT_SECS: u64 = 20;
-const MAX_INVESTMENT_RESEARCH_PRIMARY_TIMEOUT_SECS: u64 = 90;
-const MAX_INVESTMENT_RESEARCH_FAST_COMPLETION_TIMEOUT_SECS: u64 = 30;
+const MAX_INVESTMENT_MONITOR_FAST_COMPLETION_TIMEOUT_SECS: u64 = 60;
 const MAX_INVESTMENT_CONTENT_FILTER_MONITOR_RETRY_TIMEOUT_SECS: u64 = 20;
 const MAX_INVESTMENT_CONTENT_FILTER_RESEARCH_RETRY_TIMEOUT_SECS: u64 = 45;
 
@@ -47,6 +45,7 @@ pub fn run_task(params: &RunTaskParams) -> Result<RunTaskOutput, RunTaskError> {
             scheduler_actions_error: None,
             token_usage: None,
             recovery_note: None,
+            terminal_error_message: None,
         });
     }
 
@@ -220,6 +219,10 @@ fn maybe_finalize_generic_content_filter_reply(
     };
     fs::write(&reply_path, reply_body)?;
 
+    let recovery_note =
+        "Returned an explicit Azure/OpenAI content-filter explanation to the user instead of retrying hidden output."
+            .to_string();
+
     Ok(Some(RunTaskOutput {
         reply_html_path: reply_path,
         reply_attachments_dir,
@@ -229,10 +232,8 @@ fn maybe_finalize_generic_content_filter_reply(
         scheduler_actions: Vec::new(),
         scheduler_actions_error: None,
         token_usage: None,
-        recovery_note: Some(
-            "Returned an explicit Azure/OpenAI content-filter explanation to the user instead of retrying hidden output."
-                .to_string(),
-        ),
+        recovery_note: Some(recovery_note.clone()),
+        terminal_error_message: Some(recovery_note),
     }))
 }
 
@@ -365,7 +366,8 @@ fn maybe_finalize_investment_operational_failure_reply(
         scheduler_actions: Vec::new(),
         scheduler_actions_error: None,
         token_usage: None,
-        recovery_note: Some(recovery_note),
+        recovery_note: Some(recovery_note.clone()),
+        terminal_error_message: Some(recovery_note),
     }))
 }
 
@@ -490,20 +492,14 @@ fn codex_fast_completion_budget_split(
         }
     }
 
-    let desired_primary = Duration::from_secs(MAX_INVESTMENT_RESEARCH_PRIMARY_TIMEOUT_SECS);
-    let desired_reserve = Duration::from_secs(MAX_INVESTMENT_RESEARCH_FAST_COMPLETION_TIMEOUT_SECS);
-    if total_budget >= desired_primary + desired_reserve {
-        return Ok(Some((desired_primary, desired_reserve)));
+    if !investment_monitor_request_for_workspace(request.workspace_dir)? {
+        return Ok(None);
     }
 
     let Some((primary_timeout, reserve_timeout)) = split_reply_completion_budget(total_budget)
     else {
         return Ok(None);
     };
-
-    if investment_monitor_request_for_workspace(request.workspace_dir)? {
-        return Ok(Some((primary_timeout, reserve_timeout)));
-    }
 
     Ok(Some((primary_timeout, reserve_timeout)))
 }
@@ -843,7 +839,7 @@ mod tests {
             .expect("split")
             .expect("budget split");
         assert_eq!(split.0.as_secs(), 30);
-        assert_eq!(split.1.as_secs(), 20);
+        assert_eq!(split.1.as_secs(), 60);
 
         match prior_timeout {
             Some(value) => env::set_var("RUN_TASK_CODEX_TIMEOUT_SECS", value),
@@ -889,7 +885,53 @@ mod tests {
             .expect("split")
             .expect("budget split");
         assert_eq!(split.0.as_secs(), 30);
-        assert_eq!(split.1.as_secs(), 20);
+        assert_eq!(split.1.as_secs(), 60);
+
+        match prior_timeout {
+            Some(value) => env::set_var("RUN_TASK_CODEX_TIMEOUT_SECS", value),
+            None => env::remove_var("RUN_TASK_CODEX_TIMEOUT_SECS"),
+        }
+    }
+
+    #[test]
+    fn codex_fast_completion_budget_split_skips_deep_research_requests() {
+        let _lock = acquire_env_test_lock();
+        let temp = TempDir::new().expect("tempdir");
+        let incoming = temp.path().join("incoming_email");
+        fs::create_dir_all(&incoming).expect("incoming dir");
+        fs::write(
+            incoming.join("thread_request.md"),
+            "Help deep research SMH ETF holdings, top 20 portfolio companies, and whether this is a good entry point.\n",
+        )
+        .expect("thread request");
+
+        let prior_timeout = env::var_os("RUN_TASK_CODEX_TIMEOUT_SECS");
+        env::set_var("RUN_TASK_CODEX_TIMEOUT_SECS", "480");
+
+        let replies = vec!["user@example.com".to_string()];
+        let identities = UserIdentities::default();
+        let request = RunTaskRequest {
+            workspace_dir: temp.path(),
+            input_email_dir: Path::new("incoming_email"),
+            input_attachments_dir: Path::new("incoming_attachments"),
+            memory_dir: Path::new("memory"),
+            reference_dir: Path::new("references"),
+            model_name: "gpt-5.4",
+            reply_to: &replies,
+            channel: "email",
+            google_access_token: None,
+            notion_access_token: None,
+            has_unified_account: true,
+            user_identities: &identities,
+            thread_epoch: None,
+            thread_state_path: None,
+        };
+
+        let split = codex_fast_completion_budget_split("codex", &request).expect("split");
+        assert!(
+            split.is_none(),
+            "deep research investment requests must not be forced through the short monitor budget split"
+        );
 
         match prior_timeout {
             Some(value) => env::set_var("RUN_TASK_CODEX_TIMEOUT_SECS", value),

--- a/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/reply_contract.rs
@@ -95,6 +95,12 @@ const INCOMPLETE_FAIL_SOFT_MARKERS: &[&str] = &[
     "best-available timed artifact",
     "best-available timed reply",
     "incomplete monitor check",
+    "unable to verify",
+    "no recommendation",
+    "could not finish a reliable investment update",
+    "within the bounded runtime",
+    "bounded monitor reply",
+    "half-verified buy",
 ];
 #[allow(dead_code)]
 const INCOMPLETE_RESEARCH_MARKERS: &[&str] = &[
@@ -137,6 +143,8 @@ const INVESTMENT_INTENT_KEYWORDS: &[&str] = &[
     "buy before",
     "starter position",
     "buy now",
+    "buy, hold, or sell",
+    "buy / hold / sell",
     "add or trim",
     "trim or exit",
     "avoid for now",
@@ -294,8 +302,22 @@ fn investment_contract_violations(
     } else {
         reply_body.clone()
     };
+    let normalized_reply = normalize_search_text(&visible_text);
     if visible_text.trim().is_empty() {
         violations.push("reply artifact has no visible text".to_string());
+    }
+    if chat_reply_contains_html_shell(reply_path, &reply_body) {
+        violations
+            .push("chat reply artifact contains HTML markup instead of plain text".to_string());
+    }
+    if is_incomplete_fail_soft_artifact(&normalized_reply)
+        || is_incomplete_research_artifact(&normalized_reply)
+        || reply_looks_like_templated_incomplete_investment_output(&normalized_reply)
+    {
+        violations.push(
+            "investment reply is an incomplete/fail-soft runtime artifact, not a valid user-facing investment answer"
+                .to_string(),
+        );
     }
 
     if violations.is_empty() {
@@ -312,6 +334,16 @@ fn looks_like_html_reply(reply_path: &Path, body: &str) -> bool {
     ) || body.contains('<')
 }
 
+fn chat_reply_contains_html_shell(reply_path: &Path, body: &str) -> bool {
+    if reply_path.file_name().and_then(|value| value.to_str()) != Some("reply_message.txt") {
+        return false;
+    }
+    let lower = body.to_ascii_lowercase();
+    ["<html", "<body", "<p", "<section", "<table", "<h1", "<h2"]
+        .iter()
+        .any(|marker| lower.contains(marker))
+}
+
 #[allow(dead_code)]
 fn detect_contract_type(normalized_reply: &str) -> &'static str {
     if normalized_reply.contains("why now")
@@ -325,14 +357,12 @@ fn detect_contract_type(normalized_reply: &str) -> &'static str {
     }
 }
 
-#[allow(dead_code)]
 fn is_incomplete_fail_soft_artifact(normalized_reply: &str) -> bool {
     INCOMPLETE_FAIL_SOFT_MARKERS
         .iter()
         .any(|marker| normalized_reply.contains(marker))
 }
 
-#[allow(dead_code)]
 fn is_incomplete_research_artifact(normalized_reply: &str) -> bool {
     INCOMPLETE_RESEARCH_MARKERS
         .iter()
@@ -1096,7 +1126,7 @@ mod tests {
     }
 
     #[test]
-    fn incomplete_research_pseudo_memo_passes_mechanical_validation() {
+    fn incomplete_research_pseudo_memo_fails_contract_validation() {
         let workspace = write_workspace(
             "Give me a deep research about the Nokia stock, and tell me whether it is a good time to buy.",
             r#"
@@ -1170,12 +1200,13 @@ mod tests {
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
-        ensure_expected_reply_artifact(&workspace, &reply_path, "")
-            .expect("runtime should not block based on semantic completeness");
+        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
+            .expect_err("incomplete research artifact should not be user-facing success");
+        assert!(err.to_string().contains("incomplete/fail-soft"));
     }
 
     #[test]
-    fn incomplete_short_monitor_artifact_passes_mechanical_validation() {
+    fn incomplete_short_monitor_artifact_fails_contract_validation() {
         let workspace = write_workspace(
             "Check whether anything material changed for NVDA since your last note. Only tell me if I should act.",
             r#"
@@ -1217,7 +1248,35 @@ mod tests {
         );
         let reply_path = workspace.join("reply_email_draft.html");
 
-        ensure_expected_reply_artifact(&workspace, &reply_path, "")
-            .expect("runtime should not block based on semantic completeness");
+        let err = ensure_expected_reply_artifact(&workspace, &reply_path, "")
+            .expect_err("short monitor fail-soft should not be user-facing success");
+        assert!(err.to_string().contains("incomplete/fail-soft"));
+    }
+
+    #[test]
+    fn slack_html_fail_soft_investment_reply_fails_contract_validation() {
+        let workspace = write_workspace(
+            "You are a Wall Street Analyst. Watch out for the stock SOFI and HOOD. Let me know buy, hold, or sell.",
+            r#"
+            <html>
+              <body>
+                <h1>Quick update on SOFI (SOFI)</h1>
+                <p><strong>As of:</strong> 2026-05-08</p>
+                <p><strong>Status:</strong> Unable to Verify</p>
+                <p><strong>Action:</strong> No recommendation</p>
+                <p><strong>Why:</strong> I could not finish a reliable investment update within the bounded runtime, so I am not sending a half-verified buy / wait / avoid call.</p>
+              </body>
+            </html>
+            "#,
+        );
+        let email_reply = workspace.join("reply_email_draft.html");
+        let slack_reply = workspace.join("reply_message.txt");
+        fs::rename(email_reply, &slack_reply).expect("rename reply");
+
+        let err = ensure_expected_reply_artifact(&workspace, &slack_reply, "")
+            .expect_err("Slack investment reply must not accept stale HTML fail-soft");
+        let rendered = err.to_string();
+        assert!(rendered.contains("HTML markup instead of plain text"));
+        assert!(rendered.contains("incomplete/fail-soft"));
     }
 }

--- a/DoWhiz_service/run_task_module/src/run_task/types.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/types.rs
@@ -225,4 +225,8 @@ pub struct RunTaskOutput {
     pub scheduler_actions_error: Option<String>,
     pub token_usage: Option<TokenUsage>,
     pub recovery_note: Option<String>,
+    /// Set when a user-facing failure artifact was intentionally written and
+    /// should be delivered, but the scheduler execution must still be marked
+    /// failed rather than completed.
+    pub terminal_error_message: Option<String>,
 }

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -1234,14 +1234,22 @@ sleep 20
     let html = fs::read_to_string(&result.reply_html_path).unwrap();
     assert!(html.contains("Investment analysis could not be completed"));
     assert!(html.contains("No investment recommendation is included"));
-    assert_eq!(fs::read_to_string(&counter_path).unwrap(), "2");
-    assert!(workspace.join("codex_fast_completion_context.md").exists());
+    assert_eq!(fs::read_to_string(&counter_path).unwrap(), "1");
+    assert!(!workspace.join("codex_fast_completion_context.md").exists());
     assert!(!html.contains("Quick update on"));
     assert!(!html.contains("Unable to Verify"));
     assert!(!html.contains("No recommendation"));
     let note = result.recovery_note.as_deref().unwrap_or("");
     assert!(note.contains("operational failure reply"));
     assert!(!note.contains("Claude fallback"));
+    assert!(
+        result
+            .terminal_error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("operational failure reply"),
+        "operational failure reply should not be recorded as a successful task execution"
+    );
 }
 
 #[test]
@@ -1568,6 +1576,14 @@ exit 7
     );
     let note = result.recovery_note.unwrap_or_default();
     assert!(note.contains("content-filter explanation"));
+    assert!(
+        result
+            .terminal_error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("content-filter explanation"),
+        "content-filter explanation replies should be delivered but recorded as failed executions"
+    );
 }
 
 #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -24,7 +24,7 @@ use super::store::{
     SchedulerStore,
 };
 use super::types::{
-    RunTaskTask, Schedule, ScheduledTask, SchedulerError, SendReplyTask, TaskKind,
+    RunTaskTask, Schedule, ScheduledTask, SchedulerError, SendReplyTask, TaskExecution, TaskKind,
     RUN_TASK_FAILURE_DIR, RUN_TASK_FAILURE_LIMIT, RUN_TASK_FAILURE_NOTICE,
     RUN_TASK_FAILURE_REPORT_DIR,
 };
@@ -303,18 +303,17 @@ impl<E: TaskExecutor> Scheduler<E> {
 
         match result {
             Ok(execution) => {
-                if let Err(err) = self.store.reset_retry_count(&task_id.to_string()) {
-                    warn!(
-                        "failed to reset retry count for task {} after success: {}",
-                        task_id, err
-                    );
+                let terminal_outcome = execution_terminal_outcome(&execution);
+                let terminal_status = terminal_outcome.status.as_str();
+                let terminal_note = terminal_outcome.note;
+                if terminal_status != "failed" {
+                    if let Err(err) = self.store.reset_retry_count(&task_id.to_string()) {
+                        warn!(
+                            "failed to reset retry count for task {} after terminal status {}: {}",
+                            task_id, terminal_status, err
+                        );
+                    }
                 }
-                let terminal_status = if execution.superseded {
-                    "superseded"
-                } else {
-                    "success"
-                };
-                let terminal_note = execution.terminal_note.clone();
                 self.store.record_execution_finish(
                     task_id,
                     execution_handle,
@@ -415,14 +414,14 @@ impl<E: TaskExecutor> Scheduler<E> {
                             err
                         );
                     }
-                    // Sync success status to user's account-level storage for Discord/Slack
+                    // Sync terminal status to user's account-level storage for Discord/Slack.
                     sync_task_status_to_user_storage(
                         task_id,
                         task,
                         execution_handle,
                         executed_at,
-                        "success",
-                        None,
+                        terminal_status,
+                        terminal_note.as_deref(),
                     );
                 }
                 if let Some(session) = archive_session.take() {
@@ -430,8 +429,8 @@ impl<E: TaskExecutor> Scheduler<E> {
                         &task_before_snapshot,
                         &self.tasks[index],
                         executed_at,
-                        "success",
-                        None,
+                        terminal_status,
+                        terminal_note.as_deref(),
                     ) {
                         Ok(record) => {
                             if let Err(err) = self.store.record_task_debug_archive(&record) {
@@ -630,6 +629,27 @@ impl<E: TaskExecutor> Scheduler<E> {
         }
         // Update in database
         self.store.disable_task_by_id(task_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExecutionTerminalOutcome {
+    pub status: String,
+    pub note: Option<String>,
+}
+
+pub(crate) fn execution_terminal_outcome(execution: &TaskExecution) -> ExecutionTerminalOutcome {
+    let status = if execution.superseded {
+        "superseded"
+    } else {
+        execution.terminal_status.as_deref().unwrap_or("success")
+    };
+    ExecutionTerminalOutcome {
+        status: status.to_string(),
+        note: execution
+            .terminal_error_message
+            .clone()
+            .or_else(|| execution.terminal_note.clone()),
     }
 }
 

--- a/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
@@ -1765,8 +1765,14 @@ impl TaskExecutor for ModuleExecutor {
                         ))
                     })?;
                 }
-                if let Some(account_id) = account_id {
-                    track_task_success_markers(account_id, task, &task_dedupe_key);
+                let terminal_status = output
+                    .terminal_error_message
+                    .as_ref()
+                    .map(|_| "failed".to_string());
+                if terminal_status.as_deref() != Some("failed") {
+                    if let Some(account_id) = account_id {
+                        track_task_success_markers(account_id, task, &task_dedupe_key);
+                    }
                 }
                 Ok(TaskExecution {
                     follow_up_tasks: output.scheduled_tasks,
@@ -1776,6 +1782,8 @@ impl TaskExecutor for ModuleExecutor {
                     skip_auto_reply: false,
                     superseded: false,
                     terminal_note: output.recovery_note,
+                    terminal_status,
+                    terminal_error_message: output.terminal_error_message,
                 })
             }
             TaskKind::Noop => Ok(TaskExecution::empty()),
@@ -1897,6 +1905,7 @@ mod tests {
             scheduler_actions_error: None,
             token_usage: None,
             recovery_note: recovery_note.map(str::to_string),
+            terminal_error_message: None,
         }
     }
 

--- a/DoWhiz_service/scheduler_module/src/scheduler/outbound.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/outbound.rs
@@ -76,6 +76,34 @@ fn resolve_slack_bot_token_for_send(task: &SendReplyTask) -> Result<String, Sche
     })
 }
 
+fn parse_slack_compound_reply_target(value: &str) -> Option<(String, Option<String>)> {
+    let mut parts = value.splitn(4, ':');
+    if parts.next()? != "slack" {
+        return None;
+    }
+    let channel = parts.next()?.trim();
+    if channel.is_empty() {
+        return None;
+    }
+    let thread_ts = parts
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    Some((channel.to_string(), thread_ts.map(ToOwned::to_owned)))
+}
+
+fn slack_inactive_account_error(task: &SendReplyTask) -> SchedulerError {
+    let metadata = task.normalized_channel_metadata();
+    SchedulerError::TaskFailed(format!(
+        "Slack account is inactive for team {}. Reinstall or relink the Slack integration for employee {} before retrying this Slack-originated task.",
+        metadata
+            .slack_team_id
+            .as_deref()
+            .unwrap_or("unknown"),
+        task.employee_id.as_deref().unwrap_or("unknown")
+    ))
+}
+
 /// Execute a SendReplyTask via Slack.
 pub(crate) fn execute_slack_send(task: &SendReplyTask) -> Result<(), SchedulerError> {
     use crate::adapters::slack::SlackOutboundAdapter;
@@ -84,6 +112,10 @@ pub(crate) fn execute_slack_send(task: &SendReplyTask) -> Result<(), SchedulerEr
     dotenvy::dotenv().ok();
     let bot_token = resolve_slack_bot_token_for_send(task)?;
     let metadata = task.normalized_channel_metadata();
+    let compound_target = task
+        .to
+        .iter()
+        .find_map(|value| parse_slack_compound_reply_target(value));
 
     let adapter = SlackOutboundAdapter::new(bot_token);
 
@@ -105,12 +137,17 @@ pub(crate) fn execute_slack_send(task: &SendReplyTask) -> Result<(), SchedulerEr
         html_body: String::new(),
         html_path: Some(task.html_path.clone()),
         attachments_dir: Some(task.attachments_dir.clone()),
-        thread_id: task.in_reply_to.clone(), // Use in_reply_to as thread_ts for Slack
+        thread_id: task.in_reply_to.clone().or_else(|| {
+            compound_target
+                .as_ref()
+                .and_then(|(_, thread_ts)| thread_ts.clone())
+        }),
         metadata: ChannelMetadata {
             // For Slack, reply_to[0] = user_id, reply_to[1] = channel_id
             slack_channel_id: metadata
                 .slack_channel_id
                 .clone()
+                .or_else(|| compound_target.as_ref().map(|(channel, _)| channel.clone()))
                 .or_else(|| task.to.get(1).cloned())
                 .or_else(|| task.to.first().cloned()),
             slack_team_id: metadata.slack_team_id.clone(),
@@ -118,9 +155,14 @@ pub(crate) fn execute_slack_send(task: &SendReplyTask) -> Result<(), SchedulerEr
         },
     };
 
-    let result = adapter
-        .send(&message)
-        .map_err(|err| SchedulerError::TaskFailed(format!("Slack send failed: {}", err)))?;
+    let result = adapter.send(&message).map_err(|err| {
+        let err_text = err.to_string();
+        if err_text.contains("account_inactive") {
+            slack_inactive_account_error(task)
+        } else {
+            SchedulerError::TaskFailed(format!("Slack send failed: {}", err_text))
+        }
+    })?;
 
     if !result.success {
         if result.error.as_deref() == Some("channel_not_found") {
@@ -135,6 +177,9 @@ pub(crate) fn execute_slack_send(task: &SendReplyTask) -> Result<(), SchedulerEr
             return Err(SchedulerError::TaskFailed(
                 "Slack user not found in this workspace. The recipient may have linked their Slack account from a different workspace. Please ask them to re-link Slack from the correct workspace in their DoWhiz settings.".to_string()
             ));
+        }
+        if result.error.as_deref() == Some("account_inactive") {
+            return Err(slack_inactive_account_error(task));
         }
         return Err(SchedulerError::TaskFailed(format!(
             "Slack API error: {}",
@@ -1045,8 +1090,8 @@ pub(crate) fn execute_notion_send(task: &SendReplyTask) -> Result<(), SchedulerE
 #[cfg(test)]
 mod tests {
     use super::{
-        execute_email_send, is_discord_unknown_message_reference, split_discord_message_chunks,
-        DISCORD_MAX_CONTENT_CHARS,
+        execute_email_send, execute_slack_send, is_discord_unknown_message_reference,
+        parse_slack_compound_reply_target, split_discord_message_chunks, DISCORD_MAX_CONTENT_CHARS,
     };
     use crate::channel::Channel;
     use crate::scheduler::types::SendReplyTask;
@@ -1110,6 +1155,73 @@ mod tests {
         assert_eq!(chunks[0].chars().count(), DISCORD_MAX_CONTENT_CHARS);
         assert_eq!(chunks[1].chars().count(), 3);
         assert_eq!(chunks.concat(), text);
+    }
+
+    #[test]
+    fn parse_slack_compound_reply_target_extracts_channel_and_thread() {
+        assert_eq!(
+            parse_slack_compound_reply_target("slack:C123:1777269474.488829"),
+            Some(("C123".to_string(), Some("1777269474.488829".to_string())))
+        );
+        assert_eq!(
+            parse_slack_compound_reply_target("slack:D123"),
+            Some(("D123".to_string(), None))
+        );
+        assert_eq!(parse_slack_compound_reply_target("C123"), None);
+    }
+
+    #[test]
+    fn execute_slack_send_reports_inactive_account_with_relink_guidance(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut server = Server::new();
+        let slack_mock = server
+            .mock("POST", "/chat.postMessage")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":false,"error":"account_inactive"}"#)
+            .expect(1)
+            .create();
+
+        let _env = EnvGuard::set(&[
+            ("SLACK_BOT_TOKEN", "xoxb-inactive"),
+            ("SLACK_BOT_USER_ID", "UINACTIVE"),
+            ("SLACK_API_BASE_URL", server.url().as_str()),
+        ]);
+        let temp = TempDir::new()?;
+        let reply_path = temp.path().join("reply_message.txt");
+        fs::write(&reply_path, "hello")?;
+        let attachments_dir = temp.path().join("reply_attachments");
+        fs::create_dir_all(&attachments_dir)?;
+        let task = SendReplyTask {
+            channel: Channel::Slack,
+            subject: "Slack reply".to_string(),
+            html_path: reply_path,
+            attachments_dir,
+            from: None,
+            to: vec!["slack:C123:1777269474.488829".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            in_reply_to: None,
+            references: None,
+            archive_root: None,
+            thread_epoch: None,
+            thread_state_path: None,
+            employee_id: Some("little_bear".to_string()),
+            channel_metadata: Default::default(),
+        };
+
+        let err = execute_slack_send(&task).expect_err("inactive Slack token should fail");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("Slack account is inactive"),
+            "unexpected error: {rendered}"
+        );
+        assert!(
+            rendered.contains("Reinstall or relink"),
+            "unexpected error: {rendered}"
+        );
+        slack_mock.assert();
+        Ok(())
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -15,6 +15,7 @@ use super::{
     actions::{
         apply_scheduler_actions, resolve_schedule_request_with_context, schedule_send_email,
     },
+    core::execution_terminal_outcome,
     is_user_visible_routine_task, maybe_repair_legacy_weekday_cron_task, prepare_task_for_resume,
     snapshot::build_scheduler_snapshot,
     RunTaskTask, Schedule, ScheduledTask, Scheduler, SchedulerError, TaskExecution, TaskExecutor,
@@ -45,6 +46,21 @@ impl FailingExecutor {
 impl TaskExecutor for FailingExecutor {
     fn execute(&self, _task: &TaskKind) -> Result<TaskExecution, SchedulerError> {
         Err(SchedulerError::TaskFailed(self.message.clone()))
+    }
+}
+
+#[derive(Default)]
+struct TerminalFailureReplyExecutor;
+
+impl TaskExecutor for TerminalFailureReplyExecutor {
+    fn execute(&self, _task: &TaskKind) -> Result<TaskExecution, SchedulerError> {
+        Ok(TaskExecution {
+            terminal_status: Some("failed".to_string()),
+            terminal_error_message: Some(
+                "Investment analysis runners failed after all configured attempts".to_string(),
+            ),
+            ..TaskExecution::empty()
+        })
     }
 }
 
@@ -733,6 +749,80 @@ fn execution_status_can_be_recorded_for_task() {
         assert_eq!(tasks[0].id, specific_id.to_string());
         assert_eq!(tasks[0].execution_status, Some("success".to_string()));
     }
+}
+
+#[test]
+fn terminal_failure_reply_outcome_uses_failed_status_and_error_note() {
+    let execution = TaskExecution {
+        terminal_status: Some("failed".to_string()),
+        terminal_error_message: Some(
+            "Investment analysis runners failed after all configured attempts".to_string(),
+        ),
+        terminal_note: Some("generic recovery note".to_string()),
+        ..TaskExecution::empty()
+    };
+
+    let outcome = execution_terminal_outcome(&execution);
+    assert_eq!(outcome.status, "failed");
+    assert_eq!(
+        outcome.note.as_deref(),
+        Some("Investment analysis runners failed after all configured attempts")
+    );
+}
+
+#[test]
+fn terminal_failure_reply_is_sent_but_run_task_status_is_failed() {
+    use super::store::SchedulerStore;
+
+    if !mongo_execution_tests_enabled() {
+        eprintln!("skipping Mongo-backed scheduler integration test: MONGODB_URI/MONGODB_DATABASE not set");
+        return;
+    }
+
+    let temp = TempDir::new().expect("tempdir");
+    let tasks_db = temp.path().join("tasks.db");
+    let workspace = temp.path().join("workspace");
+    let mail_root = temp.path().join("mail");
+    fs::create_dir_all(&workspace).expect("workspace");
+    fs::create_dir_all(&mail_root).expect("mail");
+    fs::write(
+        workspace.join("reply_email_draft.html"),
+        "<html><body><p>Analysis could not be completed.</p></body></html>",
+    )
+    .expect("reply draft");
+
+    let run_task = base_run_task(&workspace, &mail_root);
+    let task_id = {
+        let mut scheduler =
+            Scheduler::load(&tasks_db, TerminalFailureReplyExecutor).expect("load scheduler");
+        let task_id = scheduler
+            .add_one_shot_in(Duration::from_secs(0), TaskKind::RunTask(run_task))
+            .expect("add run task");
+        scheduler.tick().expect("tick");
+        task_id
+    };
+
+    let store = SchedulerStore::new(tasks_db).expect("open store");
+    let tasks = store.list_tasks_with_status().expect("list tasks");
+    let run_task_summary = tasks
+        .iter()
+        .find(|task| task.id == task_id.to_string())
+        .expect("run task summary");
+    assert_eq!(run_task_summary.execution_status.as_deref(), Some("failed"));
+    assert!(
+        run_task_summary
+            .error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("Investment analysis runners failed"),
+        "terminal failure message should be visible on the failed run task"
+    );
+    assert!(
+        tasks
+            .iter()
+            .any(|task| task.kind == "send_email" && task.channel == "email"),
+        "terminal failure reply should still schedule an outbound email"
+    );
 }
 
 #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/types.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/types.rs
@@ -272,6 +272,8 @@ pub struct TaskExecution {
     pub skip_auto_reply: bool,
     pub superseded: bool,
     pub terminal_note: Option<String>,
+    pub terminal_status: Option<String>,
+    pub terminal_error_message: Option<String>,
 }
 
 impl TaskExecution {

--- a/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
@@ -148,6 +148,11 @@ impl TaskExecutor for RecordingExecutor {
                     skip_auto_reply: false,
                     superseded: false,
                     terminal_note: output.recovery_note,
+                    terminal_status: output
+                        .terminal_error_message
+                        .as_ref()
+                        .map(|_| "failed".to_string()),
+                    terminal_error_message: output.terminal_error_message,
                 })
             }
             TaskKind::SendReply(_) => Ok(TaskExecution::default()),

--- a/DoWhiz_service/scheduler_module/tests/scheduler_agent_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_agent_e2e.rs
@@ -83,6 +83,11 @@ impl TaskExecutor for RecordingExecutor {
                     skip_auto_reply: false,
                     superseded: false,
                     terminal_note: output.recovery_note,
+                    terminal_status: output
+                        .terminal_error_message
+                        .as_ref()
+                        .map(|_| "failed".to_string()),
+                    terminal_error_message: output.terminal_error_message,
                 })
             }
             TaskKind::SendReply(send) => {

--- a/DoWhiz_service/scheduler_module/tests/scheduler_followups.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_followups.rs
@@ -33,6 +33,8 @@ impl TaskExecutor for FollowUpExecutor {
                     skip_auto_reply: false,
                     superseded: false,
                     terminal_note: None,
+                    terminal_status: None,
+                    terminal_error_message: None,
                 })
             }
             _ => Ok(TaskExecution::default()),

--- a/DoWhiz_service/scheduler_module/tests/scheduler_x402_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_x402_env_e2e.rs
@@ -99,6 +99,11 @@ impl TaskExecutor for RecordingExecutor {
                     skip_auto_reply: false,
                     superseded: false,
                     terminal_note: output.recovery_note,
+                    terminal_status: output
+                        .terminal_error_message
+                        .as_ref()
+                        .map(|_| "failed".to_string()),
+                    terminal_error_message: output.terminal_error_message,
                 })
             }
             TaskKind::SendReply(_) => Ok(TaskExecution::default()),

--- a/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
@@ -134,6 +134,11 @@ impl TaskExecutor for RecordingExecutor {
                     skip_auto_reply: false,
                     superseded: false,
                     terminal_note: output.recovery_note,
+                    terminal_status: output
+                        .terminal_error_message
+                        .as_ref()
+                        .map(|_| "failed".to_string()),
+                    terminal_error_message: output.terminal_error_message,
                 })
             }
             TaskKind::SendReply(send) => {


### PR DESCRIPTION
## Summary
- Mark user-facing failure artifacts as failed terminal outcomes while still sending the explanatory reply.
- Stop routing deep investment research through short monitor fast-completion budgets.
- Reject stale/fail-soft investment artifacts and improve Slack reply target/error handling.

## Validation
- cargo fmt --all --check
- git diff --check
- cargo check --locked -p run_task_module
- cargo check --locked -p scheduler_module --lib
- cargo check --locked -p scheduler_module --all-targets
- cargo test --locked -p run_task_module
- cargo test --locked -p run_task_module run_task_generic_content_filter_returns_explanatory_reply_without_claude_fallback
- cargo test --locked -p scheduler_module terminal_failure_reply
- cargo test --locked -p scheduler_module parse_slack_compound_reply_target_extracts_channel_and_thread
- cargo test --locked -p scheduler_module execute_slack_send_reports_inactive_account_with_relink_guidance

Note: a broad diagnostic `cargo test --locked -p scheduler_module slack` was intentionally not used as validation because it pulls unrelated Mongo/mock-dependent Slack tests and fails locally without MONGODB_URI.