### PR TITLE
Recover primary artifacts after ACI show timeout

### DIFF
--- a/DoWhiz_service/run_task_module/src/run_task/codex.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/codex.rs
@@ -857,7 +857,10 @@ fn reply_artifact_changed_since(path: &Path, baseline: Option<&ReplyArtifactSnap
 }
 
 fn timeout_reply_recovery_supported_command(command: &str) -> bool {
-    matches!(command, "codex" | "docker run" | "az container create")
+    matches!(
+        command,
+        "codex" | "docker run" | "az container create" | "az container show"
+    )
 }
 
 fn maybe_recover_from_recent_ready_reply_artifact(
@@ -3554,7 +3557,23 @@ fn poll_aci_state(
             .arg("--output")
             .arg("tsv")
             .arg("--only-show-errors");
-        let output = run_command_with_timeout(show_cmd, show_timeout, "az container show")?;
+        let output = match run_command_with_timeout(show_cmd, show_timeout, "az container show") {
+            Ok(output) => output,
+            Err(RunTaskError::CommandTimeout { output, .. }) => {
+                if let Some(state) = parse_terminal_aci_state_from_output(&output) {
+                    return Ok(AciPollState {
+                        container_state: state,
+                        remote_artifact_completion: false,
+                    });
+                }
+                return Err(RunTaskError::CommandTimeout {
+                    command: "az container show",
+                    timeout_secs: show_timeout.as_secs(),
+                    output,
+                });
+            }
+            Err(err) => return Err(err),
+        };
         if !output.status.success() {
             let mut combined = String::new();
             combined.push_str(&String::from_utf8_lossy(&output.stdout));
@@ -3598,6 +3617,21 @@ fn poll_aci_state(
 
 fn remote_aci_result_ready(remote_exit_code_path: &Path) -> bool {
     remote_exit_code_path.is_file()
+}
+
+fn parse_terminal_aci_state_from_output(output: &str) -> Option<String> {
+    output.lines().find_map(|line| {
+        let state = line.trim().trim_matches('"');
+        if state.eq_ignore_ascii_case("Succeeded")
+            || state.eq_ignore_ascii_case("Failed")
+            || state.eq_ignore_ascii_case("Terminated")
+            || state.eq_ignore_ascii_case("Stopped")
+        {
+            Some(state.to_string())
+        } else {
+            None
+        }
+    })
 }
 
 fn azure_aci_execution_succeeded(
@@ -7009,6 +7043,48 @@ exit 3
 
         assert!(note.contains("Recovered ready reply artifact written during this run"));
         assert!(note.contains("ACI container provisioning timed out"));
+    }
+
+    #[test]
+    fn test_maybe_accept_timeout_with_ready_reply_artifact_recovers_aci_show_timeout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reply = temp.path().join("reply_email_draft.html");
+        let baseline = snapshot_reply_artifact(&reply);
+        let run_started_at = SystemTime::now();
+        fs::write(&reply, "<html><body>ready after show timeout</body></html>")
+            .expect("write reply");
+
+        let err = RunTaskError::CommandTimeout {
+            command: "az container show",
+            timeout_secs: 60,
+            output: "Succeeded".to_string(),
+        };
+
+        let note = maybe_accept_timeout_with_ready_reply_artifact(
+            run_started_at,
+            true,
+            temp.path(),
+            &reply,
+            &err,
+            Some(&baseline),
+        )
+        .expect("expected timeout recovery");
+
+        assert!(note.contains("Recovered ready reply artifact written during this run"));
+        assert!(note.contains("ACI container polling timed out"));
+    }
+
+    #[test]
+    fn test_parse_terminal_aci_state_from_timed_out_show_output() {
+        assert_eq!(
+            parse_terminal_aci_state_from_output("warning\nSucceeded\n"),
+            Some("Succeeded".to_string())
+        );
+        assert_eq!(
+            parse_terminal_aci_state_from_output("\"Failed\"\n"),
+            Some("Failed".to_string())
+        );
+        assert_eq!(parse_terminal_aci_state_from_output("Running\n"), None);
     }
 
     #[test]

--- a/DoWhiz_service/run_task_module/src/run_task/core.rs
+++ b/DoWhiz_service/run_task_module/src/run_task/core.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::claude::run_claude_task;
 use super::codex::{
@@ -13,6 +13,7 @@ use super::errors::RunTaskError;
 use super::investment_fail_soft::maybe_write_investment_operational_failure_artifact;
 use super::reply_contract::{
     investment_monitor_request_for_workspace, investment_request_for_workspace,
+    reply_artifact_ready_for_workspace,
 };
 use super::trace::RUN_TASK_TRACE_DIRNAME;
 use super::types::{RunTaskOutput, RunTaskParams, RunTaskRequest};
@@ -496,13 +497,14 @@ pub fn run_claude_fallback_after_codex_failure(
     let (reply_html_path, reply_attachments_dir) = prepare_workspace(&request)?;
     let fallback_model = resolve_claude_fallback_model(params.model_name.as_str());
     archive_primary_codex_trace(&workspace_dir)?;
-    let archived_primary_reply = archive_primary_reply_artifact(&workspace_dir, &reply_html_path)?;
+    let archived_primary_artifacts =
+        archive_primary_artifacts(&workspace_dir, &reply_html_path, &reply_attachments_dir)?;
     reset_reply_artifacts(&reply_html_path, &reply_attachments_dir)?;
     let fallback_result = run_claude_task(
         build_request(&workspace_dir, params, fallback_model.as_str()),
         "claude",
-        reply_html_path,
-        reply_attachments_dir,
+        reply_html_path.clone(),
+        reply_attachments_dir.clone(),
         true,
     );
 
@@ -515,7 +517,7 @@ pub fn run_claude_fallback_after_codex_failure(
                 fallback_model.as_str(),
                 &primary_err,
                 None,
-                archived_primary_reply.as_deref(),
+                archived_primary_artifacts.reply_path.as_deref(),
             )?;
             output.recovery_note = Some(match output.recovery_note.take() {
                 Some(existing) => format!("{}\n{}", existing, note),
@@ -530,12 +532,31 @@ pub fn run_claude_fallback_after_codex_failure(
                 fallback_model.as_str(),
                 &primary_err,
                 Some(&fallback_err),
-                archived_primary_reply.as_deref(),
+                archived_primary_artifacts.reply_path.as_deref(),
             )?;
+            if let Some(recovery_note) = maybe_restore_archived_primary_artifacts(
+                &workspace_dir,
+                &reply_html_path,
+                &reply_attachments_dir,
+                &archived_primary_artifacts,
+            )? {
+                return Ok(RunTaskOutput {
+                    reply_html_path,
+                    reply_attachments_dir,
+                    codex_output: fallback_err.to_string(),
+                    scheduled_tasks: Vec::new(),
+                    scheduled_tasks_error: None,
+                    scheduler_actions: Vec::new(),
+                    scheduler_actions_error: None,
+                    token_usage: None,
+                    recovery_note: Some(recovery_note),
+                    terminal_error_message: None,
+                });
+            }
             Err(RunTaskError::FallbackFailed {
                 primary: primary_error_with_archived_reply(
                     &primary_err,
-                    archived_primary_reply.as_deref(),
+                    archived_primary_artifacts.reply_path.as_deref(),
                 ),
                 fallback: fallback_err.to_string(),
             })
@@ -753,28 +774,131 @@ fn archive_primary_codex_trace(workspace_dir: &Path) -> Result<(), RunTaskError>
     Ok(())
 }
 
-fn archive_primary_reply_artifact(
+#[derive(Debug, Default)]
+struct ArchivedPrimaryArtifacts {
+    reply_path: Option<PathBuf>,
+    attachments_dir: Option<PathBuf>,
+    reply_fresh_for_primary_trace: bool,
+}
+
+fn archive_primary_artifacts(
     workspace_dir: &Path,
     reply_path: &Path,
-) -> Result<Option<PathBuf>, RunTaskError> {
-    if !reply_path.exists() {
-        return Ok(None);
-    }
+    reply_attachments_dir: &Path,
+) -> Result<ArchivedPrimaryArtifacts, RunTaskError> {
+    let mut archived = ArchivedPrimaryArtifacts::default();
 
     let archive_dir = workspace_dir.join(".run_task_trace_codex_primary");
     if !archive_dir.exists() {
-        return Ok(None);
+        return Ok(archived);
     }
 
     let preserved_dir = archive_dir.join("preserved_artifacts");
     fs::create_dir_all(&preserved_dir)?;
-    let file_name = reply_path
-        .file_name()
-        .and_then(|value| value.to_str())
-        .unwrap_or("reply_email_draft.html");
-    let preserved_path = preserved_dir.join(file_name);
-    fs::copy(reply_path, &preserved_path)?;
-    Ok(Some(preserved_path))
+    if reply_path.exists() {
+        archived.reply_fresh_for_primary_trace =
+            reply_artifact_fresh_for_archived_primary_trace(workspace_dir, reply_path);
+        let file_name = reply_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("reply_email_draft.html");
+        let preserved_path = preserved_dir.join(file_name);
+        fs::copy(reply_path, &preserved_path)?;
+        archived.reply_path = Some(preserved_path);
+    }
+
+    if reply_attachments_dir.exists() {
+        let dir_name = reply_attachments_dir
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("reply_attachments");
+        let preserved_attachments_dir = preserved_dir.join(dir_name);
+        remove_path_if_exists(&preserved_attachments_dir)?;
+        copy_dir_recursive(reply_attachments_dir, &preserved_attachments_dir)?;
+        archived.attachments_dir = Some(preserved_attachments_dir);
+    }
+
+    Ok(archived)
+}
+
+fn maybe_restore_archived_primary_artifacts(
+    workspace_dir: &Path,
+    reply_path: &Path,
+    reply_attachments_dir: &Path,
+    archived: &ArchivedPrimaryArtifacts,
+) -> Result<Option<String>, RunTaskError> {
+    if !archived.reply_fresh_for_primary_trace {
+        return Ok(None);
+    }
+    let Some(archived_reply_path) = archived.reply_path.as_deref() else {
+        return Ok(None);
+    };
+    if !reply_artifact_ready_for_workspace(workspace_dir, archived_reply_path) {
+        return Ok(None);
+    }
+
+    remove_path_if_exists(reply_path)?;
+    if let Some(parent) = reply_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(archived_reply_path, reply_path)?;
+
+    remove_path_if_exists(reply_attachments_dir)?;
+    if let Some(archived_attachments_dir) = archived.attachments_dir.as_deref() {
+        copy_dir_recursive(archived_attachments_dir, reply_attachments_dir)?;
+    } else {
+        fs::create_dir_all(reply_attachments_dir)?;
+    }
+
+    if !reply_artifact_ready_for_workspace(workspace_dir, reply_path) {
+        return Ok(None);
+    }
+
+    Ok(Some(
+        "Recovered valid primary Codex reply artifact after Claude fallback failed; the fallback failure did not overwrite the completed deliverable."
+            .to_string(),
+    ))
+}
+
+fn reply_artifact_fresh_for_archived_primary_trace(
+    workspace_dir: &Path,
+    reply_path: &Path,
+) -> bool {
+    let Some(started_at) = archived_primary_trace_started_at(workspace_dir) else {
+        return false;
+    };
+    let freshness_floor = started_at
+        .checked_sub(Duration::from_secs(2))
+        .unwrap_or(UNIX_EPOCH);
+    fs::metadata(reply_path)
+        .and_then(|metadata| metadata.modified())
+        .is_ok_and(|modified| modified >= freshness_floor)
+}
+
+fn archived_primary_trace_started_at(workspace_dir: &Path) -> Option<SystemTime> {
+    let metadata_path = workspace_dir
+        .join(".run_task_trace_codex_primary")
+        .join("metadata.json");
+    let raw = fs::read_to_string(metadata_path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let started_at_ms = value.get("started_at_unix_ms")?.as_u64()?;
+    UNIX_EPOCH.checked_add(Duration::from_millis(started_at_ms))
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), RunTaskError> {
+    fs::create_dir_all(dest)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&src_path)?;
+        if metadata.is_dir() {
+            copy_dir_recursive(&src_path, &dest_path)?;
+        } else if metadata.is_file() {
+            fs::copy(&src_path, &dest_path)?;
+        }
+    }
+    Ok(())
 }
 
 fn reset_reply_artifacts(

--- a/DoWhiz_service/run_task_module/tests/run_task_tests.rs
+++ b/DoWhiz_service/run_task_module/tests/run_task_tests.rs
@@ -7,7 +7,7 @@ use send_emails_module::normalize_email_html;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use support::{
     build_params, create_workspace, install_runtime_skills_and_employee_guidance,
     write_fake_claude, write_fake_codex, write_fake_gh, EnvGuard, EnvUnsetGuard, FakeClaudeMode,
@@ -773,6 +773,83 @@ fn azure_aci_timeout_error_falls_back_to_claude() {
             "Recovered via Claude fallback after primary Codex failure (Azure ACI Codex timed out) using Claude model claude-sonnet-4-5"
         )
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn run_task_restores_fresh_primary_artifact_when_claude_fallback_fails() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let temp = TempDir::new("codex_task_restore_primary_after_fallback_failure").unwrap();
+    let workspace = create_workspace(&temp.path).unwrap();
+
+    let home_dir = temp.path.join("home");
+    let bin_dir = temp.path.join("bin");
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_claude(&bin_dir, FakeClaudeMode::Fail).unwrap();
+
+    let trace_dir = workspace.join(".run_task_trace");
+    fs::create_dir_all(&trace_dir).unwrap();
+    let started_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .saturating_sub(1000);
+    fs::write(
+        trace_dir.join("metadata.json"),
+        format!(r#"{{"started_at_unix_ms":{started_at_ms}}}"#),
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("reply_email_draft.html"),
+        "<html><body>Primary Codex reply was already complete</body></html>",
+    )
+    .unwrap();
+    let attachments_dir = workspace.join("reply_email_attachments");
+    fs::create_dir_all(&attachments_dir).unwrap();
+    fs::write(
+        attachments_dir.join("primary.csv"),
+        "ticker,view\nSMH,starter\n",
+    )
+    .unwrap();
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), old_path);
+    let _env = EnvGuard::set(&[
+        ("HOME", home_dir.to_str().unwrap()),
+        ("PATH", &new_path),
+        ("AZURE_OPENAI_API_KEY_BACKUP", "test-key"),
+        ("AZURE_OPENAI_ENDPOINT_BACKUP", "https://example.azure.com/"),
+        ("GH_AUTH_DISABLED", "1"),
+    ]);
+
+    let params = build_params(&workspace);
+    let result = run_claude_fallback_after_codex_failure(
+        &params,
+        RunTaskError::CommandTimeout {
+            command: "az container show",
+            timeout_secs: 60,
+            output: "Succeeded".to_string(),
+        },
+    )
+    .expect("fresh primary artifact should be restored when fallback fails");
+
+    let html = fs::read_to_string(&result.reply_html_path).unwrap();
+    assert!(html.contains("Primary Codex reply was already complete"));
+    assert_eq!(
+        fs::read_to_string(result.reply_attachments_dir.join("primary.csv")).unwrap(),
+        "ticker,view\nSMH,starter\n"
+    );
+    let note = result.recovery_note.unwrap_or_default();
+    assert!(note.contains("Recovered valid primary Codex reply artifact"));
+    let fallback_note = fs::read_to_string(
+        workspace
+            .join(".run_task_trace")
+            .join("recovery")
+            .join("codex_to_claude_fallback.txt"),
+    )
+    .unwrap();
+    assert!(fallback_note.contains("status=failed"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Accept terminal ACI states when az container show times out after printing a terminal state.
- Allow ready-reply recovery for az container show polling timeouts.
- Preserve and restore fresh primary Codex reply artifacts and attachments if Claude fallback fails, instead of overwriting a completed deliverable with an operational failure reply.

## Root cause
The SMH task generated a complete primary Codex reply plus attachment, but orchestration treated an az container show timeout after outputting Succeeded as primary failure. Claude fallback then timed out and overwrote the completed primary artifact with the generic investment operational failure reply.

## Tests
- cargo fmt --all --check
- git diff --check
- cargo test --locked -p run_task_module aci_show_timeout -- --nocapture
- cargo test --locked -p run_task_module timed_out_show_output -- --nocapture
- cargo test --locked -p run_task_module restores_fresh_primary -- --nocapture
- Earlier before PR: cargo test --locked -p run_task_module -- --test-threads=1
- Earlier before PR: cargo clippy --locked -p run_task_module --all-targets -- -D warnings