### PR TITLE
Fix Notion webhook credential fallback

### DIFF
--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
@@ -19,7 +19,7 @@ use tracing::{debug, info, warn};
 
 use scheduler_module::channel::{Channel, ChannelMetadata, InboundMessage};
 use scheduler_module::notion_browser::models::NotionMention;
-use scheduler_module::notion_store::{NotionStore, NotionStoreError};
+use scheduler_module::notion_store::{NotionCredential, NotionStore, NotionStoreError};
 
 use super::handlers::{build_envelope, enqueue_envelope};
 use super::state::{GatewayState, RouteDecision};
@@ -109,8 +109,9 @@ pub struct NotionWebhookPayload {
     /// Timestamp of the event
     #[serde(default)]
     pub timestamp: Option<String>,
-    /// The integration that received this webhook (same as bot_id from OAuth)
+    /// The integration that received this webhook.
     pub integration_id: String,
+    #[serde(default)]
     pub workspace_id: String,
     #[serde(default)]
     pub workspace_name: Option<String>,
@@ -259,6 +260,12 @@ impl NotionWebhookPayload {
                 return Some(id.to_string());
             }
         }
+        // Newer webhook payloads carry the changed object under `entity`.
+        if let Some(entity) = self.entity.as_ref() {
+            if let Some(id) = entity.get("id").and_then(|v| v.as_str()) {
+                return Some(id.to_string());
+            }
+        }
         // From extra fields
         self.extra
             .get("comment_id")
@@ -322,6 +329,30 @@ impl NotionWebhookPayload {
         None
     }
 
+    /// Bot IDs that can identify the workspace-specific OAuth credential.
+    pub fn credential_lookup_bot_ids(&self) -> Vec<String> {
+        let mut bot_ids = Vec::new();
+
+        if let Some(accessible_by) = &self.accessible_by {
+            for principal in accessible_by {
+                if principal.author_type == "bot" {
+                    push_unique(&mut bot_ids, &principal.id);
+                }
+            }
+        }
+
+        if let Some(authors) = &self.authors {
+            for author in authors {
+                if author.author_type == "bot" {
+                    push_unique(&mut bot_ids, &author.id);
+                }
+            }
+        }
+
+        push_unique(&mut bot_ids, &self.integration_id);
+        bot_ids
+    }
+
     /// Check if the comment contains an @mention for a specific bot/integration.
     pub fn contains_bot_mention(&self, integration_id: &str) -> bool {
         let Some(data) = self.comment_data_value() else {
@@ -371,6 +402,72 @@ impl NotionWebhookPayload {
         }
         false
     }
+}
+
+fn push_unique(values: &mut Vec<String>, candidate: &str) {
+    let candidate = candidate.trim();
+    if !candidate.is_empty() && !values.iter().any(|value| value == candidate) {
+        values.push(candidate.to_string());
+    }
+}
+
+trait NotionCredentialLookup {
+    fn lookup_by_workspace(&self, workspace_id: &str)
+        -> Result<NotionCredential, NotionStoreError>;
+    fn lookup_by_bot_id(&self, bot_id: &str) -> Result<NotionCredential, NotionStoreError>;
+}
+
+impl NotionCredentialLookup for NotionStore {
+    fn lookup_by_workspace(
+        &self,
+        workspace_id: &str,
+    ) -> Result<NotionCredential, NotionStoreError> {
+        self.get_credential_by_workspace(workspace_id)
+    }
+
+    fn lookup_by_bot_id(&self, bot_id: &str) -> Result<NotionCredential, NotionStoreError> {
+        self.get_credential_by_bot_id(bot_id)
+    }
+}
+
+fn lookup_notion_credential(
+    lookup: &impl NotionCredentialLookup,
+    payload: &NotionWebhookPayload,
+) -> Result<NotionCredential, NotionStoreError> {
+    let workspace_id = payload.workspace_id.trim();
+    let mut not_found_reasons = Vec::new();
+
+    if !workspace_id.is_empty() {
+        match lookup.lookup_by_workspace(workspace_id) {
+            Ok(credential) => return Ok(credential),
+            Err(NotionStoreError::NotFound(reason)) => {
+                not_found_reasons.push(format!("workspace_id={workspace_id}: {reason}"));
+            }
+            Err(error) => return Err(error),
+        }
+    } else {
+        not_found_reasons.push("workspace_id missing or empty".to_string());
+    }
+
+    for bot_id in payload.credential_lookup_bot_ids() {
+        match lookup.lookup_by_bot_id(&bot_id) {
+            Ok(credential) => {
+                info!(
+                    "notion webhook credential matched by bot_id fallback: bot_id={} workspace_id={} original_workspace_id={:?}",
+                    bot_id,
+                    credential.workspace_id,
+                    workspace_id
+                );
+                return Ok(credential);
+            }
+            Err(NotionStoreError::NotFound(reason)) => {
+                not_found_reasons.push(format!("bot_id={bot_id}: {reason}"));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(NotionStoreError::NotFound(not_found_reasons.join("; ")))
 }
 
 /// Check if this webhook is for our environment's integration.
@@ -473,11 +570,14 @@ pub async fn ingest_notion_webhook(
         }
     };
 
-    // Look up credential by workspace_id
-    let credential = match notion_store.get_credential_by_workspace(&payload.workspace_id) {
+    // Look up credential by workspace_id first. Some real deliveries have
+    // arrived with an empty workspace_id, so fall back to the bot principal IDs
+    // Notion includes for public integration webhooks.
+    let credential = match lookup_notion_credential(&notion_store, &payload) {
         Ok(cred) => cred,
         Err(e) => return notion_credential_lookup_failure_response(&payload.workspace_id, e),
     };
+    let resolved_workspace_id = credential.workspace_id.clone();
 
     // Check for self-trigger using the workspace-specific bot_id from credential
     // The bot_id is the bot's user ID within this workspace, while integration_id is the public integration ID
@@ -503,11 +603,11 @@ pub async fn ingest_notion_webhook(
     }
 
     // Build routing decision based on employee directory
-    let route = resolve_notion_route(&payload, &credential, &state);
+    let route = resolve_notion_route(&resolved_workspace_id, &credential, &state);
     let Some(route) = route else {
         info!(
             "notion webhook no route for workspace_id={}",
-            payload.workspace_id
+            resolved_workspace_id
         );
         return (StatusCode::OK, Json(json!({"status": "no_route"})));
     };
@@ -664,7 +764,7 @@ pub async fn ingest_notion_webhook(
     );
 
     // Build InboundMessage
-    let thread_id = format!("notion:{}:{}", payload.workspace_id, discussion_id);
+    let thread_id = format!("notion:{}:{}", resolved_workspace_id, discussion_id);
     let message_id = format!("notion-comment-{}", comment_id);
 
     let message = InboundMessage {
@@ -683,7 +783,7 @@ pub async fn ingest_notion_webhook(
         metadata: ChannelMetadata {
             notion_page_id: Some(page_id.clone()),
             notion_comment_id: Some(comment_id.clone()),
-            notion_workspace_id: Some(payload.workspace_id.clone()),
+            notion_workspace_id: Some(resolved_workspace_id.clone()),
             ..Default::default()
         },
     };
@@ -691,10 +791,11 @@ pub async fn ingest_notion_webhook(
     // Convert webhook payload to NotionMention format for worker compatibility
     let notion_mention = NotionMention {
         id: payload.id.clone(),
-        workspace_id: payload.workspace_id.clone(),
+        workspace_id: resolved_workspace_id.clone(),
         workspace_name: payload
             .workspace_name
             .clone()
+            .or_else(|| credential.workspace_name.clone())
             .unwrap_or_else(|| "Unknown".to_string()),
         page_id: page_id.clone(),
         page_title: format!("Notion Page {}", page_id), // Title not available in webhook
@@ -786,12 +887,12 @@ fn notion_credential_lookup_failure_response(
 
 /// Resolve routing for Notion webhook based on workspace/integration mapping.
 fn resolve_notion_route(
-    payload: &NotionWebhookPayload,
+    workspace_id: &str,
     credential: &scheduler_module::notion_store::NotionCredential,
     state: &GatewayState,
 ) -> Option<RouteDecision> {
     // Try to find employee by workspace_id in routes
-    let route_key = payload.workspace_id.clone();
+    let route_key = workspace_id.to_string();
 
     // Check explicit routes first
     if let Some(route) = super::routes::resolve_route(Channel::Notion, &route_key, state) {
@@ -827,6 +928,9 @@ fn resolve_notion_route(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
 
     fn make_test_payload(authors: Option<Vec<NotionWebhookAuthor>>) -> NotionWebhookPayload {
         NotionWebhookPayload {
@@ -851,6 +955,66 @@ mod tests {
             discussion_id: None,
             comment_id: None,
             extra: std::collections::HashMap::new(),
+        }
+    }
+
+    fn test_credential(workspace_id: &str, bot_id: &str) -> NotionCredential {
+        NotionCredential {
+            account_id: uuid::Uuid::nil(),
+            workspace_id: workspace_id.to_string(),
+            workspace_name: Some("Test Workspace".to_string()),
+            access_token: "secret_test_token".to_string(),
+            bot_id: bot_id.to_string(),
+            owner_user_id: Some("owner-user".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeCredentialLookup {
+        by_workspace: HashMap<String, NotionCredential>,
+        by_bot_id: HashMap<String, NotionCredential>,
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl FakeCredentialLookup {
+        fn with_workspace(mut self, workspace_id: &str, credential: NotionCredential) -> Self {
+            self.by_workspace
+                .insert(workspace_id.to_string(), credential);
+            self
+        }
+
+        fn with_bot_id(mut self, bot_id: &str, credential: NotionCredential) -> Self {
+            self.by_bot_id.insert(bot_id.to_string(), credential);
+            self
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl NotionCredentialLookup for FakeCredentialLookup {
+        fn lookup_by_workspace(
+            &self,
+            workspace_id: &str,
+        ) -> Result<NotionCredential, NotionStoreError> {
+            self.calls
+                .borrow_mut()
+                .push(format!("workspace:{workspace_id}"));
+            self.by_workspace
+                .get(workspace_id)
+                .cloned()
+                .ok_or_else(|| NotionStoreError::NotFound(workspace_id.to_string()))
+        }
+
+        fn lookup_by_bot_id(&self, bot_id: &str) -> Result<NotionCredential, NotionStoreError> {
+            self.calls.borrow_mut().push(format!("bot:{bot_id}"));
+            self.by_bot_id
+                .get(bot_id)
+                .cloned()
+                .ok_or_else(|| NotionStoreError::NotFound(format!("bot_id: {bot_id}")))
         }
     }
 
@@ -941,6 +1105,23 @@ mod tests {
     }
 
     #[test]
+    fn test_get_comment_id_from_entity() {
+        let mut payload = make_test_payload(None);
+        payload.data = Some(serde_json::json!({
+            "page_id": "page-789"
+        }));
+        payload.entity = Some(serde_json::json!({
+            "id": "comment-from-entity",
+            "type": "comment"
+        }));
+
+        assert_eq!(
+            payload.get_comment_id(),
+            Some("comment-from-entity".to_string())
+        );
+    }
+
+    #[test]
     fn test_author_name() {
         let payload = make_test_payload(None);
         assert_eq!(payload.author_name(), Some("Test User".to_string()));
@@ -971,6 +1152,67 @@ mod tests {
     }
 
     #[test]
+    fn credential_lookup_uses_workspace_before_bot_ids() {
+        let payload = make_test_payload(None);
+        let lookup = FakeCredentialLookup::default()
+            .with_workspace("ws-456", test_credential("ws-456", "workspace-bot"))
+            .with_bot_id("bot-123", test_credential("other-ws", "bot-123"));
+
+        let credential = lookup_notion_credential(&lookup, &payload).unwrap();
+
+        assert_eq!(credential.workspace_id, "ws-456");
+        assert_eq!(lookup.calls(), vec!["workspace:ws-456"]);
+    }
+
+    #[test]
+    fn credential_lookup_falls_back_to_accessible_bot_when_workspace_empty() {
+        let mut payload = make_test_payload(None);
+        payload.workspace_id.clear();
+        payload.integration_id = "public-integration".to_string();
+        payload.accessible_by = Some(vec![
+            NotionWebhookAuthor {
+                id: "person-1".to_string(),
+                author_type: "person".to_string(),
+            },
+            NotionWebhookAuthor {
+                id: "workspace-bot".to_string(),
+                author_type: "bot".to_string(),
+            },
+        ]);
+        let lookup = FakeCredentialLookup::default().with_bot_id(
+            "workspace-bot",
+            test_credential("resolved-ws", "workspace-bot"),
+        );
+
+        let credential = lookup_notion_credential(&lookup, &payload).unwrap();
+
+        assert_eq!(credential.workspace_id, "resolved-ws");
+        assert_eq!(lookup.calls(), vec!["bot:workspace-bot"]);
+    }
+
+    #[test]
+    fn credential_lookup_falls_back_to_bot_when_workspace_not_found() {
+        let mut payload = make_test_payload(None);
+        payload.workspace_id = "missing-ws".to_string();
+        payload.accessible_by = Some(vec![NotionWebhookAuthor {
+            id: "workspace-bot".to_string(),
+            author_type: "bot".to_string(),
+        }]);
+        let lookup = FakeCredentialLookup::default().with_bot_id(
+            "workspace-bot",
+            test_credential("resolved-ws", "workspace-bot"),
+        );
+
+        let credential = lookup_notion_credential(&lookup, &payload).unwrap();
+
+        assert_eq!(credential.workspace_id, "resolved-ws");
+        assert_eq!(
+            lookup.calls(),
+            vec!["workspace:missing-ws", "bot:workspace-bot"]
+        );
+    }
+
+    #[test]
     fn test_deserialize_comment_created() {
         let json = r#"{
             "id": "event-123",
@@ -990,6 +1232,41 @@ mod tests {
         assert_eq!(payload.event_type, Some(NotionEventType::CommentCreated));
         assert_eq!(payload.integration_id, "abc-123");
         assert_eq!(payload.extract_comment_text(), "Hello");
+    }
+
+    #[test]
+    fn test_deserialize_comment_created_without_workspace_id() {
+        let json = r#"{
+            "id": "event-123",
+            "type": "comment.created",
+            "integration_id": "public-integration",
+            "accessible_by": [
+                {"id": "workspace-bot", "type": "bot"},
+                {"id": "person-1", "type": "person"}
+            ],
+            "entity": {
+                "id": "comment-from-entity",
+                "type": "comment"
+            },
+            "data": {
+                "page_id": "page-1"
+            }
+        }"#;
+
+        let payload: NotionWebhookPayload = serde_json::from_str(json).unwrap();
+
+        assert_eq!(payload.workspace_id, "");
+        assert_eq!(
+            payload.get_comment_id(),
+            Some("comment-from-entity".to_string())
+        );
+        assert_eq!(
+            payload.credential_lookup_bot_ids(),
+            vec![
+                "workspace-bot".to_string(),
+                "public-integration".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
@@ -19,7 +19,7 @@ use tracing::{debug, info, warn};
 
 use scheduler_module::channel::{Channel, ChannelMetadata, InboundMessage};
 use scheduler_module::notion_browser::models::NotionMention;
-use scheduler_module::notion_store::NotionStore;
+use scheduler_module::notion_store::{NotionStore, NotionStoreError};
 
 use super::handlers::{build_envelope, enqueue_envelope};
 use super::state::{GatewayState, RouteDecision};
@@ -476,16 +476,7 @@ pub async fn ingest_notion_webhook(
     // Look up credential by workspace_id
     let credential = match notion_store.get_credential_by_workspace(&payload.workspace_id) {
         Ok(cred) => cred,
-        Err(e) => {
-            warn!(
-                "notion webhook no credential found for workspace_id={}: {}",
-                payload.workspace_id, e
-            );
-            return (
-                StatusCode::OK,
-                Json(json!({"status": "ignored", "reason": "no_credential"})),
-            );
-        }
+        Err(e) => return notion_credential_lookup_failure_response(&payload.workspace_id, e),
     };
 
     // Check for self-trigger using the workspace-specific bot_id from credential
@@ -765,6 +756,34 @@ pub async fn ingest_notion_webhook(
     result
 }
 
+fn notion_credential_lookup_failure_response(
+    workspace_id: &str,
+    error: NotionStoreError,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match error {
+        NotionStoreError::NotFound(reason) => {
+            warn!(
+                "notion webhook no credential found for workspace_id={}: {}",
+                workspace_id, reason
+            );
+            (
+                StatusCode::OK,
+                Json(json!({"status": "ignored", "reason": "no_credential"})),
+            )
+        }
+        error => {
+            warn!(
+                "notion webhook credential lookup failed for workspace_id={}: {}",
+                workspace_id, error
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"status": "credential_lookup_error"})),
+            )
+        }
+    }
+}
+
 /// Resolve routing for Notion webhook based on workspace/integration mapping.
 fn resolve_notion_route(
     payload: &NotionWebhookPayload,
@@ -925,6 +944,30 @@ mod tests {
     fn test_author_name() {
         let payload = make_test_payload(None);
         assert_eq!(payload.author_name(), Some("Test User".to_string()));
+    }
+
+    #[test]
+    fn credential_lookup_not_found_remains_non_retryable_no_credential() {
+        let (status, Json(body)) = notion_credential_lookup_failure_response(
+            "ws-456",
+            NotionStoreError::NotFound("ws-456".to_string()),
+        );
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], "ignored");
+        assert_eq!(body["reason"], "no_credential");
+    }
+
+    #[test]
+    fn credential_lookup_store_errors_are_retryable_failures() {
+        let (status, Json(body)) = notion_credential_lookup_failure_response(
+            "ws-456",
+            NotionStoreError::MongoConfig("missing MONGODB_URI".to_string()),
+        );
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["status"], "credential_lookup_error");
+        assert!(body.get("reason").is_none());
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/notion_store.rs
+++ b/DoWhiz_service/scheduler_module/src/notion_store.rs
@@ -270,20 +270,32 @@ impl NotionStore {
         }
     }
 
-    /// Get credential by bot_id (integration_id in webhook payloads).
+    /// Get credential by bot_id.
     ///
-    /// The bot_id from OAuth is called `integration_id` in Notion webhook payloads.
-    /// This method is used to look up credentials when processing incoming webhooks.
+    /// This is used as a webhook fallback when the payload exposes the
+    /// workspace-specific bot principal but not a usable workspace_id.
     pub fn get_credential_by_bot_id(
         &self,
         bot_id: &str,
     ) -> Result<NotionCredential, NotionStoreError> {
-        let doc = self
-            .credentials
-            .find_one(doc! { "bot_id": bot_id }, None)?
-            .ok_or_else(|| NotionStoreError::NotFound(format!("bot_id: {}", bot_id)))?;
+        self.get_credentials_by_bot_id_candidates(bot_id)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| NotionStoreError::NotFound(format!("bot_id: {}", bot_id)))
+    }
 
-        Self::doc_to_credential(doc)
+    /// Get all credentials matching a bot_id, newest first.
+    ///
+    /// Public integration webhooks can be mapped back to a workspace-specific
+    /// OAuth token through the bot principal in `accessible_by`. Multiple
+    /// accounts may have connected the same workspace, so keep selection
+    /// deterministic and prefer the most recently updated token.
+    pub fn get_credentials_by_bot_id_candidates(
+        &self,
+        bot_id: &str,
+    ) -> Result<Vec<NotionCredential>, NotionStoreError> {
+        let cursor = self.credentials.find(doc! { "bot_id": bot_id }, None)?;
+        collect_credentials_newest_first(cursor)
     }
 
     /// Get any available credential (fallback when workspace_name is unknown).

--- a/DoWhiz_service/scheduler_module/src/notion_store.rs
+++ b/DoWhiz_service/scheduler_module/src/notion_store.rs
@@ -4,7 +4,7 @@
 
 use chrono::{DateTime, Utc};
 use mongodb::bson::{doc, Bson, DateTime as BsonDateTime, Document};
-use mongodb::options::{FindOptions, IndexOptions, UpdateOptions};
+use mongodb::options::{IndexOptions, UpdateOptions};
 use mongodb::sync::Collection;
 use mongodb::IndexModel;
 
@@ -176,14 +176,11 @@ impl NotionStore {
         &self,
         workspace_id: &str,
     ) -> Result<Vec<NotionCredential>, NotionStoreError> {
-        let options = FindOptions::builder()
-            .sort(doc! { "updated_at": -1, "created_at": -1 })
-            .build();
         let cursor = self.credentials.find(
             doc! { "workspace_id": { "$in": Self::workspace_id_variants(workspace_id) } },
-            options,
+            None,
         )?;
-        collect_credentials(cursor)
+        collect_credentials_newest_first(cursor)
     }
 
     /// Normalize workspace_id to canonical UUID format with dashes.
@@ -243,11 +240,9 @@ impl NotionStore {
         // Normalize the search term: lowercase, remove non-alphanumeric
         let normalized_search = Self::normalize_workspace_name(name_or_slug);
 
-        // Get all credentials and find a match
-        let options = FindOptions::builder()
-            .sort(doc! { "updated_at": -1, "created_at": -1 })
-            .build();
-        let cursor = self.credentials.find(doc! {}, options)?;
+        // Get all credentials and find a match. Keep sorting client-side because
+        // Cosmos Mongo requires composite indexes for server-side ORDER BY.
+        let cursor = self.credentials.find(doc! {}, None)?;
         let mut matches = Vec::new();
 
         for result in cursor {
@@ -270,6 +265,7 @@ impl NotionStore {
                 name_or_slug
             )))
         } else {
+            sort_credentials_newest_first(&mut matches);
             Ok(matches)
         }
     }
@@ -303,11 +299,8 @@ impl NotionStore {
     pub fn get_all_credentials_newest_first(
         &self,
     ) -> Result<Vec<NotionCredential>, NotionStoreError> {
-        let options = FindOptions::builder()
-            .sort(doc! { "updated_at": -1, "created_at": -1 })
-            .build();
-        let cursor = self.credentials.find(doc! {}, options)?;
-        collect_credentials(cursor)
+        let cursor = self.credentials.find(doc! {}, None)?;
+        collect_credentials_newest_first(cursor)
     }
 
     /// Normalize a workspace name for comparison.
@@ -395,19 +388,81 @@ impl NotionStore {
     }
 }
 
-fn collect_credentials(
+fn collect_credentials_newest_first(
     cursor: mongodb::sync::Cursor<Document>,
 ) -> Result<Vec<NotionCredential>, NotionStoreError> {
     let mut credentials = Vec::new();
     for result in cursor {
         credentials.push(NotionStore::doc_to_credential(result?)?);
     }
+    sort_credentials_newest_first(&mut credentials);
     Ok(credentials)
+}
+
+fn sort_credentials_newest_first(credentials: &mut [NotionCredential]) {
+    credentials.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| b.created_at.cmp(&a.created_at))
+            .then_with(|| a.workspace_id.cmp(&b.workspace_id))
+            .then_with(|| a.account_id.cmp(&b.account_id))
+    });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_credential_with_times(
+        account_id: uuid::Uuid,
+        workspace_id: &str,
+        created_at: DateTime<Utc>,
+        updated_at: DateTime<Utc>,
+    ) -> NotionCredential {
+        NotionCredential {
+            account_id,
+            workspace_id: workspace_id.to_string(),
+            workspace_name: Some("Test Workspace".to_string()),
+            access_token: "secret_test_token".to_string(),
+            bot_id: "bot_123".to_string(),
+            owner_user_id: Some("user_456".to_string()),
+            created_at,
+            updated_at,
+        }
+    }
+
+    #[test]
+    fn sort_credentials_newest_first_prefers_updated_at_then_created_at() {
+        let account_id = uuid::Uuid::new_v4();
+        let base = DateTime::parse_from_rfc3339("2026-05-20T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let one_hour_later = base + chrono::Duration::hours(1);
+        let two_hours_later = base + chrono::Duration::hours(2);
+
+        let mut credentials = vec![
+            test_credential_with_times(account_id, "old", base, base),
+            test_credential_with_times(
+                account_id,
+                "newest-created",
+                two_hours_later,
+                one_hour_later,
+            ),
+            test_credential_with_times(account_id, "newest-updated", base, two_hours_later),
+            test_credential_with_times(account_id, "older-created", base, one_hour_later),
+        ];
+
+        sort_credentials_newest_first(&mut credentials);
+
+        let ordered_workspaces: Vec<_> = credentials
+            .iter()
+            .map(|credential| credential.workspace_id.as_str())
+            .collect();
+        assert_eq!(
+            ordered_workspaces,
+            vec!["newest-updated", "newest-created", "older-created", "old"]
+        );
+    }
 
     #[test]
     fn test_credential_roundtrip() {


### PR DESCRIPTION
## Summary
- Add Notion webhook credential lookup fallback from workspace_id to bot principals in accessible_by/authors/integration_id.
- Propagate the resolved workspace_id into routing, thread IDs, channel metadata, and NotionMention payloads.
- Make bot_id credential lookup deterministic by selecting newest-first candidates.
- Parse comment IDs from entity.id for newer webhook payload shape.

## Test Evidence
- cargo fmt -p scheduler_module
- cargo test -p scheduler_module --bin inbound_gateway notion_webhook -- --nocapture
- cargo check -p scheduler_module --bin inbound_gateway
- cargo test -p scheduler_module notion_store::tests::sort_credentials_newest_first_prefers_updated_at_then_created_at -- --nocapture
- git diff --check

## Known Caveats
- Full cargo test -p scheduler_module --bin inbound_gateway currently has unrelated failing WeChat tests; Notion tests pass within that target.
- Production SSH alias dowhizprod1 did not resolve from this environment, so live prod log re-check was not possible here.