### PR TITLE
Fix Notion token fallback and task error redaction

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/core.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/core.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use super::claude::run_claude_task;
@@ -15,7 +16,7 @@ use super::reply_contract::{
 };
 use super::trace::RUN_TASK_TRACE_DIRNAME;
 use super::types::{RunTaskOutput, RunTaskParams, RunTaskRequest};
-use super::utils::split_reply_completion_budget;
+use super::utils::{split_reply_completion_budget, tail_string};
 use super::workspace::{prepare_workspace, remap_workspace_dir, write_placeholder_reply};
 
 const MAX_INVESTMENT_MONITOR_PRIMARY_TIMEOUT_SECS: u64 = 30;
@@ -80,6 +81,9 @@ pub fn run_task(params: &RunTaskParams) -> Result<RunTaskOutput, RunTaskError> {
         Err(primary_err) => {
             let mut fallback_primary_err = primary_err;
             let mut allow_fast_completion_retry = codex_budget_split.is_some();
+            if is_notion_unrecoverable_reply_failure(params, &fallback_primary_err) {
+                return Err(fallback_primary_err);
+            }
             if runner.eq_ignore_ascii_case("codex")
                 && investment_request
                 && !params.reply_to.is_empty()
@@ -136,6 +140,9 @@ pub fn run_task(params: &RunTaskParams) -> Result<RunTaskOutput, RunTaskError> {
                 )? {
                     return Ok(output);
                 }
+            }
+            if is_notion_unrecoverable_reply_failure(params, &fallback_primary_err) {
+                return Err(fallback_primary_err);
             }
             if allow_fast_completion_retry {
                 if let Some((_, fast_completion_timeout)) = codex_budget_split {
@@ -209,6 +216,7 @@ fn maybe_finalize_generic_content_filter_reply(
     let request = build_request(workspace_dir, params, params.model_name.as_str());
     let (reply_path, reply_attachments_dir) = prepare_workspace(&request)?;
     let lower_channel = params.channel.trim().to_ascii_lowercase();
+    let is_notion = lower_channel == "notion";
     let reply_body = match lower_channel.as_str() {
         "slack" | "discord" | "telegram" | "sms" | "whatsapp" | "bluebubbles" | "lark"
         | "wechat" | "wechat_mp" | "notion" => {
@@ -217,7 +225,12 @@ fn maybe_finalize_generic_content_filter_reply(
         }
         _ => r#"<html><body><p>I couldn't show the requested result because the Azure/OpenAI content filter blocked this run.</p><p>Please revise the prompt and send a new request.</p></body></html>"#.to_string(),
     };
-    fs::write(&reply_path, reply_body)?;
+    if is_notion {
+        post_notion_text_reply(workspace_dir, &reply_body)?;
+        fs::write(&reply_path, "content-filter explanation posted to Notion\n")?;
+    } else {
+        fs::write(&reply_path, reply_body)?;
+    }
 
     let recovery_note =
         "Returned an explicit Azure/OpenAI content-filter explanation to the user instead of retrying hidden output."
@@ -235,6 +248,104 @@ fn maybe_finalize_generic_content_filter_reply(
         recovery_note: Some(recovery_note.clone()),
         terminal_error_message: Some(recovery_note),
     }))
+}
+
+fn is_notion_unrecoverable_reply_failure(params: &RunTaskParams, err: &RunTaskError) -> bool {
+    if !params.channel.trim().eq_ignore_ascii_case("notion") {
+        return false;
+    }
+    output_looks_like_notion_auth_failure(&err.to_string())
+}
+
+fn output_looks_like_notion_auth_failure(output: &str) -> bool {
+    let normalized = output.to_ascii_lowercase();
+    normalized.contains("api token is invalid")
+        || normalized.contains("401 unauthorized")
+        || normalized.contains("no notion integration available")
+        || normalized.contains("notion auth")
+        || normalized.contains("relink or refresh the notion integration")
+        || normalized.contains("link your notion workspace")
+}
+
+fn post_notion_text_reply(workspace_dir: &Path, reply_body: &str) -> Result<(), RunTaskError> {
+    let page_id = read_notion_page_id(workspace_dir)?;
+    let token = read_notion_api_token(workspace_dir)?;
+    let output = Command::new("notion_api_cli")
+        .arg("create-comment")
+        .arg("--page-id")
+        .arg(&page_id)
+        .arg("--content")
+        .arg(reply_body)
+        .env("NOTION_API_TOKEN", token)
+        .current_dir(workspace_dir)
+        .output()?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    Err(RunTaskError::OutputMissing {
+        path: workspace_dir.join(".notion_api_replied"),
+        output: format!(
+            "Failed to post content-filter explanation to Notion page {page_id}. notion_api_cli exit status {:?}. Output tail:\n{}",
+            output.status.code(),
+            tail_string(&combined, 2000)
+        ),
+    })
+}
+
+fn read_notion_page_id(workspace_dir: &Path) -> Result<String, RunTaskError> {
+    for file_name in [".notion_context.json", ".notion_email_context.json"] {
+        let path = workspace_dir.join(file_name);
+        if !path.exists() {
+            continue;
+        }
+        let content = fs::read_to_string(&path)?;
+        let parsed: serde_json::Value = serde_json::from_str(&content).map_err(|err| {
+            RunTaskError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+        })?;
+        if let Some(page_id) = parsed.get("page_id").and_then(|value| value.as_str()) {
+            let trimmed = page_id.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+        }
+    }
+
+    Err(RunTaskError::OutputMissing {
+        path: workspace_dir.join(".notion_context.json"),
+        output: "Cannot post Notion reply because no page_id was found in Notion context files."
+            .to_string(),
+    })
+}
+
+fn read_notion_api_token(workspace_dir: &Path) -> Result<String, RunTaskError> {
+    let path = workspace_dir.join(".notion_env");
+    let content = fs::read_to_string(&path).map_err(|err| match err.kind() {
+        std::io::ErrorKind::NotFound => RunTaskError::OutputMissing {
+            path: path.clone(),
+            output: "Cannot post Notion reply because .notion_env is missing.".to_string(),
+        },
+        _ => RunTaskError::Io(err),
+    })?;
+    for line in content.lines() {
+        let Some(value) = line.trim().strip_prefix("NOTION_API_TOKEN=") else {
+            continue;
+        };
+        let token = value.trim().trim_matches('"').trim_matches('\'');
+        if !token.is_empty() {
+            return Ok(token.to_string());
+        }
+    }
+
+    Err(RunTaskError::OutputMissing {
+        path,
+        output: "Cannot post Notion reply because .notion_env does not contain NOTION_API_TOKEN."
+            .to_string(),
+    })
 }
 
 fn output_looks_like_content_filter_failure(output: &str) -> bool {

--- a/DoWhiz_service/run_task_module/src/run_task/errors.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/errors.rs
@@ -71,6 +71,132 @@ pub enum RunTaskError {
     },
 }
 
+const REDACTED_SECRET: &str = "REDACTED";
+const SECRET_TOKEN_PREFIXES: &[&str] = &[
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "GOCSPX-",
+    "ya29.",
+    "ntn_",
+    "secret_",
+];
+const SECRET_ASSIGNMENT_KEYS: &[&str] = &[
+    "access_token",
+    "api_key",
+    "apikey",
+    "auth_token",
+    "client_secret",
+    "connection_string",
+    "notion_api_token",
+    "oauth_token",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "storage_key",
+];
+const SECRET_QUERY_PARAMS: &[&str] = &[
+    "access_token",
+    "code",
+    "sig",
+    "se",
+    "sp",
+    "sr",
+    "ss",
+    "srt",
+    "st",
+    "sv",
+];
+
+pub fn redact_sensitive_text_for_display(input: &str) -> String {
+    let mut redacted = redact_sensitive_assignment_lines(input);
+    for prefix in SECRET_TOKEN_PREFIXES {
+        redacted = redact_prefixed_token(&redacted, prefix);
+    }
+    for key in SECRET_QUERY_PARAMS {
+        redacted = redact_query_param(&redacted, key);
+    }
+    redacted
+}
+
+fn redact_sensitive_assignment_lines(input: &str) -> String {
+    let mut redacted = String::with_capacity(input.len());
+    for line in input.split_inclusive('\n') {
+        let (body, newline) = line
+            .strip_suffix('\n')
+            .map(|body| (body, "\n"))
+            .unwrap_or((line, ""));
+        let lower = body.to_ascii_lowercase();
+        if SECRET_ASSIGNMENT_KEYS.iter().any(|key| lower.contains(key)) {
+            if let Some(idx) = body.find(':').or_else(|| body.find('=')) {
+                redacted.push_str(body[..=idx].trim_end());
+                redacted.push(' ');
+                redacted.push_str(REDACTED_SECRET);
+            } else {
+                redacted.push_str(REDACTED_SECRET);
+            }
+        } else {
+            redacted.push_str(body);
+        }
+        redacted.push_str(newline);
+    }
+    redacted
+}
+
+fn redact_prefixed_token(input: &str, prefix: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut remaining = input;
+    while let Some(idx) = remaining.find(prefix) {
+        let token_start = idx + prefix.len();
+        output.push_str(&remaining[..token_start]);
+        output.push_str(REDACTED_SECRET);
+        let tail = &remaining[token_start..];
+        let token_end = tail
+            .char_indices()
+            .find_map(|(offset, ch)| {
+                if is_token_boundary(ch) {
+                    Some(offset)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(tail.len());
+        remaining = &tail[token_end..];
+    }
+    output.push_str(remaining);
+    output
+}
+
+fn is_token_boundary(ch: char) -> bool {
+    !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+}
+
+fn redact_query_param(input: &str, key: &str) -> String {
+    let pattern = format!("{key}=");
+    let mut output = String::with_capacity(input.len());
+    let mut remaining = input;
+    while let Some(idx) = remaining.find(&pattern) {
+        let value_start = idx + pattern.len();
+        output.push_str(&remaining[..value_start]);
+        output.push_str(REDACTED_SECRET);
+        let tail = &remaining[value_start..];
+        let value_end = tail
+            .char_indices()
+            .find_map(|(offset, ch)| match ch {
+                '&' | ' ' | '\n' | '\r' | '\t' | '"' | '\'' | '<' | '>' => Some(offset),
+                _ => None,
+            })
+            .unwrap_or(tail.len());
+        remaining = &tail[value_end..];
+    }
+    output.push_str(remaining);
+    output
+}
+
 impl fmt::Display for RunTaskError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -91,22 +217,29 @@ impl fmt::Display for RunTaskError {
             RunTaskError::CodexFailed { status, output } => write!(
                 f,
                 "Codex failed (status: {:?}). Output tail:\n{}",
-                status, output
+                status,
+                redact_sensitive_text_for_display(output)
             ),
             RunTaskError::ClaudeNotFound => write!(f, "Claude CLI not found on PATH."),
             RunTaskError::ClaudeInstallFailed { output } => {
-                write!(f, "Failed to install Claude CLI. Output tail:\n{}", output)
+                write!(
+                    f,
+                    "Failed to install Claude CLI. Output tail:\n{}",
+                    redact_sensitive_text_for_display(output)
+                )
             }
             RunTaskError::ClaudeFailed { status, output } => write!(
                 f,
                 "Claude failed (status: {:?}). Output tail:\n{}",
-                status, output
+                status,
+                redact_sensitive_text_for_display(output)
             ),
             RunTaskError::DockerNotFound => write!(f, "Docker CLI not found on PATH."),
             RunTaskError::DockerFailed { status, output } => write!(
                 f,
                 "Docker run failed (status: {:?}). Output tail:\n{}",
-                status, output
+                status,
+                redact_sensitive_text_for_display(output)
             ),
             RunTaskError::AzureCliNotFound => write!(f, "Azure CLI (az) not found on PATH."),
             RunTaskError::LocalExecutionForbidden { deploy_target } => write!(
@@ -121,12 +254,15 @@ impl fmt::Display for RunTaskError {
             } => write!(
                 f,
                 "Command timed out ({} after {}s). Output tail:\n{}",
-                command, timeout_secs, output
+                command,
+                timeout_secs,
+                redact_sensitive_text_for_display(output)
             ),
             RunTaskError::Canceled { reason, output } => write!(
                 f,
                 "Run task canceled: {}\nOutput tail:\n{}",
-                reason, output
+                reason,
+                redact_sensitive_text_for_display(output)
             ),
             RunTaskError::GitHubAuthCommandNotFound { command } => {
                 write!(f, "GitHub auth command not found on PATH: {}", command)
@@ -138,24 +274,28 @@ impl fmt::Display for RunTaskError {
             } => write!(
                 f,
                 "GitHub auth command failed ({} status: {:?}). Output tail:\n{}",
-                command, status, output
+                command,
+                status,
+                redact_sensitive_text_for_display(output)
             ),
             RunTaskError::BrowserbaseFailed { action, output } => write!(
                 f,
                 "Browserbase {} failed. Output tail:\n{}",
-                action, output
+                action,
+                redact_sensitive_text_for_display(output)
             ),
             RunTaskError::FallbackFailed { primary, fallback } => write!(
                 f,
                 "Primary runner failed:\n{}\n\nClaude fallback failed:\n{}",
-                primary, fallback
+                redact_sensitive_text_for_display(primary),
+                redact_sensitive_text_for_display(fallback)
             ),
             RunTaskError::OutputMissing { path, output } => {
                 write!(
                     f,
                     "Expected output not found: {}\nCodex output tail:\n{}",
                     path.display(),
-                    output
+                    redact_sensitive_text_for_display(output)
                 )
             }
             RunTaskError::OutputContractViolation {
@@ -167,7 +307,7 @@ impl fmt::Display for RunTaskError {
                 "Output contract violation at {}: {}\nCodex output tail:\n{}",
                 path.display(),
                 reason,
-                output
+                redact_sensitive_text_for_display(output)
             ),
         }
     }
@@ -178,5 +318,34 @@ impl std::error::Error for RunTaskError {}
 impl From<io::Error> for RunTaskError {
     fn from(err: io::Error) -> Self {
         RunTaskError::Io(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_redacts_common_secret_shapes() {
+        let err = RunTaskError::CodexFailed {
+            status: Some(1),
+            output: r#"--- .config/gh/hosts.yml ---
+oauth_token: ghp_abcdefghijklmnopqrstuvwxyz1234567890
+--- .secrets/google_workspace_cli_credentials.json ---
+{
+  "client_secret": "GOCSPX-secretvalue",
+  "refresh_token": "1//06refreshsecret"
+}
+https://example.blob.core.windows.net/share?sig=leakedSig&se=2099-01-01
+"#
+            .to_string(),
+        };
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("REDACTED"));
+        assert!(!rendered.contains("abcdefghijklmnopqrstuvwxyz"));
+        assert!(!rendered.contains("GOCSPX-secretvalue"));
+        assert!(!rendered.contains("06refreshsecret"));
+        assert!(!rendered.contains("leakedSig"));
     }
 }

--- a/DoWhiz_service/run_task_module/src/run_task/mod.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/mod.rs
@@ -29,7 +29,7 @@ pub use codex::{
     query_aci_container_status, run_codex_warm_pool, AciContainerStatus,
 };
 pub use core::{run_claude_fallback_after_codex_failure, run_task};
-pub use errors::RunTaskError;
+pub use errors::{redact_sensitive_text_for_display, RunTaskError};
 pub use pool_manager::{PoolConfig, PoolManager};
 pub use timing::{
     clear_timing_log, get_timing_log_path, QueueLatencyCollector, StageStats, TaskTiming,

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -1588,6 +1588,148 @@ exit 7
 
 #[test]
 #[cfg(unix)]
+fn run_task_notion_auth_failure_does_not_run_claude_fallback() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_notion_auth_failure").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    let claude_counter_path = temp.path.join("claude_invocations.txt");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_shell_script(
+        &bin_dir,
+        "codex",
+        r#"#!/bin/sh
+set -e
+echo "API Error: API request failed: Status 401 Unauthorized: {\"code\":\"unauthorized\",\"message\":\"API token is invalid.\"}" >&2
+exit 1
+"#,
+    );
+    write_shell_script(
+        &bin_dir,
+        "claude",
+        r#"#!/bin/sh
+set -e
+echo invoked >> "$CLAUDE_COUNTER_PATH"
+touch .notion_api_replied
+"#,
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("CLAUDE_COUNTER_PATH", claude_counter_path.to_str().unwrap()),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let mut params = build_params(&workspace);
+    params.channel = "notion".to_string();
+    let err = run_task(&params).unwrap_err();
+    assert!(err.to_string().contains("API token is invalid"));
+    assert!(
+        !workspace.join(".notion_api_replied").exists(),
+        "Notion auth failures must not be converted into a local marker without a posted Notion comment"
+    );
+    assert!(
+        !claude_counter_path.exists(),
+        "Claude fallback cannot repair invalid Notion auth and should not run"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn run_task_notion_content_filter_posts_explanation_via_notion_cli() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_notion_content_filter_notice").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    let posted_path = temp.path.join("posted_notion_comment.txt");
+    let claude_counter_path = temp.path.join("claude_invocations.txt");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    fs::write(
+        workspace.join(".notion_context.json"),
+        r#"{"page_id":"35d37bc1-a421-81cb-887c-c2510bbb37b9"}"#,
+    )
+    .unwrap();
+    fs::write(
+        workspace.join(".notion_env"),
+        "NOTION_API_TOKEN=valid-token\n",
+    )
+    .unwrap();
+    write_shell_script(
+        &bin_dir,
+        "codex",
+        r#"#!/bin/sh
+set -e
+echo "I'm sorry, but I cannot assist with that request." >&2
+echo "stream disconnected before completion: Incomplete response returned, reason: content_filter" >&2
+exit 1
+"#,
+    );
+    write_shell_script(
+        &bin_dir,
+        "notion_api_cli",
+        r#"#!/bin/sh
+set -e
+if [ "$1" != "create-comment" ]; then
+  echo "unexpected command $1" >&2
+  exit 2
+fi
+printf '%s\n' "$@" > "$POSTED_NOTION_COMMENT_PATH"
+"#,
+    );
+    write_shell_script(
+        &bin_dir,
+        "claude",
+        r#"#!/bin/sh
+set -e
+echo invoked >> "$CLAUDE_COUNTER_PATH"
+exit 7
+"#,
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("POSTED_NOTION_COMMENT_PATH", posted_path.to_str().unwrap()),
+        ("CLAUDE_COUNTER_PATH", claude_counter_path.to_str().unwrap()),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let mut params = build_params(&workspace);
+    params.channel = "notion".to_string();
+    let result = run_task(&params).unwrap();
+    assert!(workspace.join(".notion_api_replied").exists());
+    let posted = fs::read_to_string(posted_path).unwrap();
+    assert!(posted.contains("create-comment"));
+    assert!(posted.contains("35d37bc1-a421-81cb-887c-c2510bbb37b9"));
+    assert!(posted.contains("Azure/OpenAI content filter"));
+    assert!(!claude_counter_path.exists());
+    assert!(
+        result
+            .terminal_error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("content-filter explanation"),
+        "Notion content-filter explanation should be delivered but recorded as failed terminal status"
+    );
+}
+
+#[test]
+#[cfg(unix)]
 fn run_task_recovers_generic_reply_after_timeout_without_fallback() {
     let _lock = ENV_MUTEX.lock().unwrap();
     let temp = TempDir::new("codex_task_timeout_preserve_primary_draft").unwrap();

--- a/DoWhiz_service/scheduler_module/src/notion_store.rs
+++ b/DoWhiz_service/scheduler_module/src/notion_store.rs
@@ -4,7 +4,7 @@
 
 use chrono::{DateTime, Utc};
 use mongodb::bson::{doc, Bson, DateTime as BsonDateTime, Document};
-use mongodb::options::{IndexOptions, UpdateOptions};
+use mongodb::options::{FindOptions, IndexOptions, UpdateOptions};
 use mongodb::sync::Collection;
 use mongodb::IndexModel;
 
@@ -161,39 +161,29 @@ impl NotionStore {
         &self,
         workspace_id: &str,
     ) -> Result<NotionCredential, NotionStoreError> {
-        // Normalize to canonical UUID format with dashes
-        let normalized_id = Self::normalize_workspace_id(workspace_id);
+        self.get_credentials_by_workspace_candidates(workspace_id)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| NotionStoreError::NotFound(workspace_id.to_string()))
+    }
 
-        // Try with normalized (dashed) format first
-        if let Some(doc) = self
-            .credentials
-            .find_one(doc! { "workspace_id": &normalized_id }, None)?
-        {
-            return Self::doc_to_credential(doc);
-        }
-
-        // Try with original format as fallback
-        if normalized_id != workspace_id {
-            if let Some(doc) = self
-                .credentials
-                .find_one(doc! { "workspace_id": workspace_id }, None)?
-            {
-                return Self::doc_to_credential(doc);
-            }
-        }
-
-        // Try without dashes as last resort
-        let no_dashes = workspace_id.replace('-', "");
-        if no_dashes != workspace_id && no_dashes != normalized_id {
-            if let Some(doc) = self
-                .credentials
-                .find_one(doc! { "workspace_id": &no_dashes }, None)?
-            {
-                return Self::doc_to_credential(doc);
-            }
-        }
-
-        Err(NotionStoreError::NotFound(workspace_id.to_string()))
+    /// Get all credentials matching a workspace_id, newest first.
+    ///
+    /// Multiple users can connect the same Notion workspace. Returning an arbitrary
+    /// matching document is unsafe: a stale revoked token can shadow a newer valid
+    /// token for the same workspace.
+    pub fn get_credentials_by_workspace_candidates(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Vec<NotionCredential>, NotionStoreError> {
+        let options = FindOptions::builder()
+            .sort(doc! { "updated_at": -1, "created_at": -1 })
+            .build();
+        let cursor = self.credentials.find(
+            doc! { "workspace_id": { "$in": Self::workspace_id_variants(workspace_id) } },
+            options,
+        )?;
+        collect_credentials(cursor)
     }
 
     /// Normalize workspace_id to canonical UUID format with dashes.
@@ -216,6 +206,17 @@ impl NotionStore {
         }
     }
 
+    fn workspace_id_variants(workspace_id: &str) -> Vec<String> {
+        let mut variants = vec![
+            Self::normalize_workspace_id(workspace_id),
+            workspace_id.to_string(),
+            workspace_id.replace('-', ""),
+        ];
+        variants.sort();
+        variants.dedup();
+        variants
+    }
+
     /// Get credential by workspace_name with fuzzy matching.
     ///
     /// This is useful for matching email URL slugs (e.g., "myworkspace")
@@ -226,11 +227,28 @@ impl NotionStore {
         &self,
         name_or_slug: &str,
     ) -> Result<NotionCredential, NotionStoreError> {
+        self.get_credentials_by_workspace_name_fuzzy_candidates(name_or_slug)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                NotionStoreError::NotFound(format!("no workspace matching '{}'", name_or_slug))
+            })
+    }
+
+    /// Get all fuzzy workspace-name matches, newest first.
+    pub fn get_credentials_by_workspace_name_fuzzy_candidates(
+        &self,
+        name_or_slug: &str,
+    ) -> Result<Vec<NotionCredential>, NotionStoreError> {
         // Normalize the search term: lowercase, remove non-alphanumeric
         let normalized_search = Self::normalize_workspace_name(name_or_slug);
 
         // Get all credentials and find a match
-        let cursor = self.credentials.find(doc! {}, None)?;
+        let options = FindOptions::builder()
+            .sort(doc! { "updated_at": -1, "created_at": -1 })
+            .build();
+        let cursor = self.credentials.find(doc! {}, options)?;
+        let mut matches = Vec::new();
 
         for result in cursor {
             let doc = result?;
@@ -241,15 +259,19 @@ impl NotionStore {
                     || normalized_stored.contains(&normalized_search)
                     || normalized_search.contains(&normalized_stored)
                 {
-                    return Self::doc_to_credential(doc);
+                    matches.push(Self::doc_to_credential(doc)?);
                 }
             }
         }
 
-        Err(NotionStoreError::NotFound(format!(
-            "no workspace matching '{}'",
-            name_or_slug
-        )))
+        if matches.is_empty() {
+            Err(NotionStoreError::NotFound(format!(
+                "no workspace matching '{}'",
+                name_or_slug
+            )))
+        } else {
+            Ok(matches)
+        }
     }
 
     /// Get credential by bot_id (integration_id in webhook payloads).
@@ -271,16 +293,21 @@ impl NotionStore {
     /// Get any available credential (fallback when workspace_name is unknown).
     /// Returns the first credential found in the collection.
     pub fn get_any_credential(&self) -> Result<NotionCredential, NotionStoreError> {
-        let cursor = self.credentials.find(doc! {}, None)?;
+        self.get_all_credentials_newest_first()?
+            .into_iter()
+            .next()
+            .ok_or_else(|| NotionStoreError::NotFound("no credentials available".to_string()))
+    }
 
-        for result in cursor {
-            let doc = result?;
-            return Self::doc_to_credential(doc);
-        }
-
-        Err(NotionStoreError::NotFound(
-            "no credentials available".to_string(),
-        ))
+    /// Get every credential, newest first.
+    pub fn get_all_credentials_newest_first(
+        &self,
+    ) -> Result<Vec<NotionCredential>, NotionStoreError> {
+        let options = FindOptions::builder()
+            .sort(doc! { "updated_at": -1, "created_at": -1 })
+            .build();
+        let cursor = self.credentials.find(doc! {}, options)?;
+        collect_credentials(cursor)
     }
 
     /// Normalize a workspace name for comparison.
@@ -366,6 +393,16 @@ impl NotionStore {
             updated_at,
         })
     }
+}
+
+fn collect_credentials(
+    cursor: mongodb::sync::Cursor<Document>,
+) -> Result<Vec<NotionCredential>, NotionStoreError> {
+    let mut credentials = Vec::new();
+    for result in cursor {
+        credentials.push(NotionStore::doc_to_credential(result?)?);
+    }
+    Ok(credentials)
 }
 
 #[cfg(test)]

--- a/DoWhiz_service/scheduler_module/src/scheduler/debug_archive.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/debug_archive.rs
@@ -19,6 +19,7 @@ use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipWriter};
 
 use crate::env_alias::{bool_with_scale_oliver, var_with_scale_oliver};
+use run_task_module::redact_sensitive_text_for_display;
 
 use super::store::TaskDebugArchiveRecord;
 use super::types::{ScheduledTask, SchedulerError, TaskKind};
@@ -44,6 +45,7 @@ const HEAVY_SKIP_DIRS: &[&str] = &[
 ];
 const REDACTED_FILE_NAMES: &[&str] = &[
     ".google_access_token",
+    ".notion_env",
     "google_workspace_cli_credentials.json",
     "credentials.json",
 ];
@@ -298,6 +300,10 @@ impl PendingTaskDebugArchive {
                     .contains("/.run_task_trace/aci/container_logs.txt")
         });
 
+        let sanitized_error_summary = error_summary
+            .map(redact_sensitive_text_for_display)
+            .map(|value| truncate_string(&value, 4000));
+
         let manifest = ArchiveManifest {
             archive_type: ARCHIVE_TYPE.to_string(),
             archive_version: ARCHIVE_VERSION,
@@ -322,7 +328,7 @@ impl PendingTaskDebugArchive {
             has_workspace_after: true,
             has_run_task_trace,
             has_aci_logs,
-            error_summary: error_summary.map(|value| truncate_string(value, 4000)),
+            error_summary: sanitized_error_summary.clone(),
         };
         let execution_summary = ExecutionSummary {
             task_id: self.task_id.to_string(),
@@ -333,7 +339,7 @@ impl PendingTaskDebugArchive {
             duration_ms: finished_at
                 .signed_duration_since(self.started_at)
                 .num_milliseconds(),
-            error_summary: error_summary.map(|value| truncate_string(value, 4000)),
+            error_summary: sanitized_error_summary.clone(),
         };
 
         let zip_path = self.staging_dir.path().join("task_debug_bundle.zip");
@@ -403,7 +409,7 @@ impl PendingTaskDebugArchive {
             has_workspace_after: true,
             has_run_task_trace,
             has_aci_logs,
-            error_summary: error_summary.map(|value| truncate_string(value, 4000)),
+            error_summary: sanitized_error_summary,
             created_at: Utc::now(),
         })
     }
@@ -586,10 +592,10 @@ fn classify_snapshot_file(relative_path: &Path) -> SnapshotDecision {
     {
         return SnapshotDecision::Redact("credential_file_redacted");
     }
-    if relative_path
-        .components()
-        .any(|component| component.as_os_str() == ".secrets" || component.as_os_str() == ".auth")
-    {
+    if relative_path.components().any(|component| {
+        let value = component.as_os_str();
+        value == ".secrets" || value == ".auth" || value == ".config"
+    }) {
         return SnapshotDecision::Redact("secret_directory_redacted");
     }
     if let Some(extension) = relative_path.extension().and_then(|value| value.to_str()) {
@@ -709,10 +715,38 @@ fn add_snapshot_files(
 ) -> Result<(), SchedulerError> {
     for entry in &snapshot.included_files {
         let archive_path = format!("{}/{}", prefix, entry.relative_path);
-        let data = fs::read(&entry.source_path)?;
+        let mut data = fs::read(&entry.source_path)?;
+        if should_sanitize_included_file(&entry.relative_path) {
+            data = redact_sensitive_text_for_display(&String::from_utf8_lossy(&data)).into_bytes();
+        }
         write_bytes_entry(zip, &archive_path, &data)?;
     }
     Ok(())
+}
+
+fn should_sanitize_included_file(relative_path: &str) -> bool {
+    let path = Path::new(relative_path);
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if file_name.ends_with(".log")
+        || file_name.ends_with(".txt")
+        || file_name.ends_with(".json")
+        || file_name.ends_with(".jsonl")
+        || file_name.ends_with(".md")
+        || file_name.ends_with(".html")
+        || file_name.ends_with(".toml")
+        || file_name.ends_with(".yaml")
+        || file_name.ends_with(".yml")
+    {
+        return true;
+    }
+    matches!(
+        file_name.as_str(),
+        "stdout" | "stderr" | "combined" | "remote_output" | "container_logs"
+    )
 }
 
 fn write_json_entry<T: Serialize>(
@@ -1396,6 +1430,14 @@ mod tests {
             SnapshotDecision::Redact(_)
         ));
         assert!(matches!(
+            classify_snapshot_file(Path::new(".notion_env")),
+            SnapshotDecision::Redact(_)
+        ));
+        assert!(matches!(
+            classify_snapshot_file(Path::new(".config/gh/hosts.yml")),
+            SnapshotDecision::Redact(_)
+        ));
+        assert!(matches!(
             classify_snapshot_file(Path::new("incoming_email/body.txt")),
             SnapshotDecision::Include
         ));
@@ -1449,7 +1491,7 @@ mod tests {
                 .join(run_task_module::RUN_TASK_TRACE_DIRNAME)
                 .join("aci")
                 .join("container_logs.txt"),
-            "aci logs",
+            "oauth_token: ghp_should_not_leak\nclient_secret: GOCSPX-secret\nsig=leakedSig\n",
         )
         .expect("aci logs");
 
@@ -1496,6 +1538,15 @@ mod tests {
                 .is_ok(),
             "reply draft should be captured in after snapshot"
         );
+        let mut logs = String::new();
+        zip.by_name("workspace_after/.run_task_trace/aci/container_logs.txt")
+            .expect("aci logs entry")
+            .read_to_string(&mut logs)
+            .expect("read logs");
+        assert!(logs.contains("REDACTED"));
+        assert!(!logs.contains("ghp_should_not_leak"));
+        assert!(!logs.contains("GOCSPX-secret"));
+        assert!(!logs.contains("leakedSig"));
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/service/inbound/notion_email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/notion_email.rs
@@ -23,7 +23,7 @@ use crate::adapters::google_docs::contains_employee_mention;
 use crate::channel::Channel;
 use crate::index_store::IndexStore;
 use crate::notion_email_detector::{NotionEmailNotification, NotionNotificationType};
-use crate::notion_store::NotionStore;
+use crate::notion_store::{NotionCredential, NotionStore};
 use crate::user_store::{extract_emails, UserStore};
 use crate::{ModuleExecutor, RunTaskTask, Scheduler, TaskKind};
 
@@ -197,156 +197,21 @@ pub(crate) fn process_notion_email(
         .map(|v| v.trim().to_string());
     let thread_state = bump_thread_state(&thread_state_path, &thread_key, message_id.clone())?;
 
-    // Try to get Notion OAuth token and account_id
-    // Priority: 1) env var, 2) workspace_id (from tracking URL), 3) workspace_name fuzzy, 4) any credential
-    let (access_token, credential_account_id): (Option<String>, Option<uuid::Uuid>) = if let Ok(
-        token,
-    ) =
-        std::env::var("NOTION_API_TOKEN")
-    {
-        (Some(token), None)
-    } else {
-        match NotionStore::new() {
-            Ok(store) => {
-                // Try #1: workspace_id from decoded tracking URL (most reliable)
-                if let Some(ref ws_id) = notification.workspace_id {
-                    info!("Looking for Notion token by workspace_id: {}", ws_id);
-                    match store.get_credential_by_workspace(ws_id) {
-                        Ok(credential) => {
-                            info!(
-                                    "Found Notion token by workspace_id '{}' (workspace_name: {:?}, account_id: {})",
-                                    ws_id,
-                                    credential.workspace_name,
-                                    credential.account_id
-                                );
-                            (Some(credential.access_token), Some(credential.account_id))
-                        }
-                        Err(e) => {
-                            warn!("No Notion token found for workspace_id '{}': {}", ws_id, e);
-                            // Try next method
-                            if let Some(ref ws_name) = notification.workspace_name {
-                                info!("Looking for Notion token by workspace_name: {}", ws_name);
-                                match store.get_credential_by_workspace_name_fuzzy(ws_name) {
-                                    Ok(credential) => {
-                                        info!(
-                                                "Found Notion token for workspace_name '{}' (matched: {:?}, account_id: {})",
-                                                ws_name,
-                                                credential.workspace_name,
-                                                credential.account_id
-                                            );
-                                        (Some(credential.access_token), Some(credential.account_id))
-                                    }
-                                    Err(e2) => {
-                                        warn!(
-                                            "No Notion token found for workspace_name '{}': {}",
-                                            ws_name, e2
-                                        );
-                                        // Try fallback
-                                        match store.get_any_credential() {
-                                            Ok(credential) => {
-                                                info!(
-                                                        "Found fallback Notion token (workspace_id: {}, workspace_name: {:?}, account_id: {})",
-                                                        credential.workspace_id,
-                                                        credential.workspace_name,
-                                                        credential.account_id
-                                                    );
-                                                (
-                                                    Some(credential.access_token),
-                                                    Some(credential.account_id),
-                                                )
-                                            }
-                                            Err(e3) => {
-                                                warn!(
-                                                    "No fallback Notion credential available: {}",
-                                                    e3
-                                                );
-                                                (None, None)
-                                            }
-                                        }
-                                    }
-                                }
-                            } else {
-                                // No workspace_name, try fallback directly
-                                match store.get_any_credential() {
-                                    Ok(credential) => {
-                                        info!(
-                                                "Found fallback Notion token (workspace_id: {}, workspace_name: {:?}, account_id: {})",
-                                                credential.workspace_id,
-                                                credential.workspace_name,
-                                                credential.account_id
-                                            );
-                                        (Some(credential.access_token), Some(credential.account_id))
-                                    }
-                                    Err(e2) => {
-                                        warn!("No fallback Notion credential available: {}", e2);
-                                        (None, None)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else if let Some(ref ws_name) = notification.workspace_name {
-                    // Try #2: workspace_name fuzzy match (from direct URLs)
-                    info!("Looking for Notion token by workspace_name: {}", ws_name);
-                    match store.get_credential_by_workspace_name_fuzzy(ws_name) {
-                        Ok(credential) => {
-                            info!(
-                                    "Found Notion token for workspace_name '{}' (matched: {:?}, account_id: {})",
-                                    ws_name,
-                                    credential.workspace_name,
-                                    credential.account_id
-                                );
-                            (Some(credential.access_token), Some(credential.account_id))
-                        }
-                        Err(e) => {
-                            warn!(
-                                "No Notion token found for workspace_name '{}': {}",
-                                ws_name, e
-                            );
-                            // Try fallback
-                            match store.get_any_credential() {
-                                Ok(credential) => {
-                                    info!(
-                                            "Found fallback Notion token (workspace_id: {}, workspace_name: {:?}, account_id: {})",
-                                            credential.workspace_id,
-                                            credential.workspace_name,
-                                            credential.account_id
-                                        );
-                                    (Some(credential.access_token), Some(credential.account_id))
-                                }
-                                Err(e2) => {
-                                    warn!("No fallback Notion credential available: {}", e2);
-                                    (None, None)
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    // Fallback #3: try to get any available credential
-                    info!("Trying fallback: looking for any available Notion credential");
-                    match store.get_any_credential() {
-                        Ok(credential) => {
-                            info!(
-                                    "Found fallback Notion token (workspace_id: {}, workspace_name: {:?}, account_id: {})",
-                                    credential.workspace_id,
-                                    credential.workspace_name,
-                                    credential.account_id
-                                );
-                            (Some(credential.access_token), Some(credential.account_id))
-                        }
-                        Err(e) => {
-                            warn!("No fallback Notion credential available: {}", e);
-                            (None, None)
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                warn!("Failed to connect to NotionStore: {}", e);
-                (None, None)
-            }
-        }
-    };
+    // Try to get a usable Notion OAuth token and account_id.
+    // Priority: env var override, workspace_id, workspace_name fuzzy, latest fallback.
+    // Candidate sets are validated before selection so a stale revoked token for the
+    // same workspace cannot shadow a newer valid credential.
+    let (access_token, credential_account_id): (Option<String>, Option<uuid::Uuid>) =
+        if let Ok(token) = std::env::var("NOTION_API_TOKEN") {
+            (Some(token), None)
+        } else {
+            resolve_valid_notion_credential(notification)
+                .map(|credential| {
+                    let account_id = credential.account_id;
+                    (Some(credential.access_token), Some(account_id))
+                })
+                .unwrap_or((None, None))
+        };
 
     // Write Notion context to workspace
     write_notion_email_context(
@@ -460,6 +325,178 @@ pub(crate) fn process_notion_email(
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NotionCredentialValidation {
+    Valid,
+    Invalid(String),
+    Unknown(String),
+}
+
+fn resolve_valid_notion_credential(
+    notification: &NotionEmailNotification,
+) -> Option<NotionCredential> {
+    let store = match NotionStore::new() {
+        Ok(store) => store,
+        Err(err) => {
+            warn!("Failed to connect to NotionStore: {}", err);
+            return None;
+        }
+    };
+
+    if let Some(ws_id) = notification.workspace_id.as_deref() {
+        info!("Looking for Notion token by workspace_id: {}", ws_id);
+        match store.get_credentials_by_workspace_candidates(ws_id) {
+            Ok(candidates) => {
+                if let Some(credential) = select_preferred_notion_credential(
+                    "workspace_id",
+                    candidates,
+                    validate_notion_credential,
+                ) {
+                    return Some(credential);
+                }
+            }
+            Err(err) => warn!(
+                "No Notion token found for workspace_id '{}': {}",
+                ws_id, err
+            ),
+        }
+    }
+
+    if let Some(ws_name) = notification.workspace_name.as_deref() {
+        info!("Looking for Notion token by workspace_name: {}", ws_name);
+        match store.get_credentials_by_workspace_name_fuzzy_candidates(ws_name) {
+            Ok(candidates) => {
+                if let Some(credential) = select_preferred_notion_credential(
+                    "workspace_name",
+                    candidates,
+                    validate_notion_credential,
+                ) {
+                    return Some(credential);
+                }
+            }
+            Err(err) => warn!(
+                "No Notion token found for workspace_name '{}': {}",
+                ws_name, err
+            ),
+        }
+    }
+
+    info!("Trying fallback: looking for any available Notion credential");
+    match store.get_all_credentials_newest_first() {
+        Ok(candidates) => {
+            select_preferred_notion_credential("fallback", candidates, validate_notion_credential)
+        }
+        Err(err) => {
+            warn!("No fallback Notion credential available: {}", err);
+            None
+        }
+    }
+}
+
+fn select_preferred_notion_credential<F>(
+    source: &str,
+    candidates: Vec<NotionCredential>,
+    mut validate: F,
+) -> Option<NotionCredential>
+where
+    F: FnMut(&NotionCredential) -> NotionCredentialValidation,
+{
+    let mut first_unknown: Option<(NotionCredential, String)> = None;
+    for credential in candidates {
+        match validate(&credential) {
+            NotionCredentialValidation::Valid => {
+                info!(
+                    "Selected valid Notion credential source={} workspace_id={} workspace_name={:?} account_id={} bot_id={} owner_user_id={:?}",
+                    source,
+                    credential.workspace_id,
+                    credential.workspace_name,
+                    credential.account_id,
+                    credential.bot_id,
+                    credential.owner_user_id
+                );
+                return Some(credential);
+            }
+            NotionCredentialValidation::Invalid(reason) => {
+                warn!(
+                    "Rejected invalid Notion credential source={} workspace_id={} account_id={} bot_id={} owner_user_id={:?}: {}",
+                    source,
+                    credential.workspace_id,
+                    credential.account_id,
+                    credential.bot_id,
+                    credential.owner_user_id,
+                    reason
+                );
+            }
+            NotionCredentialValidation::Unknown(reason) => {
+                warn!(
+                    "Could not validate Notion credential source={} workspace_id={} account_id={} bot_id={} owner_user_id={:?}; keeping as fallback candidate: {}",
+                    source,
+                    credential.workspace_id,
+                    credential.account_id,
+                    credential.bot_id,
+                    credential.owner_user_id,
+                    reason
+                );
+                if first_unknown.is_none() {
+                    first_unknown = Some((credential, reason));
+                }
+            }
+        }
+    }
+
+    if let Some((credential, reason)) = first_unknown {
+        warn!(
+            "Using newest Notion credential with unknown validation result source={} workspace_id={} account_id={} bot_id={} owner_user_id={:?}: {}",
+            source,
+            credential.workspace_id,
+            credential.account_id,
+            credential.bot_id,
+            credential.owner_user_id,
+            reason
+        );
+        return Some(credential);
+    }
+
+    None
+}
+
+fn validate_notion_credential(credential: &NotionCredential) -> NotionCredentialValidation {
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => return NotionCredentialValidation::Unknown(err.to_string()),
+    };
+
+    let response = client
+        .get("https://api.notion.com/v1/users/me")
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", credential.access_token),
+        )
+        .header("Notion-Version", "2022-06-28")
+        .send();
+
+    match response {
+        Ok(response) if response.status().is_success() => NotionCredentialValidation::Valid,
+        Ok(response)
+            if response.status() == reqwest::StatusCode::UNAUTHORIZED
+                || response.status() == reqwest::StatusCode::FORBIDDEN =>
+        {
+            NotionCredentialValidation::Invalid(format!(
+                "Notion API validation returned {}",
+                response.status()
+            ))
+        }
+        Ok(response) => NotionCredentialValidation::Unknown(format!(
+            "Notion API validation returned {}",
+            response.status()
+        )),
+        Err(err) => NotionCredentialValidation::Unknown(err.to_string()),
+    }
 }
 
 /// Create a unique thread key for a Notion notification.
@@ -697,5 +734,56 @@ mod tests {
 
         let thread_key = create_notion_thread_key(&notification, &payload);
         assert_eq!(thread_key, "notion:page:abc123");
+    }
+
+    #[test]
+    fn select_preferred_notion_credential_skips_invalid_and_uses_valid() {
+        let stale = test_credential("stale-token", "account-a");
+        let fresh = test_credential("fresh-token", "account-b");
+
+        let selected =
+            select_preferred_notion_credential("test", vec![stale, fresh.clone()], |credential| {
+                if credential.access_token == "fresh-token" {
+                    NotionCredentialValidation::Valid
+                } else {
+                    NotionCredentialValidation::Invalid("revoked".to_string())
+                }
+            })
+            .expect("valid credential selected");
+
+        assert_eq!(selected.account_id, fresh.account_id);
+        assert_eq!(selected.access_token, "fresh-token");
+    }
+
+    #[test]
+    fn select_preferred_notion_credential_rejects_all_invalid_candidates() {
+        let selected = select_preferred_notion_credential(
+            "test",
+            vec![
+                test_credential("stale-token-a", "account-a"),
+                test_credential("stale-token-b", "account-b"),
+            ],
+            |_| NotionCredentialValidation::Invalid("revoked".to_string()),
+        );
+
+        assert!(selected.is_none());
+    }
+
+    fn test_credential(token: &str, account_seed: &str) -> NotionCredential {
+        let account_id = if account_seed == "account-a" {
+            uuid::Uuid::parse_str("00000000-0000-4000-8000-00000000000a").unwrap()
+        } else {
+            uuid::Uuid::parse_str("00000000-0000-4000-8000-00000000000b").unwrap()
+        };
+        NotionCredential {
+            account_id,
+            workspace_id: "workspace-1".to_string(),
+            workspace_name: Some("Workspace".to_string()),
+            access_token: token.to_string(),
+            bot_id: format!("bot-{account_seed}"),
+            owner_user_id: Some(format!("owner-{account_seed}")),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Validate and prefer fresh Notion credentials so stale revoked workspace tokens do not shadow usable credentials.
- Stop wasting Claude fallback on unrecoverable Notion auth failures, and post content-filter explanations to Notion via the real Notion API path.
- Redact sensitive token-like output from run_task errors and task debug archives.

## Test Evidence
- cargo fmt --all --check
- git diff --check
- cargo check --locked -p run_task_module
- cargo check --locked -p scheduler_module --lib
- cargo test --locked -p run_task_module
- cargo test --locked -p scheduler_module select_preferred_notion_credential --lib
- cargo test --locked -p scheduler_module scheduler::debug_archive::tests --lib

## Notes
- Full cargo test --locked -p scheduler_module --lib is not clean in this local environment due to unrelated existing env/time/mock-dependent failures such as missing MONGODB_URI and WECHAT_ENCODING_AES_KEY. The affected targeted scheduler tests pass.
- No config or env changes required.