### PR TITLE
Rewire Oliver Postmark inbound routing

### DIFF
--- a/DoWhiz_service/employee.toml
+++ b/DoWhiz_service/employee.toml
@@ -12,6 +12,9 @@ addresses = [
   "oliver@dowhiz.com",
   "little-bear@dowhiz.com",
   "agent@dowhiz.com",
+  # Current production Postmark inbound address. Keep after verified senders so
+  # replies still use oliver@dowhiz.com as From.
+  "f4539b87b9eb29a0ecce5585895e7a6c@inbound.postmarkapp.com",
 ]
 notion_user_id = "300d872b-594c-81eb-b5fe-000281acc42c"
 agents_path = "employees/little_bear/AGENTS.md"

--- a/DoWhiz_service/gateway.toml
+++ b/DoWhiz_service/gateway.toml
@@ -24,6 +24,12 @@ tenant_id = "default"
 
 [[routes]]
 channel = "email"
+key = "f4539b87b9eb29a0ecce5585895e7a6c@inbound.postmarkapp.com"
+employee_id = "little_bear"
+tenant_id = "default"
+
+[[routes]]
+channel = "email"
 key = "proto@dowhiz.com"
 employee_id = "boiled_egg"
 tenant_id = "default"

--- a/DoWhiz_service/scheduler_module/src/service/chat_history.rs
+++ b/DoWhiz_service/scheduler_module/src/service/chat_history.rs
@@ -2156,6 +2156,7 @@ mod tests {
             discord_enabled: true,
             slack_enabled: true,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         };
         let employee_directory = crate::employee_config::EmployeeDirectory {
             default_employee_id: Some("little_bear".to_string()),

--- a/DoWhiz_service/scheduler_module/src/service/config.rs
+++ b/DoWhiz_service/scheduler_module/src/service/config.rs
@@ -488,6 +488,7 @@ mod tests {
             discord_enabled: false,
             slack_enabled: false,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         }
     }
 

--- a/DoWhiz_service/scheduler_module/src/service/email.rs
+++ b/DoWhiz_service/scheduler_module/src/service/email.rs
@@ -1219,6 +1219,7 @@ mod tests {
             discord_enabled: false,
             slack_enabled: false,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         };
         let workspace = ensure_thread_workspace(&user_paths, "user123", &thread, &employee, None)
             .expect("create workspace");

--- a/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/discord.rs
@@ -667,6 +667,7 @@ mod tests {
             discord_enabled: false,
             slack_enabled: false,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         };
         let mut employee_by_id = HashMap::new();
         employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/src/service/inbound/google_workspace.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/google_workspace.rs
@@ -580,6 +580,7 @@ mod tests {
             discord_enabled: false,
             slack_enabled: false,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         };
         let mut employee_by_id = HashMap::new();
         employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/notion.rs
@@ -701,6 +701,7 @@ mod tests {
             tokens_to_hours: Some(0.0),
             purchased_hours: Some(1.0),
             organization_id: None,
+            organization_accept_status: None,
         }
     }
 

--- a/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
@@ -850,6 +850,7 @@ mod tests {
             discord_enabled: false,
             slack_enabled: false,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         };
         let mut employee_by_id = HashMap::new();
         employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/src/service/inbound/sms.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/sms.rs
@@ -265,6 +265,7 @@ mod tests {
             discord_enabled: false,
             slack_enabled: false,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         };
         let mut employee_by_id = HashMap::new();
         employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/src/service/scheduler.rs
+++ b/DoWhiz_service/scheduler_module/src/service/scheduler.rs
@@ -1322,6 +1322,7 @@ mod tests {
             discord_enabled: false,
             slack_enabled: false,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         };
         let mut employee_by_id = HashMap::new();
         employee_by_id.insert(employee_profile.id.clone(), employee_profile.clone());

--- a/DoWhiz_service/scheduler_module/src/service/workspace.rs
+++ b/DoWhiz_service/scheduler_module/src/service/workspace.rs
@@ -973,6 +973,7 @@ mod tests {
             discord_enabled: false,
             slack_enabled: false,
             bluebubbles_enabled: false,
+            notion_user_id: None,
         };
 
         let service_root = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/DoWhiz_service/scheduler_module/tests/email_html_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/email_html_e2e.rs
@@ -78,6 +78,7 @@ fn test_employee_directory() -> (EmployeeProfile, EmployeeDirectory) {
         discord_enabled: false,
         slack_enabled: false,
         bluebubbles_enabled: false,
+        notion_user_id: None,
     };
     let mut employee_by_id = HashMap::new();
     employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/tests/email_html_e2e_2.rs
+++ b/DoWhiz_service/scheduler_module/tests/email_html_e2e_2.rs
@@ -125,6 +125,7 @@ fn test_employee_directory() -> (EmployeeProfile, EmployeeDirectory) {
         discord_enabled: false,
         slack_enabled: false,
         bluebubbles_enabled: false,
+        notion_user_id: None,
     };
     let mut employee_by_id = HashMap::new();
     employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
@@ -101,6 +101,7 @@ fn test_employee_directory() -> (EmployeeProfile, EmployeeDirectory) {
         discord_enabled: false,
         slack_enabled: false,
         bluebubbles_enabled: false,
+        notion_user_id: None,
     };
     let mut employee_by_id = HashMap::new();
     employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/tests/scheduler_concurrency.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_concurrency.rs
@@ -42,6 +42,7 @@ fn test_employee_directory() -> (EmployeeProfile, EmployeeDirectory) {
         discord_enabled: false,
         slack_enabled: false,
         bluebubbles_enabled: false,
+        notion_user_id: None,
     };
     let mut employee_by_id = HashMap::new();
     employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/tests/secrets_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/secrets_e2e.rs
@@ -93,6 +93,7 @@ fn test_employee_directory() -> (EmployeeProfile, EmployeeDirectory) {
         discord_enabled: false,
         slack_enabled: false,
         bluebubbles_enabled: false,
+        notion_user_id: None,
     };
     let mut employee_by_id = HashMap::new();
     employee_by_id.insert(employee.id.clone(), employee.clone());

--- a/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
@@ -78,6 +78,7 @@ fn test_employee_directory(root: &Path) -> (EmployeeProfile, EmployeeDirectory) 
         discord_enabled: false,
         slack_enabled: false,
         bluebubbles_enabled: false,
+        notion_user_id: None,
     };
     let mut employee_by_id = HashMap::new();
     employee_by_id.insert(employee.id.clone(), employee.clone());


### PR DESCRIPTION
## Summary
- Add the current production Postmark inbound hash address to Oliver/little_bear service addresses.
- Add a gateway email route for that Postmark hash address to little_bear.
- Update stale scheduler test fixtures for current EmployeeProfile/Account fields so focused Rust validation compiles.

## Validation
- cargo fmt
- cargo test -p scheduler_module postmark -- --nocapture
- cargo clippy --all-targets --all-features
- Parsed employee.toml and gateway.toml with tomllib and confirmed the Postmark hash maps to little_bear.
- Deployed the config-only routing change to production after backing up remote config, restarted dw_gateway and dw_worker, and verified both health endpoints returned ok.
- Sent a production synthetic [HAG:...] Postmark webhook to https://api.production1.dowhiz.com/postmark/inbound; gateway returned accepted, worker claimed the Email envelope, handled the HAG payload, and logged ingestion processed successfully.

## Operational Note
This PR fixes DoWhiz service-side routing for Postmark hash-address delivery. Real mail sent to oliver@dowhiz.com still requires Google Workspace dual delivery or forwarding to f4539b87b9eb29a0ecce5585895e7a6c@inbound.postmarkapp.com, because dowhiz.com MX currently prioritizes Google Workspace over Postmark.