### PR TITLE
Merge dev to main for production deploy

### DIFF
--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
@@ -19,7 +19,7 @@ use tracing::{debug, info, warn};
 
 use scheduler_module::channel::{Channel, ChannelMetadata, InboundMessage};
 use scheduler_module::notion_browser::models::NotionMention;
-use scheduler_module::notion_store::{NotionStore, NotionStoreError};
+use scheduler_module::notion_store::{NotionCredential, NotionStore, NotionStoreError};
 
 use super::handlers::{build_envelope, enqueue_envelope};
 use super::state::{GatewayState, RouteDecision};
@@ -109,8 +109,9 @@ pub struct NotionWebhookPayload {
     /// Timestamp of the event
     #[serde(default)]
     pub timestamp: Option<String>,
-    /// The integration that received this webhook (same as bot_id from OAuth)
+    /// The integration that received this webhook.
     pub integration_id: String,
+    #[serde(default)]
     pub workspace_id: String,
     #[serde(default)]
     pub workspace_name: Option<String>,
@@ -259,6 +260,12 @@ impl NotionWebhookPayload {
                 return Some(id.to_string());
             }
         }
+        // Newer webhook payloads carry the changed object under `entity`.
+        if let Some(entity) = self.entity.as_ref() {
+            if let Some(id) = entity.get("id").and_then(|v| v.as_str()) {
+                return Some(id.to_string());
+            }
+        }
         // From extra fields
         self.extra
             .get("comment_id")
@@ -322,6 +329,30 @@ impl NotionWebhookPayload {
         None
     }
 
+    /// Bot IDs that can identify the workspace-specific OAuth credential.
+    pub fn credential_lookup_bot_ids(&self) -> Vec<String> {
+        let mut bot_ids = Vec::new();
+
+        if let Some(accessible_by) = &self.accessible_by {
+            for principal in accessible_by {
+                if principal.author_type == "bot" {
+                    push_unique(&mut bot_ids, &principal.id);
+                }
+            }
+        }
+
+        if let Some(authors) = &self.authors {
+            for author in authors {
+                if author.author_type == "bot" {
+                    push_unique(&mut bot_ids, &author.id);
+                }
+            }
+        }
+
+        push_unique(&mut bot_ids, &self.integration_id);
+        bot_ids
+    }
+
     /// Check if the comment contains an @mention for a specific bot/integration.
     pub fn contains_bot_mention(&self, integration_id: &str) -> bool {
         let Some(data) = self.comment_data_value() else {
@@ -371,6 +402,72 @@ impl NotionWebhookPayload {
         }
         false
     }
+}
+
+fn push_unique(values: &mut Vec<String>, candidate: &str) {
+    let candidate = candidate.trim();
+    if !candidate.is_empty() && !values.iter().any(|value| value == candidate) {
+        values.push(candidate.to_string());
+    }
+}
+
+trait NotionCredentialLookup {
+    fn lookup_by_workspace(&self, workspace_id: &str)
+        -> Result<NotionCredential, NotionStoreError>;
+    fn lookup_by_bot_id(&self, bot_id: &str) -> Result<NotionCredential, NotionStoreError>;
+}
+
+impl NotionCredentialLookup for NotionStore {
+    fn lookup_by_workspace(
+        &self,
+        workspace_id: &str,
+    ) -> Result<NotionCredential, NotionStoreError> {
+        self.get_credential_by_workspace(workspace_id)
+    }
+
+    fn lookup_by_bot_id(&self, bot_id: &str) -> Result<NotionCredential, NotionStoreError> {
+        self.get_credential_by_bot_id(bot_id)
+    }
+}
+
+fn lookup_notion_credential(
+    lookup: &impl NotionCredentialLookup,
+    payload: &NotionWebhookPayload,
+) -> Result<NotionCredential, NotionStoreError> {
+    let workspace_id = payload.workspace_id.trim();
+    let mut not_found_reasons = Vec::new();
+
+    if !workspace_id.is_empty() {
+        match lookup.lookup_by_workspace(workspace_id) {
+            Ok(credential) => return Ok(credential),
+            Err(NotionStoreError::NotFound(reason)) => {
+                not_found_reasons.push(format!("workspace_id={workspace_id}: {reason}"));
+            }
+            Err(error) => return Err(error),
+        }
+    } else {
+        not_found_reasons.push("workspace_id missing or empty".to_string());
+    }
+
+    for bot_id in payload.credential_lookup_bot_ids() {
+        match lookup.lookup_by_bot_id(&bot_id) {
+            Ok(credential) => {
+                info!(
+                    "notion webhook credential matched by bot_id fallback: bot_id={} workspace_id={} original_workspace_id={:?}",
+                    bot_id,
+                    credential.workspace_id,
+                    workspace_id
+                );
+                return Ok(credential);
+            }
+            Err(NotionStoreError::NotFound(reason)) => {
+                not_found_reasons.push(format!("bot_id={bot_id}: {reason}"));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(NotionStoreError::NotFound(not_found_reasons.join("; ")))
 }
 
 /// Check if this webhook is for our environment's integration.
@@ -473,11 +570,14 @@ pub async fn ingest_notion_webhook(
         }
     };
 
-    // Look up credential by workspace_id
-    let credential = match notion_store.get_credential_by_workspace(&payload.workspace_id) {
+    // Look up credential by workspace_id first. Some real deliveries have
+    // arrived with an empty workspace_id, so fall back to the bot principal IDs
+    // Notion includes for public integration webhooks.
+    let credential = match lookup_notion_credential(&notion_store, &payload) {
         Ok(cred) => cred,
         Err(e) => return notion_credential_lookup_failure_response(&payload.workspace_id, e),
     };
+    let resolved_workspace_id = credential.workspace_id.clone();
 
     // Check for self-trigger using the workspace-specific bot_id from credential
     // The bot_id is the bot's user ID within this workspace, while integration_id is the public integration ID
@@ -503,11 +603,11 @@ pub async fn ingest_notion_webhook(
     }
 
     // Build routing decision based on employee directory
-    let route = resolve_notion_route(&payload, &credential, &state);
+    let route = resolve_notion_route(&resolved_workspace_id, &credential, &state);
     let Some(route) = route else {
         info!(
             "notion webhook no route for workspace_id={}",
-            payload.workspace_id
+            resolved_workspace_id
         );
         return (StatusCode::OK, Json(json!({"status": "no_route"})));
     };
@@ -664,7 +764,7 @@ pub async fn ingest_notion_webhook(
     );
 
     // Build InboundMessage
-    let thread_id = format!("notion:{}:{}", payload.workspace_id, discussion_id);
+    let thread_id = format!("notion:{}:{}", resolved_workspace_id, discussion_id);
     let message_id = format!("notion-comment-{}", comment_id);
 
     let message = InboundMessage {
@@ -683,7 +783,7 @@ pub async fn ingest_notion_webhook(
         metadata: ChannelMetadata {
             notion_page_id: Some(page_id.clone()),
             notion_comment_id: Some(comment_id.clone()),
-            notion_workspace_id: Some(payload.workspace_id.clone()),
+            notion_workspace_id: Some(resolved_workspace_id.clone()),
             ..Default::default()
         },
     };
@@ -691,10 +791,11 @@ pub async fn ingest_notion_webhook(
     // Convert webhook payload to NotionMention format for worker compatibility
     let notion_mention = NotionMention {
         id: payload.id.clone(),
-        workspace_id: payload.workspace_id.clone(),
+        workspace_id: resolved_workspace_id.clone(),
         workspace_name: payload
             .workspace_name
             .clone()
+            .or_else(|| credential.workspace_name.clone())
             .unwrap_or_else(|| "Unknown".to_string()),
         page_id: page_id.clone(),
         page_title: format!("Notion Page {}", page_id), // Title not available in webhook
@@ -786,12 +887,12 @@ fn notion_credential_lookup_failure_response(
 
 /// Resolve routing for Notion webhook based on workspace/integration mapping.
 fn resolve_notion_route(
-    payload: &NotionWebhookPayload,
+    workspace_id: &str,
     credential: &scheduler_module::notion_store::NotionCredential,
     state: &GatewayState,
 ) -> Option<RouteDecision> {
     // Try to find employee by workspace_id in routes
-    let route_key = payload.workspace_id.clone();
+    let route_key = workspace_id.to_string();
 
     // Check explicit routes first
     if let Some(route) = super::routes::resolve_route(Channel::Notion, &route_key, state) {
@@ -827,6 +928,9 @@ fn resolve_notion_route(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
 
     fn make_test_payload(authors: Option<Vec<NotionWebhookAuthor>>) -> NotionWebhookPayload {
         NotionWebhookPayload {
@@ -851,6 +955,66 @@ mod tests {
             discussion_id: None,
             comment_id: None,
             extra: std::collections::HashMap::new(),
+        }
+    }
+
+    fn test_credential(workspace_id: &str, bot_id: &str) -> NotionCredential {
+        NotionCredential {
+            account_id: uuid::Uuid::nil(),
+            workspace_id: workspace_id.to_string(),
+            workspace_name: Some("Test Workspace".to_string()),
+            access_token: "secret_test_token".to_string(),
+            bot_id: bot_id.to_string(),
+            owner_user_id: Some("owner-user".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeCredentialLookup {
+        by_workspace: HashMap<String, NotionCredential>,
+        by_bot_id: HashMap<String, NotionCredential>,
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl FakeCredentialLookup {
+        fn with_workspace(mut self, workspace_id: &str, credential: NotionCredential) -> Self {
+            self.by_workspace
+                .insert(workspace_id.to_string(), credential);
+            self
+        }
+
+        fn with_bot_id(mut self, bot_id: &str, credential: NotionCredential) -> Self {
+            self.by_bot_id.insert(bot_id.to_string(), credential);
+            self
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl NotionCredentialLookup for FakeCredentialLookup {
+        fn lookup_by_workspace(
+            &self,
+            workspace_id: &str,
+        ) -> Result<NotionCredential, NotionStoreError> {
+            self.calls
+                .borrow_mut()
+                .push(format!("workspace:{workspace_id}"));
+            self.by_workspace
+                .get(workspace_id)
+                .cloned()
+                .ok_or_else(|| NotionStoreError::NotFound(workspace_id.to_string()))
+        }
+
+        fn lookup_by_bot_id(&self, bot_id: &str) -> Result<NotionCredential, NotionStoreError> {
+            self.calls.borrow_mut().push(format!("bot:{bot_id}"));
+            self.by_bot_id
+                .get(bot_id)
+                .cloned()
+                .ok_or_else(|| NotionStoreError::NotFound(format!("bot_id: {bot_id}")))
         }
     }
 
@@ -941,6 +1105,23 @@ mod tests {
     }
 
     #[test]
+    fn test_get_comment_id_from_entity() {
+        let mut payload = make_test_payload(None);
+        payload.data = Some(serde_json::json!({
+            "page_id": "page-789"
+        }));
+        payload.entity = Some(serde_json::json!({
+            "id": "comment-from-entity",
+            "type": "comment"
+        }));
+
+        assert_eq!(
+            payload.get_comment_id(),
+            Some("comment-from-entity".to_string())
+        );
+    }
+
+    #[test]
     fn test_author_name() {
         let payload = make_test_payload(None);
         assert_eq!(payload.author_name(), Some("Test User".to_string()));
@@ -971,6 +1152,67 @@ mod tests {
     }
 
     #[test]
+    fn credential_lookup_uses_workspace_before_bot_ids() {
+        let payload = make_test_payload(None);
+        let lookup = FakeCredentialLookup::default()
+            .with_workspace("ws-456", test_credential("ws-456", "workspace-bot"))
+            .with_bot_id("bot-123", test_credential("other-ws", "bot-123"));
+
+        let credential = lookup_notion_credential(&lookup, &payload).unwrap();
+
+        assert_eq!(credential.workspace_id, "ws-456");
+        assert_eq!(lookup.calls(), vec!["workspace:ws-456"]);
+    }
+
+    #[test]
+    fn credential_lookup_falls_back_to_accessible_bot_when_workspace_empty() {
+        let mut payload = make_test_payload(None);
+        payload.workspace_id.clear();
+        payload.integration_id = "public-integration".to_string();
+        payload.accessible_by = Some(vec![
+            NotionWebhookAuthor {
+                id: "person-1".to_string(),
+                author_type: "person".to_string(),
+            },
+            NotionWebhookAuthor {
+                id: "workspace-bot".to_string(),
+                author_type: "bot".to_string(),
+            },
+        ]);
+        let lookup = FakeCredentialLookup::default().with_bot_id(
+            "workspace-bot",
+            test_credential("resolved-ws", "workspace-bot"),
+        );
+
+        let credential = lookup_notion_credential(&lookup, &payload).unwrap();
+
+        assert_eq!(credential.workspace_id, "resolved-ws");
+        assert_eq!(lookup.calls(), vec!["bot:workspace-bot"]);
+    }
+
+    #[test]
+    fn credential_lookup_falls_back_to_bot_when_workspace_not_found() {
+        let mut payload = make_test_payload(None);
+        payload.workspace_id = "missing-ws".to_string();
+        payload.accessible_by = Some(vec![NotionWebhookAuthor {
+            id: "workspace-bot".to_string(),
+            author_type: "bot".to_string(),
+        }]);
+        let lookup = FakeCredentialLookup::default().with_bot_id(
+            "workspace-bot",
+            test_credential("resolved-ws", "workspace-bot"),
+        );
+
+        let credential = lookup_notion_credential(&lookup, &payload).unwrap();
+
+        assert_eq!(credential.workspace_id, "resolved-ws");
+        assert_eq!(
+            lookup.calls(),
+            vec!["workspace:missing-ws", "bot:workspace-bot"]
+        );
+    }
+
+    #[test]
     fn test_deserialize_comment_created() {
         let json = r#"{
             "id": "event-123",
@@ -990,6 +1232,41 @@ mod tests {
         assert_eq!(payload.event_type, Some(NotionEventType::CommentCreated));
         assert_eq!(payload.integration_id, "abc-123");
         assert_eq!(payload.extract_comment_text(), "Hello");
+    }
+
+    #[test]
+    fn test_deserialize_comment_created_without_workspace_id() {
+        let json = r#"{
+            "id": "event-123",
+            "type": "comment.created",
+            "integration_id": "public-integration",
+            "accessible_by": [
+                {"id": "workspace-bot", "type": "bot"},
+                {"id": "person-1", "type": "person"}
+            ],
+            "entity": {
+                "id": "comment-from-entity",
+                "type": "comment"
+            },
+            "data": {
+                "page_id": "page-1"
+            }
+        }"#;
+
+        let payload: NotionWebhookPayload = serde_json::from_str(json).unwrap();
+
+        assert_eq!(payload.workspace_id, "");
+        assert_eq!(
+            payload.get_comment_id(),
+            Some("comment-from-entity".to_string())
+        );
+        assert_eq!(
+            payload.credential_lookup_bot_ids(),
+            vec![
+                "workspace-bot".to_string(),
+                "public-integration".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
+++ b/DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs
@@ -19,7 +19,7 @@ use tracing::{debug, info, warn};
 
 use scheduler_module::channel::{Channel, ChannelMetadata, InboundMessage};
 use scheduler_module::notion_browser::models::NotionMention;
-use scheduler_module::notion_store::NotionStore;
+use scheduler_module::notion_store::{NotionStore, NotionStoreError};
 
 use super::handlers::{build_envelope, enqueue_envelope};
 use super::state::{GatewayState, RouteDecision};
@@ -476,16 +476,7 @@ pub async fn ingest_notion_webhook(
     // Look up credential by workspace_id
     let credential = match notion_store.get_credential_by_workspace(&payload.workspace_id) {
         Ok(cred) => cred,
-        Err(e) => {
-            warn!(
-                "notion webhook no credential found for workspace_id={}: {}",
-                payload.workspace_id, e
-            );
-            return (
-                StatusCode::OK,
-                Json(json!({"status": "ignored", "reason": "no_credential"})),
-            );
-        }
+        Err(e) => return notion_credential_lookup_failure_response(&payload.workspace_id, e),
     };
 
     // Check for self-trigger using the workspace-specific bot_id from credential
@@ -765,6 +756,34 @@ pub async fn ingest_notion_webhook(
     result
 }
 
+fn notion_credential_lookup_failure_response(
+    workspace_id: &str,
+    error: NotionStoreError,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match error {
+        NotionStoreError::NotFound(reason) => {
+            warn!(
+                "notion webhook no credential found for workspace_id={}: {}",
+                workspace_id, reason
+            );
+            (
+                StatusCode::OK,
+                Json(json!({"status": "ignored", "reason": "no_credential"})),
+            )
+        }
+        error => {
+            warn!(
+                "notion webhook credential lookup failed for workspace_id={}: {}",
+                workspace_id, error
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"status": "credential_lookup_error"})),
+            )
+        }
+    }
+}
+
 /// Resolve routing for Notion webhook based on workspace/integration mapping.
 fn resolve_notion_route(
     payload: &NotionWebhookPayload,
@@ -925,6 +944,30 @@ mod tests {
     fn test_author_name() {
         let payload = make_test_payload(None);
         assert_eq!(payload.author_name(), Some("Test User".to_string()));
+    }
+
+    #[test]
+    fn credential_lookup_not_found_remains_non_retryable_no_credential() {
+        let (status, Json(body)) = notion_credential_lookup_failure_response(
+            "ws-456",
+            NotionStoreError::NotFound("ws-456".to_string()),
+        );
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], "ignored");
+        assert_eq!(body["reason"], "no_credential");
+    }
+
+    #[test]
+    fn credential_lookup_store_errors_are_retryable_failures() {
+        let (status, Json(body)) = notion_credential_lookup_failure_response(
+            "ws-456",
+            NotionStoreError::MongoConfig("missing MONGODB_URI".to_string()),
+        );
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["status"], "credential_lookup_error");
+        assert!(body.get("reason").is_none());
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/notion_store.rs
+++ b/DoWhiz_service/scheduler_module/src/notion_store.rs
@@ -270,20 +270,32 @@ impl NotionStore {
         }
     }
 
-    /// Get credential by bot_id (integration_id in webhook payloads).
+    /// Get credential by bot_id.
     ///
-    /// The bot_id from OAuth is called `integration_id` in Notion webhook payloads.
-    /// This method is used to look up credentials when processing incoming webhooks.
+    /// This is used as a webhook fallback when the payload exposes the
+    /// workspace-specific bot principal but not a usable workspace_id.
     pub fn get_credential_by_bot_id(
         &self,
         bot_id: &str,
     ) -> Result<NotionCredential, NotionStoreError> {
-        let doc = self
-            .credentials
-            .find_one(doc! { "bot_id": bot_id }, None)?
-            .ok_or_else(|| NotionStoreError::NotFound(format!("bot_id: {}", bot_id)))?;
+        self.get_credentials_by_bot_id_candidates(bot_id)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| NotionStoreError::NotFound(format!("bot_id: {}", bot_id)))
+    }
 
-        Self::doc_to_credential(doc)
+    /// Get all credentials matching a bot_id, newest first.
+    ///
+    /// Public integration webhooks can be mapped back to a workspace-specific
+    /// OAuth token through the bot principal in `accessible_by`. Multiple
+    /// accounts may have connected the same workspace, so keep selection
+    /// deterministic and prefer the most recently updated token.
+    pub fn get_credentials_by_bot_id_candidates(
+        &self,
+        bot_id: &str,
+    ) -> Result<Vec<NotionCredential>, NotionStoreError> {
+        let cursor = self.credentials.find(doc! { "bot_id": bot_id }, None)?;
+        collect_credentials_newest_first(cursor)
     }
 
     /// Get any available credential (fallback when workspace_name is unknown).

--- a/DoWhiz_service/scheduler_module/src/notion_store.rs
+++ b/DoWhiz_service/scheduler_module/src/notion_store.rs
@@ -4,7 +4,7 @@
 
 use chrono::{DateTime, Utc};
 use mongodb::bson::{doc, Bson, DateTime as BsonDateTime, Document};
-use mongodb::options::{FindOptions, IndexOptions, UpdateOptions};
+use mongodb::options::{IndexOptions, UpdateOptions};
 use mongodb::sync::Collection;
 use mongodb::IndexModel;
 
@@ -176,14 +176,11 @@ impl NotionStore {
         &self,
         workspace_id: &str,
     ) -> Result<Vec<NotionCredential>, NotionStoreError> {
-        let options = FindOptions::builder()
-            .sort(doc! { "updated_at": -1, "created_at": -1 })
-            .build();
         let cursor = self.credentials.find(
             doc! { "workspace_id": { "$in": Self::workspace_id_variants(workspace_id) } },
-            options,
+            None,
         )?;
-        collect_credentials(cursor)
+        collect_credentials_newest_first(cursor)
     }
 
     /// Normalize workspace_id to canonical UUID format with dashes.
@@ -243,11 +240,9 @@ impl NotionStore {
         // Normalize the search term: lowercase, remove non-alphanumeric
         let normalized_search = Self::normalize_workspace_name(name_or_slug);
 
-        // Get all credentials and find a match
-        let options = FindOptions::builder()
-            .sort(doc! { "updated_at": -1, "created_at": -1 })
-            .build();
-        let cursor = self.credentials.find(doc! {}, options)?;
+        // Get all credentials and find a match. Keep sorting client-side because
+        // Cosmos Mongo requires composite indexes for server-side ORDER BY.
+        let cursor = self.credentials.find(doc! {}, None)?;
         let mut matches = Vec::new();
 
         for result in cursor {
@@ -270,6 +265,7 @@ impl NotionStore {
                 name_or_slug
             )))
         } else {
+            sort_credentials_newest_first(&mut matches);
             Ok(matches)
         }
     }
@@ -303,11 +299,8 @@ impl NotionStore {
     pub fn get_all_credentials_newest_first(
         &self,
     ) -> Result<Vec<NotionCredential>, NotionStoreError> {
-        let options = FindOptions::builder()
-            .sort(doc! { "updated_at": -1, "created_at": -1 })
-            .build();
-        let cursor = self.credentials.find(doc! {}, options)?;
-        collect_credentials(cursor)
+        let cursor = self.credentials.find(doc! {}, None)?;
+        collect_credentials_newest_first(cursor)
     }
 
     /// Normalize a workspace name for comparison.
@@ -395,19 +388,81 @@ impl NotionStore {
     }
 }
 
-fn collect_credentials(
+fn collect_credentials_newest_first(
     cursor: mongodb::sync::Cursor<Document>,
 ) -> Result<Vec<NotionCredential>, NotionStoreError> {
     let mut credentials = Vec::new();
     for result in cursor {
         credentials.push(NotionStore::doc_to_credential(result?)?);
     }
+    sort_credentials_newest_first(&mut credentials);
     Ok(credentials)
+}
+
+fn sort_credentials_newest_first(credentials: &mut [NotionCredential]) {
+    credentials.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| b.created_at.cmp(&a.created_at))
+            .then_with(|| a.workspace_id.cmp(&b.workspace_id))
+            .then_with(|| a.account_id.cmp(&b.account_id))
+    });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_credential_with_times(
+        account_id: uuid::Uuid,
+        workspace_id: &str,
+        created_at: DateTime<Utc>,
+        updated_at: DateTime<Utc>,
+    ) -> NotionCredential {
+        NotionCredential {
+            account_id,
+            workspace_id: workspace_id.to_string(),
+            workspace_name: Some("Test Workspace".to_string()),
+            access_token: "secret_test_token".to_string(),
+            bot_id: "bot_123".to_string(),
+            owner_user_id: Some("user_456".to_string()),
+            created_at,
+            updated_at,
+        }
+    }
+
+    #[test]
+    fn sort_credentials_newest_first_prefers_updated_at_then_created_at() {
+        let account_id = uuid::Uuid::new_v4();
+        let base = DateTime::parse_from_rfc3339("2026-05-20T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let one_hour_later = base + chrono::Duration::hours(1);
+        let two_hours_later = base + chrono::Duration::hours(2);
+
+        let mut credentials = vec![
+            test_credential_with_times(account_id, "old", base, base),
+            test_credential_with_times(
+                account_id,
+                "newest-created",
+                two_hours_later,
+                one_hour_later,
+            ),
+            test_credential_with_times(account_id, "newest-updated", base, two_hours_later),
+            test_credential_with_times(account_id, "older-created", base, one_hour_later),
+        ];
+
+        sort_credentials_newest_first(&mut credentials);
+
+        let ordered_workspaces: Vec<_> = credentials
+            .iter()
+            .map(|credential| credential.workspace_id.as_str())
+            .collect();
+        assert_eq!(
+            ordered_workspaces,
+            vec!["newest-updated", "newest-created", "older-created", "old"]
+        );
+    }
 
     #[test]
     fn test_credential_roundtrip() {

--- a/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::account_store::AccountStore;
+use crate::account_store::{Account, AccountStore, BalanceInfo};
 use crate::channel::Channel;
 use crate::index_store::IndexStore;
 use crate::notion_browser::models::NotionMention;
@@ -21,6 +21,71 @@ use super::super::config::ServiceConfig;
 use super::super::default_thread_state_path;
 use super::super::workspace::ensure_thread_workspace;
 use crate::service::BoxError;
+
+#[derive(Debug, Clone)]
+struct AuthorizedNotionRequester {
+    account: Account,
+    notion_identifier: String,
+    balance_hours: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum NotionAuthorAuthorizationFailure {
+    MissingWorkspaceId,
+    MissingAuthorId,
+    AccountLookupFailed {
+        notion_identifier: String,
+        error: String,
+    },
+    NotLinked {
+        notion_identifier: String,
+    },
+    BalanceLookupFailed {
+        account_id: Uuid,
+        error: String,
+    },
+    InsufficientBalance {
+        account_id: Uuid,
+        balance_hours: f64,
+    },
+}
+
+impl std::fmt::Display for NotionAuthorAuthorizationFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingWorkspaceId => write!(f, "missing workspace id"),
+            Self::MissingAuthorId => write!(f, "missing author id"),
+            Self::AccountLookupFailed {
+                notion_identifier,
+                error,
+            } => write!(
+                f,
+                "failed to look up Notion account identifier {}: {}",
+                notion_identifier, error
+            ),
+            Self::NotLinked { notion_identifier } => write!(
+                f,
+                "Notion author identifier {} is not linked to a DoWhiz account",
+                notion_identifier
+            ),
+            Self::BalanceLookupFailed { account_id, error } => {
+                write!(
+                    f,
+                    "failed to look up balance for account {}: {}",
+                    account_id, error
+                )
+            }
+            Self::InsufficientBalance {
+                account_id,
+                balance_hours,
+            } => write!(
+                f,
+                "account {} has no available hours (balance_hours={})",
+                account_id, balance_hours
+            ),
+        }
+    }
+}
 
 /// Process an incoming Notion mention/comment.
 pub(crate) fn process_notion_message(
@@ -52,81 +117,89 @@ pub(crate) fn process_notion_message(
         .as_deref()
         .unwrap_or("Untitled");
 
-    // Try to get the Notion credential for OAuth token (needed for API calls)
-    // Also try to get the linked account for email attribution (optional)
-    let (notion_credential, notion_linked_account) = if workspace_id != "unknown" {
-        match NotionStore::new() {
-            Ok(store) => match store.get_credential_by_workspace(workspace_id) {
-                Ok(cred) => {
-                    // Found credential - try to look up the linked account (optional)
-                    let linked_account = match account_store.get_account(cred.account_id) {
-                        Ok(Some(account)) => {
-                            // Get the account's email identifier to use as reply_to
-                            let account_email = account_store
-                                .list_identifiers(account.id)
-                                .ok()
-                                .and_then(|ids| {
-                                    ids.into_iter()
-                                        .find(|id| id.identifier_type == "email" && id.verified)
-                                        .map(|id| id.identifier)
-                                });
-                            info!(
-                                "Found linked DoWhiz account {} for Notion workspace {} (email: {:?})",
-                                account.id, workspace_id, account_email
-                            );
-                            Some((account, account_email))
-                        }
-                        Ok(None) => {
-                            warn!(
-                                "NotionCredential references account {} but account not found (will still use OAuth token)",
-                                cred.account_id
-                            );
-                            None
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Failed to look up account {}: {} (will still use OAuth token)",
-                                cred.account_id, e
-                            );
-                            None
-                        }
-                    };
-                    (Some(cred), linked_account)
-                }
-                Err(crate::notion_store::NotionStoreError::NotFound(_)) => {
-                    info!(
-                        "No OAuth credential found for Notion workspace_id={}",
-                        workspace_id
-                    );
-                    (None, None)
-                }
-                Err(e) => {
-                    warn!("Failed to look up Notion credential: {}", e);
-                    (None, None)
-                }
-            },
-            Err(e) => {
-                warn!("Failed to connect to NotionStore: {}", e);
-                (None, None)
+    let authorized_requester =
+        match authorize_notion_requester(account_store, workspace_id, &message.sender) {
+            Ok(requester) => requester,
+            Err(reason) => {
+                warn!(
+                    workspace_id,
+                    author_id = %message.sender,
+                    message_id = ?message.message_id,
+                    reason = %reason,
+                    "skipping notion task before enqueue"
+                );
+                return Ok(());
             }
+        };
+
+    let requester_email = account_store
+        .list_identifiers(authorized_requester.account.id)
+        .map(|ids| {
+            ids.into_iter()
+                .find(|id| id.identifier_type == "email" && id.verified)
+                .map(|id| id.identifier)
+        })
+        .map_err(|err| {
+            warn!(
+                "failed to look up email identifier for authorized Notion account {}: {}",
+                authorized_requester.account.id, err
+            );
+            err
+        })
+        .ok()
+        .flatten();
+
+    info!(
+        "authorized Notion requester account={} notion_identifier={} balance_hours={}",
+        authorized_requester.account.id,
+        authorized_requester.notion_identifier,
+        authorized_requester.balance_hours
+    );
+
+    // The credential is workspace-scoped API capability. The requester account above
+    // is still the billing/authorization subject.
+    let notion_credential = match NotionStore::new() {
+        Ok(store) => match store.get_credential_by_workspace(workspace_id) {
+            Ok(cred) => {
+                info!(
+                    "found Notion OAuth credential for workspace {} credential_account={} requester_account={}",
+                    workspace_id,
+                    cred.account_id,
+                    authorized_requester.account.id
+                );
+                cred
+            }
+            Err(crate::notion_store::NotionStoreError::NotFound(_)) => {
+                warn!(
+                    "skipping notion task before enqueue: no OAuth credential for workspace_id={} requester_account={} message_id={:?}",
+                    workspace_id,
+                    authorized_requester.account.id,
+                    message.message_id
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Failed to look up Notion credential for workspace {}: {}",
+                    workspace_id, e
+                )
+                .into());
+            }
+        },
+        Err(e) => {
+            return Err(format!("Failed to connect to NotionStore: {}", e).into());
         }
-    } else {
-        (None, None)
     };
 
-    // Determine user email: prefer linked account's email, fall back to extracted/synthetic
-    let user_email = if let Some((_, Some(ref email))) = notion_linked_account {
-        email.clone()
-    } else {
-        let extracted_email = extract_emails(&message.sender).into_iter().next();
-        match extracted_email {
-            Some(email) if email != "unknown@unknown.com" => email,
-            _ => {
-                // Use sender name or ID as fallback
-                format!("notion_{}@local", message.sender.replace(' ', "_"))
-            }
-        }
-    };
+    // Determine user email: prefer the authorized account's verified email, fall back to
+    // a workspace-scoped synthetic address for local workspace storage.
+    let user_email = requester_email.unwrap_or_else(|| {
+        extract_emails(&message.sender)
+            .into_iter()
+            .next()
+            .filter(|email| email != "unknown@unknown.com")
+            .unwrap_or_else(|| synthetic_notion_email(&authorized_requester.notion_identifier))
+    });
 
     // Create or get user
     let user = user_store.get_or_create_user("notion", &user_email)?;
@@ -163,20 +236,18 @@ pub(crate) fn process_notion_message(
     // Write Notion context to workspace for agent
     write_notion_context_to_workspace(&workspace, &mention, page_id, page_title)?;
 
-    // Write OAuth token to .notion_env if we have a credential (even if account not found)
-    if let Some(ref cred) = notion_credential {
-        let env_path = workspace.join(".notion_env");
-        if let Err(e) = std::fs::write(
-            &env_path,
-            format!("NOTION_API_TOKEN={}\n", cred.access_token),
-        ) {
-            warn!("Failed to write .notion_env: {}", e);
-        } else {
-            info!(
-                "Wrote Notion OAuth token to workspace for workspace_id={}",
-                workspace_id
-            );
-        }
+    // Write OAuth token to .notion_env so the agent can read/reply through Notion API.
+    let env_path = workspace.join(".notion_env");
+    if let Err(e) = std::fs::write(
+        &env_path,
+        format!("NOTION_API_TOKEN={}\n", notion_credential.access_token),
+    ) {
+        warn!("Failed to write .notion_env: {}", e);
+    } else {
+        info!(
+            "Wrote Notion OAuth token to workspace for workspace_id={}",
+            workspace_id
+        );
     }
 
     // Determine model
@@ -194,11 +265,6 @@ pub(crate) fn process_notion_message(
             }
         }
     };
-
-    // Get account_id from linked account if available
-    let resolved_account_id = notion_linked_account
-        .as_ref()
-        .map(|(account, _)| account.id);
 
     // Create RunTask
     let run_task = RunTaskTask {
@@ -219,9 +285,9 @@ pub(crate) fn process_notion_message(
         channel: Channel::Notion,
         slack_team_id: None,
         employee_id: Some(config.employee_profile.id.clone()),
-        requester_identifier_type: Some("notion_user".to_string()),
-        requester_identifier: Some(user_email.clone()),
-        account_id: resolved_account_id,
+        requester_identifier_type: Some("notion".to_string()),
+        requester_identifier: Some(authorized_requester.notion_identifier.clone()),
+        account_id: Some(authorized_requester.account.id),
         channel_metadata: Default::default(),
     };
 
@@ -259,24 +325,8 @@ pub(crate) fn process_notion_message(
         thread_state.epoch
     );
 
-    // Check for linked account - prefer the one we already found from NotionCredential
-    let linked_account = if let Some((account, _)) = notion_linked_account {
-        Some(account)
-    } else {
-        // Fall back to email-based lookup
-        match account_store.get_account_by_identifier("email", &user_email) {
-            Ok(account) => account,
-            Err(err) => {
-                warn!(
-                    "Failed to look up account for Notion user '{}': {}",
-                    user_email, err
-                );
-                None
-            }
-        }
-    };
-
-    if let Some(account) = linked_account {
+    {
+        let account = authorized_requester.account;
         info!(
             "Found account {} for Notion user {}",
             account.id, user_email
@@ -324,14 +374,101 @@ pub(crate) fn process_notion_message(
                 }
             }
         }
-    } else {
-        info!(
-            "No account linked for Notion user '{}', skipping account-level task",
-            user_email
-        );
     }
 
     Ok(())
+}
+
+fn authorize_notion_requester(
+    account_store: &AccountStore,
+    workspace_id: &str,
+    author_id: &str,
+) -> Result<AuthorizedNotionRequester, NotionAuthorAuthorizationFailure> {
+    authorize_notion_requester_with(
+        workspace_id,
+        author_id,
+        |notion_identifier| account_store.get_account_by_identifier("notion", notion_identifier),
+        |account_id| account_store.get_balance(account_id),
+    )
+}
+
+fn authorize_notion_requester_with<GetAccount, GetBalance, StoreError>(
+    workspace_id: &str,
+    author_id: &str,
+    mut get_account_by_notion_identifier: GetAccount,
+    mut get_balance: GetBalance,
+) -> Result<AuthorizedNotionRequester, NotionAuthorAuthorizationFailure>
+where
+    GetAccount: FnMut(&str) -> Result<Option<Account>, StoreError>,
+    GetBalance: FnMut(Uuid) -> Result<BalanceInfo, StoreError>,
+    StoreError: std::fmt::Display,
+{
+    let notion_identifier = notion_author_identifier(workspace_id, author_id)?;
+    let account = get_account_by_notion_identifier(&notion_identifier)
+        .map_err(
+            |err| NotionAuthorAuthorizationFailure::AccountLookupFailed {
+                notion_identifier: notion_identifier.clone(),
+                error: err.to_string(),
+            },
+        )?
+        .ok_or_else(|| NotionAuthorAuthorizationFailure::NotLinked {
+            notion_identifier: notion_identifier.clone(),
+        })?;
+
+    let balance = get_balance(account.id).map_err(|err| {
+        NotionAuthorAuthorizationFailure::BalanceLookupFailed {
+            account_id: account.id,
+            error: err.to_string(),
+        }
+    })?;
+    if balance.balance_hours <= 0.0 {
+        return Err(NotionAuthorAuthorizationFailure::InsufficientBalance {
+            account_id: account.id,
+            balance_hours: balance.balance_hours,
+        });
+    }
+
+    Ok(AuthorizedNotionRequester {
+        account,
+        notion_identifier,
+        balance_hours: balance.balance_hours,
+    })
+}
+
+fn notion_author_identifier(
+    workspace_id: &str,
+    author_id: &str,
+) -> Result<String, NotionAuthorAuthorizationFailure> {
+    let workspace_id = workspace_id.trim();
+    if workspace_id.is_empty() || workspace_id.eq_ignore_ascii_case("unknown") {
+        return Err(NotionAuthorAuthorizationFailure::MissingWorkspaceId);
+    }
+
+    let author_id = author_id.trim();
+    if author_id.is_empty() || author_id.eq_ignore_ascii_case("unknown") {
+        return Err(NotionAuthorAuthorizationFailure::MissingAuthorId);
+    }
+
+    Ok(format!("{workspace_id}:{author_id}"))
+}
+
+fn synthetic_notion_email(notion_identifier: &str) -> String {
+    let local_part: String = notion_identifier
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let local_part = local_part.trim_matches('_');
+    if local_part.is_empty() {
+        "notion_unknown@local".to_string()
+    } else {
+        format!("notion_{local_part}@local")
+    }
 }
 
 fn notion_message_task_id(message: &crate::channel::InboundMessage) -> Option<Uuid> {
@@ -484,6 +621,7 @@ fn append_workspace_notion_comment(
 mod tests {
     use super::*;
     use crate::channel::{Channel, ChannelMetadata, InboundMessage};
+    use chrono::Utc;
 
     fn build_message(message_id: &str) -> InboundMessage {
         InboundMessage {
@@ -508,6 +646,25 @@ mod tests {
         }
     }
 
+    fn test_account(account_id: Uuid) -> Account {
+        Account {
+            id: account_id,
+            auth_user_id: Uuid::new_v4(),
+            created_at: Utc::now(),
+            tokens_to_hours: Some(0.0),
+            purchased_hours: Some(1.0),
+            organization_id: None,
+        }
+    }
+
+    fn test_balance(balance_hours: f64) -> BalanceInfo {
+        BalanceInfo {
+            purchased_hours: balance_hours.max(0.0),
+            used_hours: 0.0,
+            balance_hours,
+        }
+    }
+
     #[test]
     fn notion_message_task_id_is_stable_for_duplicate_delivery() {
         let mut first = build_message("notion-comment-comment-1");
@@ -529,6 +686,117 @@ mod tests {
         assert_ne!(
             notion_message_task_id(&first),
             notion_message_task_id(&second)
+        );
+    }
+
+    #[test]
+    fn notion_author_identifier_matches_oauth_binding_shape() {
+        assert_eq!(
+            notion_author_identifier("workspace-1", "author-1").unwrap(),
+            "workspace-1:author-1"
+        );
+    }
+
+    #[test]
+    fn notion_author_identifier_rejects_unknown_workspace_or_author() {
+        assert_eq!(
+            notion_author_identifier("unknown", "author-1"),
+            Err(NotionAuthorAuthorizationFailure::MissingWorkspaceId)
+        );
+        assert_eq!(
+            notion_author_identifier("workspace-1", "unknown"),
+            Err(NotionAuthorAuthorizationFailure::MissingAuthorId)
+        );
+        assert_eq!(
+            notion_author_identifier(" ", "author-1"),
+            Err(NotionAuthorAuthorizationFailure::MissingWorkspaceId)
+        );
+        assert_eq!(
+            notion_author_identifier("workspace-1", " "),
+            Err(NotionAuthorAuthorizationFailure::MissingAuthorId)
+        );
+    }
+
+    #[test]
+    fn authorize_notion_requester_rejects_unlinked_author() {
+        let result = authorize_notion_requester_with(
+            "workspace-1",
+            "author-1",
+            |_identifier| Ok::<Option<Account>, &'static str>(None),
+            |_account_id| Ok::<BalanceInfo, &'static str>(test_balance(1.0)),
+        );
+
+        assert_eq!(
+            result.unwrap_err(),
+            NotionAuthorAuthorizationFailure::NotLinked {
+                notion_identifier: "workspace-1:author-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn authorize_notion_requester_rejects_zero_or_negative_balance() {
+        let account_id = Uuid::new_v4();
+        let account = test_account(account_id);
+
+        let zero_result = authorize_notion_requester_with(
+            "workspace-1",
+            "author-1",
+            |_identifier| Ok::<Option<Account>, &'static str>(Some(account.clone())),
+            |_account_id| Ok::<BalanceInfo, &'static str>(test_balance(0.0)),
+        );
+        assert_eq!(
+            zero_result.unwrap_err(),
+            NotionAuthorAuthorizationFailure::InsufficientBalance {
+                account_id,
+                balance_hours: 0.0,
+            }
+        );
+
+        let negative_result = authorize_notion_requester_with(
+            "workspace-1",
+            "author-1",
+            |_identifier| Ok::<Option<Account>, &'static str>(Some(account.clone())),
+            |_account_id| Ok::<BalanceInfo, &'static str>(test_balance(-0.5)),
+        );
+        assert_eq!(
+            negative_result.unwrap_err(),
+            NotionAuthorAuthorizationFailure::InsufficientBalance {
+                account_id,
+                balance_hours: -0.5,
+            }
+        );
+    }
+
+    #[test]
+    fn authorize_notion_requester_allows_linked_author_with_positive_balance() {
+        let account_id = Uuid::new_v4();
+        let account = test_account(account_id);
+
+        let requester = authorize_notion_requester_with(
+            "workspace-1",
+            "author-1",
+            |identifier| {
+                assert_eq!(identifier, "workspace-1:author-1");
+                Ok::<Option<Account>, &'static str>(Some(account.clone()))
+            },
+            |id| {
+                assert_eq!(id, account_id);
+                Ok::<BalanceInfo, &'static str>(test_balance(0.25))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(requester.account.id, account_id);
+        assert_eq!(requester.notion_identifier, "workspace-1:author-1");
+        assert_eq!(requester.balance_hours, 0.25);
+    }
+
+    #[test]
+    fn synthetic_notion_email_is_workspace_scoped_and_local_safe() {
+        assert_eq!(
+            synthetic_notion_email("workspace:author id"),
+            "notion_workspace_author_id@local"
         );
     }
 }

--- a/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
@@ -12,7 +12,7 @@ use crate::account_store::{Account, AccountStore, BalanceInfo};
 use crate::channel::Channel;
 use crate::index_store::IndexStore;
 use crate::notion_browser::models::NotionMention;
-use crate::notion_store::NotionStore;
+use crate::notion_store::{NotionCredential, NotionStore, NotionStoreError};
 use crate::user_store::{extract_emails, UserStore};
 use crate::{ModuleExecutor, RunTaskTask, Scheduler, TaskKind};
 
@@ -48,6 +48,30 @@ enum NotionAuthorAuthorizationFailure {
         account_id: Uuid,
         balance_hours: f64,
     },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum NotionCredentialResolutionFailure {
+    NotFound { workspace_id: String },
+    LookupFailed { workspace_id: String, error: String },
+}
+
+impl std::fmt::Display for NotionCredentialResolutionFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound { workspace_id } => {
+                write!(f, "no OAuth credential for workspace {}", workspace_id)
+            }
+            Self::LookupFailed {
+                workspace_id,
+                error,
+            } => write!(
+                f,
+                "failed to look up Notion credential for workspace {}: {}",
+                workspace_id, error
+            ),
+        }
+    }
 }
 
 impl std::fmt::Display for NotionAuthorAuthorizationFailure {
@@ -158,37 +182,34 @@ pub(crate) fn process_notion_message(
 
     // The credential is workspace-scoped API capability. The requester account above
     // is still the billing/authorization subject.
-    let notion_credential = match NotionStore::new() {
-        Ok(store) => match store.get_credential_by_workspace(workspace_id) {
-            Ok(cred) => {
-                info!(
-                    "found Notion OAuth credential for workspace {} credential_account={} requester_account={}",
-                    workspace_id,
-                    cred.account_id,
-                    authorized_requester.account.id
-                );
-                cred
-            }
-            Err(crate::notion_store::NotionStoreError::NotFound(_)) => {
-                warn!(
+    let store =
+        NotionStore::new().map_err(|e| format!("Failed to connect to NotionStore: {}", e))?;
+    let notion_credential = match resolve_notion_workspace_credential_with(workspace_id, |id| {
+        match store.get_credential_by_workspace(id) {
+            Ok(cred) => Ok(Some(cred)),
+            Err(NotionStoreError::NotFound(_)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }) {
+        Ok(cred) => {
+            info!(
+                "found Notion OAuth credential for workspace {} credential_account={} requester_account={}",
+                workspace_id,
+                cred.account_id,
+                authorized_requester.account.id
+            );
+            cred
+        }
+        Err(NotionCredentialResolutionFailure::NotFound { .. }) => {
+            warn!(
                     "skipping notion task before enqueue: no OAuth credential for workspace_id={} requester_account={} message_id={:?}",
                     workspace_id,
                     authorized_requester.account.id,
                     message.message_id
                 );
-                return Ok(());
-            }
-            Err(e) => {
-                return Err(format!(
-                    "Failed to look up Notion credential for workspace {}: {}",
-                    workspace_id, e
-                )
-                .into());
-            }
-        },
-        Err(e) => {
-            return Err(format!("Failed to connect to NotionStore: {}", e).into());
+            return Ok(());
         }
+        Err(reason) => return Err(reason.to_string().into()),
     };
 
     // Determine user email: prefer the authorized account's verified email, fall back to
@@ -390,6 +411,31 @@ fn authorize_notion_requester(
         |notion_identifier| account_store.get_account_by_identifier("notion", notion_identifier),
         |account_id| account_store.get_balance(account_id),
     )
+}
+
+fn resolve_notion_workspace_credential_with<GetCredential, StoreError>(
+    workspace_id: &str,
+    mut get_credential_by_workspace: GetCredential,
+) -> Result<NotionCredential, NotionCredentialResolutionFailure>
+where
+    GetCredential: FnMut(&str) -> Result<Option<NotionCredential>, StoreError>,
+    StoreError: std::fmt::Display,
+{
+    let workspace_id = workspace_id.trim();
+    if workspace_id.is_empty() || workspace_id.eq_ignore_ascii_case("unknown") {
+        return Err(NotionCredentialResolutionFailure::NotFound {
+            workspace_id: workspace_id.to_string(),
+        });
+    }
+
+    get_credential_by_workspace(workspace_id)
+        .map_err(|err| NotionCredentialResolutionFailure::LookupFailed {
+            workspace_id: workspace_id.to_string(),
+            error: err.to_string(),
+        })?
+        .ok_or_else(|| NotionCredentialResolutionFailure::NotFound {
+            workspace_id: workspace_id.to_string(),
+        })
 }
 
 fn authorize_notion_requester_with<GetAccount, GetBalance, StoreError>(
@@ -665,6 +711,19 @@ mod tests {
         }
     }
 
+    fn test_notion_credential(workspace_id: &str) -> NotionCredential {
+        NotionCredential {
+            account_id: Uuid::new_v4(),
+            workspace_id: workspace_id.to_string(),
+            workspace_name: Some("Workspace".to_string()),
+            access_token: "secret-token".to_string(),
+            bot_id: "bot-1".to_string(),
+            owner_user_id: Some("owner-1".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
     #[test]
     fn notion_message_task_id_is_stable_for_duplicate_delivery() {
         let mut first = build_message("notion-comment-comment-1");
@@ -693,6 +752,14 @@ mod tests {
     fn notion_author_identifier_matches_oauth_binding_shape() {
         assert_eq!(
             notion_author_identifier("workspace-1", "author-1").unwrap(),
+            "workspace-1:author-1"
+        );
+    }
+
+    #[test]
+    fn notion_author_identifier_trims_workspace_and_author() {
+        assert_eq!(
+            notion_author_identifier(" workspace-1 ", " author-1 ").unwrap(),
             "workspace-1:author-1"
         );
     }
@@ -730,6 +797,45 @@ mod tests {
             result.unwrap_err(),
             NotionAuthorAuthorizationFailure::NotLinked {
                 notion_identifier: "workspace-1:author-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn authorize_notion_requester_reports_account_lookup_errors() {
+        let result = authorize_notion_requester_with(
+            "workspace-1",
+            "author-1",
+            |_identifier| Err::<Option<Account>, _>("db down"),
+            |_account_id| Ok::<BalanceInfo, &'static str>(test_balance(1.0)),
+        );
+
+        assert_eq!(
+            result.unwrap_err(),
+            NotionAuthorAuthorizationFailure::AccountLookupFailed {
+                notion_identifier: "workspace-1:author-1".to_string(),
+                error: "db down".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn authorize_notion_requester_reports_balance_lookup_errors() {
+        let account_id = Uuid::new_v4();
+        let account = test_account(account_id);
+
+        let result = authorize_notion_requester_with(
+            "workspace-1",
+            "author-1",
+            |_identifier| Ok::<Option<Account>, &'static str>(Some(account.clone())),
+            |_account_id| Err::<BalanceInfo, _>("balance db down"),
+        );
+
+        assert_eq!(
+            result.unwrap_err(),
+            NotionAuthorAuthorizationFailure::BalanceLookupFailed {
+                account_id,
+                error: "balance db down".to_string(),
             }
         );
     }
@@ -797,6 +903,81 @@ mod tests {
         assert_eq!(
             synthetic_notion_email("workspace:author id"),
             "notion_workspace_author_id@local"
+        );
+    }
+
+    #[test]
+    fn synthetic_notion_email_handles_empty_identifier() {
+        assert_eq!(synthetic_notion_email(":::"), "notion_unknown@local");
+    }
+
+    #[test]
+    fn resolve_notion_workspace_credential_allows_existing_credential() {
+        let credential = test_notion_credential("workspace-1");
+
+        let resolved = resolve_notion_workspace_credential_with(" workspace-1 ", |workspace_id| {
+            assert_eq!(workspace_id, "workspace-1");
+            Ok::<Option<NotionCredential>, &'static str>(Some(credential.clone()))
+        })
+        .unwrap();
+
+        assert_eq!(resolved.workspace_id, "workspace-1");
+        assert_eq!(resolved.access_token, "secret-token");
+    }
+
+    #[test]
+    fn resolve_notion_workspace_credential_rejects_missing_or_unknown_workspace() {
+        assert_eq!(
+            resolve_notion_workspace_credential_with(" ", |_workspace_id| {
+                Ok::<Option<NotionCredential>, &'static str>(Some(test_notion_credential(
+                    "workspace-1",
+                )))
+            })
+            .unwrap_err(),
+            NotionCredentialResolutionFailure::NotFound {
+                workspace_id: String::new(),
+            }
+        );
+
+        assert_eq!(
+            resolve_notion_workspace_credential_with("unknown", |_workspace_id| {
+                Ok::<Option<NotionCredential>, &'static str>(Some(test_notion_credential(
+                    "workspace-1",
+                )))
+            })
+            .unwrap_err(),
+            NotionCredentialResolutionFailure::NotFound {
+                workspace_id: "unknown".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_notion_workspace_credential_rejects_unconnected_workspace() {
+        let result = resolve_notion_workspace_credential_with("workspace-1", |_workspace_id| {
+            Ok::<Option<NotionCredential>, &'static str>(None)
+        });
+
+        assert_eq!(
+            result.unwrap_err(),
+            NotionCredentialResolutionFailure::NotFound {
+                workspace_id: "workspace-1".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_notion_workspace_credential_reports_lookup_errors() {
+        let result = resolve_notion_workspace_credential_with("workspace-1", |_workspace_id| {
+            Err::<Option<NotionCredential>, _>("mongo down")
+        });
+
+        assert_eq!(
+            result.unwrap_err(),
+            NotionCredentialResolutionFailure::LookupFailed {
+                workspace_id: "workspace-1".to_string(),
+                error: "mongo down".to_string(),
+            }
         );
     }
 }


### PR DESCRIPTION
## Summary
- Merge latest `dev` into `main` for production deployment.
- Includes Notion webhook credential lookup hardening from #1828.
- Includes Notion author account authorization and expanded regression tests from #1829.

## Scope
Changed backend Notion ingestion paths only:
- `DoWhiz_service/scheduler_module/src/bin/inbound_gateway/notion_webhook.rs`
- `DoWhiz_service/scheduler_module/src/notion_store.rs`
- `DoWhiz_service/scheduler_module/src/service/inbound/notion.rs`

## Validation already completed before production merge
- Public PR checks for #1829 passed: `rust`, `website`, `Vercel`, `Vercel Preview Comments`.
- Focused local Notion authorization tests passed: `cargo test -p scheduler_module service::inbound::notion::tests -- --nocapture`.
- Local backend checks passed: `cargo fmt -p scheduler_module -- --check`, `cargo check -p scheduler_module --all-targets`, `cargo clippy -p scheduler_module --all-targets --all-features`, `cargo test -p run_task_module`, `cargo test -p send_emails_module`.

## Production deployment
Merging this PR into `main` triggers `.github/workflows/CICD-production.yml`.
