### PR TITLE
Fix cron billing hours UX

### DIFF
--- a/DoWhiz_service/scheduler_module/src/account_store.rs
+++ b/DoWhiz_service/scheduler_module/src/account_store.rs
@@ -687,6 +687,26 @@ impl AccountStore {
         }))
     }
 
+    /// Get the auth.users email for an account, if the account still has an auth user.
+    pub fn get_account_auth_email(
+        &self,
+        account_id: Uuid,
+    ) -> Result<Option<String>, AccountStoreError> {
+        let mut conn = self.conn()?;
+        let row = conn.query_opt(
+            "SELECT u.email
+             FROM accounts a
+             JOIN auth.users u ON u.id = a.auth_user_id
+             WHERE a.id = $1",
+            &[&account_id],
+        )?;
+        Ok(row.and_then(|r| {
+            r.get::<_, Option<String>>(0)
+                .map(|email| email.trim().to_string())
+                .filter(|email| !email.is_empty())
+        }))
+    }
+
     /// Look up account by channel identifier (for message routing)
     pub fn get_account_by_identifier(
         &self,

--- a/DoWhiz_service/scheduler_module/src/scheduler/actions.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/actions.rs
@@ -1566,7 +1566,11 @@ pub(crate) fn apply_scheduler_actions<E: TaskExecutor>(
                         continue;
                     }
                 };
+                let inherited_account_id = resolve_account_id_for_run_task(task);
                 let mut new_task = task.clone();
+                if new_task.account_id.is_none() {
+                    new_task.account_id = inherited_account_id;
+                }
                 if let Some(model_name) =
                     model_name.as_ref().filter(|value| !value.trim().is_empty())
                 {
@@ -1577,6 +1581,9 @@ pub(crate) fn apply_scheduler_actions<E: TaskExecutor>(
                 }
                 if !reply_to.is_empty() {
                     new_task.reply_to = reply_to.clone();
+                }
+                if new_task.account_id.is_none() {
+                    new_task.account_id = resolve_account_id_for_run_task(&new_task);
                 }
                 match schedule {
                     Schedule::Cron { expression, .. } => {
@@ -2191,6 +2198,16 @@ addresses = ["proto@dowhiz.com", "boiled-egg@dowhiz.com"]
     }
 
     #[test]
+    fn resolve_account_id_for_run_task_prefers_persisted_account_when_reply_to_is_thread_key() {
+        let account_id = Uuid::new_v4();
+        let mut task = make_test_task(vec!["slack:D0AVC970Z3L:1777218656.751839".to_string()]);
+        task.channel = Channel::Slack;
+        task.account_id = Some(account_id);
+
+        assert_eq!(resolve_account_id_for_run_task(&task), Some(account_id));
+    }
+
+    #[test]
     fn create_run_task_actions_are_mirrored_to_account_storage() {
         let _lock = env_lock().lock().expect("env lock");
         let temp = TempDir::new().expect("tempdir");
@@ -2231,12 +2248,20 @@ addresses = ["proto@dowhiz.com", "boiled-egg@dowhiz.com"]
             },
             model_name: None,
             codex_disabled: None,
-            reply_to: Vec::new(),
+            reply_to: vec!["slack:D0AVC970Z3L:1777218656.751839".to_string()],
         }];
 
         apply_scheduler_actions(&mut scheduler, &task, &actions).expect("apply actions");
 
         let created_task = scheduler.tasks().last().cloned().expect("created task");
+        let TaskKind::RunTask(created_run_task) = &created_task.kind else {
+            panic!("expected created run task");
+        };
+        assert_eq!(created_run_task.account_id, Some(account_id));
+        assert_eq!(
+            created_run_task.reply_to,
+            vec!["slack:D0AVC970Z3L:1777218656.751839".to_string()]
+        );
         let account_db = users_root
             .join(account_id.to_string())
             .join("state")

--- a/DoWhiz_service/scheduler_module/src/scheduler/core.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/core.rs
@@ -328,19 +328,35 @@ impl<E: TaskExecutor> Scheduler<E> {
                     reset_reconciliation_failure_counter();
                 }
                 self.tasks[index].last_run = Some(executed_at);
-                match &mut self.tasks[index].schedule {
-                    Schedule::Cron {
-                        expression,
-                        next_run,
-                    } => {
-                        *next_run = next_run_after(expression, executed_at)?;
-                    }
-                    Schedule::OneShot { .. } => {
-                        self.tasks[index].enabled = false;
+                let disable_current_task_reason = execution.disable_current_task_reason.clone();
+                if disable_current_task_reason.is_some() {
+                    self.tasks[index].enabled = false;
+                } else {
+                    match &mut self.tasks[index].schedule {
+                        Schedule::Cron {
+                            expression,
+                            next_run,
+                        } => {
+                            *next_run = next_run_after(expression, executed_at)?;
+                        }
+                        Schedule::OneShot { .. } => {
+                            self.tasks[index].enabled = false;
+                        }
                     }
                 }
                 let updated_task = self.tasks[index].clone();
                 self.store.update_task(&updated_task)?;
+                if let Some(reason) = disable_current_task_reason.as_deref() {
+                    if let Err(err) = self
+                        .store
+                        .disable_task_by_id_with_reason(&task_id.to_string(), reason)
+                    {
+                        warn!(
+                            "failed to persist auto-disable reason for task {}: {}",
+                            task_id, err
+                        );
+                    }
+                }
                 if execution.superseded {
                     if let TaskKind::RunTask(task) = &task_kind {
                         sync_task_status_to_user_storage(

--- a/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/executor.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use serde_json::json;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -93,6 +94,8 @@ use super::utils::{
     load_google_access_token_from_service_env, load_notion_access_token_for_account,
 };
 
+const INSUFFICIENT_BALANCE_DISABLE_REASON: &str = "insufficient_billing_hours";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct GitHubInboundContext {
     is_github_notification: bool,
@@ -131,6 +134,15 @@ fn resolve_account_for_run_task(
 ) -> Option<Uuid> {
     if let Some(account_id) = task.account_id {
         return Some(account_id);
+    }
+
+    if let (Some(identifier_type), Some(identifier)) = (
+        task.requester_identifier_type.as_deref(),
+        task.requester_identifier.as_deref(),
+    ) {
+        if let Some(account_id) = lookup_account_by_identifier(identifier_type, identifier) {
+            return Some(account_id);
+        }
     }
 
     if let Some(identifier) = task.reply_to.first() {
@@ -582,6 +594,12 @@ fn default_billing_link() -> String {
         .unwrap_or_else(|| "https://www.dowhiz.com/auth/index.html".to_string())
 }
 
+fn notification_sender_email() -> Option<String> {
+    ["POSTMARK_FROM_EMAIL", "HUMAN_APPROVAL_FROM", "ADMIN_EMAIL"]
+        .iter()
+        .find_map(|key| read_non_empty_env(key))
+}
+
 fn html_escape(value: &str) -> String {
     value
         .replace('&', "&amp;")
@@ -593,7 +611,8 @@ fn html_escape(value: &str) -> String {
 fn build_insufficient_balance_plain_text(payment_link: &str) -> String {
     format!(
         "Insufficient balance. I could not run this request.\n\
-Please add more employee hours, then resend your message.\n\
+If this was a scheduled or routine task, it has been disabled so it will not keep retrying without hours.\n\
+Please add more employee hours, then re-enable or resend your request.\n\
 Payment link: {payment_link}"
     )
 }
@@ -606,7 +625,8 @@ fn build_insufficient_balance_email_html(payment_link: &str) -> String {
 <body>
   <p>Hi there,</p>
   <p>Your account currently has insufficient balance, so I could not run this request.</p>
-  <p>Please add more employee hours, then resend your message.</p>
+  <p>If this was a scheduled or routine task, it has been disabled so it will not keep retrying without hours.</p>
+  <p>Please add more employee hours, then re-enable or resend your request.</p>
   <p>Payment link: <a href="{link}">{link}</a></p>
 </body>
 </html>
@@ -618,8 +638,9 @@ fn build_insufficient_balance_email_html(payment_link: &str) -> String {
 fn write_insufficient_balance_notice_body(
     task: &super::types::RunTaskTask,
     payment_link: &str,
+    notice_channel: &Channel,
 ) -> Result<PathBuf, SchedulerError> {
-    let (filename, body) = match task.channel {
+    let (filename, body) = match notice_channel {
         Channel::Email => (
             ".insufficient_balance_notice.html",
             build_insufficient_balance_email_html(payment_link),
@@ -632,6 +653,62 @@ fn write_insufficient_balance_notice_body(
     let path = task.workspace_dir.join(filename);
     std::fs::write(&path, body)?;
     Ok(path)
+}
+
+fn push_unique_email_recipient(
+    recipients: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+    raw: &str,
+) {
+    let email = raw.trim();
+    if email.is_empty() {
+        return;
+    }
+    let key = email.to_ascii_lowercase();
+    if seen.insert(key) {
+        recipients.push(email.to_string());
+    }
+}
+
+fn billing_notice_email_recipients(account_id: Uuid) -> Vec<String> {
+    let mut recipients = Vec::new();
+    let mut seen = HashSet::new();
+    let Some(store) = get_global_account_store() else {
+        warn!(
+            "cannot resolve billing notice email recipients for account {}: account store unavailable",
+            account_id
+        );
+        return recipients;
+    };
+
+    match store.list_identifiers(account_id) {
+        Ok(identifiers) => {
+            for identifier in identifiers {
+                if identifier.verified && identifier.identifier_type == "email" {
+                    push_unique_email_recipient(&mut recipients, &mut seen, &identifier.identifier);
+                }
+            }
+        }
+        Err(err) => {
+            warn!(
+                "failed to list identifiers for insufficient-balance email account={}: {}",
+                account_id, err
+            );
+        }
+    }
+
+    match store.get_account_auth_email(account_id) {
+        Ok(Some(email)) => push_unique_email_recipient(&mut recipients, &mut seen, &email),
+        Ok(None) => {}
+        Err(err) => {
+            warn!(
+                "failed to read auth email for insufficient-balance email account={}: {}",
+                account_id, err
+            );
+        }
+    }
+
+    recipients
 }
 
 fn dispatch_send_reply_task(task: &SendReplyTask) -> Result<(), SchedulerError> {
@@ -710,9 +787,29 @@ fn send_insufficient_balance_notice(
     task: &super::types::RunTaskTask,
     account_id: Uuid,
 ) -> Result<(), SchedulerError> {
-    if task.reply_to.is_empty() {
+    let email_recipients = billing_notice_email_recipients(account_id);
+    let (notice_channel, recipients) = if email_recipients.is_empty() {
+        if !task.reply_to.is_empty() {
+            warn!(
+                "Account {} has insufficient balance but no billing email recipients; falling back to {:?}",
+                account_id, task.channel
+            );
+            (task.channel.clone(), task.reply_to.clone())
+        } else {
+            warn!(
+                "Account {} has insufficient balance but no billing email recipients and no reply recipients for workspace {}",
+                account_id,
+                task.workspace_dir.display()
+            );
+            return Ok(());
+        }
+    } else {
+        (Channel::Email, email_recipients)
+    };
+
+    if recipients.is_empty() {
         warn!(
-            "Account {} has insufficient balance but no reply recipients for workspace {}",
+            "Account {} has insufficient balance but notice recipients were empty for workspace {}",
             account_id,
             task.workspace_dir.display()
         );
@@ -721,7 +818,7 @@ fn send_insufficient_balance_notice(
 
     let payment_link =
         configured_insufficient_balance_payment_link().unwrap_or_else(default_billing_link);
-    let body_path = write_insufficient_balance_notice_body(task, &payment_link)?;
+    let body_path = write_insufficient_balance_notice_body(task, &payment_link, &notice_channel)?;
     let attachments_dir = task
         .workspace_dir
         .join(".insufficient_balance_notice_attachments");
@@ -729,27 +826,51 @@ fn send_insufficient_balance_notice(
     let reply_context = super::reply::load_reply_context(&task.workspace_dir);
 
     let send_task = SendReplyTask {
-        channel: task.channel.clone(),
-        subject: reply_context.subject,
+        channel: notice_channel.clone(),
+        subject: "Action needed: DoWhiz hours are exhausted".to_string(),
         html_path: body_path,
         attachments_dir,
-        from: task.reply_from.clone().or(reply_context.from),
-        to: task.reply_to.clone(),
+        from: task
+            .reply_from
+            .clone()
+            .or(reply_context.from)
+            .or_else(notification_sender_email),
+        to: recipients,
         cc: Vec::new(),
         bcc: Vec::new(),
-        in_reply_to: reply_context.in_reply_to,
-        references: reply_context.references,
+        in_reply_to: if notice_channel == Channel::Email {
+            reply_context.in_reply_to
+        } else {
+            None
+        },
+        references: if notice_channel == Channel::Email {
+            reply_context.references
+        } else {
+            None
+        },
         archive_root: task.archive_root.clone(),
-        thread_epoch: task.thread_epoch,
-        thread_state_path: task.thread_state_path.clone(),
+        thread_epoch: if notice_channel == task.channel {
+            task.thread_epoch
+        } else {
+            None
+        },
+        thread_state_path: if notice_channel == task.channel {
+            task.thread_state_path.clone()
+        } else {
+            None
+        },
         employee_id: task.employee_id.clone(),
-        channel_metadata: task.normalized_channel_metadata(),
+        channel_metadata: if notice_channel == task.channel {
+            task.normalized_channel_metadata()
+        } else {
+            Default::default()
+        },
     };
 
     dispatch_send_reply_task(&send_task)?;
     info!(
         "sent insufficient-balance notice for account {} via {:?}",
-        account_id, task.channel
+        account_id, notice_channel
     );
     Ok(())
 }
@@ -1311,9 +1432,20 @@ impl TaskExecutor for ModuleExecutor {
                                         "channel": task.channel.to_string(),
                                     }),
                                 );
-                                send_insufficient_balance_notice(task, account_id)?;
+                                if let Err(err) = send_insufficient_balance_notice(task, account_id)
+                                {
+                                    warn!(
+                                        "failed to send insufficient-balance notice for account {}: {}",
+                                        account_id, err
+                                    );
+                                }
                                 let mut execution = TaskExecution::empty();
                                 execution.skip_auto_reply = true;
+                                execution.disable_current_task_reason =
+                                    Some(INSUFFICIENT_BALANCE_DISABLE_REASON.to_string());
+                                execution.terminal_status = Some("failed".to_string());
+                                execution.terminal_error_message =
+                                    Some(INSUFFICIENT_BALANCE_DISABLE_REASON.to_string());
                                 return Ok(execution);
                             }
                             Ok(true) => {}
@@ -1781,6 +1913,7 @@ impl TaskExecutor for ModuleExecutor {
                     scheduler_actions_error: output.scheduler_actions_error,
                     skip_auto_reply: false,
                     superseded: false,
+                    disable_current_task_reason: None,
                     terminal_note: output.recovery_note,
                     terminal_status,
                     terminal_error_message: output.terminal_error_message,
@@ -1907,6 +2040,43 @@ mod tests {
             recovery_note: recovery_note.map(str::to_string),
             terminal_error_message: None,
         }
+    }
+
+    #[test]
+    fn push_unique_email_recipient_dedupes_case_insensitively() {
+        let mut recipients = Vec::new();
+        let mut seen = HashSet::new();
+
+        push_unique_email_recipient(&mut recipients, &mut seen, " User@Example.com ");
+        push_unique_email_recipient(&mut recipients, &mut seen, "user@example.com");
+        push_unique_email_recipient(&mut recipients, &mut seen, "other@example.com");
+        push_unique_email_recipient(&mut recipients, &mut seen, " ");
+
+        assert_eq!(
+            recipients,
+            vec![
+                "User@Example.com".to_string(),
+                "other@example.com".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn insufficient_balance_email_notice_mentions_scheduled_task_disable() {
+        let temp = TempDir::new().expect("tempdir");
+        let task = sample_email_task(temp.path().to_path_buf());
+
+        let path = write_insufficient_balance_notice_body(
+            &task,
+            "https://billing.example.test",
+            &Channel::Email,
+        )
+        .expect("write notice");
+        let body = fs::read_to_string(path).expect("notice body");
+
+        assert!(body.contains("insufficient balance"));
+        assert!(body.contains("scheduled or routine task"));
+        assert!(body.contains("disabled"));
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/schedule.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/schedule.rs
@@ -29,7 +29,7 @@ pub(crate) fn next_run_after(
 ) -> Result<DateTime<Utc>, SchedulerError> {
     validate_cron_expression(expression)?;
     let schedule = CronSchedule::from_str(expression)?;
-    for datetime in schedule.upcoming(Utc) {
+    for datetime in schedule.after(&after) {
         if datetime > after {
             return Ok(datetime);
         }
@@ -73,4 +73,34 @@ fn request_implies_monday_through_friday(text: &str) -> bool {
 
 fn is_legacy_weekday_field(field: &str) -> bool {
     matches!(field.trim(), "0-4" | "0,1,2,3,4" | "1-5" | "1,2,3,4,5")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn validate_cron_expression_requires_six_fields() {
+        assert!(validate_cron_expression("0 0 9 * * *").is_ok());
+
+        let err = validate_cron_expression("0 9 * * *").expect_err("five fields invalid");
+        assert!(matches!(err, SchedulerError::InvalidCron(5)));
+    }
+
+    #[test]
+    fn next_run_after_returns_same_day_future_occurrence() {
+        let after = Utc.with_ymd_and_hms(2026, 6, 30, 8, 59, 0).unwrap();
+        let expected = Utc.with_ymd_and_hms(2026, 6, 30, 9, 0, 0).unwrap();
+
+        assert_eq!(next_run_after("0 0 9 * * *", after).unwrap(), expected);
+    }
+
+    #[test]
+    fn next_run_after_is_strictly_after_reference_time() {
+        let after = Utc.with_ymd_and_hms(2026, 6, 30, 9, 0, 0).unwrap();
+        let expected = Utc.with_ymd_and_hms(2026, 7, 1, 9, 0, 0).unwrap();
+
+        assert_eq!(next_run_after("0 0 9 * * *", after).unwrap(), expected);
+    }
 }

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mod.rs
@@ -165,6 +165,18 @@ impl SchedulerStore {
         Ok(())
     }
 
+    pub(crate) fn disable_task_by_id_with_reason(
+        &self,
+        task_id: &str,
+        reason: &str,
+    ) -> Result<(), SchedulerError> {
+        if let Some(mut task) = self.load_task_by_id(task_id)? {
+            task.enabled = false;
+            self.update_task(&task)?;
+        }
+        self.mongo.disable_task_by_id(task_id, reason)
+    }
+
     pub(crate) fn append_execution_event(
         &self,
         task_id: &str,

--- a/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/store/mongo.rs
@@ -1840,12 +1840,17 @@ fn derive_user_task_status(
 }
 
 fn humanize_auto_disabled_reason(raw: &str) -> String {
-    raw.trim()
+    let normalized = raw
+        .trim()
         .strip_prefix("auto-disabled:")
         .unwrap_or(raw.trim())
         .trim()
-        .trim_end_matches('.')
-        .to_string()
+        .trim_end_matches('.');
+
+    match normalized {
+        "insufficient_billing_hours" => "the billing account has no remaining hours".to_string(),
+        _ => normalized.to_string(),
+    }
 }
 
 fn resolve_aci_registration_grace_period() -> ChronoDuration {
@@ -2619,7 +2624,7 @@ mod tests {
     use mongodb::bson::{doc, Bson, DateTime as BsonDateTime};
 
     use super::{
-        apply_persisted_task_fields, build_task_status_summary,
+        apply_persisted_task_fields, build_task_status_summary, humanize_auto_disabled_reason,
         missing_aci_registry_reconciliation_reason, resolve_owner_scope_with,
         should_replace_stale_reconciliation_terminal_row, workspace_peer_supersede_reason,
         workspace_suggests_recent_inflight_aci_result_handling, ExecutionRow,
@@ -2832,6 +2837,20 @@ mod tests {
         assert!(summary.can_resubmit);
         assert!(!summary.will_retry);
         assert!(summary.retry_at.is_none());
+    }
+
+    #[test]
+    fn humanize_auto_disabled_reason_explains_insufficient_billing_hours() {
+        assert_eq!(
+            humanize_auto_disabled_reason("insufficient_billing_hours"),
+            "the billing account has no remaining hours"
+        );
+        assert_eq!(
+            humanize_auto_disabled_reason(
+                "auto-disabled: execution started but ACI container was never created."
+            ),
+            "execution started but ACI container was never created"
+        );
     }
 
     #[test]

--- a/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/tests.rs
@@ -64,6 +64,21 @@ impl TaskExecutor for TerminalFailureReplyExecutor {
     }
 }
 
+#[derive(Default)]
+struct DisableCurrentTaskExecutor;
+
+impl TaskExecutor for DisableCurrentTaskExecutor {
+    fn execute(&self, _task: &TaskKind) -> Result<TaskExecution, SchedulerError> {
+        Ok(TaskExecution {
+            skip_auto_reply: true,
+            disable_current_task_reason: Some("insufficient_billing_hours".to_string()),
+            terminal_status: Some("failed".to_string()),
+            terminal_error_message: Some("insufficient_billing_hours".to_string()),
+            ..TaskExecution::empty()
+        })
+    }
+}
+
 fn base_run_task(workspace: &Path, mail_root: &Path) -> RunTaskTask {
     RunTaskTask {
         workspace_dir: workspace.to_path_buf(),
@@ -767,6 +782,97 @@ fn terminal_failure_reply_outcome_uses_failed_status_and_error_note() {
     assert_eq!(
         outcome.note.as_deref(),
         Some("Investment analysis runners failed after all configured attempts")
+    );
+}
+
+#[test]
+fn terminal_outcome_defaults_to_success_for_empty_execution() {
+    let outcome = execution_terminal_outcome(&TaskExecution::empty());
+
+    assert_eq!(outcome.status, "success");
+    assert_eq!(outcome.note, None);
+}
+
+#[test]
+fn terminal_outcome_superseded_overrides_explicit_failure_status() {
+    let mut execution = TaskExecution {
+        terminal_status: Some("failed".to_string()),
+        terminal_error_message: Some("terminal error wins note precedence".to_string()),
+        terminal_note: Some("superseded by newer request".to_string()),
+        ..TaskExecution::empty()
+    };
+    execution.superseded = true;
+
+    let outcome = execution_terminal_outcome(&execution);
+
+    assert_eq!(outcome.status, "superseded");
+    assert_eq!(
+        outcome.note.as_deref(),
+        Some("terminal error wins note precedence")
+    );
+}
+
+#[test]
+fn disable_current_task_reason_disables_due_cron_and_persists_reason() {
+    if !mongo_execution_tests_enabled() {
+        eprintln!("skipping mongo-backed test: MONGODB_URI/MONGODB_DATABASE not set");
+        return;
+    }
+
+    let _lock = env_lock();
+    let temp = TempDir::new().expect("tempdir");
+    let user_id = format!("cron_disable_{}", Uuid::new_v4());
+    let tasks_db = user_scoped_tasks_db(&temp, &user_id);
+    let workspace = temp.path().join("workspace");
+    let mail_root = temp.path().join("mail");
+    fs::create_dir_all(&workspace).expect("workspace");
+    fs::create_dir_all(&mail_root).expect("mail root");
+
+    let mut scheduler =
+        Scheduler::load(&tasks_db, DisableCurrentTaskExecutor).expect("load scheduler");
+    let task = base_run_task(&workspace, &mail_root);
+    let task_id = scheduler
+        .add_cron_task("0 0 16 * * *", TaskKind::RunTask(task))
+        .expect("add cron");
+
+    let due_next_run = Utc::now() - chrono::Duration::seconds(5);
+    let index = scheduler
+        .tasks
+        .iter()
+        .position(|task| task.id == task_id)
+        .expect("created task");
+    scheduler.tasks[index].schedule = Schedule::Cron {
+        expression: "0 0 16 * * *".to_string(),
+        next_run: due_next_run,
+    };
+    let updated = scheduler.tasks[index].clone();
+    scheduler
+        .store
+        .update_task(&updated)
+        .expect("persist due cron");
+
+    assert!(scheduler
+        .execute_task_by_id(task_id)
+        .expect("execute due cron"));
+
+    let task_after = scheduler
+        .tasks()
+        .iter()
+        .find(|task| task.id == task_id)
+        .expect("task after execution");
+    assert!(!task_after.enabled);
+    assert!(task_after.last_run.is_some());
+    match &task_after.schedule {
+        Schedule::Cron { next_run, .. } => assert_eq!(*next_run, due_next_run),
+        other => panic!("expected cron schedule, got {other:?}"),
+    }
+
+    let task_docs = load_task_documents(&user_id, task_id);
+    assert_eq!(task_docs.len(), 1);
+    assert_eq!(task_docs[0].get_bool("enabled"), Ok(false));
+    assert_eq!(
+        task_docs[0].get_str("auto_disabled_reason"),
+        Ok("insufficient_billing_hours")
     );
 }
 

--- a/DoWhiz_service/scheduler_module/src/scheduler/types.rs
+++ b/DoWhiz_service/scheduler_module/src/scheduler/types.rs
@@ -271,6 +271,7 @@ pub struct TaskExecution {
     pub scheduler_actions_error: Option<String>,
     pub skip_auto_reply: bool,
     pub superseded: bool,
+    pub disable_current_task_reason: Option<String>,
     pub terminal_note: Option<String>,
     pub terminal_status: Option<String>,
     pub terminal_error_message: Option<String>,
@@ -285,3 +286,59 @@ impl TaskExecution {
 pub(crate) const RUN_TASK_FAILURE_NOTICE: &str = "We could not complete your request";
 pub(crate) const RUN_TASK_FAILURE_DIR: &str = "failure_notifications";
 pub(crate) const RUN_TASK_FAILURE_REPORT_DIR: &str = "dowhiz_failure_reports";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone};
+
+    fn test_task(schedule: Schedule) -> ScheduledTask {
+        ScheduledTask {
+            id: Uuid::new_v4(),
+            kind: TaskKind::Noop,
+            schedule,
+            enabled: true,
+            created_at: Utc.with_ymd_and_hms(2026, 6, 30, 8, 0, 0).unwrap(),
+            last_run: None,
+        }
+    }
+
+    #[test]
+    fn cron_task_is_due_when_next_run_is_now_or_past() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 30, 9, 0, 0).unwrap();
+        let due_now = test_task(Schedule::Cron {
+            expression: "0 0 9 * * *".to_string(),
+            next_run: now,
+        });
+        let due_past = test_task(Schedule::Cron {
+            expression: "0 0 9 * * *".to_string(),
+            next_run: now - Duration::seconds(1),
+        });
+
+        assert!(due_now.is_due(now));
+        assert!(due_past.is_due(now));
+    }
+
+    #[test]
+    fn cron_task_is_not_due_when_next_run_is_future() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 30, 9, 0, 0).unwrap();
+        let task = test_task(Schedule::Cron {
+            expression: "0 0 9 * * *".to_string(),
+            next_run: now + Duration::seconds(1),
+        });
+
+        assert!(!task.is_due(now));
+    }
+
+    #[test]
+    fn one_shot_due_uses_run_at_cutoff() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 30, 9, 0, 0).unwrap();
+        let due = test_task(Schedule::OneShot { run_at: now });
+        let future = test_task(Schedule::OneShot {
+            run_at: now + Duration::seconds(1),
+        });
+
+        assert!(due.is_due(now));
+        assert!(!future.is_due(now));
+    }
+}

--- a/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
+++ b/DoWhiz_service/scheduler_module/src/service/inbound/slack.rs
@@ -117,6 +117,19 @@ pub(crate) fn process_slack_event(
         thread_state.epoch
     );
 
+    let linked_account_id = match account_store.get_account_by_identifier("slack", &message.sender)
+    {
+        Ok(Some(account)) => Some(account.id),
+        Ok(None) => None,
+        Err(err) => {
+            warn!(
+                "failed to resolve slack sender {} to billing account: {}",
+                message.sender, err
+            );
+            None
+        }
+    };
+
     // Create RunTask to process the message
     let run_task = RunTaskTask {
         workspace_dir: workspace.clone(),
@@ -137,9 +150,9 @@ pub(crate) fn process_slack_event(
         channel: Channel::Slack,
         slack_team_id: message.metadata.slack_team_id.clone(),
         employee_id: Some(config.employee_profile.id.clone()),
-        requester_identifier_type: None,
-        requester_identifier: None,
-        account_id: None,
+        requester_identifier_type: Some("slack".to_string()),
+        requester_identifier: Some(message.sender.clone()),
+        account_id: linked_account_id,
         channel_metadata: message.metadata.clone(),
     };
 
@@ -185,14 +198,13 @@ pub(crate) fn process_slack_event(
         thread_state.epoch
     );
 
-    // If the Slack user has linked their account, also write to account-level tasks.db
-    // message.sender contains the Slack user ID
-    if let Ok(Some(account)) = account_store.get_account_by_identifier("slack", &message.sender) {
-        let account_tasks_dir = config.users_root.join(account.id.to_string()).join("state");
+    // If the Slack user has linked their account, also write to account-level tasks.db.
+    if let Some(account_id) = linked_account_id {
+        let account_tasks_dir = config.users_root.join(account_id.to_string()).join("state");
         if let Err(err) = std::fs::create_dir_all(&account_tasks_dir) {
             warn!(
                 "failed to create account tasks dir for account {}: {}",
-                account.id, err
+                account_id, err
             );
         } else {
             let account_tasks_db_path = account_tasks_dir.join("tasks.db");
@@ -207,19 +219,19 @@ pub(crate) fn process_slack_event(
                         Ok(true) => {
                             info!(
                                 "also enqueued task to account-level storage account={} task_id={}",
-                                account.id, task_id
+                                account_id, task_id
                             );
                         }
                         Ok(false) => {
                             info!(
                                 "skipping duplicate slack account-level enqueue account={} task_id={}",
-                                account.id, task_id
+                                account_id, task_id
                             );
                         }
                         Err(err) => {
                             warn!(
                                 "failed to add task to account scheduler for account {}: {}",
-                                account.id, err
+                                account_id, err
                             );
                         }
                     }
@@ -227,7 +239,7 @@ pub(crate) fn process_slack_event(
                 Err(err) => {
                     warn!(
                         "failed to load account scheduler for account {}: {}",
-                        account.id, err
+                        account_id, err
                     );
                 }
             }

--- a/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/github_env_e2e.rs
@@ -148,6 +148,7 @@ impl TaskExecutor for RecordingExecutor {
                     scheduler_actions_error: output.scheduler_actions_error,
                     skip_auto_reply: false,
                     superseded: false,
+                    disable_current_task_reason: None,
                     terminal_note: output.recovery_note,
                     terminal_status: output
                         .terminal_error_message

--- a/DoWhiz_service/scheduler_module/tests/scheduler_agent_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_agent_e2e.rs
@@ -82,6 +82,7 @@ impl TaskExecutor for RecordingExecutor {
                     scheduler_actions_error: output.scheduler_actions_error,
                     skip_auto_reply: false,
                     superseded: false,
+                    disable_current_task_reason: None,
                     terminal_note: output.recovery_note,
                     terminal_status: output
                         .terminal_error_message

--- a/DoWhiz_service/scheduler_module/tests/scheduler_followups.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_followups.rs
@@ -32,6 +32,7 @@ impl TaskExecutor for FollowUpExecutor {
                     scheduler_actions_error: None,
                     skip_auto_reply: false,
                     superseded: false,
+                    disable_current_task_reason: None,
                     terminal_note: None,
                     terminal_status: None,
                     terminal_error_message: None,

--- a/DoWhiz_service/scheduler_module/tests/scheduler_x402_env_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/scheduler_x402_env_e2e.rs
@@ -98,6 +98,7 @@ impl TaskExecutor for RecordingExecutor {
                     scheduler_actions_error: output.scheduler_actions_error,
                     skip_auto_reply: false,
                     superseded: false,
+                    disable_current_task_reason: None,
                     terminal_note: output.recovery_note,
                     terminal_status: output
                         .terminal_error_message

--- a/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
+++ b/DoWhiz_service/scheduler_module/tests/thread_latest_epoch_e2e.rs
@@ -134,6 +134,7 @@ impl TaskExecutor for RecordingExecutor {
                     scheduler_actions_error: output.scheduler_actions_error,
                     skip_auto_reply: false,
                     superseded: false,
+                    disable_current_task_reason: None,
                     terminal_note: output.recovery_note,
                     terminal_status: output
                         .terminal_error_message


### PR DESCRIPTION
## Summary

This PR fixes the cron/routine billing-hours UX and brings Slack-created scheduled tasks into the billing-account path.

When a scheduled or routine task ran after the linked account had exhausted employee hours, the previous behavior was not user-friendly or consistently enforceable: the task could fail without a clear billing notice, and Slack-originated scheduled tasks could lose the billing account association when scheduler actions rewrote `reply_to` into a Slack thread key. That meant balance checks and token-to-hours accounting could be skipped for some Slack scheduled work.

## Root Cause

There were two separate problems.

First, insufficient-balance handling only skipped the current execution. It did not consistently disable the routine with a persisted reason and did not prioritize notifying the account billing email. That could leave cron jobs repeatedly trying to run without hours.

Second, Slack inbound tasks did not persist enough requester/account identity into the `RunTaskTask` payload. Scheduler-created follow-up recurring tasks could inherit a Slack thread routing target instead of the original Slack user/account identity, so account resolution could fail later.

While testing cron behavior, I also found that `next_run_after` ignored its `after` argument and used real current time. That made resume/reschedule behavior time-reference dependent and could compute the wrong next cron run for tests or repaired schedules.

## Changes

- Add `disable_current_task_reason` to `TaskExecution` and teach scheduler core to disable the current task instead of advancing cron when that reason is set.
- On insufficient billing hours, send a notice, mark the execution failed, skip normal auto-reply, and disable the scheduled/routine task with `insufficient_billing_hours`.
- Prefer verified billing email recipients for insufficient-hours notices, with channel fallback only when no billing email can be resolved.
- Preserve Slack requester identity and linked `account_id` from inbound Slack messages.
- Preserve/inherit `account_id` when scheduler actions create recurring `RunTask` tasks, even if `reply_to` is replaced by model output.
- Fix `next_run_after` to compute from the supplied reference time.
- Humanize dashboard auto-disable reason text so users see a readable no-hours explanation instead of `insufficient_billing_hours`.
- Add focused tests around cron due behavior, next-run calculation, billing notice content, account inheritance, terminal outcome handling, and dashboard reason text.

## Validation

Passed:

- `gh --version`
- `gh auth status`
- `git pull --ff-only origin dev`
- `git diff --check`
- `cargo fmt -p scheduler_module -- --check`
- `cargo test -p scheduler_module scheduler::schedule::tests --lib -- --nocapture`
- `cargo test -p scheduler_module scheduler::types::tests --lib -- --nocapture`
- `cargo test -p scheduler_module terminal_outcome_ --lib -- --nocapture`
- `cargo test -p scheduler_module insufficient_balance_email_notice_mentions_scheduled_task_disable --lib -- --nocapture`
- `cargo test -p scheduler_module push_unique_email_recipient_dedupes_case_insensitively --lib -- --nocapture`
- `cargo test -p scheduler_module resolve_account_id_for_run_task_prefers_persisted_account_when_reply_to_is_thread_key --lib -- --nocapture`
- `cargo test -p scheduler_module humanize_auto_disabled_reason_explains_insufficient_billing_hours --lib -- --nocapture`
- `cargo test -p scheduler_module disable_current_task_reason_disables_due_cron_and_persists_reason --lib -- --nocapture`

The Mongo-backed disable test passed through its local skip path because `MONGODB_URI/MONGODB_DATABASE` are not set locally.

Also ran full lib suite after these changes:

- `cargo test -p scheduler_module --lib -- --nocapture`

Result: `689 passed; 36 failed; 4 ignored`. The failures are environment-dependent local failures from missing `MONGODB_URI`, missing `WECHAT_ENCODING_AES_KEY`, and env-lock poison errors cascading from missing Mongo-backed tests. The focused cron/billing tests added or touched by this PR passed.

## Remaining Risk

This PR does not change the existing fail-open behavior when the account store exists but balance lookup errors. That is still a billing enforcement risk and should be handled separately if the desired policy is fail-closed for scheduled tasks.

Existing orphan Slack scheduled tasks that were created before this account propagation fix may still need a migration/backfill if they have no persisted `account_id` or resolvable requester identifier.
